### PR TITLE
feat(dashboard): redesign baton panel for multi-ticket parallel display

### DIFF
--- a/dashboard/css/baton.css
+++ b/dashboard/css/baton.css
@@ -1,69 +1,81 @@
-/* Baton Flow — Agent role pipeline visualization */
+/* Baton Flow — Multi-ticket parallel visualization */
 
 .baton-flow {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 0.5rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.baton-header {
+.baton-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: 0.82rem;
+  text-align: center;
+  padding: 0.5rem;
+}
+
+.baton-row {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  background: var(--bg);
+}
+
+.baton-meta {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.4rem;
-  padding-bottom: 0.3rem;
-  border-bottom: 1px solid var(--border);
+  gap: 0.4rem;
+  margin-bottom: 0.3rem;
+  flex-wrap: wrap;
 }
 
-.baton-issue { font-size: 0.95rem; font-weight: 700; color: var(--blue); }
-.baton-idle { color: var(--text-muted); font-style: italic; font-size: 0.82rem; }
-.baton-agent { font-size: 0.78rem; color: var(--text); padding: 0.15rem 0; }
+.baton-issue { font-size: 0.9rem; font-weight: 700; color: var(--blue); }
+.baton-agent { font-size: 0.75rem; color: var(--text); margin-left: auto; }
 
 .baton-pipeline {
   display: flex;
   align-items: center;
-  justify-content: center;
   gap: 0;
   flex-wrap: wrap;
 }
 
 .baton-step {
   text-align: center;
-  padding: 0.25rem 0.5rem;
-  border-radius: 6px;
-  border: 2px solid var(--border);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  border: 1.5px solid var(--border);
   background: var(--bg);
-  min-width: 75px;
+  font-size: 0.85rem;
+  opacity: 0.4;
   transition: all 0.3s ease;
-  opacity: 0.5;
 }
 
-.baton-step.done { border-color: var(--green); opacity: 0.7; }
+.baton-step.done { border-color: var(--green); opacity: 0.65; }
 
 .baton-step.active {
   border-color: var(--blue);
   background: color-mix(in srgb, var(--blue) 12%, var(--bg));
   opacity: 1;
-  box-shadow: 0 0 8px color-mix(in srgb, var(--blue) 25%, transparent);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--blue) 20%, transparent);
 }
 
