### PR TITLE
feat(skills): implement ticket-as-baton Agile governance system

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a defect in dashboard, hooks, scripts, or agents
-labels: ["type: bug-fix"]
+labels: ["type:bug", "status:backlog"]
 body:
   - type: input
     id: summary

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,6 +1,6 @@
 name: Epic
 description: Large initiative spanning multiple issues
-labels: ["type: epic"]
+labels: ["type:epic", "status:backlog"]
 body:
   - type: input
     id: summary

--- a/.github/ISSUE_TEMPLATE/research.yml
+++ b/.github/ISSUE_TEMPLATE/research.yml
@@ -1,0 +1,50 @@
+name: Research
+description: Investigation, evaluation, or spike
+labels: ["type:research", "status:backlog"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Research summary
+      description: Imperative verb phrase (≤72 chars)
+      placeholder: "Evaluate free-tier LLM providers for fleet routing"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context and questions
+      description: What needs to be investigated and why
+    validations:
+      required: true
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Expected deliverables
+      description: What the research should produce
+      value: |
+        - [ ] ADR or research document
+        - [ ] Recommendation with evidence
+        - [ ] Follow-up tickets created if action needed
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - dashboard
+        - hooks
+        - skills
+        - instructions
+        - agents
+        - scripts
+        - infrastructure
+    validations:
+      required: true
+  - type: input
+    id: timebox
+    attributes:
+      label: Timebox
+      description: Maximum effort before reporting findings
+      placeholder: "2 hours"

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,20 +1,20 @@
-name: Task
-description: Request a feature, improvement, or work item
-labels: ["type:task", "status:backlog"]
+name: Story
+description: User-facing feature or capability
+labels: ["type:story", "status:backlog"]
 body:
   - type: input
     id: summary
     attributes:
-      label: Task summary
+      label: Story summary
       description: Imperative verb phrase (≤72 chars)
-      placeholder: "Add LLM router log panel to dashboard"
+      placeholder: "Add fleet health dashboard panel"
     validations:
       required: true
   - type: textarea
-    id: context
+    id: user_story
     attributes:
-      label: Context and motivation
-      description: Why this work is needed
+      label: User story
+      description: "As a [role], I want [capability], so that [benefit]"
     validations:
       required: true
   - type: textarea
@@ -29,6 +29,12 @@ body:
         - [ ] Tests pass
     validations:
       required: true
+  - type: input
+    id: parent_epic
+    attributes:
+      label: Parent Epic
+      description: "Issue number of parent epic (e.g. #11)"
+      placeholder: "#11"
   - type: dropdown
     id: area
     attributes:
@@ -53,3 +59,9 @@ body:
         - P3 — nice to have
     validations:
       required: true
+  - type: input
+    id: story_points
+    attributes:
+      label: Story points
+      description: Estimation (1, 2, 3, 5, 8, 13)
+      placeholder: "5"

--- a/instructions/feature-completion-governance.instructions.md
+++ b/instructions/feature-completion-governance.instructions.md
@@ -4,10 +4,10 @@ applyTo: "**"
 
 When asked to "complete" a feature-add (or equivalent language), completion requires all four role batons:
 
-1) Manager complete → `MANAGER_HANDOFF` emitted
-2) Collaborator complete → `COLLABORATOR_HANDOFF` emitted
-3) Admin complete → `ADMIN_HANDOFF` emitted
-4) Consultant closeout → `CONSULTANT_CLOSEOUT` emitted
+1) Manager complete → `MANAGER_HANDOFF` emitted, `status:ready` set
+2) Collaborator complete → `COLLABORATOR_HANDOFF` emitted, `status:in-progress` set
+3) Admin complete → `ADMIN_HANDOFF` emitted, `status:review` set
+4) Consultant closeout → `CONSULTANT_CLOSEOUT` emitted, `status:done` set, issue closed
 
 Each role must emit its named artifact before the next role begins.
 Do not stop at "tests pass". Tests passing only closes Collaborator.

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -6,12 +6,21 @@ applyTo: "**"
 
 # Role Baton Routing
 
