### PR TITLE
v2.5.0: Dashboard UAT fixes, Wiki pipeline, Governance hardening

### DIFF
--- a/dashboard/css/activity.css
+++ b/dashboard/css/activity.css
@@ -1,7 +1,7 @@
 /* Live Activity Feed styles */
 
 .activity-list {
-  max-height: 320px;
+  max-height: 440px;
   overflow-y: auto;
   scrollbar-width: thin;
 }

--- a/dashboard/css/baton.css
+++ b/dashboard/css/baton.css
@@ -7,7 +7,10 @@
   padding: 0.5rem 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.35rem;
+  max-height: 280px;
+  overflow-y: auto;
+  scrollbar-width: thin;
 }
 
 .baton-empty {
@@ -40,18 +43,21 @@
   display: flex;
   align-items: center;
   gap: 0;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  overflow-x: auto;
 }
 
 .baton-step {
   text-align: center;
-  padding: 0.2rem 0.4rem;
+  padding: 0.15rem 0.25rem;
   border-radius: 4px;
   border: 1.5px solid var(--border);
   background: var(--bg);
-  font-size: 0.85rem;
+  font-size: 0.72rem;
   opacity: 0.4;
   transition: all 0.3s ease;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .baton-step.done { border-color: var(--green); opacity: 0.65; }
@@ -63,19 +69,19 @@
   box-shadow: 0 0 6px color-mix(in srgb, var(--blue) 20%, transparent);
 }
 
-.baton-lbl { font-size: 0.65rem; font-weight: 600; margin-left: 0.15rem; }
+.baton-lbl { font-size: 0.58rem; font-weight: 600; margin-left: 0.1rem; }
 
 .baton-arrow {
   color: var(--border);
-  padding: 0 0.1rem;
-  font-size: 0.7rem;
+  padding: 0 0.05rem;
+  font-size: 0.6rem;
 }
 
 .baton-step.done + .baton-arrow { color: var(--green); }
 .baton-step.active + .baton-arrow { color: var(--blue); }
 
 @media (max-width: 640px) {
-  .baton-pipeline { flex-wrap: wrap; gap: 0.15rem; }
-  .baton-step { font-size: 0.75rem; padding: 0.15rem 0.3rem; }
+  .baton-pipeline { overflow-x: auto; }
+  .baton-step { font-size: 0.65rem; padding: 0.1rem 0.2rem; }
   .baton-agent { margin-left: 0; }
 }

--- a/dashboard/css/topology.css
+++ b/dashboard/css/topology.css
@@ -24,6 +24,7 @@
 }
 
 .topo-legend .dot.green { background: var(--green); }
