### PR TITLE
fix(skills): add parallel ticket dispatch and research lifecycle

### DIFF
--- a/skills/manager-ticket-lifecycle/SKILL.md
+++ b/skills/manager-ticket-lifecycle/SKILL.md
@@ -38,7 +38,25 @@ backlog → ready → in-progress → review → done
 
 ## Epic decomposition
 
-For large work, create Epic issue, then sub-issues referencing parent. Each sub-issue gets its own label set and full lifecycle.
+For large work, create Epic issue, then sub-issues referencing parent.
+Each sub-issue gets its own label set and full lifecycle.
+
+## Parallel dispatch protocol
+
+Manager assigns independent tickets to different collaborators:
+- Research → Rex Research (web search, analysis)
+- Code impl → Cody Builder (features, fixes)
+- UI/CSS → Dash Styles (visual, layout)
+- Docs → Petra Prose (technical writing)
+All assigned tickets execute concurrently. Each has its own baton.
+
+## Research ticket lifecycle
+
+Research tickets use the full baton but skip branching:
+1. No branch created — research produces findings, not code.
+2. Collaborator posts research findings as ticket comment.
+3. Admin reviews wiki/research/ storage — no merge needed.
+4. Consultant validates research quality and wiki placement.
 
 ## Role comment protocol
 

--- a/skills/role-baton-orchestrator/SKILL.md
+++ b/skills/role-baton-orchestrator/SKILL.md
@@ -12,14 +12,31 @@ disable-model-invocation: false
 
 Provide deterministic role sequencing for end-to-end tasks while preventing overlap and instruction drift.
 
-## Sequence (fixed)
+## Sequence (fixed, per ticket)
 
 1. Manager
 2. Collaborator
 3. Admin
 4. Consultant
 
-Only one role may be active at a time.
+Only one role may be active **per ticket** at a time.
+Multiple tickets may have different active roles concurrently.
+
+## Parallel dispatch
+
+Manager may hand off N tickets to N different collaborators simultaneously.
+Each ticket carries its own baton independently. Constraints:
+- Each collaborator owns exactly one ticket at a time.
+- Admin merges are serialized (one PR at a time) to avoid conflicts.
+- Collaborators pull latest main before creating PR.
+
+## Research ticket lifecycle
+
+Research tickets skip branch/PR/merge. Baton sequence:
+1. Manager: scope research question, assign collaborator (fleet LLM).
+2. Collaborator: produce research, post findings on ticket.
+3. Admin: review storage placement (wiki/research/), no merge.
+4. Consultant: validate quality, close ticket.
 
 ## Entry criteria
 


### PR DESCRIPTION
Closes #65

## Changes
- **role-baton-orchestrator**: Per-ticket baton (not global mutex), parallel dispatch rules, research ticket lifecycle
- **manager-ticket-lifecycle**: Parallel dispatch protocol with fleet agent roster, research lifecycle (no branch/merge)

## Agent Notes
🎯 Manny Scope: Scoped in #65 comment
🔧 Cody Builder: 2 files, +38/-3 lines, lint passes
⚙️ Addie Merges: This PR