-Execute every task through a single active role at a time:
+The GitHub issue **is** the baton. Execute every task through a single active role at a time. Each role writes a structured comment on the ticket and transitions the status label.
 
-1. **Manager**: scope, constraints, acceptance criteria, gate plan → **create/link GitHub issue** → emit `MANAGER_HANDOFF` with `issue: #N`.
-2. **Collaborator**: implementation and validation → emit `COLLABORATOR_HANDOFF`.
-3. **Admin**: operational execution (services, git/PR/release ops) → emit `ADMIN_HANDOFF`.
-4. **Consultant**: independent critique and residual-risk assessment → emit `CONSULTANT_CLOSEOUT`.
+## Status workflow
+
+```
+status:backlog → status:ready → status:in-progress → status:review → status:done
+  (create)        (Manager)       (Collaborator)       (Admin)         (Consultant)
+```
+
+## Sequence
+
+1. **Manager**: scope, AC, gates → create/link issue → set `status:ready`, `role:manager` → emit `MANAGER_HANDOFF` → swap to `role:collaborator`.
+2. **Collaborator**: implement + validate → set `status:in-progress` → emit `COLLABORATOR_HANDOFF` → swap to `role:admin`.
+3. **Admin**: commit/PR/merge ops → set `status:review` → emit `ADMIN_HANDOFF` → swap to `role:consultant`.
+4. **Consultant**: critique + CLOSEOUT → set `status:done`, remove `role:*` labels, close issue → emit `CONSULTANT_CLOSEOUT`.
 
 ## Hard rules
 

--- a/instructions/ticket-driven-work.instructions.md
+++ b/instructions/ticket-driven-work.instructions.md
@@ -1,6 +1,6 @@
 ---
 name: Ticket-Driven Work Management
-description: Every task is tracked by a GitHub issue. Manager creates tickets before work begins. All changes link to tickets.
+description: The GitHub issue is the baton. Every task is tracked by an issue with standardized labels and status transitions.
 applyTo: "**"
 ---
 
@@ -10,46 +10,33 @@ applyTo: "**"
 
 ## Ticket Types
 
-| Type | Purpose | Example | Estimate |
-|---|---|---|---|
-| **Epic** | Major feature or initiative | "Global task router" | Story points |
-| **Story** | User-facing feature | "Add router lane visualization to dashboard" | 5–13 pts |
-| **Task** | Internal/technical work | "Refactor router module to export classifyPrompt" | 2–8 pts |
-| **Bug** | Defect fix | "Router misclassifies edge prompts" | 3–5 pts |
-| **Doc** | Documentation | "Write README for router" | 2–3 pts |
+| Type | Purpose | Label |
+|---|---|---|
+| Epic | Major feature or initiative | `type:epic` |
+| Story | User-facing feature | `type:story` |
+| Task | Internal/technical work | `type:task` |
+| Bug | Defect fix | `type:bug` |
+| Doc | Documentation | `type:doc` |
+| Research | Investigation/spike | `type:research` |
 
-## Labels (Scrum)
+## Label taxonomy
 
-- `scrum:epic` — Epic
-- `scrum:story` — Story
-- `scrum:task` — Task
-- `scrum:bug` — Bug
-- `scrum:doc` — Documentation
-- `status:backlog` — Not started
-- `status:ready` — Ready to pull
-- `status:in-progress` — Assigned and work begun
-- `status:review` — PR open
-- `status:done` — Merged/closed
+- **Status**: `status:backlog` → `status:ready` → `status:in-progress` → `status:review` → `status:done`
+- **Priority**: `priority:P1` (urgent) · `priority:P2` (normal) · `priority:P3` (low)
+- **Area**: `area:dashboard` · `area:hooks` · `area:skills` · `area:instructions` · `area:agents` · `area:scripts` · `area:infra`
+- **Role** (current baton holder): `role:manager` · `role:collaborator` · `role:admin` · `role:consultant`
 
 ## Manager Responsibilities
 
 1. **Create tickets before work starts** — never code first.
