### PR TITLE
feat(dashboard): add Agile audit logging to activity feed

### DIFF
--- a/dashboard/css/activity.css
+++ b/dashboard/css/activity.css
@@ -40,3 +40,13 @@
   font-style: italic;
   padding: 0.3rem;
 }
+
+/* Agile event type colors */
+.activity-row.ticket .activity-icon { color: var(--blue); }
+.activity-row.role .activity-icon { color: #a78bfa; }
+.activity-row.branch .activity-icon,
+.activity-row.commit .activity-icon { color: var(--green); }
+.activity-row.pr .activity-icon,
+.activity-row.merge .activity-icon { color: #f59e0b; }
+.activity-row.deploy .activity-icon { color: #06b6d4; }
+.activity-row.error .activity-msg { color: var(--red); }

--- a/dashboard/js/activity-feed.js
+++ b/dashboard/js/activity-feed.js
@@ -1,6 +1,6 @@
-// Live Activity Feed — real-time event log for Fleet view
+// Live Activity Feed — Agile lifecycle event log
 
-const MAX_ACTIVITY = 15;
+const MAX_ACTIVITY = 20;
 
 function addActivity(log, type, message, detail) {
   log.unshift({
@@ -16,11 +16,11 @@ function renderActivityFeed(log) {
   if (!log || !log.length) {
     return `<div class="activity-empty">
       <p>No activity yet. Events appear on refresh,
-      test runs, and role transitions.</p></div>`;
+      test runs, and Agile role transitions.</p></div>`;
   }
   const rows = log.map(e => {
     const icon = activityIcon(e.type);
-    return `<div class="activity-row">
+    return `<div class="activity-row ${e.type}">
       <span class="activity-time">${esc(e.time)}</span>
       <span class="activity-icon">${icon}</span>
       <span class="activity-msg">${esc(e.message)}</span>
@@ -33,7 +33,9 @@ function renderActivityFeed(log) {
 function activityIcon(type) {
   const icons = {
     refresh: '↻', test: '🧪', baton: '🔄',
-    router: '🛣️', system: '⚙️', error: '❌', warn: '⚠️'
+    router: '🛣️', system: '⚙️', error: '❌', warn: '⚠️',
+    ticket: '🎫', role: '🏷️', branch: '🌿',
+    pr: '🔀', commit: '📝', merge: '✅', deploy: '🚀'
   };
   return icons[type] || '📌';
 }

--- a/dashboard/js/event-bus.js
+++ b/dashboard/js/event-bus.js
@@ -13,11 +13,14 @@ async function fetchEvents(since) {
 
 function eventToActivity(e) {
   const map = {
-    'baton:': 'baton', 'ticket:': 'system',
-    'git:': 'system', 'test:': 'test'
+    'baton:': 'baton', 'ticket:created': 'ticket',
+    'ticket:status': 'ticket', 'ticket:role': 'role',
+    'git:branch': 'branch', 'git:pr': 'pr',
+    'git:commit': 'commit', 'git:merge': 'merge',
+    'deploy:': 'deploy', 'test:': 'test'
   };
-  const prefix = Object.keys(map).find(k => e.type.startsWith(k));
-  const type = prefix ? map[prefix] : 'info';
+  const key = Object.keys(map).find(k => e.type.startsWith(k));
+  const type = key ? map[key] : 'system';
   const msg = e.agent
     ? `[${e.agent}] ${e.detail || e.type}`
     : (e.detail || e.type);

--- a/scripts/global/emit-event.js
+++ b/scripts/global/emit-event.js
@@ -56,3 +56,26 @@ if (require.main === module) {
 
 // Module mode — importable by other scripts
 module.exports = { emit, findRepoRoot };
+
+// Convenience helpers for Agile lifecycle events
+function emitTicket(issue, detail, agent) {
+  return emit({ type: 'ticket:created', issue, detail, agent });
+}
+function emitStatus(issue, status, agent) {
+  return emit({ type: 'ticket:status', issue, detail: status, agent });
+}
+function emitRole(issue, role, agent) {
+  return emit({ type: 'ticket:role', issue, role, agent, detail: role });
+}
+function emitBranch(issue, branch, agent) {
+  return emit({ type: 'git:branch', issue, detail: branch, agent });
+}
+function emitPR(issue, pr, agent) {
+  return emit({ type: 'git:pr', issue, detail: `PR #${pr}`, agent });
+}
+function emitMerge(issue, pr, agent) {
+  return emit({ type: 'git:merge', issue, detail: `Merged #${pr}`, agent });
+}
+Object.assign(module.exports, {
+  emitTicket, emitStatus, emitRole, emitBranch, emitPR, emitMerge
+});


### PR DESCRIPTION
## Summary

Adds Agile lifecycle event types to the dashboard activity feed and event emission system.

### Changes
- **activity-feed.js**: New icon set covering ticket, role, branch, PR, merge, deploy events. Max log increased to 20.
- **event-bus.js**: Enhanced type mapping for all Agile event prefixes (ticket:created, ticket:status, ticket:role, git:branch, git:pr, git:merge, deploy:).
- **activity.css**: Color-coded Agile event types (blue=ticket, purple=role, green=git, amber=PR/merge, cyan=deploy).
- **emit-event.js**: Convenience helpers (emitTicket, emitStatus, emitRole, emitBranch, emitPR, emitMerge).

### Testing
- Lint: ✅ All 125 files pass (≤100 lines)

Closes #63