### PR TITLE
feat(wiki): Phase 2 Core Ops — ingest, lint, search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@
 ## [Unreleased]
 
 ### Added
+- **LLM Wiki Phase 2 — Core Ops** (#25, #26, #27):
+  `ingest.js` ingests raw sources via OpenClaw LLM compilation.
+  `lint.js` checks broken wikilinks, orphans, frontmatter, index sync.
+  `search.js` keyword scoring + LLM synthesis for wiki queries.
+  `wiki-llm.js` failover: OpenClaw→Groq→Cerebras. `wiki-io.js` I/O.
+  `npm run wiki:ingest|wiki:lint|wiki:search` scripts added.
 - **LLM Wiki Phase 1 — Foundation**: Directory scaffold (`raw/`, `wiki/`,
   `scripts/wiki/`), `WIKI.md` governance schema, `wiki/index.md`,
   `wiki/log.md`. Based on Karpathy's LLM Wiki pattern.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "router:dispatch": "node scripts/global/task-router-dispatch.js",
     "repo:scope": "node scripts/global/repo-scope.js",
     "ticket:create": "node scripts/global/ticket-create.js",
+    "wiki:ingest": "node scripts/wiki/ingest.js",
+    "wiki:lint": "node scripts/wiki/lint.js",
+    "wiki:search": "node scripts/wiki/search.js",
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
     "test:quality": "npx playwright test tests/google-quality.spec.js"

--- a/raw/articles/karpathy-llm-wiki-pattern.md
+++ b/raw/articles/karpathy-llm-wiki-pattern.md
@@ -1,0 +1,37 @@
+---
+title: "Karpathy LLM Wiki Pattern"
+date: 2026-04-13
+source_url: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+author: Andrej Karpathy
+tags: [llm-wiki, knowledge-management, obsidian, compilation]
+status: ingested
+---
+
+# Karpathy LLM Wiki Pattern
+
+The LLM Wiki is a pattern for building personal knowledge bases using LLMs.
+Instead of retrieval (RAG), the LLM **compiles** knowledge into a persistent
+wiki of interlinked markdown files.
+
+## Architecture
+
+Three layers:
+- **Raw sources** — immutable, human-curated documents
+- **Wiki** — LLM-generated markdown (summaries, entities, concepts)
+- **Schema** — governance conventions (CLAUDE.md or AGENTS.md)
+
+## Operations
+
+- **Ingest**: Drop source → LLM reads, summarizes, cross-references
+- **Query**: Ask questions → LLM reads index, synthesizes answer
+- **Lint**: Health-check for contradictions, orphans, stale claims
+
+## Key Insight
+
+"Obsidian is the IDE; the LLM is the programmer; the wiki is the codebase."
+The human curates sources and asks questions. The LLM does all bookkeeping.
+
+## Community
+
+5000+ stars, 3800+ forks. Implementations include wiki-kb, CacheZero,
+Memoriki, Cortex, SwarmVault. Key debate: model collapse risk.

--- a/scripts/wiki/ingest.js
+++ b/scripts/wiki/ingest.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// scripts/wiki/ingest.js — Ingest a raw source into the wiki
+// Fleet routing: OpenClaw (primary) → Groq → Cerebras (failover)
+// Usage: node scripts/wiki/ingest.js raw/articles/my-source.md
+
+const fs = require('fs');
+const path = require('path');
+const { callLLM, INGEST_PROMPT } = require('./wiki-llm');
+const { updateIndex, appendLog, parseFrontmatter } = require('./wiki-io');
+
+const WIKI_DIR = path.join(__dirname, '../../wiki');
+
+async function ingest(sourcePath) {
+  if (!fs.existsSync(sourcePath)) {
+    console.error(`❌ Source not found: ${sourcePath}`);
+    process.exit(1);
+  }
+  const raw = fs.readFileSync(sourcePath, 'utf-8');
+  const { frontmatter, body } = parseFrontmatter(raw);
+  const rawTitle = frontmatter.title || path.basename(sourcePath, '.md');
+  const title = rawTitle.replace(/^["']|["']$/g, '');
+  const slug = path.basename(sourcePath, '.md');
+
+  console.log(`📥 Ingesting: ${title}`);
+  console.log(`   Source: ${sourcePath}`);
+
+  // Step 1: Call LLM for structured extraction
+  const prompt = INGEST_PROMPT(title, body);
+  const result = await callLLM(prompt);
+  if (!result) {
+    console.error('❌ LLM unreachable — ingest aborted. Try again later.');
+    process.exit(1);
+  }
+
+  // Step 2: Write source summary page
+  const today = new Date().toISOString().split('T')[0];
+  const summaryPath = path.join(WIKI_DIR, 'sources', `${slug}.md`);
+  const summaryContent = buildSourcePage(title, today, sourcePath, result);
+  fs.writeFileSync(summaryPath, summaryContent);
+  console.log(`   ✅ wiki/sources/${slug}.md`);
+
+  // Step 3: Update index and log
+  updateIndex(slug, title, 'source');
+  appendLog(today, 'ingest', title);
+  console.log(`   ✅ index.md + log.md updated`);
+
+  // Step 4: Mark raw source as ingested
+  markIngested(sourcePath, raw);
+  console.log(`   ✅ Raw source marked ingested`);
+  console.log(`\n🎉 Ingest complete: ${title}`);
+}
+
+function buildSourcePage(title, date, sourcePath, llmResult) {
+  return [
+    '---',
+    `title: "${title}"`,
+    'type: source',
+    `created: ${date}`,
+    `updated: ${date}`,
+    `tags: []`,
+    `sources: [${sourcePath}]`,
+    `related: []`,
+    'status: draft',
+    '---',
+    '',
+    `# ${title}`,
+    '',
+    '## Summary',
+    '',
+    llmResult.trim(),
+    '',
+    `*Source: ${sourcePath}*`,
+  ].join('\n');
+}
+
+function markIngested(filePath, raw) {
+  const updated = raw.includes('status:')
+    ? raw.replace(/status:\s*\w+/, 'status: ingested')
+    : raw.replace('---\n', '---\nstatus: ingested\n');
+  fs.writeFileSync(filePath, updated);
+}
+
+const sourceArg = process.argv[2];
+if (!sourceArg) {
+  console.log('Usage: node scripts/wiki/ingest.js <raw-source-path>');
+  process.exit(1);
+}
+ingest(path.resolve(sourceArg));

--- a/scripts/wiki/lint.js
+++ b/scripts/wiki/lint.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// scripts/wiki/lint.js — Wiki structural health checker
+// Fleet routing: local (no LLM needed — pure structural checks)
+// Usage: node scripts/wiki/lint.js
+
+const fs = require('fs');
+const path = require('path');
+const { parseFrontmatter, listPages, WIKI_DIR } = require('./wiki-io');
+
+const REQUIRED_FIELDS = ['title', 'type', 'created', 'status'];
+const issues = { broken: [], orphans: [], frontmatter: [], index: [] };
+
+function lint() {
+  const pages = listPages();
+  if (pages.length === 0) {
+    console.log('📋 Wiki is empty — nothing to lint.');
+    process.exit(0);
+  }
+
+  // Collect all wikilinks and build link graph
+  const linkGraph = {};  // slug → Set of outbound slugs
+  const allSlugs = new Set(pages.map((p) => p.slug));
+
+  for (const page of pages) {
+    const content = fs.readFileSync(page.path, 'utf-8');
+    const { frontmatter } = parseFrontmatter(content);
+
+    // Check required frontmatter
+    for (const field of REQUIRED_FIELDS) {
+      if (!frontmatter[field]) {
+        issues.frontmatter.push(`${page.slug}: missing '${field}'`);
+      }
+    }
+
+    // Extract [[wikilinks]]
+    const links = [...content.matchAll(/\[\[([^\]]+)\]\]/g)].map((m) => m[1]);
+    linkGraph[page.slug] = new Set(links);
+
+    // Check for broken links
+    for (const link of links) {
+      if (!allSlugs.has(link)) {
+        issues.broken.push(`${page.slug} → [[${link}]] (not found)`);
+      }
+    }
+  }
+
+  // Check for orphan pages (no inbound links)
+  const inbound = new Set();
+  for (const [, targets] of Object.entries(linkGraph)) {
+    for (const t of targets) inbound.add(t);
+  }
+  for (const slug of allSlugs) {
+    if (!inbound.has(slug)) issues.orphans.push(slug);
+  }
+
+  // Check index.md sync
+  const indexContent = fs.readFileSync(path.join(WIKI_DIR, 'index.md'), 'utf-8');
+  for (const page of pages) {
+    if (!indexContent.includes(`[[${page.slug}]]`)) {
+      issues.index.push(`${page.slug} missing from index.md`);
+    }
+  }
+
+  printReport(pages.length);
+}
+
+function printReport(pageCount) {
+  const total = Object.values(issues).reduce((s, a) => s + a.length, 0);
+  console.log(`\n📋 Wiki Lint Report — ${pageCount} pages scanned\n`);
+
+  if (total === 0) {
+    console.log('✅ All checks pass. Wiki is healthy.\n');
+    process.exit(0);
+  }
+
+  const sections = [
+    ['🔗 Broken Wikilinks', issues.broken],
+    ['🏝️  Orphan Pages', issues.orphans],
+    ['📝 Missing Frontmatter', issues.frontmatter],
+    ['📇 Index Sync', issues.index],
+  ];
+  for (const [label, items] of sections) {
+    if (items.length === 0) continue;
+    console.log(`${label} (${items.length}):`);
+    items.forEach((i) => console.log(`  - ${i}`));
+    console.log();
+  }
+
+  console.log(`Total issues: ${total}`);
+  process.exit(1);
+}
+
+lint();

--- a/scripts/wiki/search.js
+++ b/scripts/wiki/search.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// scripts/wiki/search.js — Query the wiki with natural language
+// Fleet routing: OpenClaw (primary) → Groq → Cerebras (failover)
+// Usage: node scripts/wiki/search.js "your question here"
+
+const fs = require('fs');
+const { callLLM, SEARCH_PROMPT } = require('./wiki-llm');
+const { listPages, WIKI_DIR } = require('./wiki-io');
+const path = require('path');
+
+async function search(question) {
+  console.log(`🔍 Query: ${question}\n`);
+
+  // Step 1: Read index to find relevant pages
+  const indexPath = path.join(WIKI_DIR, 'index.md');
+  const index = fs.readFileSync(indexPath, 'utf-8');
+  const pages = listPages();
+
+  if (pages.length === 0) {
+    console.log('📋 Wiki is empty — ingest some sources first.');
+    process.exit(0);
+  }
+
+  // Step 2: Simple keyword matching against index + page contents
+  const qWords = question.toLowerCase().split(/\s+/);
+  const scored = pages.map((p) => {
+    const content = fs.readFileSync(p.path, 'utf-8').toLowerCase();
+    const hits = qWords.filter((w) => content.includes(w)).length;
+    return { ...p, score: hits };
+  });
+  scored.sort((a, b) => b.score - a.score);
+  const relevant = scored.filter((p) => p.score > 0).slice(0, 5);
+
+  if (relevant.length === 0) {
+    console.log('No relevant wiki pages found for this query.');
+    console.log('Try ingesting more sources or rephrasing your question.');
+    process.exit(0);
+  }
+
+  console.log(`📄 Found ${relevant.length} relevant page(s):`);
+  relevant.forEach((p) => console.log(`   - [[${p.slug}]] (${p.type}, score: ${p.score})`));
+
+  // Step 3: Build context from top pages
+  const context = relevant
+    .map((p) => {
+      const content = fs.readFileSync(p.path, 'utf-8');
+      return `--- ${p.slug} (${p.type}) ---\n${content}`;
+    })
+    .join('\n\n');
+
+  // Step 4: Call LLM for synthesis
+  console.log('\n💭 Synthesizing answer...\n');
+  const answer = await callLLM(SEARCH_PROMPT(question, context));
+
+  if (!answer) {
+    console.log('⚠️  LLM unavailable. Showing raw page matches instead:\n');
+    relevant.forEach((p) => {
+      console.log(`## [[${p.slug}]]`);
+      const lines = fs.readFileSync(p.path, 'utf-8').split('\n').slice(0, 10);
+      console.log(lines.join('\n') + '\n...\n');
+    });
+    return;
+  }
+
+  console.log('---');
+  console.log(answer);
+  console.log('---');
+  console.log(`\nSources: ${relevant.map((p) => `[[${p.slug}]]`).join(', ')}`);
+}
+
+const question = process.argv.slice(2).join(' ');
+if (!question) {
+  console.log('Usage: node scripts/wiki/search.js "your question"');
+  process.exit(1);
+}
+search(question);

--- a/scripts/wiki/wiki-io.js
+++ b/scripts/wiki/wiki-io.js
@@ -1,0 +1,97 @@
+// scripts/wiki/wiki-io.js — File I/O helpers for wiki operations
+
+const fs = require('fs');
+const path = require('path');
+
+const WIKI_DIR = path.join(__dirname, '../../wiki');
+
+/** Parse YAML-ish frontmatter from markdown */
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) return { frontmatter: {}, body: content };
+  const fm = {};
+  match[1].split('\n').forEach((line) => {
+    const [key, ...rest] = line.split(':');
+    if (key && rest.length) fm[key.trim()] = rest.join(':').trim();
+  });
+  return { frontmatter: fm, body: match[2] };
+}
+
+/** Add an entry to wiki/index.md under the appropriate section */
+function updateIndex(slug, title, type) {
+  const indexPath = path.join(WIKI_DIR, 'index.md');
+  let content = fs.readFileSync(indexPath, 'utf-8');
+  const sectionMap = {
+    entity: '## Entities',
+    concept: '## Concepts',
+    source: '## Source Summaries',
+    synthesis: '## Syntheses',
+  };
+  const dirMap = {
+    entity: 'entities',
+    concept: 'concepts',
+    source: 'sources',
+    synthesis: 'syntheses',
+  };
+  const section = sectionMap[type] || '## Source Summaries';
+  const entry = `- [[${slug}]] — ${title}`;
+
+  if (content.includes(`[[${slug}]]`)) return; // already indexed
+
+  const sectionIdx = content.indexOf(section);
+  if (sectionIdx === -1) return;
+  const nextSection = content.indexOf('\n## ', sectionIdx + 1);
+  const insertAt = nextSection !== -1 ? nextSection : content.indexOf('\n---');
+  if (insertAt === -1) {
+    content += `\n${entry}\n`;
+  } else {
+    content = content.slice(0, insertAt) + `\n${entry}\n` + content.slice(insertAt);
+  }
+
+  // Update stats line
+  const dir = path.join(WIKI_DIR, dirMap[type] || 'sources');
+  const pages = countPages();
+  content = content.replace(
+    /\*\*Pages\*\*:.*$/m,
+    `**Pages**: ${pages} | **Last updated**: ${new Date().toISOString().split('T')[0]}`
+  );
+  fs.writeFileSync(indexPath, content);
+}
+
+/** Append a log entry to wiki/log.md */
+function appendLog(date, operation, subject) {
+  const logPath = path.join(WIKI_DIR, 'log.md');
+  const entry = `\n## [${date}] ${operation} | ${subject}\n`;
+  fs.appendFileSync(logPath, entry);
+}
+
+/** Count all .md files in wiki subdirs (not index/log) */
+function countPages() {
+  const dirs = ['entities', 'concepts', 'sources', 'syntheses'];
+  let count = 0;
+  for (const d of dirs) {
+    const dp = path.join(WIKI_DIR, d);
+    if (!fs.existsSync(dp)) continue;
+    count += fs.readdirSync(dp).filter((f) => f.endsWith('.md')).length;
+  }
+  return count;
+}
+
+/** List all wiki page slugs with their paths */
+function listPages() {
+  const dirs = ['entities', 'concepts', 'sources', 'syntheses'];
+  const pages = [];
+  for (const d of dirs) {
+    const dp = path.join(WIKI_DIR, d);
+    if (!fs.existsSync(dp)) continue;
+    for (const f of fs.readdirSync(dp).filter((x) => x.endsWith('.md'))) {
+      pages.push({ slug: f.replace('.md', ''), type: d, path: path.join(dp, f) });
+    }
+  }
+  return pages;
+}
+
+module.exports = {
+  parseFrontmatter, updateIndex, appendLog,
+  countPages, listPages, WIKI_DIR,
+};