-2. **Validate ticket completeness** — title, description, type, labels, estimation.
-3. **Link ticket to branch** — branch naming: `<issue>#<number>-<slug>`.
-4. **Link ticket to PR** — PR body includes `Closes #N`.
-5. **Enforce ticket closure** — close issue only after merge + validation.
+2. **Apply full label set** — type + status:backlog + priority + area.
+3. **Write scope comment** — objective, AC, constraints.
+4. **Link ticket to branch** — branch: `<type>/<issue#>-<slug>`.
+5. **Link ticket to PR** — PR body includes `Closes #N`.
+6. **Enforce ticket closure** — close only after merge + Consultant CLOSEOUT.
 
 ## Linking Rules
 
-- Branch: `#2-add-router-dashboard` or `#2-add-dashboard-panel`
-- Commit: `git commit -m "feat(dashboard): add router panel (closes #2)"`
-- PR: Body must include `Closes #2` + link to merge evidence
-
-## Manager Automation
-
-Manager CLI creates tickets with:
-- Title, description, type
-- Auto-assigned labels
-- Story point estimation (prompt for user input)
-- Link to related tickets (if any)
-- Default milestone (current sprint or backlog)
+- Branch: `feat/11-ticket-baton-system`
+- Commit: `feat(skills): implement ticket-as-baton governance #11`
+- PR: Body must include `Closes #11` + validation evidence

--- a/skills/github-ticket-lifecycle-orchestrator/SKILL.md
+++ b/skills/github-ticket-lifecycle-orchestrator/SKILL.md
@@ -1,180 +1,78 @@
 ---
 name: github-ticket-lifecycle-orchestrator
-description: Orchestrate end-to-end ticket lifecycle across manager, collaborator, reviewer, and admin roles in GitHub: create/refine, assign, branch, develop, PR, review, merge, and closeout with evidence.
-argument-hint: [phase: intake|planning|assignment|execution|pre-pr|review|pre-merge|closeout] [scope: repo|org] [policy-profile: strict|standard|light]
+description: Naming conventions and phase protocol for GitHub ticket lifecycle. Baton workflow in manager-ticket-lifecycle.
+argument-hint: [phase: intake|planning|execution|pre-pr|review|merge|closeout]
 user-invocable: true
 disable-model-invocation: false
 ---
 
 # GitHub Ticket Lifecycle Orchestrator
 
-## Purpose
-
-Provide one bounded operating flow that connects issue management, branching, development execution, review, and merge administration.
-
 ## Hard constraints
 
-1. No unbounded loops.
-2. Max one lifecycle pass per invocation.
-3. If required evidence is missing, return `NO_CHANGE` with missing artifacts.
-4. Do not claim merge/closeout success without verification evidence.
+1. No unbounded loops. Max one lifecycle pass per invocation.
+2. If required evidence is missing, return `NO_CHANGE` with missing artifacts.
+3. Do not claim merge/closeout success without verification evidence.
 
-## Issue ID and title standard (universal — all repos)
+## Issue title format — plain imperative
 
-This standard applies to every repository managed under this skill set. Agents
-must apply it at intake for every new issue and enforce it during triage audits.
+`<Imperative verb phrase describing the desired outcome>` [≤ 72 chars]
 
-### Canonical ticket identifier
+- Start with imperative verb: "Fix", "Add", "Normalize", "Audit", "Stabilize"
+- Plain English, human-scannable in boards and notifications
+- **No `type(scope):` prefix** — type/scope expressed via labels
+- No bracket tags `[BUG]`, no parallel IDs `TICKET-NNN`
 
-- The GitHub issue number (`#N`) is the **sole canonical ticket identifier**.
-- Do **not** create or maintain parallel local ID schemes (`TICKET-NNN`, `JIRA-123`,
-  audit-doc sequential IDs, etc.). These diverge from `#N` and break closing keywords,
-  branch linkage, and cross-repo references.
-- When migrating tickets from external sources (audit docs, Notion, spreadsheets),
-  use the assigned `#N` immediately after creation; discard the source ID or note
-  it as an alias only.
+Good: `Fix header nav contrast on dark hero backgrounds`
+Bad: ~~`fix(nav): fix header nav contrast`~~ ~~`TICKET-008: Fix header`~~
 
