### PR TITLE
feat: Live Event System — Epic 1 (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 # Ephemeral hook state (runtime-only)
 hooks/state/
 
+# Event bus runtime log
+.dashboard/
+
 # Node
 node_modules/
 package-lock.json

--- a/dashboard/css/baton.css
+++ b/dashboard/css/baton.css
@@ -18,6 +18,7 @@
 
 .baton-issue { font-size: 0.95rem; font-weight: 700; color: var(--blue); }
 .baton-idle { color: var(--text-muted); font-style: italic; font-size: 0.82rem; }
+.baton-agent { font-size: 0.78rem; color: var(--text); padding: 0.15rem 0; }
 
 .baton-pipeline {
   display: flex;

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -21,7 +21,7 @@
     <script src="js/fleet-topology.js"></script>
     <script src="js/baton-flow.js"></script>
     <script src="js/resource-monitor.js"></script>
-    <script src="js/activity-feed.js"></script>
+    <script src="js/activity-feed.js"></script><script src="js/event-bus.js"></script>
     <script src="js/render-panels.js"></script>
     <script src="js/config-panel.js"></script>
     <script src="js/stress-test.js"></script>

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -44,14 +44,15 @@ function dashboardApp() {
       this.loading = true;
       try {
         const ids = this.devices.filter(d => d.ollama).map(d => d.id);
-        const [checks, stats, lq, rs] = await Promise.all([
+        const [checks, stats, lq, rs, evBaton] = await Promise.all([
           runHealthChecks(this.devices), fetchAllFleetStats(ids),
-          fetchAllLiveQuotas(), fetchRouterLaneStats()
+          fetchAllLiveQuotas(), fetchRouterLaneStats(),
+          pollEventBus(this.activityLog)
         ]);
         this.devices = mergeHealthStatus(this.devices, checks);
         this.fleetStats = stats;
         this.routerStats = rs;
-        this.batonState = buildBatonState(getRouterLog());
+        this.batonState = evBaton || buildBatonState(getRouterLog());
         if (lq.length) this.liveQuotas = lq;
         this.wikiHealth = await fetchWikiHealth();
         this.lastRefresh = new Date().toLocaleTimeString();

--- a/dashboard/js/baton-flow.js
+++ b/dashboard/js/baton-flow.js
@@ -28,6 +28,7 @@ function renderBatonFlow(batonState) {
 
   const header = issue
     ? `<div class="baton-header"><span class="baton-issue">#${issue}</span><span class="baton-status badge ${statusBadge(status)}">${status}</span></div>`
+    + (batonState?.agent ? `<div class="baton-agent">🎭 ${esc(batonState.agent)}</div>` : '')
     : '<div class="baton-header"><span class="baton-idle">No active baton</span></div>';
 
   return `<div class="baton-flow">${header}<div class="baton-pipeline">${steps}</div></div>`;

--- a/dashboard/js/event-bus.js
+++ b/dashboard/js/event-bus.js
@@ -1,0 +1,47 @@
+// Event Bus Client — polls /api/events for live dashboard updates
+// Converts JSONL events into activity log entries and baton state
+
+let _lastEventTs = null;
+
+async function fetchEvents(since) {
+  const url = since
+    ? '/api/events?since=' + encodeURIComponent(since)
+    : '/api/events';
+  try { const r = await fetch(url); return r.ok ? await r.json() : []; }
+  catch { return []; }
+}
+
+function eventToActivity(e) {
+  const map = {
+    'baton:': 'baton', 'ticket:': 'system',
+    'git:': 'system', 'test:': 'test'
+  };
+  const prefix = Object.keys(map).find(k => e.type.startsWith(k));
+  const type = prefix ? map[prefix] : 'info';
+  const msg = e.agent
+    ? `[${e.agent}] ${e.detail || e.type}`
+    : (e.detail || e.type);
+  return { type, message: msg, detail: e.issue ? `#${e.issue}` : '' };
+}
+
+function batonFromEvents(events) {
+  const last = [...events].reverse().find(e => e.role);
+  if (!last) return null;
+  return {
+    activeRole: last.role || 'idle',
+    issue: last.issue || null,
+    status: 'in-progress',
+    agent: last.agent || ''
+  };
+}
+
+async function pollEventBus(activityLog) {
+  const events = await fetchEvents(_lastEventTs);
+  if (!events.length) return null;
+  _lastEventTs = events[events.length - 1].ts;
+  for (const e of events) {
+    const a = eventToActivity(e);
+    addActivity(activityLog, a.type, a.message, a.detail);
+  }
+  return batonFromEvents(events);
+}

--- a/scripts/dashboard-server.js
+++ b/scripts/dashboard-server.js
@@ -54,6 +54,7 @@ async function handleApi(req, res) {
   }
   if (u === '/api/router/metrics') { try { const { getRouterMetrics } = require('./global/router-metrics'); return jsonRes(res,200,getRouterMetrics()); } catch(e){ return jsonRes(res,200,{timestamp:new Date().toISOString(),lanes:{free:0,fleet:0,premium:0}}); } }
   if (u === '/api/wiki-health') { return jsonRes(res, 200, getWikiHealth()); }
+  if (u.startsWith('/api/events')) { const { readEvents } = require('./global/event-reader'); return jsonRes(res, 200, readEvents(u)); }
   jsonRes(res, 404, { error: 'not found' });
 }
 

--- a/scripts/global/emit-event.js
+++ b/scripts/global/emit-event.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// emit-event.js — Append a structured event to .dashboard/events.jsonl
+// Global utility: deploy to ~/.copilot/scripts/ via npm run deploy:apply
+// Usage: node emit-event.js --type ticket:status --issue 35 --role manager --agent "Manny Scope" --detail "Created epic"
+
+const fs = require('fs');
+const path = require('path');
+
+function findRepoRoot(start) {
+  let dir = start;
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, '.git'))) return dir;
+    dir = path.dirname(dir);
+  }
+  return start;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 2) {
+    const key = argv[i].replace(/^--/, '');
+    args[key] = argv[i + 1] || '';
+  }
+  return args;
+}
+
+function emit(args) {
+  const root = findRepoRoot(process.cwd());
+  const dir = path.join(root, '.dashboard');
+  const file = path.join(dir, 'events.jsonl');
+
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  const event = {
+    ts: new Date().toISOString(),
+    type: args.type || 'system',
+    issue: args.issue ? Number(args.issue) : null,
+    role: args.role || null,
+    agent: args.agent || null,
+    model: args.model || null,
+    detail: args.detail || '',
+  };
+
+  fs.appendFileSync(file, JSON.stringify(event) + '\n');
+  if (!args.quiet) {
+    console.log(JSON.stringify(event));
+  }
+  return event;
+}
+
+// CLI mode
+if (require.main === module) {
+  const args = parseArgs(process.argv);
+  emit(args);
+}
+
+// Module mode — importable by other scripts
+module.exports = { emit, findRepoRoot };

--- a/scripts/global/event-reader.js
+++ b/scripts/global/event-reader.js
@@ -1,0 +1,26 @@
+// Event Reader — reads .dashboard/events.jsonl for dashboard API
+// Companion to emit-event.js; used by dashboard-server /api/events
+
+const fs = require('fs');
+const path = require('path');
+
+const EVENTS_DIR = path.resolve(__dirname, '..', '..', '.dashboard');
+const EVENTS_FILE = path.join(EVENTS_DIR, 'events.jsonl');
+const MAX_EVENTS = 100;
+
+function readEvents(urlPath) {
+  const since = urlPath.includes('since=')
+    ? decodeURIComponent(urlPath.split('since=')[1].split('&')[0])
+    : null;
+  if (!fs.existsSync(EVENTS_FILE)) return [];
+  const raw = fs.readFileSync(EVENTS_FILE, 'utf-8').trim();
+  if (!raw) return [];
+  const events = [];
+  for (const line of raw.split('\n')) {
+    try { events.push(JSON.parse(line)); } catch { /* skip */ }
+  }
+  if (since) return events.filter(e => e.ts > since);
+  return events.slice(-MAX_EVENTS);
+}
+
+module.exports = { readEvents };


### PR DESCRIPTION
## Epic 1: Live Event System

Adds a complete event bus infrastructure so the dashboard shows live activity during agent work.

### New Files
- `scripts/global/emit-event.js` (58 lines) — CLI + module JSONL event emitter
- `scripts/global/event-reader.js` (26 lines) — server-side events reader
- `dashboard/js/event-bus.js` (47 lines) — client-side polling + baton state

### Modified Files
- `scripts/dashboard-server.js` — `/api/events?since=<ts>` endpoint
- `dashboard/js/app.js` — event polling in refreshAll
- `dashboard/js/baton-flow.js` — agent name display
- `dashboard/css/baton.css` — agent name styling
- `dashboard/index.html` — event-bus.js script tag
- `.gitignore` — exclude `.dashboard/` runtime dir

### Architecture
```
emit-event.js → .dashboard/events.jsonl → event-reader.js → /api/events → event-bus.js → dashboard
```

### Tickets
Closes #39, closes #40, closes #41, closes #42, closes #43
Refs #35

### Validation
- Lint: ✅ All 99 files within 100-line limit
- API: `/api/events` returns events, `?since=` filter works
- Dashboard: Live Activity feed shows agent events, Baton panel shows agent names
- 8 events emitted during this workflow as proof of concept