--- a/scripts/wiki/wiki-llm.js
+++ b/scripts/wiki/wiki-llm.js
@@ -1,0 +1,96 @@
+// scripts/wiki/wiki-llm.js — LLM integration for wiki operations
+// Fleet routing: OpenClaw (primary) → Groq → Cerebras (failover)
+
+const ENDPOINTS = [
+  {
+    name: 'OpenClaw',
+    url: 'http://100.78.22.13:4000/v1/chat/completions',
+    model: 'ollama/mistral',
+    key: process.env.OPENCLAW_API_KEY || 'sk-1234',
+  },
+  {
+    name: 'OpenClaw-7B',
+    url: 'http://100.78.22.13:4000/v1/chat/completions',
+    model: 'ollama/qwen2.5:7b-instruct',
+    key: process.env.OPENCLAW_API_KEY || 'sk-1234',
+  },
+  {
+    name: 'Groq',
+    url: 'https://api.groq.com/openai/v1/chat/completions',
+    model: 'llama-3.3-70b-versatile',
+    key: process.env.GROQ_API_KEY || '',
+  },
+  {
+    name: 'Cerebras',
+    url: 'https://api.cerebras.ai/v1/chat/completions',
+    model: 'llama-3.3-70b',
+    key: process.env.CEREBRAS_API_KEY || '',
+  },
+];
+
+async function callLLM(prompt) {
+  for (const ep of ENDPOINTS) {
+    if (!ep.key && ep.name !== 'OpenClaw') continue;
+    try {
+      console.log(`   🔗 Trying ${ep.name} (${ep.model})...`);
+      const resp = await fetch(ep.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${ep.key}`,
+        },
+        body: JSON.stringify({
+          model: ep.model,
+          messages: [{ role: 'user', content: prompt }],
+          max_tokens: 1500,
+          temperature: 0.3,
+        }),
+        signal: AbortSignal.timeout(300000),
+      });
+      if (!resp.ok) {
+        console.log(`   ⚠️  ${ep.name}: HTTP ${resp.status}`);
+        continue;
+      }
+      const data = await resp.json();
+      const text = data.choices?.[0]?.message?.content;
+      if (text) {
+        console.log(`   ✅ ${ep.name} responded (${text.length} chars)`);
+        return text;
+      }
+    } catch (err) {
+      console.log(`   ⚠️  ${ep.name}: ${err.message}`);
+    }
+  }
+  return null;
+}
+
+function INGEST_PROMPT(title, body) {
+  return `You are a wiki compiler. Read this source and produce a concise summary.
+
+SOURCE TITLE: ${title}
+
+SOURCE CONTENT:
+${body.slice(0, 6000)}
+
+INSTRUCTIONS:
+1. Write a 3-5 sentence summary of the key points.
+2. List the main entities mentioned (people, tools, services, devices).
+3. List the main concepts (ideas, patterns, decisions).
+4. Note any claims that could contradict existing knowledge.
+
+Format as plain markdown (no frontmatter). Keep under 60 lines.`;
+}
+
+function SEARCH_PROMPT(question, context) {
+  return `Answer this question using ONLY the wiki pages provided.
+Cite pages with [[page-name]] wikilinks.
+
+QUESTION: ${question}
+
+WIKI CONTEXT:
+${context.slice(0, 6000)}
+
+Answer concisely. If the context is insufficient, say so.`;
+}
+
+module.exports = { callLLM, INGEST_PROMPT, SEARCH_PROMPT };

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -22,10 +22,12 @@ _No concept pages yet._
 
 _No source summaries yet._
 
+- [[karpathy-llm-wiki-pattern]] — "Karpathy LLM Wiki Pattern"
+
 ## Syntheses
 
 _No synthesis pages yet._
 
 ---
 
-**Pages**: 0 | **Sources ingested**: 0 | **Last updated**: 2026-04-13
+**Pages**: 1 | **Last updated**: 2026-04-14

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -17,3 +17,5 @@ Brief description of what happened.
 ## [2026-04-13] init | Wiki system scaffolded
 Phase 1 foundation created. Directories: raw/, wiki/, scripts/wiki/.
 Schema: WIKI.md. No sources ingested yet.
+
+## [2026-04-14] ingest | "Karpathy LLM Wiki Pattern"

--- a/wiki/sources/karpathy-llm-wiki-pattern.md
+++ b/wiki/sources/karpathy-llm-wiki-pattern.md
@@ -1,0 +1,39 @@
+---
+title: ""Karpathy LLM Wiki Pattern""
+type: source
+created: 2026-04-14
+updated: 2026-04-14
+tags: []
+sources: [/home/curtisfranks/devenv-ops/raw/articles/karpathy-llm-wiki-pattern.md]
+related: []
+status: draft
+---
+
+# "Karpathy LLM Wiki Pattern"
+
+## Summary
+
+## Summary
+The Karpathy LLM Wiki Pattern is a method for creating personal knowledge bases using Language Models (LLMs) to compile information into a persistent wiki of interlinked Markdown files. The architecture consists of three layers: raw sources, the wiki, and schema. Operations include ingesting, querying, and linting. The pattern is popular with over 5000 stars on GitHub and has various implementations such as wiki-kb, CacheZero, Memoriki, Cortex, and SwarmVault. A key debate revolves around the risk of model collapse.
+
+## Entities
+- Karpathy LLM Wiki Pattern
+- Language Models (LLMs)
+- Obsidian
+- Markdown files
+- CLAUDE.md or AGENTS.md (governance conventions)
+- wiki-kb, CacheZero, Memoriki, Cortex, SwarmVault (implementations)
+
+## Concepts
+- Personal knowledge bases
+- Retrieval (RAG)
+- Compiling knowledge
+- Persistent wikis
+- Governance conventions
+- Ingesting, querying, linting operations
+- Model collapse risk
+
+## Potential Contradictions
+The claim of model collapse risk could contradict existing knowledge about the robustness and reliability of large language models in certain applications.
+
+*Source: /home/curtisfranks/devenv-ops/raw/articles/karpathy-llm-wiki-pattern.md*


### PR DESCRIPTION
## Summary
Build the three core LLM Wiki operations validated end-to-end via OpenClaw.

### Changes
- **ingest.js** (#25): Raw source → LLM compilation → wiki source page
- **lint.js** (#26): Structural health checks (wikilinks, orphans, frontmatter, index sync)
- **search.js** (#27): Keyword scoring + LLM synthesis queries
- **wiki-llm.js**: OpenClaw (mistral) → OpenClaw (qwen2.5:7b) → Groq → Cerebras failover (300s timeout)
- **wiki-io.js**: Frontmatter parsing, index/log updates, page listing
- `npm run wiki:ingest|wiki:lint|wiki:search` scripts added

### Validation Evidence
- ✅ Ingest: OpenClaw (mistral) compiled 1119 chars from raw source
- ✅ Lint: Correctly identified 1 orphan page (expected for single-page wiki)
- ✅ Search: Found relevant page (score 4), synthesized 469 char answer
- ✅ All files ≤100 lines, project lint passes
- ✅ Fleet routing: OpenClaw primary, Groq/Cerebras failover

Closes #25, closes #26, closes #27