-### Issue title format — plain imperative (human-scannable)
+## Commit and PR title format — Conventional Commits
 
-Issue titles must be readable in a project board, search result, or notification
-without any parsing. **Do not apply Conventional Commits prefixes to issue titles.**
-Type and scope are expressed via labels, not the title.
+`<type>(<scope>): <imperative description>` [≤ 72 chars]
 
-```
-<Imperative verb phrase describing the desired outcome>  [≤ 72 chars]
-```
+Types: `feat` `fix` `chore` `content` `perf` `refactor` `docs` `style` `test`
 
-| Rule                           | Detail                                                            |
-| ------------------------------ | ----------------------------------------------------------------- |
-| Start with an imperative verb  | "Fix", "Add", "Normalize", "Redesign", "Audit", "Stabilize"       |
-| Plain English, human-scannable | Must make sense standalone in a board or search result            |
-| No `type(scope):` prefix       | Type is a label (`type: bug-fix`); scope is a label (`area: seo`) |
-| ≤ 72 chars                     | Fits project board columns and notification subjects              |
+## Branch naming
 
-**Correct examples:**
+`<type>/<issue-number>-<short-slug>` — e.g. `fix/5-nav-contrast`, `feat/11-footer-redesign`
 
-- `Fix header nav contrast on dark hero backgrounds`
-- `Normalize /services-store title and meta description for Austin SEO`
-- `Redesign footer layout, hierarchy, and mobile composition`
-- `Audit interactive states and produce sitewide affordance spec`
-- `Stabilize Playwright QA runtime for repeatable pre-publish checks`
+## Template requirements
 
-**Incorrect — do not use:**
+Every repo must have `.github/ISSUE_TEMPLATE/` with at minimum: bug, task, epic forms.
+Config: `blank_issues_enabled: false`. Plus `PULL_REQUEST_TEMPLATE.md` with issue linkage.
 
-- ~~`fix(nav-contrast): fix header nav contrast`~~ — Conventional Commits belongs on commits/PRs, not issues; also redundant
-- ~~`TICKET-008: Fix header nav contrast`~~ — parallel ID scheme
-- ~~`[BUG] header nav contrast issue`~~ — bracket tags are label substitutes
+## Phase protocol (compact)
 
-### Commit and PR title format — Conventional Commits
+| Phase | Key actions |
+|---|---|
+| **intake** | Validate issue, apply labels/priority/milestone |
+| **planning** | Split to sub-issues, add dependencies, set project fields |
+| **execution** | One branch per ticket, link in Development panel, atomic commits |
+| **pre-pr** | PR links issue with closing keywords, test evidence attached |
+| **review** | Resolve feedback, re-run checks after changes |
+| **merge** | Required reviews/checks satisfied, merge per repo policy |
+| **closeout** | Issue state transition, branch deletion, post-merge cleanup |
 
-The `type(scope): description` format (Conventional Commits) belongs on **commit
-messages and PR titles** — not issue titles.
+## Label taxonomy reference
 
-```
-<type>(<scope>): <imperative description>  [≤ 72 chars]
-```
+See `manager-ticket-lifecycle` for full label taxonomy:
+`type:*`, `status:*`, `priority:*`, `area:*`, `role:*`
 