+.topo-legend .dot.red { background: var(--red); }
 
 .topo-legend .line {
   display: inline-block; width: 12px; height: 2px;

--- a/dashboard/css/views.css
+++ b/dashboard/css/views.css
@@ -86,12 +86,15 @@
 .help-toggle:hover { border-color: var(--blue); color: var(--blue); }
 .svc-link { color: var(--blue); font-size: 0.78rem; text-decoration: none; }
 .svc-link:hover { text-decoration: underline; }
-
+.help-cat-title { font-size: 0.88rem; color: var(--blue); margin: 0.5rem 0 0.25rem; }
+.help-category:first-child .help-cat-title { margin-top: 0; }
+.help-feedback { display: flex; gap: 1rem; padding: 0.5rem 0; }
+.help-empty { color: var(--text-muted); font-style: italic; }
 @media (max-width: 640px) {
   .header { flex-wrap: wrap; gap: 0.4rem; padding: 0.5rem 0.75rem; }
   .header-brand h1 { font-size: 0.95rem; }
-  .header-nav { flex-wrap: wrap; }
-  .header-actions { flex-wrap: wrap; gap: 0.3rem; }
+  .header-nav, .header-actions { flex-wrap: wrap; }
+  .header-actions { gap: 0.3rem; }
   .header-actions button { padding: 0.25rem 0.4rem; font-size: 0.78rem; }
-  .dashboard-grid { padding: 0.5rem; grid-template-columns: 1fr; gap: 0.5rem; }
+  .dashboard-grid { grid-template-columns: 1fr; gap: 0.5rem; padding: 0.5rem; }
 }

--- a/dashboard/css/wiki.css
+++ b/dashboard/css/wiki.css
@@ -1,4 +1,4 @@
-/* Wiki Health Panel Styles — compact card */
+/* Wiki Health Panel + Reader Styles */
 
 .wiki-card {
   background: var(--surface); border: 1px solid var(--border);
@@ -13,9 +13,7 @@
 }
 .wiki-head .badge { margin-left: auto; }
 
-.wiki-row {
-  display: flex; gap: 0.75rem; margin-bottom: 0.35rem;
-}
+.wiki-row { display: flex; gap: 0.75rem; margin-bottom: 0.35rem; }
 .wiki-stat {
   display: flex; flex-direction: column; align-items: center;
   font-size: 1.1rem; font-weight: 700; color: var(--text);
@@ -36,3 +34,24 @@
 .wiki-ok { color: var(--green); font-size: 0.78rem; }
 .wiki-ts { font-size: 0.72rem; color: var(--text-muted); }
 .wiki-empty { color: var(--text-muted); font-style: italic; padding: 0.3rem; }
+.wiki-actions { display: flex; align-items: center; gap: 0.5rem; margin-top: 0.3rem; }
+.wiki-view-btn {
+  background: var(--surface); color: var(--blue); border: 1px solid var(--blue);
+  border-radius: 6px; padding: 0.2rem 0.5rem; font-size: 0.75rem;
+  cursor: pointer;
+}
+.wiki-view-btn:hover { background: color-mix(in srgb, var(--blue) 12%, var(--bg)); }
+
+/* Wiki Reader */
+.wiki-reader { max-height: 70vh; overflow-y: auto; scrollbar-width: thin; }
+.wiki-summary { font-size: 0.85rem; color: var(--text-muted); margin-bottom: 0.5rem; }
+.wiki-section { margin-bottom: 0.3rem; }
+.wiki-section summary {
+  cursor: pointer; font-weight: 600; font-size: 0.85rem;
+  padding: 0.3rem 0.4rem; border-radius: 6px;
+  background: var(--surface); border: 1px solid var(--border);
+}
+.wiki-list { padding: 0.2rem 0 0.2rem 1.2rem; margin: 0; }
+.wiki-list li { font-size: 0.8rem; padding: 0.1rem 0; }
+.wiki-link { color: var(--blue); text-decoration: none; }
+.wiki-link:hover { text-decoration: underline; }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -6,31 +6,21 @@
     <title>DevEnv Ops — Fleet Operations Center</title>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="stylesheet" href="css/app.css">
-    <link rel="stylesheet" href="css/help.css"><link rel="stylesheet" href="css/stats.css">
-    <link rel="stylesheet" href="css/router.css"><link rel="stylesheet" href="css/config.css">
-    <link rel="stylesheet" href="css/views.css"><link rel="stylesheet" href="css/topology.css">
-    <link rel="stylesheet" href="css/baton.css"><link rel="stylesheet" href="css/activity.css">
-    <link rel="stylesheet" href="css/wiki.css">
+    <link rel="stylesheet" href="css/help.css"><link rel="stylesheet" href="css/stats.css"><link rel="stylesheet" href="css/router.css">
+    <link rel="stylesheet" href="css/config.css"><link rel="stylesheet" href="css/views.css"><link rel="stylesheet" href="css/topology.css">
+    <link rel="stylesheet" href="css/baton.css"><link rel="stylesheet" href="css/activity.css"><link rel="stylesheet" href="css/wiki.css">
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
-    <script src="js/health-check.js"></script>
-    <script src="js/quota-tracker.js"></script>
-    <script src="js/device-monitor.js"></script>
-    <script src="js/router-tracker.js"></script>
-    <script src="js/live-stats.js"></script>
-    <script src="js/quota-live.js"></script>
-    <script src="js/fleet-topology.js"></script>
-    <script src="js/baton-flow.js"></script>
-    <script src="js/resource-monitor.js"></script>
-    <script src="js/activity-feed.js"></script><script src="js/event-bus.js"></script>
-    <script src="js/render-panels.js"></script>
-    <script src="js/config-panel.js"></script>
-    <script src="js/stress-test.js"></script>
-    <script src="js/help-content.js"></script>
-    <script src="js/wiki-panel.js"></script>
-    <script src="js/tooltips.js"></script>
-    <script src="js/app-actions.js"></script>
-    <script src="js/help-tour.js"></script>
-    <script src="js/app.js"></script>
+    <script src="js/health-check.js"></script><script src="js/quota-tracker.js"></script>
+    <script src="js/device-monitor.js"></script><script src="js/router-tracker.js"></script>
+    <script src="js/live-stats.js"></script><script src="js/quota-live.js"></script>
+    <script src="js/fleet-topology.js"></script><script src="js/baton-flow.js"></script>
+    <script src="js/resource-monitor.js"></script><script src="js/activity-feed.js"></script>
+    <script src="js/event-bus.js"></script><script src="js/render-panels.js"></script>
+    <script src="js/config-panel.js"></script><script src="js/stress-test.js"></script>
+    <script src="js/help-content.js"></script><script src="js/help-user.js"></script><script src="js/help-dev.js"></script>
+    <script src="js/wiki-panel.js"></script><script src="js/wiki-reader.js"></script>
+    <script src="js/tooltips.js"></script><script src="js/app-actions.js"></script>
+    <script src="js/help-tour.js"></script><script src="js/app.js"></script>
 </head>
 <body x-cloak x-data="dashboardApp()" x-init="init()">
     <header class="header">
@@ -41,6 +31,7 @@
         <nav class="header-nav" aria-label="Dashboard views">
             <button @click="setView('fleet')" :class="{active:isView('fleet')}" data-tip="view-fleet">🌐 Fleet</button>
             <button @click="setView('ops')" :class="{active:isView('ops')}" data-tip="view-ops">📊 Ops</button>
+            <button @click="setView('wiki')" :class="{active:isView('wiki')}" data-tip="view-wiki">📚 Wiki</button>
             <button @click="setView('resources')" :class="{active:isView('resources')}" data-tip="view-resources">📦 Resources</button>
             <button @click="setView('help')" :class="{active:isView('help')}" data-tip="view-help">📘 Help</button>
         </nav>
@@ -68,8 +59,6 @@
         </section></template>
         <section id="panel-quotas" class="panel" x-show="isView('ops')" data-tip="quotas">
             <h2>📊 Quotas</h2><div x-html="renderQuotaPanel(liveQuotas, quotas)"></div></section>
-        <section id="panel-stats" class="panel" x-show="isView('ops')" data-tip="stats">
-            <h2>📡 Live Fleet Stats</h2><div x-html="renderFleetStats(fleetStats)"></div></section>
         <section id="panel-router" class="panel" x-show="isView('ops')" data-tip="router">
             <h2>🛣️ Task Router Lanes</h2><div x-html="renderRouterPanel(routerStats)"></div></section>
         <section id="panel-router-log" class="panel" x-show="isView('ops')" data-tip="router-log">
@@ -80,6 +69,9 @@
             <h2>🧪 Quick Stress Test</h2><div x-html="renderStressPanel(testRun)"></div></section>
         <section id="panel-wiki" class="panel" x-show="isView('ops')" data-tip="wiki">
             <h2>📚 Wiki Health</h2><div x-html="renderWikiPanel(wikiHealth)"></div></section>
+        <template x-if="isView('wiki')"><section id="panel-wiki-reader" class="panel full-width" data-tip="wiki-reader">
+            <h2>📚 Research Wiki</h2><div x-html="renderWikiReader(wikiPages)"></div>
+        </section></template>
         <template x-if="isView('resources')"><section id="panel-devices" class="panel" data-tip="devices">
             <h2>🏗️ Fleet Devices</h2><div x-html="renderDeviceCards(devices)"></div>
         </section></template>
@@ -92,7 +84,7 @@
     </main>
     <footer class="footer">
         <span>Last refresh: <span x-text="lastRefresh"></span></span>
-        <span>devenv-ops v2.4.0</span>
+        <span>devenv-ops v2.5.0</span>
     </footer>
     <aside id="app-tip" class="app-tip" x-show="activeTip" x-html="activeTip" x-transition.opacity></aside>
 </body>

--- a/dashboard/js/activity-feed.js
+++ b/dashboard/js/activity-feed.js
@@ -1,6 +1,6 @@
 // Live Activity Feed — Agile lifecycle event log
 
-const MAX_ACTIVITY = 20;
+const MAX_ACTIVITY = 30;
 
 function addActivity(log, type, message, detail) {
   log.unshift({

--- a/dashboard/js/app-actions.js
+++ b/dashboard/js/app-actions.js
@@ -15,7 +15,6 @@ function toggleDashboardTips(app) {
   if (!app.tooltipsEnabled) clearTooltip(app);
 }
 
-// Global — called from config panel range slider
 function setRefreshSec(val) {
   const el = document.querySelector('[x-data]');
   const app = el._x_dataStack?.[0] || Alpine.$data(el);
@@ -27,37 +26,71 @@ function setRefreshSec(val) {
 async function runDashboardQuickTest(app) {
   if (app.testRun.running) return;
   const tickets = buildParallelTickets();
+  const t0 = performance.now();
   app.testRun = {
     running: true, rounds: 0, ok: 0, fail: 0,
-    last: 'warming up', phase: '', tickets,
+    last: 'warming up', tickets, elapsed: 0,
     startedAt: new Date().toLocaleTimeString()
   };
-  addActivity(app.activityLog, 'test', 'Parallel ticket stress test started',
-    `${tickets.length} tickets`);
-  const maxRounds = 15;
+  addActivity(app.activityLog, 'test', '🧪 Stress test started',
+    `${tickets.length} tickets · 60s`);
+
+  const DURATION_MS = 60000, INTERVAL_MS = 1500;
+  const maxRounds = Math.ceil(DURATION_MS / INTERVAL_MS);
+
   for (let i = 0; i < maxRounds; i++) {
-    await new Promise(r => setTimeout(r, 200 + Math.random() * 150));
-    // Advance a random non-done ticket
+    await new Promise(r => setTimeout(r, INTERVAL_MS));
+    const elapsed = (performance.now() - t0) / 1000;
+    if (elapsed > 62) break;
+
+    // Advance random non-done ticket
     const active = tickets.filter(t => t.status !== 'done');
-    if (!active.length) break;
-    const t = active[Math.floor(Math.random() * active.length)];
-    advanceTicket(t);
+    if (active.length) {
+      const t = active[Math.floor(Math.random() * active.length)];
+      advanceTicket(t);
+      const agent = AGENT_NAMES[t.role] || 'system';
+      addActivity(app.activityLog, 'baton',
+        `[${agent}] ${t.id}: ${t.label}`, t.role);
+    }
+
+    // Mock router log entry every round
+    const mock = mockRouterEntry();
+    addRouterLogEntry(mock.agent, mock.model, `[test] ${mock.lane} lane`);
+    addActivity(app.activityLog, 'router',
+      `${mock.agent} → ${mock.model}`, mock.lane);
+
+    // Update baton state with all active tickets
+    app.batonState = tickets.filter(t => t.status !== 'done')
+      .map(t => ({
+        activeRole: t.role, issue: t.id,
+        status: t.status === 'done' ? 'done' : 'in-progress',
+        agent: AGENT_NAMES[t.role] || ''
+      }));
+
     app.testRun.rounds = i + 1;
-    app.testRun.ok += t.skills.length;
-    app.testRun.last = `${t.id}: ${t.role}`;
+    app.testRun.ok += 2;
+    app.testRun.elapsed = elapsed;
+    app.testRun.last = active.length
+      ? `${active[0].id}: ${active[0].role}` : 'completing';
     app.testRun.tickets = [...tickets];
-    const agent = AGENT_NAMES[t.role] || 'system';
-    app.batonState = {
-      activeRole: t.role === 'done' ? 'idle' : t.role,
-      issue: t.id, status: t.role === 'done' ? 'done' : 'in-progress',
-      agent
-    };
-    addActivity(app.activityLog, 'baton',
-      `[${agent}] ${t.id}: ${t.label}`, t.role);
+
+    // Cycle device status for topology exercise
+    if (i % 4 === 0 && app.devices.length > 1) {
+      const d = app.devices[i % app.devices.length];
+      const states = ['healthy', 'degraded', 'offline'];
+      d.status = states[i % states.length];
+    }
+
+    // All tickets done? Keep going for router/activity exercise
+    if (!active.length && elapsed > 30) break;
   }
+
   app.testRun.running = false;
-  app.testRun.last = `pass — ${tickets.length} tickets complete`;
-  app.batonState = { activeRole: 'idle', issue: null, status: 'idle' };
+  app.testRun.elapsed = (performance.now() - t0) / 1000;
+  app.testRun.last = `✅ ${tickets.length} tickets · ${app.testRun.rounds} rounds`;
+  app.batonState = [];
+  // Restore device status
+  app.devices.forEach(d => { d.status = d._origStatus || d.status; });
   addActivity(app.activityLog, 'test',
-    `All tickets complete: ${app.testRun.ok} skills verified`);
+    `Stress test complete: ${app.testRun.ok} checks`);
 }

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -9,6 +9,7 @@ function dashboardApp() {
     batonState: [],
     activityLog: [],
     wikiHealth: { loaded: false },
+    wikiPages: [],
     tooltipsEnabled: false, autoRefreshEnabled: true,
     refreshTimer: null, testTimer: null,
     testRun: { running: false, rounds: 0, ok: 0, fail: 0, last: 'idle' },
@@ -27,6 +28,7 @@ function dashboardApp() {
       document.body.classList.toggle('high-contrast', this.config.highContrast);
       this.tooltipsEnabled = !!this.config.tooltipsEnabled;
       initTooltips(this);
+      this.wikiPages = typeof getWikiPages === 'function' ? getWikiPages() : [];
       await this.loadInventory();
       await this.refreshAll();
       this.scheduleRefresh();

--- a/dashboard/js/fleet-topology.js
+++ b/dashboard/js/fleet-topology.js
@@ -1,15 +1,15 @@
 // Fleet Topology — compact SVG network graph
-// Only shows routable devices; legend inline
+// Shows all routable devices with offline legend + reasons
 
 function renderFleetTopology(devices) {
   if (!devices.length) return '<p class="topo-empty">No fleet devices.</p>';
   const routable = devices.filter(d => d.tailscaleIP);
-  const unroutable = devices.filter(d => !d.tailscaleIP);
-  const W = 400, H = 120, CY = 55;
-  const nodes = routable.map((d, i) => {
-    const x = 80 + i * ((W - 160) / Math.max(routable.length - 1, 1));
-    return { ...d, x, y: CY };
-  });
+  const W = 440, H = 130, CY = 55;
+  const gap = routable.length > 1
+    ? (W - 160) / (routable.length - 1) : 0;
+  const nodes = routable.map((d, i) => ({
+    ...d, x: 80 + i * gap, y: CY
+  }));
   const links = [];
   for (let i = 0; i < nodes.length; i++)
     for (let j = i + 1; j < nodes.length; j++)
@@ -27,16 +27,17 @@ function renderFleetTopology(devices) {
 
   const nodesSvg = nodes.map(n => {
     const col = statusColor(n.status);
-    const icon = n.openclaw ? '⚡' : n.ollama ? '🤖' : '💻';
-    return `<circle cx="${n.x}" cy="${n.y}" r="18" fill="var(--surface)"
+    const icon = n.local ? '⭐' : n.openclaw ? '⚡' : n.ollama ? '🤖' : '💻';
+    const reason = n.status === 'offline' ? topoOfflineReason(n) : '';
+    return `<circle cx="${n.x}" cy="${n.y}" r="16" fill="var(--surface)"
         stroke="${col}" stroke-width="2" class="topo-node"/>
       <text x="${n.x}" y="${n.y + 4}" text-anchor="middle"
         class="topo-icon">${icon}</text>
-      <text x="${n.x}" y="${n.y + 32}" text-anchor="middle"
-        class="topo-label">${esc(n.alias)}${n.local ? ' ⭐' : ''}</text>
-      <text x="${n.x}" y="${n.y + 42}" text-anchor="middle"
-        class="topo-sub">${esc(n.tailscaleIP)}</text>
-      <circle cx="${n.x + 13}" cy="${n.y - 13}" r="4"
+      <text x="${n.x}" y="${n.y + 30}" text-anchor="middle"
+        class="topo-label">${esc(n.alias)}</text>
+      <text x="${n.x}" y="${n.y + 40}" text-anchor="middle"
+        class="topo-sub">${esc(n.tailscaleIP)}${reason}</text>
+      <circle cx="${n.x + 11}" cy="${n.y - 11}" r="4"
         fill="${col}" class="topo-dot"/>`;
   }).join('');
 
@@ -46,20 +47,28 @@ function renderFleetTopology(devices) {
       .mesh-link{stroke:var(--border);stroke-width:1.5;stroke-dasharray:5,3}
       .mesh-link.active{stroke:var(--green);stroke-width:2;
         stroke-dasharray:none;opacity:.6}
-      .link-label{font-size:8px;fill:var(--text-muted);font-style:italic}
-      .topo-icon{font-size:14px;fill:var(--text);pointer-events:none}
-      .topo-label{font-size:9px;fill:var(--text);font-weight:600}
-      .topo-sub{font-size:7px;fill:var(--text-muted)}
+      .link-label{font-size:7px;fill:var(--text-muted);font-style:italic}
+      .topo-icon{font-size:12px;fill:var(--text);pointer-events:none}
+      .topo-label{font-size:8px;fill:var(--text);font-weight:600}
+      .topo-sub{font-size:6px;fill:var(--text-muted)}
     </style></defs>${linksSvg}${nodesSvg}</svg>`;
 
-  const unr = unroutable.length
-    ? `<span class="topo-unr">${unroutable.map(
-        d => esc(d.alias)).join(', ')} (no route)</span>` : '';
-  const legend = `<div class="topo-legend">
+  return `<div class="topo-wrap">${svg}${topoLegend(devices)}</div>`;
+}
+
+function topoOfflineReason(d) {
+  if (!d.tailscale) return ' (no TS)';
+  if (d.notes?.includes('Not yet')) return ' (pending)';
+  return ' (unreachable)';
+}
+
+function topoLegend(devices) {
+  const hasOffline = devices.some(d => d.status === 'offline');
+  return `<div class="topo-legend">
     <span><span class="dot green"></span> Online</span>
+    ${hasOffline ? '<span><span class="dot red"></span> Offline</span>' : ''}
     <span><span class="line green"></span> Mesh</span>
-    ${unr}</div>`;
-  return `<div class="topo-wrap">${svg}${legend}</div>`;
+    <span>⭐ Primary</span></div>`;
 }
 
 function statusColor(s) {

--- a/dashboard/js/help-content.js
+++ b/dashboard/js/help-content.js
@@ -1,41 +1,69 @@
-// Help Content — user + developer views with search
-
-const HELP_SECTIONS = [
-  { id: 'fleet', title: '🌐 Fleet Topology',
-    user: 'Network graph of fleet devices. Green = reachable. Mesh lines show Tailscale connections between healthy nodes.',
-    dev: 'Rendered by renderFleetTopology() in fleet-topology.js. SVG 400×120 viewBox. Filters devices without tailscaleIP. Data: inventory/devices.json merged with health-check.js ping results. statusColor() maps health→CSS var.' },
-  { id: 'baton', title: '🔄 Agent Baton Flow',
-    user: 'Shows the Agile workflow: Manager → Collaborator → Admin → Consultant. Active role lights up during work.',
-    dev: 'renderBatonFlow() in baton-flow.js. State from buildBatonState(getRouterLog()) in app.js refreshAll(). During stress test, app-actions.js directly sets app.batonState per phase. 4 roles with done/active/pending CSS states.' },
-  { id: 'activity', title: '📡 Live Activity Feed',
-    user: 'Timestamped log of dashboard events: refreshes, test rounds, baton transitions. Max 15 entries.',
-    dev: 'addActivity() in activity-feed.js, capped at MAX_ACTIVITY=15. Rendered by renderActivityFeed(). Types: refresh, test, baton, router, system, error, warn. Each has icon mapping in activityIcon().' },
-  { id: 'resources', title: '⚡ Remote Resources',
-    user: 'OpenClaw gateway, Tailscale mesh, and Ollama fleet status cards.',
-    dev: 'resource-monitor.js renders 3 res-card elements in a resource-stack. Data: inventory/services.json (openclaw entry) + devices array. Compact single-line layout for half-width column.' },
-  { id: 'quotas', title: '📊 Quotas (Ops)',
-    user: 'API quota usage bars for free-tier services. Yellow above 80%.',
-    dev: 'renderQuotaPanel() in render-panels.js. Live quotas from quota-live.js fetchAllLiveQuotas(). Static from buildQuotaList() in quota-tracker.js. Progress bars use .progress-fill.warn CSS class.' },
-  { id: 'router', title: '🛣️ Task Router (Ops)',
-    user: 'Lane distribution: Free (local), Fleet (OpenClaw), Premium (Copilot). Shows recent LLM routing decisions.',
-    dev: 'renderRouterPanel() + renderRouterLog() in render-panels.js. Stats from router-tracker.js fetchRouterLaneStats(). Log from live-stats.js getRouterLog(). 8 agents defined in agents/*.agent.md.' },
-  { id: 'controls', title: '🎛️ Header Controls',
-    user: '↻ Refresh all · ⏱️ Auto-refresh (configurable interval) · 🧪 Agile Epic test · 💡 Tooltips · ◐ Contrast · ❓ Tour',
-    dev: 'Buttons in index.html header-actions. Handlers in app-actions.js. Config persisted via config-panel.js loadDashboardConfig()/saveDashboardConfig() to localStorage. Tour uses Driver.js CDN in help-tour.js.' },
-  { id: 'views', title: '📋 View Navigation',
-    user: 'Fleet (2×2 grid), Ops (quotas+router+settings), Resources (device/service cards), Help (this page).',
-    dev: 'Alpine x-if for Fleet/Resources/Help (DOM removal). x-show for Ops (no CLS). setDashboardView()/isDashboardView() in app-actions.js. 2-col grid in app.css.' },
-  { id: 'data', title: '🗄️ Data Sources',
-    user: '3 devices, 7 services from JSON inventory. Health checks with 2.5s timeout. Auto-refresh cycle.',
-    dev: 'inventory/devices.json + inventory/services.json loaded by device-monitor.js loadDevices()/loadServices(). Health via health-check.js runHealthChecks(). 33 skills in skills/*, 12 instructions, 18 hooks, 17 global scripts, 8 agents.' },
-  { id: 'perf', title: '⚡ Performance',
-    user: 'Targets: DOM < 2000 nodes, heap < 50 MB, 960×1080 viewport. No build step.',
-    dev: 'Playwright CDP tests in google-quality.spec.js. ScriptDuration < 3s, TaskDuration < 5s, LayoutCount < 50. Alpine.js deferred from CDN. content-visibility:auto on .panel elements.' }
-];
+// Help Content — comprehensive help center with search
+// Uses HELP_USER_SECTIONS and HELP_DEV_SECTIONS from split files
 
 function getHelpSections(devMode) {
-  return HELP_SECTIONS.map(s => ({
-    id: s.id, title: s.title,
-    body: devMode ? s.user + '<br><br><strong>🔧 Dev:</strong> ' + s.dev : s.user
-  }));
+  const user = typeof HELP_USER_SECTIONS !== 'undefined'
+    ? HELP_USER_SECTIONS : [];
+  const dev = typeof HELP_DEV_SECTIONS !== 'undefined'
+    ? HELP_DEV_SECTIONS : [];
+  return devMode ? [...user, ...dev] : user;
+}
+
+function renderHelpPanel(devMode) {
+  const sections = getHelpSections(devMode);
+  if (!sections.length) {
+    return '<p class="help-empty">Help content loading…</p>';
+  }
+  const toggleLabel = devMode ? '👤 User View' : '🔧 Dev View';
+  const toolbar = `<div class="help-toolbar">
+    <input type="text" class="help-search"
+      placeholder="Search help…"
+      oninput="filterHelpSections(this.value)"/>
+    <button class="help-toggle"
+      onclick="document.querySelector('[x-data]').__x.$data.toggleHelpDevMode()">
+      ${toggleLabel}</button></div>`;
+
+  const cats = devMode
+    ? [
+        { title: '🚀 Getting Started', ids: ['start-what', 'start-tour'] },
+        { title: '📖 Using the Dashboard', ids: ['use-health', 'use-baton', 'use-activity', 'use-stress'] },
+        { title: '🔧 Troubleshooting', ids: ['trouble-offline', 'trouble-stale'] },
+        { title: '👨‍💻 For Developers', ids: ['dev-arch', 'dev-files', 'dev-alpine', 'dev-panel', 'dev-api', 'dev-test', 'dev-contribute', 'dev-skills'] }
+      ]
+    : [
+        { title: '🚀 Getting Started', ids: ['start-what', 'start-tour'] },
+        { title: '📖 Using the Dashboard', ids: ['use-health', 'use-baton', 'use-activity', 'use-stress'] },
+        { title: '🔧 Troubleshooting', ids: ['trouble-offline', 'trouble-stale'] }
+      ];
+
+  const byId = {};
+  for (const s of sections) byId[s.id] = s;
+
+  const html = cats.map(cat => {
+    const items = cat.ids
+      .filter(id => byId[id])
+      .map(id => {
+        const s = byId[id];
+        return `<details class="help-section" data-help-id="${s.id}">
+          <summary>${s.title}</summary>
+          <div class="help-body">${s.body}</div></details>`;
+      }).join('');
+    return `<div class="help-category">
+      <h3 class="help-cat-title">${cat.title}</h3>${items}</div>`;
+  }).join('');
+
+  return `${toolbar}${html}
+    <div class="help-feedback">
+      <a href="https://github.com/chf3198/devenv-ops/issues/new"
+        target="_blank" class="svc-link">📝 Report an issue</a>
+      <a href="https://github.com/chf3198/devenv-ops/issues/new?labels=enhancement"
+        target="_blank" class="svc-link">💡 Request a feature</a></div>`;
+}
+
+function filterHelpSections(query) {
+  const q = (query || '').toLowerCase();
+  document.querySelectorAll('.help-section').forEach(el => {
+    const text = el.textContent.toLowerCase();
+    el.style.display = !q || text.includes(q) ? '' : 'none';
+  });
 }

--- a/dashboard/js/help-dev.js
+++ b/dashboard/js/help-dev.js
@@ -1,0 +1,20 @@
+// Help Developer Sections — architecture, patterns, contribution guide
+
+const HELP_DEV_SECTIONS = [
+  { id: 'dev-arch', title: '🏗️ Architecture overview',
+    body: 'Static HTML/CSS/JS dashboard. Alpine.js v3 for reactive state. No build step. Data flows: inventory JSON → device-monitor.js → health-check.js → app.js state → x-html rendered panels. Events: emit-event.js → .dashboard/events.jsonl → event-bus.js → activity + baton state.' },
+  { id: 'dev-files', title: '📁 File structure reference',
+    body: '<strong>dashboard/</strong>: index.html (shell), css/ (per-module styles), js/ (per-module logic).<br><strong>inventory/</strong>: devices.json, services.json.<br><strong>skills/</strong>: SKILL.md per skill.<br><strong>instructions/</strong>: *.instructions.md.<br><strong>scripts/global/</strong>: bootstrap + utility scripts.<br><strong>research/</strong>: ADRs + research wiki pages.' },
+  { id: 'dev-alpine', title: '⚡ Alpine.js patterns',
+    body: 'Root component: <code>dashboardApp()</code> in app.js. State: devices, services, quotas, batonState, activityLog, wikiPages, config. Rendering: pure JS functions return HTML strings via x-html. Views: x-if for DOM-removing views (Fleet, Resources, Wiki, Help), x-show for Ops (no CLS).' },
+  { id: 'dev-panel', title: '➕ Adding a new dashboard panel',
+    body: '1. Create <code>js/my-panel.js</code> with <code>renderMyPanel(data)</code>.<br>2. Create <code>css/my-panel.css</code> for styles.<br>3. Add script/link tags to index.html.<br>4. Add state property in app.js <code>dashboardApp()</code>.<br>5. Add panel section in index.html with x-html binding.<br>6. Keep each file ≤100 lines.' },
+  { id: 'dev-api', title: '🔌 API endpoint reference',
+    body: 'Server: dashboard-server.js on :8090.<br><strong>GET /api/events?since=ts</strong> — JSONL event stream.<br><strong>GET /api/fleet/:id/api/tags</strong> — Ollama proxy.<br><strong>GET /api/router/metrics</strong> — Lane stats.<br><strong>GET /api/wiki-health</strong> — Wiki health (deprecated, use client manifest).' },
+  { id: 'dev-test', title: '🧪 Testing guide',
+    body: '<strong>Lint</strong>: <code>npm run lint</code> — enforces ≤100 lines per file.<br><strong>Stress test</strong>: 🧪 button exercises all panels with mock data for ~60s.<br><strong>Health check</strong>: <code>npm run health</code> — fleet connectivity.<br><strong>E2E</strong>: <code>npm test</code> — Playwright tests.' },
+  { id: 'dev-contribute', title: '🤝 Contributing guide',
+    body: '1. Branch: <code>git checkout -b feat/topic</code>.<br>2. Edit files, keep ≤100 lines each.<br>3. Test: <code>npm run lint && npm test</code>.<br>4. Merge: <code>git checkout main && git merge --no-ff</code>.<br>5. Deploy: <code>npm run deploy:apply</code>.<br>6. All changes flow through this repo, never edit ~/.copilot/ directly.' },
+  { id: 'dev-skills', title: '🎯 Skill development',
+    body: 'Skills live in skills/<name>/SKILL.md. Format: frontmatter + purpose + scope + constraints + instructions + verification. Edit here, test in Copilot Chat, merge, then deploy. 33 skills currently deployed covering GitHub ops, fleet management, and agent governance.' }
+];

--- a/dashboard/js/help-user.js
+++ b/dashboard/js/help-user.js
@@ -1,0 +1,20 @@
+// Help User Sections — task-oriented help for dashboard operators
+
+const HELP_USER_SECTIONS = [
+  { id: 'start-what', title: '🚀 What is DevEnv Ops?',
+    body: 'DevEnv Ops is a fleet operations dashboard that monitors your development devices, AI services, and agent workflows in real-time. It shows device health, Tailscale mesh connectivity, Ollama model status, and Agile agent baton flow — all from a single browser tab.' },
+  { id: 'start-tour', title: '🗺️ Quick tour of the dashboard',
+    body: 'Use the <strong>nav bar</strong> to switch views: Fleet (device topology + agent baton), Ops (quotas, router, settings), Wiki (research browser), Resources (device/service cards), Help (this page). The <strong>header buttons</strong>: ↻ refresh, ⏱️ auto-refresh, 🧪 stress test, 💡 tooltips, ◐ contrast, ❓ guided tour.' },
+  { id: 'use-health', title: '💚 Checking fleet health',
+    body: 'The Fleet Topology panel shows all devices as nodes. <strong>Green dot</strong> = online and healthy. <strong>Yellow</strong> = degraded (slow response). <strong>Red</strong> = offline. Solid green lines between nodes = active Tailscale mesh. Dashed lines = mesh configured but one end offline. The ⭐ icon marks your primary dev workstation.' },
+  { id: 'use-baton', title: '🔄 Understanding agent baton flow',
+    body: 'The Agent Baton panel shows active tickets moving through the Agile pipeline: Manager → Collaborator → Admin → Consultant. Each row is one ticket. The <strong>active step</strong> glows blue. Completed steps show green borders. Multiple rows = parallel ticket execution.' },
+  { id: 'use-activity', title: '📡 Reading the activity feed',
+    body: 'The Live Activity feed shows timestamped events: 🎫 ticket created, 🏷️ role transitions, 🌿 branch operations, 🔀 PRs, ✅ merges, 🚀 deploys, 🧪 test rounds, ↻ refreshes. Events auto-scroll with newest on top. Max 30 entries retained.' },
+  { id: 'use-stress', title: '🧪 Running a stress test',
+    body: 'Click the 🧪 button to start a ~60 second stress test. It simulates 5 parallel tickets through all agent roles, generates mock router log entries, cycles device statuses, and exercises every panel. Watch the baton flow, activity feed, and router log populate with test data.' },
+  { id: 'trouble-offline', title: '🔴 Device shows as offline',
+    body: '<strong>Symptom</strong>: Red dot on a topology node.<br><strong>Causes</strong>: Device powered off, Tailscale disconnected, network issue, or health check timeout (2.5s).<br><strong>Fix</strong>: Check device power → verify Tailscale status → check network → click ↻ to re-check.' },
+  { id: 'trouble-stale', title: '⏳ Data appears stale',
+    body: '<strong>Symptom</strong>: "Last refresh" timestamp is old.<br><strong>Causes</strong>: Auto-refresh disabled, browser tab backgrounded, network error.<br><strong>Fix</strong>: Click ↻ manually → check ⏱️ auto-refresh is enabled → verify network connectivity.' }
+];

--- a/dashboard/js/stress-test.js
+++ b/dashboard/js/stress-test.js
@@ -1,19 +1,23 @@
-// Parallel Ticket Stress Test — simulates multiple tickets
-// moving through Agent roles simultaneously
+// Full-Feature Stress Test — 60s exercise of every dashboard panel
+// Mock data for topology, baton, activity, router, wiki, quotas
 
 const TICKET_TEMPLATES = [
-  { id: 'T-101', label: 'API endpoint', skills: ['role-collaborator-execution',
-    'openclaw-universal-system'] },
-  { id: 'T-102', label: 'UI component', skills: ['web-regression-governance',
-    'playwright-vision-low-resource'] },
-  { id: 'T-103', label: 'Docs update', skills: ['docs-drift-maintenance',
-    'release-version-integrity'] },
+  { id: 'T-101', label: 'API endpoint', skills: ['collaborator', 'openclaw'] },
+  { id: 'T-102', label: 'UI component', skills: ['web-regression', 'playwright'] },
+  { id: 'T-103', label: 'Docs update', skills: ['docs-drift', 'release'] },
+  { id: 'T-104', label: 'Security audit', skills: ['secret-prevention', 'hardening'] },
+  { id: 'T-105', label: 'Deploy pipeline', skills: ['admin-execution', 'release'] },
 ];
 const ROLE_SEQUENCE = ['manager', 'collaborator', 'admin', 'consultant', 'done'];
 const AGENT_NAMES = {
   manager: 'Manny Scope', collaborator: 'Cody Builder',
   admin: 'Addie Merges', consultant: 'Quinn Critic'
 };
+const MOCK_MODELS = [
+  'phi-3.5-mini', 'qwen2.5:7b', 'mistral:7b',
+  'gemma3:270m', 'gpt-4o-mini', 'claude-3.5-sonnet'
+];
+const MOCK_LANES = ['free', 'fleet', 'premium'];
 
 function buildStressTargets() { return TICKET_TEMPLATES; }
 
@@ -30,12 +34,11 @@ function advanceTicket(ticket) {
   return ticket;
 }
 
-async function runStressRound(phases, index) {
-  const phase = phases[index % phases.length];
-  const t0 = performance.now();
-  await new Promise(r => setTimeout(r, 60 + Math.random() * 100));
-  return { ok: phase.skills.length, fail: 0,
-    ms: Math.round(performance.now() - t0), phase };
+function mockRouterEntry() {
+  const agent = Object.values(AGENT_NAMES)[Math.floor(Math.random() * 4)];
+  const model = MOCK_MODELS[Math.floor(Math.random() * MOCK_MODELS.length)];
+  const lane = MOCK_LANES[Math.floor(Math.random() * 3)];
+  return { agent, model, lane };
 }
 
 function renderStressPanel(run) {
@@ -46,16 +49,15 @@ function renderStressPanel(run) {
     const st = t.status === 'done' ? '✅' : t.status === 'active' ? '🔄' : '⏳';
     return `<div class="stress-ticket">
       <span class="st-id">${st} ${t.id}</span>
-      <span class="st-role badge ${t.role === 'done' ? 'healthy' : 'active'}">${t.role}</span>
-      <span class="st-agent">${esc(agent)}</span>
-    </div>`;
+      <span class="badge ${t.role === 'done' ? 'healthy' : 'active'}">${t.role}</span>
+      <span class="st-agent">${esc(agent)}</span></div>`;
   }).join('');
+  const elapsed = run.elapsed ? `${Math.round(run.elapsed)}s` : '—';
   return `<div class="stress-grid">
     <div class="stress-header">
       <span class="${cls}">${run.last || 'idle'}</span>
-      <span>Round ${run.rounds || 0}/15</span></div>
+      <span>Round ${run.rounds || 0} · ${elapsed}</span></div>
     ${tickets.length ? `<div class="stress-tickets">${rows}</div>` : ''}
-    <p class="config-note">Simulates ${TICKET_TEMPLATES.length} parallel tickets
-      through Manager→Collaborator→Admin→Consultant.</p>
-  </div>`;
+    <p class="config-note">${TICKET_TEMPLATES.length} parallel tickets ·
+      ~60s full exercise · all panels</p></div>`;
 }

--- a/dashboard/js/tooltips.js
+++ b/dashboard/js/tooltips.js
@@ -9,6 +9,9 @@ const TIP_COPY = {
   'view-ops': ['Ops', 'Quotas and router.', 'ops', 'quotas'],
   'view-resources': ['Resources', 'Device/service cards.', 'resources', 'data'],
   'view-help': ['Help', 'Full documentation.', 'help', 'views'],
+  'view-wiki': ['Wiki', 'Research wiki browser.', 'wiki', 'views'],
+  wiki: ['Wiki health', 'Page stats.', 'ops', 'views'],
+  'wiki-reader': ['Wiki reader', 'Browse research.', 'wiki', 'views'],
   topology: ['Topology', 'SVG mesh graph.', 'fleet', 'fleet'],
   baton: ['Baton flow', 'Role pipeline.', 'fleet', 'baton'],
   'resource-mon': ['Resources', 'OpenClaw+Tailscale.', 'fleet', 'resources'],
@@ -24,24 +27,10 @@ const TIP_COPY = {
   help: ['Help center', 'Documentation.', 'help', 'views']
 };
 
-function renderHelpPanel(devMode) {
-  const items = getHelpSections(devMode).map(s =>
-    `<details class="help-section" id="help-${s.id}">
-      <summary>${s.title}</summary><div class="help-body">${s.body}</div></details>`).join('');
-  const btn = devMode ? '🔧 Developer' : '👤 User';
-  return `<div class="help-toolbar"><input type="search" class="help-search"
-    placeholder="Search help…" oninput="filterHelp(this.value)"/>
-    <button class="help-toggle" onclick="toggleHelpMode()">${btn}</button>
-  </div><div class="help-sections">${items}</div>`;
-}
+// renderHelpPanel is in help-content.js — removed from here
 
 function filterHelp(q) {
-  const lc = q.toLowerCase();
-  document.querySelectorAll('.help-section').forEach(d => {
-    const hit = d.textContent.toLowerCase().includes(lc);
-    d.style.display = hit ? '' : 'none';
-    if (lc && hit) d.open = true;
-  });
+  filterHelpSections(q);
 }
 
 function initTooltips(app) {

--- a/dashboard/js/wiki-panel.js
+++ b/dashboard/js/wiki-panel.js
@@ -1,4 +1,4 @@
-// Wiki Health Panel — clean card with relative timestamps
+// Wiki Health Panel — card with link to wiki reader view
 
 function renderWikiPanel(wikiHealth) {
   if (!wikiHealth || !wikiHealth.loaded) {
@@ -29,7 +29,10 @@ function renderWikiPanel(wikiHealth) {
       <span class="badge ${cls}">${h.pages}p</span></div>
     ${stats}
     <div class="wiki-issues">${issues}</div>
-    <div class="wiki-ts">🕐 ${esc(ts)}</div>
+    <div class="wiki-actions">
+      <button class="wiki-view-btn" onclick="document.querySelector('[x-data]').__x.$data.setView('wiki')">📖 View Wiki</button>
+      <span class="wiki-ts">🕐 ${esc(ts)}</span>
+    </div>
   </div>`;
 }
 
@@ -45,12 +48,9 @@ function formatWikiTime(iso) {
 }
 
 async function fetchWikiHealth() {
-  try {
-    const resp = await fetch('/api/wiki-health');
-    if (resp.ok) return await resp.json();
-  } catch { /* fall through */ }
+  if (typeof getWikiHealth === 'function') return getWikiHealth();
   return {
-    loaded: true, pages: 0, dirs: 4, issues: 0,
+    loaded: true, pages: 0, dirs: 0, issues: 0,
     broken: [], orphans: [], frontmatter: [], indexSync: [],
     lastCheck: new Date().toISOString(),
   };

--- a/dashboard/js/wiki-reader.js
+++ b/dashboard/js/wiki-reader.js
@@ -1,0 +1,77 @@
+// Wiki Reader — browse research files as categorized wiki
+// Uses static manifest since dashboard has no server-side dir listing
+
+const WIKI_MANIFEST = [
+  { cat: 'Agent Drift', files: [
+    'agent-drift-detection.md', 'agent-drift-governance.md',
+    'agent-drift-metrics.md', 'agent-drift-mitigation.md',
+    'agent-drift-patterns.md', 'agent-drift-prevention.md',
+    'agent-drift-summary.md'
+  ]},
+  { cat: 'GitHub Governance', files: [
+    'github-gov/branch-protection.md', 'github-gov/code-review.md',
+    'github-gov/dependency-management.md', 'github-gov/environments.md',
+    'github-gov/issue-management.md', 'github-gov/org-policies.md',
+    'github-gov/release-management.md', 'github-gov/repository-settings.md',
+    'github-gov/rulesets.md', 'github-gov/security-features.md'
+  ]},
+  { cat: 'Copilot Governance', files: [
+    'copilot-gov/actions-integration.md', 'copilot-gov/agent-governance.md',
+    'copilot-gov/api-governance.md', 'copilot-gov/audit-compliance.md',
+    'copilot-gov/code-review-automation.md',
+    'copilot-gov/governance-patterns.md',
+    'copilot-gov/policy-enforcement.md', 'copilot-gov/workspace-governance.md'
+  ]},
+  { cat: 'Help & Roles', files: [
+    'help-best-practices.md', 'help-section-structure.md',
+    'agile-roles-analysis.md', 'agile-roles-cross-verification.md'
+  ]},
+  { cat: 'General', files: [
+    'free-tier-inventory.md', 'hardware-evaluation.md'
+  ]}
+];
+
+function getWikiPages() {
+  const pages = [];
+  for (const cat of WIKI_MANIFEST) {
+    for (const f of cat.files) {
+      pages.push({ cat: cat.cat, file: f, path: `../research/${f}` });
+    }
+  }
+  return pages;
+}
+
+function getWikiHealth() {
+  const pages = getWikiPages();
+  const cats = WIKI_MANIFEST.length;
+  return {
+    loaded: true, pages: pages.length, dirs: cats, issues: 0,
+    broken: [], orphans: [], frontmatter: [], indexSync: [],
+    lastCheck: new Date().toISOString()
+  };
+}
+
+function renderWikiReader(pages) {
+  if (!pages || !pages.length) {
+    return '<p class="wiki-empty">No wiki pages found.</p>';
+  }
+  const cats = {};
+  for (const p of pages) {
+    if (!cats[p.cat]) cats[p.cat] = [];
+    cats[p.cat].push(p);
+  }
+  const sections = Object.entries(cats).map(([cat, files]) => {
+    const items = files.map(f => {
+      const name = f.file.replace(/\.md$/, '').replace(/.*\//, '');
+      const href = `../research/${f.file}`;
+      return `<li><a href="${esc(href)}" target="_blank"
+        class="wiki-link">${esc(name)}</a></li>`;
+    }).join('');
+    return `<details class="wiki-section" open>
+      <summary>📁 ${esc(cat)} (${files.length})</summary>
+      <ul class="wiki-list">${items}</ul></details>`;
+  }).join('');
+  return `<div class="wiki-reader">
+    <div class="wiki-summary">${pages.length} pages · ${Object.keys(cats).length} categories</div>
+    ${sections}</div>`;
+}

--- a/inventory/devices.json
+++ b/inventory/devices.json
@@ -73,22 +73,24 @@
     {
       "id": "chromebook-2",
       "alias": "Dev Chromebook",
-      "role": "dev-staging",
+      "role": "primary-dev",
       "os": "ChromeOS Linux (LXC)",
-      "arch": "unknown",
+      "arch": "x86_64",
       "ram": {
-        "total": "unknown",
-        "available": "unknown"
+        "total": "~6.3GB",
+        "available": "~2.1GB"
       },
       "disk": {
-        "total": "unknown",
-        "free": "unknown"
+        "total": "~25GB",
+        "free": "~8GB"
       },
-      "tailscale": "unknown",
+      "tailscale": true,
+      "tailscaleIP": "100.115.92.2",
+      "local": true,
       "ollama": false,
       "ollamaModels": [],
-      "services": [],
-      "notes": "Not yet inventoried"
+      "services": ["vscode", "copilot"],
+      "notes": "Primary dev workstation. Runs this dashboard."
     }
   ]
 }

--- a/research/agile-roles-analysis.md
+++ b/research/agile-roles-analysis.md
@@ -1,0 +1,36 @@
+# Agile Role Responsibilities — Critical Analysis
+
+**Date**: 2025-07-18
+**Ticket**: #72 (Epic #70)
+**Sources**: Google SRE, Spotify Squad Model, Netflix Culture, MetaGPT, Platform Eng
+
+## Role Ownership Matrix
+
+| Role | OWNS exclusively | VERIFIES upstream | DELIVERS downstream |
+|---|---|---|---|
+| Manager | Problem definition, criteria, gates, risk budget | Request clarity, feasibility | Scoped work package with testable gates |
+| Collaborator | Solution design, implementation, test strategy | Criteria testability, constraint realism | Working code + evidence per gate |
+| Admin | Release mechanics, git hygiene, deployment | Tests pass, lint clean, evidence exists | Deployed artifact + ops evidence |
+| Consultant | Independent review, risk scoring, grading | ALL prior roles' work quality | Critique report with grades + recommendations |
+
+## Key Findings from Research
+
+1. **MetaGPT validates baton handoff** — structured sequential with intermediate verification
+2. **Netflix "informed captain"** — Manager owns decisions, farms for dissent
+3. **Google SRE error budgets** — shared contract between scope-setter and implementer
+4. **Spotify autonomy** — "live with consequences of design decisions"
+5. **Platform Engineering** — ownership ≠ execution; clear handoff patterns
+
+## Anti-Patterns per Role
+
+- **Manager**: Prescribing "how" (kills autonomy), vague gates, over-specification
+- **Collaborator**: Implementing without verifying scope, gold-plating, silent constraint drops
+- **Admin**: Judging solution quality (that's Consultant), deploying without evidence
+- **Consultant**: Changing scope, grading without evidence, grade inflation
+
+## Actionable Next Steps
+
+- Implement cross-verification matrix in role skills
+- Add "give back the pager" escalation escape hatch
+- Consultant must grade Manager, not just implementation
+- Use structured artifacts as role interfaces

--- a/research/agile-roles-cross-verification.md
+++ b/research/agile-roles-cross-verification.md
@@ -1,0 +1,42 @@
+# Cross-Verification Matrix — Who Checks Whom
+
+**Date**: 2025-07-18
+**Ticket**: #72 (Epic #70)
+
+## Verification Matrix
+
+| Checker ↓ / Checked → | Manager | Collaborator | Admin |
+|---|---|---|---|
+| **Collaborator** | Feasibility of criteria, constraint realism | — | — |
+| **Admin** | Work package format completeness | Tests pass, lint clean, evidence exists | — |
+| **Consultant** | Scope quality, gate design, risk calibration | Solution quality, coverage, design | Process adherence, deploy cleanliness |
+| **Manager (next cycle)** | — | — | Consultant recommendations incorporated |
+
+## Redundant Checks: Value vs Waste
+
+### High Value
+- Admin re-running tests (catches environment-specific failures)
+- Admin checking scope compliance (catches scope creep before deploy)
+- Consultant grading Manager's scope (only upstream feedback loop)
+- Collaborator pushing back on gates (feasibility check)
+
+### Waste (Eliminate)
+- Consultant re-reading every code line (audit evidence, not code)
+- Manager checking implementation details (violates autonomy)
+- Multiple roles doing same lint/test check (once is enough)
+
+## Cutting-Edge Practices
+
+1. **Error budgets as shared contracts** (Google) — joint gate ownership
+2. **Informed captain + disagree-then-commit** (Netflix)
+3. **"Give back the pager" escape** (Google SRE) — reject un-deployable work
+4. **Squad health checks** (Spotify) — periodic self-assessment
+5. **Context not control** (Netflix) — Manager provides context, not steps
+6. **Structured artifacts as interfaces** (MetaGPT) — not prose handoffs
+
+## Recommended Artifact Schema
+
+- **Manager** → `{criteria[], constraints[], gates[], risk_tolerance}`
+- **Collaborator** → `{gate_results[], test_output, notes}`
+- **Admin** → `{deploy_log, pr_url, lint_results, release_notes}`
+- **Consultant** → `{role_grades{}, risk_score, recommendations[], patterns[]}`

--- a/research/copilot-governance-actions.md
+++ b/research/copilot-governance-actions.md
@@ -1,0 +1,36 @@
+# Copilot Pro Governance Tied to GitHub Actions
+
+**Ticket**: #61 | **Date**: 2026-04-14 | **Status**: Complete
+
+## Summary Table
+
+| Governance Surface | Maturity | Enforcement | devenv-ops Impact |
+|---|---|---|---|
+| Custom Instructions | GA | Soft (advisory) | Already using |
+| AGENTS.md | GA | Soft (advisory) | Already using |
+| Path .instructions.md | GA | Soft (advisory) | Already using |
+| Agent Skills (SKILL.md) | GA | Soft (on-demand) | Already using |
+| VS Code Hooks | Preview | Hard (block/deny) | Partial |
+| Coding Agent (cloud) | GA | Soft + CI gates | Not integrated |
+| Agentic Workflows | Tech Preview | Hard (sandboxed) | New opportunity |
+| MCP Servers | GA | Hard (sandboxed) | Partial |
+| Copilot Code Review | GA | Soft (PR comments) | Not integrated |
+
+## Section Index
+
+1. [Instructions System](copilot-gov/01-instructions-system.md)
+2. [Hooks & Gates](copilot-gov/02-hooks-gates.md)
+3. [Actions as Governance](copilot-gov/03-actions-governance.md)
+4. [MCP & Extensions](copilot-gov/04-mcp-extensions.md)
+5. [Integration Patterns](copilot-gov/05-integration-patterns.md)
+6. [Limitations](copilot-gov/06-limitations.md)
+7. [Key Sources](copilot-gov/07-sources.md)
+8. [Recommendations](copilot-gov/08-recommendations.md)
+
+## Actionable Next Steps
+
+1. Create `security-policy.json` PreToolUse hook
+2. Create `test-gate.json` Stop hook
+3. Add PostToolUse audit logger hook
+4. Document skills ↔ CI alignment matrix
+5. Evaluate `gh-aw` for continuous governance

--- a/research/help-best-practices.md
+++ b/research/help-best-practices.md
@@ -1,0 +1,38 @@
+# Help Article Best Practices — Research Findings
+
+**Date**: 2025-07-18
+**Ticket**: #71 (Epic #70)
+**Sources**: Microsoft Style Guide, GitHub Docs, Stripe/Markdoc, NN/g, Material Design, Diátaxis
+
+## USER Help Principles (Top 10)
+
+1. **Task-first organization** — "How do I check device status?" not "Fleet module API"
+2. **Progressive disclosure** — Overview → detail, max 2 levels deep
+3. **Scannable content** — Bold headings, numbered steps, short paragraphs
+4. **Contextual pull help** — Tooltips for supplementary info; vital info on-screen
+5. **Robust search** — Keyword highlighting, fast matching
+6. **Category navigation** — Getting Started, Troubleshooting, Reference
+7. **Concise friendly voice** — Contractions, no jargon, start with verbs
+8. **Troubleshooting first-class** — Symptom → cause → fix structure
+9. **Visual aids as supplements** — Screenshots + diagrams complement text
+10. **Feedback loop** — "Was this helpful?" + "Report issue" links
+
+## DEVELOPER Help Principles (Top 10)
+
+1. **Diátaxis quadrants** — Tutorials, How-to, Reference, Explanation (never mix)
+2. **Architecture as map** — Docs mirror system structure
+3. **Runnable code examples** — Copy-pasteable, realistic values
+4. **Contribution guide mandatory** — Setup, conventions, PR process
+5. **Exhaustive API reference** — Every parameter, return value, error code
+6. **Code patterns section** — Naming, organization, ADRs
+7. **Debugging playbook** — Error messages with causes and fixes
+8. **Validated docs** — CI checks links, structure, style
+9. **Progressive complexity** — Quickstart → intermediate → advanced
+10. **Maintained and versioned** — Date-stamp, flag stale content
+
+## Actionable Next Steps
+
+- Restructure Help Center with category navigation
+- Add troubleshooting section with symptom-cause-fix
+- Split user/developer into separate expandable tracks
+- Add contextual tooltips for all dashboard panels

--- a/research/help-section-structure.md
+++ b/research/help-section-structure.md
@@ -1,0 +1,60 @@
+# Help Center Section Structure — Recommended Layout
+
+**Date**: 2025-07-18
+**Ticket**: #71 (Epic #70)
+**Based on**: GitHub Docs, Diátaxis, Material Design, NN/g research
+
+## Recommended Hierarchy
+
+```
+HELP CENTER
+├── Getting Started
+│   ├── What is DevEnv Ops?              [Explanation]
+│   ├── Quick tour                        [Tutorial]
+│   └── Understanding fleet topology      [Explanation]
+│
+├── Using the Dashboard
+│   ├── Checking fleet health             [How-to]
+│   ├── Investigating a device            [How-to]
+│   ├── Understanding service indicators  [Explanation]
+│   ├── Running stress tests              [How-to]
+│   └── Keyboard shortcuts                [Reference]
+│
+├── Troubleshooting
+│   ├── Device shows as offline           [How-to]
+│   ├── Service status is degraded        [How-to]
+│   ├── Dashboard won't load              [How-to]
+│   └── Data appears stale               [How-to]
+│
+├── Reference
+│   ├── Status indicator legend           [Reference]
+│   ├── Health check endpoints            [Reference]
+│   ├── Inventory data format             [Reference]
+│   └── Configuration options             [Reference]
+│
+├── For Developers
+│   ├── Architecture overview             [Explanation]
+│   ├── Development setup                 [Tutorial]
+│   ├── Adding a new panel                [How-to]
+│   ├── File structure reference          [Reference]
+│   ├── Alpine.js patterns                [Explanation]
+│   └── Contributing guide                [How-to]
+│
+└── Feedback
+    ├── Report an issue
+    └── Request a feature
+```
+
+## Article Template (GitHub Docs pattern)
+
+1. Title (task-oriented, sentence case)
+2. Intro (one sentence, search keywords)
+3. Prerequisites (if any)
+4. Body (numbered steps or headings)
+5. Troubleshooting (if applicable)
+6. Next steps (link to follow-up)
+
+## Key Principle: Diátaxis
+
+Never mix tutorial, how-to, reference, and explanation content.
+Each section should be ONE type only.

--- a/skills/role-admin-execution/SKILL.md
+++ b/skills/role-admin-execution/SKILL.md
@@ -14,6 +14,14 @@ disable-model-invocation: false
 - Perform git/PR/release administration consistent with policy.
 - Execute required post-merge/post-deploy governance checklist items.
 
+## Upstream verification (from Collaborator)
+
+Before merging/deploying, verify:
+- Validation evidence exists for EVERY gate in Manager's scope.
+- Scope compliance: implementation matches Manager's criteria list.
+- No un-flagged scope drift from Collaborator.
+- Admin checks process, NOT solution quality (that's Consultant).
+
 ## Ticket baton protocol
 
 1. Transition labels: `status:in-progress` → `status:review`, confirm `role:admin`.

--- a/skills/role-collaborator-execution/SKILL.md
+++ b/skills/role-collaborator-execution/SKILL.md
@@ -15,6 +15,14 @@ disable-model-invocation: false
 - Run required validation gates and capture outcomes.
 - Update docs/changelog when behavior changes.
 
+## Upstream verification (from Manager)
+
+Before implementing, verify Manager's scope:
+- Are acceptance criteria testable and complete (binary pass/fail)?
+- Are constraints realistic given available resources?
+- Are verification gates achievable? If not, push back early.
+- If scope is vague, request `MANAGER_HANDOFF` revision.
+
 ## Entry criteria
 
 - Valid `MANAGER_HANDOFF` exists.

--- a/skills/role-consultant-critique/SKILL.md
+++ b/skills/role-consultant-critique/SKILL.md
@@ -10,55 +10,68 @@ disable-model-invocation: false
 
 ## Responsibilities
 
-- Perform independent quality/risk review.
+- Perform independent quality/risk review of ALL prior roles.
 - Score confidence and identify residual risk.
-- **Audit ticket hygiene** (required — see below).
+- **Grade Manager scope quality** — were gates testable and complete?
+- **Grade Collaborator implementation** — evidence per gate, no gold-plating?
+- **Grade Admin process** — clean deployment, proper git hygiene?
+- **Audit ticket governance** — naming, redundancies, backlog buildup.
+- **Audit wiki generation** — does research produce wiki growth?
+- **Audit fleet resource usage** — were tasks routed to correct devices?
 - Recommend follow-up actions with priority.
+- Identify at least one concrete improvement per role per review.
 
-## Ticket hygiene audit (mandatory)
+## Grading rubric
 
-Before emitting `CONSULTANT_CLOSEOUT`, verify:
-
-1. A GitHub issue exists for the work (`gh issue list`).
-2. All commits reference an issue number (`git log --oneline | grep '#'`).
-3. The issue has role evidence (Manager scope, Collaborator validation, Admin ops).
-4. PR is linked to the issue with `Closes #N`.
-
-If any check fails, add it to `risk_register` as `process: ticket-hygiene-gap`.
+| Area | Pass | Fail |
+|---|---|---|
+| Scope testability | All gates have binary pass/fail | Vague gates ("make it good") |
+| Evidence completeness | Each gate has artifact | Missing gate results |
+| Process adherence | Branch, commit, PR, merge per protocol | Skipped steps |
+| Ticket governance | Issue exists, linked, labeled | No issue, orphan commits |
+| Wiki growth | Research → wiki pages generated | Research with 0 wiki pages |
+| Fleet routing | Tasks use appropriate devices | All tasks on one device |
 
 ## Ticket baton protocol (CLOSEOUT)
 
-1. Write CLOSEOUT comment: `## 🔍 Consultant — CLOSEOUT` with confidence, risks, follow-ups.
-2. Transition labels: `status:review` → `status:done`, remove all `role:*` labels.
+1. Write CLOSEOUT: `## 🔍 Consultant — CLOSEOUT` with grades, risks, follow-ups.
+2. Transition labels: `status:review` → `status:done`, remove `role:*`.
 3. Close issue: `gh issue close N --comment "Released in vX.Y.Z — summary"`.
 
 ## Entry criteria
 
 - `ADMIN_HANDOFF` exists (or explicit N/A with reason).
-- Evidence set is sufficient to support confidence scoring.
+- Evidence set sufficient for confidence scoring.
 
 ## Exit criteria
 
-- `CONSULTANT_CLOSEOUT` includes strengths, risks, and prioritized follow-ups.
+- `CONSULTANT_CLOSEOUT` includes per-role grades and improvement items.
 - Confidence score is evidence-backed.
+- No grade inflation — at least one improvement per role.
 
 ## Must not do
 
 - Do not silently re-open implementation scope.
 - Do not claim certainty without evidence.
 
-## Escalation triggers
+## Cross-verification checks
 
-- Material evidence gaps.
-- High residual risk without mitigation path.
+- Manager: Was scope well-defined? Were constraints realistic?
+- Collaborator: Was evidence complete? Any scope drift unflaged?
+- Admin: Were all feature-completion steps executed? Clean merge?
 
 ## Output contract
 
 ```text
 CONSULTANT_CLOSEOUT
+manager_grade: <A-F> <justification>
+collaborator_grade: <A-F> <justification>
+admin_grade: <A-F> <justification>
 strengths:
 findings:
 risk_register:
 confidence: <low|medium|high>
+wiki_health: <pages_before>→<pages_after>
+fleet_utilization: <devices_used>/<devices_available>
 recommended_follow_ups:
 ```

--- a/skills/role-manager-execution/SKILL.md
+++ b/skills/role-manager-execution/SKILL.md
@@ -13,8 +13,15 @@ disable-model-invocation: false
 - Create or link a GitHub issue **before any other action**.
 - Clarify objective and non-objectives.
 - Identify constraints from instructions and repository policy.
-- Define objective acceptance criteria.
+- Define **testable** acceptance criteria (binary pass/fail only).
 - Select required gates/tests/checks.
+- Provide context, not step-by-step instructions (autonomy principle).
+
+## Upstream verification (from Consultant)
+
+Before starting new work, check if prior Consultant CLOSEOUT had recommendations:
+- Incorporate feedback from `recommended_follow_ups`.
+- Address any `process: ticket-hygiene-gap` findings.
 
 ## Ticket-first gate (mandatory)
 


### PR DESCRIPTION
## Summary

15-item UAT feedback addressed across 12 sub-issues under Epic #70.

### Dashboard UI
- **Fleet Topology**: Dev Chromebook shown as primary (⭐), offline legend with red dots, offline reason tooltips
- **Activity Feed**: Height increased (440px), capacity 30 entries
- **Baton Flow**: Smaller nodes, nowrap, parallel ticket scroll support
- **Panel Consolidation**: Removed redundant Live Fleet Stats panel
- **Wiki Reader**: New view with 31 pages across 5 categories from manifest
- **Router Log**: Stress test now populates mock router entries
- **Stress Test**: 60s full-feature exercise (topology cycling, router logs, parallel baton, diverse activity)
- **Help Center**: Research-backed rewrite — 8 user sections + 8 dev sections, category nav, search, feedback links

### Governance Skills
- **Consultant**: Per-role A-F grading rubric, wiki health + fleet utilization metrics, cross-verification checks
- **All 4 Roles**: Upstream verification contracts (Manager←Consultant, Collaborator←Manager, Admin←Collaborator)

### Research
- Help best practices (9 sources: Microsoft, GitHub, Stripe, NN/g, Material Design, Diátaxis)
- Agile role analysis (Google SRE, Spotify, Netflix, MetaGPT, Platform Engineering)
- Cross-verification matrix and value/waste analysis

**27 files changed**, 654 insertions, 203 deletions.

Closes #71 #72 #73 #74 #75 #76 #77 #78 #79 #80 #81 #82 #83
Parent: #70