-.baton-icon { font-size: 1.1rem; }
-.baton-label { font-size: 0.72rem; font-weight: 600; margin-top: 0.1rem; }
-.baton-desc { font-size: 0.62rem; color: var(--text-muted); }
+.baton-lbl { font-size: 0.65rem; font-weight: 600; margin-left: 0.15rem; }
 
 .baton-arrow {
   color: var(--border);
-  padding: 0 0.15rem;
-  display: flex;
-  align-items: center;
+  padding: 0 0.1rem;
+  font-size: 0.7rem;
 }
 
 .baton-step.done + .baton-arrow { color: var(--green); }
 .baton-step.active + .baton-arrow { color: var(--blue); }
 
 @media (max-width: 640px) {
-  .baton-pipeline { flex-direction: column; }
-  .baton-arrow { transform: rotate(90deg); }
-  .baton-step { min-width: 70px; }
+  .baton-pipeline { flex-wrap: wrap; gap: 0.15rem; }
+  .baton-step { font-size: 0.75rem; padding: 0.15rem 0.3rem; }
+  .baton-agent { margin-left: 0; }
 }

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -6,7 +6,7 @@ function dashboardApp() {
     fleetStats: {}, routerStats: {},
     config: { refreshSec: 5, highContrast: false },
     currentView: 'fleet', helpDevMode: false,
-    batonState: { activeRole: 'idle', issue: null, status: 'idle' },
+    batonState: [],
     activityLog: [],
     wikiHealth: { loaded: false },
     tooltipsEnabled: false, autoRefreshEnabled: true,

--- a/dashboard/js/baton-flow.js
+++ b/dashboard/js/baton-flow.js
@@ -1,54 +1,68 @@
-// Baton Flow — Agent role workflow visualization
-// Shows Manager→Collaborator→Admin→Consultant pipeline
+// Baton Flow — Multi-ticket parallel agent baton visualization
+// Shows Manager→Collaborator→Admin→Consultant per ticket
+
+const BATON_ROLES = [
+  { id: 'manager', icon: '🎯', label: 'Mgr' },
+  { id: 'collaborator', icon: '🔧', label: 'Collab' },
+  { id: 'admin', icon: '⚙️', label: 'Admin' },
+  { id: 'consultant', icon: '🔍', label: 'Review' }
+];
 
 function renderBatonFlow(batonState) {
-  const roles = [
-    { id: 'manager', icon: '🎯', label: 'Manager', desc: 'Scope & tickets' },
-    { id: 'collaborator', icon: '🔧', label: 'Collaborator', desc: 'Implement' },
-    { id: 'admin', icon: '⚙️', label: 'Admin', desc: 'Merge & deploy' },
-    { id: 'consultant', icon: '🔍', label: 'Consultant', desc: 'Review & close' }
-  ];
-  const active = batonState?.activeRole || 'idle';
-  const issue = batonState?.issue || null;
-  const status = batonState?.status || 'idle';
+  const tickets = normalizeBaton(batonState);
+  if (!tickets.length) {
+    return `<div class="baton-flow">
+      <div class="baton-empty">No active tickets</div></div>`;
+  }
+  const rows = tickets.map(renderBatonRow).join('');
+  return `<div class="baton-flow">${rows}</div>`;
+}
 
-  const steps = roles.map((r, i) => {
+function renderBatonRow(t) {
+  const steps = BATON_ROLES.map((r, i) => {
     let cls = 'baton-step';
-    if (r.id === active) cls += ' active';
-    else if (roles.findIndex(x => x.id === active) > i) cls += ' done';
-    const arrow = i < roles.length - 1
-      ? '<div class="baton-arrow"><svg width="20" height="14" viewBox="0 0 20 14"><path d="M0 7h16m-5-5l5 5-5 5" fill="none" stroke="currentColor" stroke-width="1.5"/></svg></div>'
-      : '';
-    return `<div class="${cls}">
-      <div class="baton-icon">${r.icon}</div>
-      <div class="baton-label">${r.label}</div>
-      <div class="baton-desc">${r.desc}</div>
-    </div>${arrow}`;
+    const ai = BATON_ROLES.findIndex(x => x.id === t.activeRole);
+    if (r.id === t.activeRole) cls += ' active';
+    else if (ai > i) cls += ' done';
+    const arrow = i < BATON_ROLES.length - 1
+      ? '<span class="baton-arrow">→</span>' : '';
+    return `<span class="${cls}" title="${r.id}">
+      ${r.icon}<span class="baton-lbl">${r.label}</span>
+    </span>${arrow}`;
   }).join('');
 
-  const header = issue
-    ? `<div class="baton-header"><span class="baton-issue">#${issue}</span><span class="baton-status badge ${statusBadge(status)}">${status}</span></div>`
-    + (batonState?.agent ? `<div class="baton-agent">🎭 ${esc(batonState.agent)}</div>` : '')
-    : '<div class="baton-header"><span class="baton-idle">No active baton</span></div>';
-
-  return `<div class="baton-flow">${header}<div class="baton-pipeline">${steps}</div></div>`;
+  const badge = statusBadge(t.status);
+  const agent = t.agent ? `<span class="baton-agent">🎭 ${esc(t.agent)}</span>` : '';
+  return `<div class="baton-row">
+    <div class="baton-meta">
+      <span class="baton-issue">#${t.issue || '?'}</span>
+      <span class="badge ${badge}">${t.status || 'idle'}</span>
+      ${agent}
+    </div>
+    <div class="baton-pipeline">${steps}</div>
+  </div>`;
 }
 
 function statusBadge(s) {
-  const m = { 'in-progress': 'active', ready: 'degraded', done: 'healthy', idle: 'unknown' };
+  const m = { 'in-progress': 'active', ready: 'degraded',
+    done: 'healthy', idle: 'unknown' };
   return m[s] || 'unknown';
 }
 
-// Simulate baton state from recent GitHub activity
+function normalizeBaton(state) {
+  if (!state) return [];
+  if (Array.isArray(state)) return state.filter(t => t.issue);
+  if (state.issue) return [state];
+  return [];
+}
+
 function buildBatonState(routerLog) {
-  if (!routerLog || !routerLog.length) {
-    return { activeRole: 'idle', issue: null, status: 'idle' };
-  }
+  if (!routerLog || !routerLog.length) return [];
   const last = routerLog[0];
   const roleMap = { router: 'manager', implementer: 'collaborator', quick: 'admin' };
-  return {
+  return [{
     activeRole: roleMap[last.agent] || 'manager',
     issue: last.task?.match(/#(\d+)/)?.[1] || null,
     status: 'in-progress'
-  };
+  }];
 }

--- a/dashboard/js/event-bus.js
+++ b/dashboard/js/event-bus.js
@@ -25,14 +25,18 @@ function eventToActivity(e) {
 }
 
 function batonFromEvents(events) {
-  const last = [...events].reverse().find(e => e.role);
-  if (!last) return null;
-  return {
-    activeRole: last.role || 'idle',
-    issue: last.issue || null,
-    status: 'in-progress',
-    agent: last.agent || ''
-  };
+  const tickets = {};
+  for (const e of events) {
+    if (!e.role || !e.issue) continue;
+    tickets[e.issue] = {
+      activeRole: e.role,
+      issue: e.issue,
+      status: e.status || 'in-progress',
+      agent: e.agent || ''
+    };
+  }
+  const arr = Object.values(tickets);
+  return arr.length ? arr : null;
 }
 
 async function pollEventBus(activityLog) {


### PR DESCRIPTION
## Summary

Redesigns the Agent Baton dashboard panel to support multiple tickets simultaneously.

### Changes
- **baton-flow.js**: Rewritten for array-based multi-ticket state. Each ticket gets its own row showing agent name, ticket #, role badge, and 4-step pipeline.
- **baton.css**: Rewritten for stacked multi-ticket rows with responsive layout.
- **app.js**: `batonState` changed from single object to array.
- **event-bus.js**: `batonFromEvents()` now aggregates per-ticket baton state from event stream.

### Testing
- Lint: ✅ All 125 files pass
- Backward compatible: `normalizeBaton()` handles both old object and new array formats

Closes #62