-Allowed types: `feat` `fix` `chore` `content` `perf` `refactor` `docs` `style` `test`
-
-Examples:
-
-- `fix(nav-contrast): apply WCAG AA contrast to header nav links`
-- `feat(footer): redesign footer layout and mobile composition`
-- `chore(qa-runtime): document mem-watchdog pause sequence in uat-guide`
-
-### Branch naming
-
-```
-<type>/<issue-number>-<short-slug>
-```
-
-Examples: `fix/5-nav-contrast`, `feat/11-footer-redesign`, `chore/13-qa-runtime`
-
-The `<issue-number>` segment creates an unambiguous link to the GitHub issue
-without relying on closing keywords alone.
-
-### Template requirements
-
-Every repository must have:
-
-- `.github/ISSUE_TEMPLATE/` containing **at minimum** one bug form, one task form, and one epic form (filenames may vary, e.g. `bug-report.yml`, `task-request.yml`)
-- `blank_issues_enabled: false` in `.github/ISSUE_TEMPLATE/config.yml`
-- A `PULL_REQUEST_TEMPLATE.md` with linked issue, validation evidence, and risk fields
-
-Recommended: include a research/audit issue form when `type: research` is used in the repository workflow.
-
-The triage phase must verify template adherence before any issue enters planning.
-
----
-
-## Phase protocol
-
-### `intake`
-
-- Validate issue statement, acceptance criteria, and business impact.
-- Apply labels, type, priority, and milestone/iteration.
-
-### `planning`
-
-- Split large work into sub-issues.
-- Add dependencies (`blocked by` / `blocking`).
-- Ensure project item fields are set (status, priority, iteration, owner).
-
-### `assignment`
-
-- Confirm single responsible owner.
-- Confirm due window/iteration and unblocker owner for blockers.
-
-### `execution`
-
-- One branch per ticket concern.
-- Link branch in issue Development panel.
-- Keep commits atomic and scoped.
-
-### `pre-pr`
-
-- PR links issue(s) with closing keywords where appropriate.
-- Test/validation evidence attached.
-- Reviewer(s) and CODEOWNERS requested.
-
-### `review`
-
-- Resolve feedback; keep conversation state clean.
-- Re-run required checks after substantive changes.
-
-### `pre-merge`
-
-- Required reviews/checks/rulesets all satisfied.
-- Merge method follows repo policy.
-
-### `closeout`
-
-- Confirm issue state transition and project status updates.
-- Confirm branch deletion and post-merge cleanup.
-
-## Output format (required)
+## Output format
 
 ```text
 TICKET_LIFECYCLE_REPORT
-phase: <intake|planning|assignment|execution|pre-pr|review|pre-merge|closeout>
+phase: <phase>
 scope: <repo|org>
 policy_profile: <strict|standard|light>
-
 checks:
 - id: C1
   result: <pass|fail|partial>
-  observation: <what was found>
-  expected: <required state>
-
+  observation: <finding>
 actions:
 1) priority: <P1|P2|P3>
-   owner: <role/person>
-   change: <specific action>
-   verification: <objective pass condition>
-
-decision:
-- <apply|defer|NO_CHANGE>
-
-missing_evidence:
-- <none or required artifacts>
+   owner: <role>
+   change: <action>
+decision: <apply|defer|NO_CHANGE>
+missing_evidence: <none or list>
 ```

--- a/skills/manager-ticket-lifecycle/SKILL.md
+++ b/skills/manager-ticket-lifecycle/SKILL.md
@@ -1,93 +1,69 @@
 ---
 name: manager-ticket-lifecycle
-description: Manager creates, links, and validates tickets for all work. Enforce ticket-first workflow and Scrum compliance.
-argument-hint: "[action: create|link|validate] [context: epic|story|task|bug|doc]"
+description: The GitHub issue IS the baton. Manager creates tickets, pre-assigns roles, enforces status transitions through the Agile workflow.
+argument-hint: "[action: create|decompose|transition|close] [type: epic|story|task|bug]"
 user-invocable: true
 disable-model-invocation: false
 ---
 
-# Manager: Ticket Lifecycle
+# Ticket-as-Baton Lifecycle
 
-## Purpose
+## Core paradigm
 
-Manager enforces ticket-first workflow: every task gets a GitHub issue before work begins.
+The GitHub issue is the **baton**. It carries work through Manager → Collaborator → Admin → Consultant. Each role writes a structured comment on the ticket and transitions the status label — mirroring a Jira card moving across a Scrum board.
 
-## Responsibilities
+## Status workflow (label transitions)
 
-1. **Create** — Issue title, description, labels, estimation
-2. **Link** — Branch naming, commit bodies, PR bodies
-3. **Validate** — Ensure completeness before Collaborator proceeds
-4. **Close** — Only after merge + post-merge checklist passes
+```
+backlog → ready → in-progress → review → done
+(create)  (scope)  (implement)   (PR/ops)  (close)
+```
 
-## Entry criteria
+## Label taxonomy
 
