### PR TITLE
fix(dashboard): Real wiki health data replaces static manifest (#88)

### DIFF
--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -28,7 +28,7 @@ function dashboardApp() {
       document.body.classList.toggle('high-contrast', this.config.highContrast);
       this.tooltipsEnabled = !!this.config.tooltipsEnabled;
       initTooltips(this);
-      this.wikiPages = typeof getWikiPages === 'function' ? getWikiPages() : [];
+      this.wikiPages = typeof loadWikiPages === 'function' ? await loadWikiPages() : [];
       await this.loadInventory();
       await this.refreshAll();
       this.scheduleRefresh();

--- a/dashboard/js/wiki-panel.js
+++ b/dashboard/js/wiki-panel.js
@@ -48,10 +48,15 @@ function formatWikiTime(iso) {
 }
 
 async function fetchWikiHealth() {
-  if (typeof getWikiHealth === 'function') return getWikiHealth();
-  return {
-    loaded: true, pages: 0, dirs: 0, issues: 0,
-    broken: [], orphans: [], frontmatter: [], indexSync: [],
-    lastCheck: new Date().toISOString(),
-  };
+  try {
+    const r = await fetch('/api/wiki-health');
+    if (!r.ok) throw new Error(r.status);
+    return await r.json();
+  } catch {
+    return {
+      loaded: false, pages: 0, dirs: 0, issues: 0,
+      broken: [], orphans: [], frontmatter: [], indexSync: [],
+      lastCheck: null,
+    };
+  }
 }

--- a/dashboard/js/wiki-reader.js
+++ b/dashboard/js/wiki-reader.js
@@ -1,55 +1,17 @@
-// Wiki Reader — browse research files as categorized wiki
-// Uses static manifest since dashboard has no server-side dir listing
+// Wiki Reader — browse real wiki pages from /api/wiki-pages
 
-const WIKI_MANIFEST = [
-  { cat: 'Agent Drift', files: [
-    'agent-drift-detection.md', 'agent-drift-governance.md',
-    'agent-drift-metrics.md', 'agent-drift-mitigation.md',
-    'agent-drift-patterns.md', 'agent-drift-prevention.md',
-    'agent-drift-summary.md'
-  ]},
-  { cat: 'GitHub Governance', files: [
-    'github-gov/branch-protection.md', 'github-gov/code-review.md',
-    'github-gov/dependency-management.md', 'github-gov/environments.md',
-    'github-gov/issue-management.md', 'github-gov/org-policies.md',
-    'github-gov/release-management.md', 'github-gov/repository-settings.md',
-    'github-gov/rulesets.md', 'github-gov/security-features.md'
-  ]},
-  { cat: 'Copilot Governance', files: [
-    'copilot-gov/actions-integration.md', 'copilot-gov/agent-governance.md',
-    'copilot-gov/api-governance.md', 'copilot-gov/audit-compliance.md',
-    'copilot-gov/code-review-automation.md',
-    'copilot-gov/governance-patterns.md',
-    'copilot-gov/policy-enforcement.md', 'copilot-gov/workspace-governance.md'
-  ]},
-  { cat: 'Help & Roles', files: [
-    'help-best-practices.md', 'help-section-structure.md',
-    'agile-roles-analysis.md', 'agile-roles-cross-verification.md'
-  ]},
-  { cat: 'General', files: [
-    'free-tier-inventory.md', 'hardware-evaluation.md'
-  ]}
-];
+let _wikiPagesCache = [];
 
-function getWikiPages() {
-  const pages = [];
-  for (const cat of WIKI_MANIFEST) {
-    for (const f of cat.files) {
-      pages.push({ cat: cat.cat, file: f, path: `../research/${f}` });
-    }
-  }
-  return pages;
+async function loadWikiPages() {
+  try {
+    const r = await fetch('/api/wiki-pages');
+    if (!r.ok) return [];
+    _wikiPagesCache = await r.json();
+    return _wikiPagesCache;
+  } catch { return []; }
 }
 
-function getWikiHealth() {
-  const pages = getWikiPages();
-  const cats = WIKI_MANIFEST.length;
-  return {
-    loaded: true, pages: pages.length, dirs: cats, issues: 0,
-    broken: [], orphans: [], frontmatter: [], indexSync: [],
-    lastCheck: new Date().toISOString()
-  };
-}
+function getWikiPages() { return _wikiPagesCache; }
 
 function renderWikiReader(pages) {
   if (!pages || !pages.length) {
@@ -57,21 +19,30 @@ function renderWikiReader(pages) {
   }
   const cats = {};
   for (const p of pages) {
-    if (!cats[p.cat]) cats[p.cat] = [];
-    cats[p.cat].push(p);
+    const cat = p.type || 'unknown';
+    if (!cats[cat]) cats[cat] = [];
+    cats[cat].push(p);
   }
+  const typeLabel = {
+    entities: '📦 Entities', concepts: '💡 Concepts',
+    sources: '📄 Sources', syntheses: '🔬 Syntheses',
+  };
   const sections = Object.entries(cats).map(([cat, files]) => {
+    const label = typeLabel[cat] || `📁 ${cat}`;
     const items = files.map(f => {
-      const name = f.file.replace(/\.md$/, '').replace(/.*\//, '');
-      const href = `../research/${f.file}`;
-      return `<li><a href="${esc(href)}" target="_blank"
-        class="wiki-link">${esc(name)}</a></li>`;
+      const name = esc(f.title || f.slug);
+      return `<li class="wiki-link">${name}
+        <small class="wiki-tags">${(f.tags || []).map(
+        t => '<span class="wiki-tag">' + esc(t) + '</span>'
+      ).join('')}</small></li>`;
     }).join('');
     return `<details class="wiki-section" open>
-      <summary>📁 ${esc(cat)} (${files.length})</summary>
+      <summary>${label} (${files.length})</summary>
       <ul class="wiki-list">${items}</ul></details>`;
   }).join('');
+  const total = pages.length;
+  const catCount = Object.keys(cats).length;
   return `<div class="wiki-reader">
-    <div class="wiki-summary">${pages.length} pages · ${Object.keys(cats).length} categories</div>
+    <div class="wiki-summary">${total} pages · ${catCount} types</div>
     ${sections}</div>`;
 }

--- a/scripts/dashboard-server.js
+++ b/scripts/dashboard-server.js
@@ -54,6 +54,7 @@ async function handleApi(req, res) {
   }
   if (u === '/api/router/metrics') { try { const { getRouterMetrics } = require('./global/router-metrics'); return jsonRes(res,200,getRouterMetrics()); } catch(e){ return jsonRes(res,200,{timestamp:new Date().toISOString(),lanes:{free:0,fleet:0,premium:0}}); } }
   if (u === '/api/wiki-health') { return jsonRes(res, 200, getWikiHealth()); }
+  if (u === '/api/wiki-pages') { return jsonRes(res, 200, getWikiPages()); }
   if (u.startsWith('/api/events')) { const { readEvents } = require('./global/event-reader'); return jsonRes(res, 200, readEvents(u)); }
   jsonRes(res, 404, { error: 'not found' });
 }
@@ -85,6 +86,10 @@ function getWikiHealth() {
     issues: broken.length + orphans.length + fmIssues.length + idxIssues.length,
     broken, orphans, frontmatter: fmIssues, indexSync: idxIssues,
     lastCheck: new Date().toISOString() };
+}
+
+function getWikiPages() {
+  return require('./wiki-pages-api')(WIKI_DIR, WIKI_CATS);
 }
 
 http.createServer((req,res)=>{ if(req.url.startsWith('/api/')) return handleApi(req,res); serveStatic(req,res); }).listen(PORT,()=>{ console.log(`Dashboard: http://localhost:${PORT} Fleet: ${Object.keys(FLEET).join(', ')}`); });

--- a/scripts/wiki-pages-api.js
+++ b/scripts/wiki-pages-api.js
@@ -1,0 +1,25 @@
+// Wiki Pages API — return structured page list from wiki/
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function getWikiPages(wikiDir, cats) {
+  const pages = [];
+  for (const d of cats) {
+    const dp = path.join(wikiDir, d);
+    if (!fs.existsSync(dp)) continue;
+    for (const f of fs.readdirSync(dp).filter(x => x.endsWith('.md'))) {
+      const slug = f.replace('.md', '');
+      const raw = fs.readFileSync(path.join(dp, f), 'utf-8');
+      const fm = raw.match(/^---\n([\s\S]*?)\n---/);
+      let title = slug, tags = [];
+      if (fm) {
+        const tl = fm[1].match(/title:\s*"?([^"\n]+)"?/);
+        const tg = fm[1].match(/tags:\s*\[([^\]]*)\]/);
+        if (tl) title = tl[1].trim();
+        if (tg) tags = tg[1].split(',').map(t => t.trim());
+      }
+      pages.push({ slug, type: d, title, tags });
+    }
+  }
+  return pages;
+};


### PR DESCRIPTION
## PR Cluster 2 — Dashboard Wiki Panel Fix

**Epic**: #85
**Tickets**: Closes #88

### Problem
Dashboard wiki panel used `WIKI_MANIFEST` with 31 hardcoded fake file paths that never existed. Showed 0 issues (false healthy). Users saw misleading data.

### Solution
- Replaced static manifest with live API calls to `/api/wiki-health` and `/api/wiki-pages`
- Server reads real `wiki/` directory, parses frontmatter, returns structured page data
- Health panel now shows actual broken links, orphans, and frontmatter issues

### Files Changed
| File | Change |
|------|--------|
| dashboard/js/wiki-reader.js | Remove static manifest, fetch /api/wiki-pages |
| dashboard/js/wiki-panel.js | fetchWikiHealth() → /api/wiki-health |
| dashboard/js/app.js | Async loadWikiPages() in init |
| scripts/dashboard-server.js | Add /api/wiki-pages route |
| scripts/wiki-pages-api.js | New: read wiki dirs + parse frontmatter |

### Verification
- `/api/wiki-health`: `{pages:33, issues:58, loaded:true}`
- `/api/wiki-pages`: 33 pages with real titles/tags/types
- Lint: all 183 files ≤100 lines