-- Work intent is known
-- No existing related ticket
+- **Type**: `type:epic|story|task|bug|doc|research`
+- **Status**: `status:backlog|ready|in-progress|review|done`
+- **Priority**: `priority:P1|P2|P3`
+- **Area**: `area:dashboard|hooks|skills|instructions|agents|scripts|infra`
+- **Role** (current holder): `role:manager|collaborator|admin|consultant`
 
-## Exit criteria
+## Manager creates ticket
 
-- GitHub issue created and assigned
-- Linking rules documented in ticket
-- Collaborator has clear ticket number to use
+1. `gh issue create --title "<imperative>" --label "type:..." --label "status:backlog" --label "priority:..." --label "area:..."`
+2. Body: description, acceptance criteria, story points, parent epic ref.
+3. Add scope comment (see role-manager-execution output contract).
+4. Transition: `status:backlog` → `status:ready`, set `role:manager`.
+5. Emit `MANAGER_HANDOFF` with `issue: #N`.
+6. Swap label: `role:manager` → `role:collaborator`.
+
+## Epic decomposition
+
+For large work, create Epic issue, then sub-issues referencing parent. Each sub-issue gets its own label set and full lifecycle.
+
+## Role comment protocol
+
+Each role writes **one structured comment** when taking the baton:
+- **Manager** 🎯: objective, AC, constraints → "Baton → Collaborator"
+- **Collaborator** 🔧: files_changed, validation → "Baton → Admin"
+- **Admin** ⚙️: commit, PR, CI, merge → "Baton → Consultant"
+- **Consultant** 🔍: confidence, risks, follow-ups → "Baton complete"
+
+## Closing rules
+
+1. Close only after merge + Consultant CLOSEOUT comment.
+2. Close comment: version, merge evidence, validation summary.
+3. Final label state: `status:done`, all `role:*` labels removed.
 
 ## Hard constraints
 
-1. No work starts without a ticket.
-2. Branch name must include ticket number.
-3. Commit body must reference ticket.
-4. PR body must include `Closes #N`.
-5. Ticket type must match work scope.
+1. No work without a ticket. 2. Branch: `<type>/<issue#>-<slug>`.
+3. Commits reference `#N`. 4. PR body: `Closes #N`.
+5. Role comments are permanent audit evidence.
 
-## Template: Create Epic
+## Definition of Done (per ticket)
 
-```markdown
-# [Feature Name]
-
-## Description
-[1-2 sentence purpose]
-
-## User Story
-As a [role], I want [capability], so that [benefit].
-
-## Acceptance Criteria
-- [ ] Criterion 1
-- [ ] Criterion 2
-
-## Related Stories
-- #N
-- #M
-
-## Estimation
-Story points: [5–13]
-```
-
-## Template: Create Story
-
-```markdown
-# [Specific Task]
-
-## Description
-[What needs to be done and why]
-
-## Acceptance Criteria
-- [ ] Must pass lint
-- [ ] Must pass smoke tests
-- [ ] Must update docs if behavior changes
-
-## Related Tickets
-- Epic: #N
-
-## Estimation
-Story points: [3–8]
-Complexity: [Simple|Moderate|Complex]
-```
-
-## Validation Checklist
-
-Before Collaborator begins:
-- [ ] Issue created and titled
-- [ ] Description explains "what" and "why"
-- [ ] Type label applied (epic, story, task, bug, doc)
-- [ ] Story points estimated
-- [ ] Linked to epic or parent ticket
-- [ ] Assigned to engineer
+- [ ] All acceptance criteria checked
+- [ ] Lint + tests pass; docs updated if behavior changed
+- [ ] PR merged with `Closes #N`
+- [ ] Consultant CLOSEOUT comment posted
+- [ ] `status:done` label applied

--- a/skills/role-admin-execution/SKILL.md
+++ b/skills/role-admin-execution/SKILL.md
@@ -14,6 +14,12 @@ disable-model-invocation: false
 - Perform git/PR/release administration consistent with policy.
 - Execute required post-merge/post-deploy governance checklist items.
 
+## Ticket baton protocol
+
+1. Transition labels: `status:in-progress` → `status:review`, confirm `role:admin`.
+2. Write ops comment: `## ⚙️ Admin — Operations Evidence` listing commit/PR/CI/merge.
+3. On ADMIN_HANDOFF: swap `role:admin` → `role:consultant`.
+
 ## Entry criteria
 
 - `COLLABORATOR_HANDOFF` validation evidence is present.
@@ -29,61 +35,22 @@ disable-model-invocation: false
 - Do not re-scope implementation.
 - Do not skip required validation evidence.
 
-## Escalation triggers
-
-- Operational preconditions fail.
-- Release/governance integrity checks fail.
-
 ---
 
-## Feature Completion Checklist (required for any feature/bugfix work)
+## Feature completion steps (required for feature/bugfix)
 
-**"All validation gates pass" = Collaborator done. It does NOT mean Admin done.**
+"All gates pass" = Collaborator done, NOT Admin done. Execute in order:
 
-When COLLABORATOR_HANDOFF is received for feature or bugfix work, execute these steps in order. Do not stop after gates pass; do not ask the user to do any of these steps.
+1. **Version check** — If extension changed: confirm version not already published
+2. **Commit** — `git add -A && git commit` with `Closes #N` and "why" context
+3. **Push** — `git push -u origin <branch-name>`
+4. **PR** — `gh pr create` with `Closes #N`, gate evidence, labels, milestone
+5. **CI green** — `gh pr checks <PR> --watch`; fix failures before merge
+6. **Merge** — `gh pr merge --merge` (or `--squash`); never push to main directly
+7. **Publish/release** — If applicable: build, publish, create GH release
+8. **Close issue** — `gh issue close N --comment "Released in vX.Y.Z"`
 
-1. **Version collision check**
-   - If `vscode-extension/` changed: confirm `package.json` version is not already published to Marketplace
-   - If collision: bump patch version in `package.json` and both CHANGELOGs before committing
-   - Command: `npx vsce show CurtisFranks.mem-watchdog-status --json 2>/dev/null | node -e "..."`
-
-2. **Commit**
-   - `git add -A && git commit -m "type(scope): imperative description"`
-   - Commit body must include `Closes #N` for the linked issue
-   - Include "why" (failure mode or root cause) per repo commit format
-
-3. **Push**
-   - `git push -u origin <branch-name>`
-
-4. **PR creation**
-   - `gh pr create --title "..." --body "..." --label "..." --milestone "..."`
-   - Body must include: `Closes #N`, gate-suite evidence (test counts, shellcheck, docs-integrity results)
-   - Assign labels: type label + domain label + priority label
-
-5. **Wait for CI green**
-   - Poll: `gh pr checks <PR-number> --watch`
-   - Do NOT merge with any failing check — fix root cause first
-
-6. **Merge**
-   - `gh pr merge <PR-number> --merge` (or `--squash` per repo policy)
-   - Never push directly to main; always go through PR + CI
-
-7. **Extension publish** (if `vscode-extension/` changed)
-   - `cd vscode-extension && npm run build && source ../.env && npx vsce publish --pat "$VSCE_PAT"`
-   - Confirm Marketplace version matches `package.json` after publish
-
-8. **Release integrity check**
-   - `bash scripts/release-integrity-check.sh --post-publish`
-   - Must pass all checks; fix any failures before proceeding
-
-9. **GitHub Release object**
-   - `gh release create vX.Y.Z --title "vX.Y.Z — <feature title>" --notes "..."`
-   - Releases must exist for every published Marketplace version
-
-10. **Close source issue**
-    - `gh issue close N --comment "Released in vX.Y.Z (Marketplace) — <brief summary>"`
-
-**A feature is NOT complete until all applicable steps above are done.**
+**Feature is NOT complete until all applicable steps are done.**
 
 ---
 

--- a/skills/role-collaborator-execution/SKILL.md
+++ b/skills/role-collaborator-execution/SKILL.md
@@ -27,6 +27,12 @@ disable-model-invocation: false
 - Do not declare the feature complete at Collaborator exit; "all gates pass" means implementation is validated, not released.
 - Any scope drift is explicitly flagged for manager re-handoff.
 
+## Ticket baton protocol
+
+1. Write implementation comment: `## 🔧 Collaborator — Validation Evidence`.
+2. Transition labels: `status:ready` → `status:in-progress`, confirm `role:collaborator`.
+3. On COLLABORATOR_HANDOFF: swap `role:collaborator` → `role:admin`.
+
 ## Must not do
 
 - Do not alter scope without manager handoff update.

--- a/skills/role-consultant-critique/SKILL.md
+++ b/skills/role-consultant-critique/SKILL.md
@@ -26,6 +26,12 @@ Before emitting `CONSULTANT_CLOSEOUT`, verify:
 
 If any check fails, add it to `risk_register` as `process: ticket-hygiene-gap`.
 
+## Ticket baton protocol (CLOSEOUT)
+
+1. Write CLOSEOUT comment: `## 🔍 Consultant — CLOSEOUT` with confidence, risks, follow-ups.
+2. Transition labels: `status:review` → `status:done`, remove all `role:*` labels.
+3. Close issue: `gh issue close N --comment "Released in vX.Y.Z — summary"`.
+
 ## Entry criteria
 
 - `ADMIN_HANDOFF` exists (or explicit N/A with reason).

--- a/skills/role-manager-execution/SKILL.md
+++ b/skills/role-manager-execution/SKILL.md
@@ -21,11 +21,17 @@ disable-model-invocation: false
 Before emitting `MANAGER_HANDOFF`, the Manager **must**:
 
 1. Run `gh issue list` to check for an existing issue matching the task.
-2. If none exists: `gh issue create --title "<imperative>" --body "..." --label "type: ..."`.
+2. If none exists: `gh issue create --title "<imperative>" --label "type:..." --label "status:backlog" --label "priority:..." --label "area:..."`.
 3. Record the issue number in `MANAGER_HANDOFF` as `issue: #N`.
 4. All subsequent commits must reference `#N` in the commit message.
 
 **Skip condition**: trivial-task escape (read-only, no file edits, no state changes).
+
+## Ticket baton protocol
+
+1. Write scope comment: `## 🎯 Manager — Scope Definition` with objective, AC, constraints.
+2. Set labels: `status:ready`, `role:manager`.
+3. On MANAGER_HANDOFF: swap `role:manager` → `role:collaborator`.
 
 ## Entry criteria
 


### PR DESCRIPTION
## Summary

Implements the ticket-as-baton Agile governance system where the GitHub issue IS the baton passed between roles (Manager → Collaborator → Admin → Consultant).

## Changes (14 files, +284 -312)

### Skills (6 files)
- **manager-ticket-lifecycle**: Full rewrite — status workflow, 5-dimension label taxonomy, role comment protocol, epic decomposition, closing rules
- **role-manager-execution**: Updated ticket-first gate to new label format, added baton protocol
- **role-collaborator-execution**: Added baton protocol with label transitions
- **role-admin-execution**: Added baton protocol, compacted Feature Completion Checklist (99→60 lines)
- **role-consultant-critique**: Added CLOSEOUT baton protocol
- **github-ticket-lifecycle-orchestrator**: Compacted 180→72 lines, moved baton workflow to manager-ticket-lifecycle

### Instructions (3 files)
- **role-baton-routing**: Added 'ticket IS the baton' language and status transition sequence
- **ticket-driven-work**: Full rewrite replacing old scrum:* labels with new taxonomy
- **feature-completion-governance**: Added status transition to each role step

### Templates (5 files)
- **story.yml**: NEW — user story template
- **research.yml**: NEW — investigation/spike template
- **bug-report.yml, task-request.yml, epic.yml**: Updated labels to namespace:value format

### GitHub Labels (26 created, 13 deleted)
type:epic|story|task|bug|doc|research, status:backlog|ready|in-progress|review|done, priority:P1|P2|P3, area:dashboard|hooks|skills|instructions|agents|scripts|infra, role:manager|collaborator|admin|consultant

## Validation
- `npm run lint`: ✅ 70 files within 100-line limit
- `npm test`: ✅ 8/8 Playwright E2E tests pass

Closes #11