### PR TITLE
feat: separate Agent Baton (active) from Ticket Log (all history)

### DIFF
--- a/dashboard/css/ticket-log.css
+++ b/dashboard/css/ticket-log.css
@@ -1,0 +1,27 @@
+/* Ticket Log panel styles */
+.tlog-wrap { display: flex; flex-direction: column; gap: 0.5rem; }
+.tlog-empty { color: var(--text-muted); font-size: 0.85rem;
+  padding: 1rem; text-align: center; }
+.tlog-section { display: flex; flex-direction: column; gap: 0.25rem; }
+.tlog-heading { font-size: 0.72rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.04em;
+  color: var(--text-muted); padding: 0.2rem 0; }
+.tlog-row { display: flex; align-items: center; gap: 0.4rem;
+  padding: 0.3rem 0.5rem; border-radius: 4px;
+  font-size: 0.82rem; background: var(--surface2); }
+.tlog-row.tl-active { border-left: 2px solid var(--accent); }
+.tlog-row.tl-closed { opacity: 0.65; }
+.tlog-row.tl-cancelled { opacity: 0.5; text-decoration: line-through; }
+.tlog-row.tl-backlog { border-left: 2px solid var(--text-muted); }
+.tlog-id { font-weight: 700; color: var(--accent); min-width: 2.8rem; }
+.tlog-epic { font-size: 0.72rem; color: var(--text-muted); }
+.tlog-title { flex: 1; white-space: nowrap;
+  overflow: hidden; text-overflow: ellipsis; }
+.tlog-badges { display: flex; gap: 0.3rem; margin-left: auto; flex-shrink: 0; }
+.tlog-role { font-size: 0.7rem; padding: 0.1rem 0.4rem;
+  border-radius: 3px; background: var(--surface3); }
+.tlog-agent { font-size: 0.72rem; color: var(--text-muted); }
+.tlog-status { font-size: 0.85rem; flex-shrink: 0; }
+.tlog-closed-group { margin-top: 0.5rem; }
+.tlog-closed-group > summary { font-size: 0.8rem;
+  color: var(--text-muted); cursor: pointer; padding: 0.2rem 0; }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -6,7 +6,7 @@
     <title>DevEnv Ops — Fleet Operations Center</title>
     <link rel="stylesheet" href="css/app.css">
     <link rel="stylesheet" href="css/help.css"><link rel="stylesheet" href="css/stats.css"><link rel="stylesheet" href="css/router.css"><link rel="stylesheet" href="css/config.css"><link rel="stylesheet" href="css/views.css"><link rel="stylesheet" href="css/topology.css">
-    <link rel="stylesheet" href="css/baton.css"><link rel="stylesheet" href="css/activity.css"><link rel="stylesheet" href="css/wiki.css"><link rel="stylesheet" href="css/fleet-health.css"><link rel="stylesheet" href="css/governance.css"><link rel="stylesheet" href="css/context.css"><link rel="stylesheet" href="css/github.css">
+    <link rel="stylesheet" href="css/baton.css"><link rel="stylesheet" href="css/ticket-log.css"><link rel="stylesheet" href="css/activity.css"><link rel="stylesheet" href="css/wiki.css"><link rel="stylesheet" href="css/fleet-health.css"><link rel="stylesheet" href="css/governance.css"><link rel="stylesheet" href="css/context.css"><link rel="stylesheet" href="css/github.css">
     <script defer src="js/alpine.min.js"></script>
     <script src="js/health-check.js"></script><script src="js/quota-tracker.js"></script>
     <script src="js/device-monitor.js"></script><script src="js/router-tracker.js"></script>
@@ -19,7 +19,7 @@
     <script src="js/wiki-panel.js"></script><script src="js/wiki-reader.js"></script>
     <script src="js/context-flow.js"></script><script src="js/llm-context.js"></script><script src="js/github-monitor.js"></script>
     <script src="js/fleet-health-log.js"></script>
-    <script src="js/governance-panel.js"></script>
+    <script src="js/governance-panel.js"></script><script src="js/ticket-log.js"></script>
     <script src="js/tooltips.js"></script><script src="js/app-actions.js"></script>
     <script src="js/event-source.js"></script><script src="js/help-tour.js"></script><script src="js/app.js"></script>
 </head>
@@ -77,6 +77,7 @@
             <h2>📋 LLM Router Log</h2><div x-html="renderRouterLog()"></div></section>
         <section id="panel-governance" class="panel" x-show="isView('ops')" data-tip="governance">
             <h2>🛡️ Governance Enforcement</h2><div x-html="renderGovernancePanel(governanceState)"></div></section>
+        <section id="panel-ticket-log" class="panel" x-show="isView('ops')" data-tip="ticket-log"><h2>📋 Ticket Log</h2><div x-html="renderTicketLog(ticketLog)"></div></section>
         <section id="panel-config" class="panel" x-show="isView('ops')" data-tip="config">
             <h2>⚙️ Dashboard Settings</h2><div x-html="renderConfigPanel(config, autoRefreshEnabled, tooltipsEnabled)"></div></section>
         <section id="panel-test" class="panel" x-show="isView('ops')" data-tip="test-panel">
@@ -96,5 +97,4 @@
             <h2>📘 Help Center</h2><div x-html="renderHelpPanel(helpDevMode)"></div>
         </section></template>
     </main>
-    <footer class="footer"><span>Last refresh: <span x-text="lastRefresh"></span></span><span>devenv-ops v3.0.0</span></footer><aside id="app-tip" class="app-tip" x-show="activeTip" x-html="activeTip" x-transition.opacity></aside>
-</body></html>
+    <footer class="footer"><span>Last refresh: <span x-text="lastRefresh"></span></span><span>devenv-ops v3.0.0</span></footer><aside id="app-tip" class="app-tip" x-show="activeTip" x-html="activeTip" x-transition.opacity></aside></body></html>

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -7,6 +7,7 @@ function dashboardApp() {
     config: { refreshSec: 5, highContrast: false },
     currentView: 'fleet', helpDevMode: false,
     batonState: [],
+    ticketLog: [],
     activityLog: [],
     governanceState: {},
     wikiHealth: { loaded: false },
@@ -60,6 +61,7 @@ function dashboardApp() {
         this.fleetStats = stats;
         this.routerStats = rs;
         this.batonState = evBaton.length ? evBaton : buildBatonState(getRouterLog());
+        this.ticketLog = getTicketLog();
         if (lq.length) this.liveQuotas = lq;
         this.wikiHealth = await fetchWikiHealth();
         if (typeof pollGitHub === 'function') this.githubData = await pollGitHub();
@@ -84,13 +86,11 @@ function dashboardApp() {
       addActivity(this.activityLog, 'system',
         this.autoRefreshEnabled ? 'Auto-refresh on' : 'Auto-refresh off');
     },
-
     setHighContrast(on) {
       this.config.highContrast = !!on;
       saveDashboardConfig(this.config);
       document.body.classList.toggle('high-contrast', this.config.highContrast);
     },
-
     setView(view) { setDashboardView(this, view); },
     isView(view) { return isDashboardView(this, view); },
     toggleTips() { toggleDashboardTips(this); },

--- a/dashboard/js/event-bus.js
+++ b/dashboard/js/event-bus.js
@@ -1,10 +1,12 @@
 // Event Bus Client — polls /api/events for live dashboard updates
-// Persistent baton map so tickets stay visible through full workflow
+// _batonTickets: active baton only (backlog→consultant, never closed)
+// _ticketLog: full audit trail of all tickets, all statuses
 
 let _lastEventTs = null;
-const _batonTickets = {};   // issue → ticket, persists across polls
+const _batonTickets = {};   // issue → ticket (active baton only)
 const _batonHistory = {};   // issue → [{role, ts}] for timeline
-const BATON_TTL_MS = 600000; // keep done tickets visible 10min
+const _ticketLog = {};      // issue → ticket (all, including closed)
+const CLOSED_STATUSES = new Set(['closed', 'cancelled', 'done']);
 
 async function fetchEvents(since) {
   const url = since
@@ -30,37 +32,37 @@ function eventToActivity(e) {
   return { type, message: msg, detail: e.issue ? `#${e.issue}` : '' };
 }
 
-/** Merge events into persistent baton ticket map */
+/** Merge events into persistent baton ticket map and ticket log */
 function mergeBatonEvents(events) {
   const now = Date.now();
   for (const e of events) {
-    if (!e.role || !e.issue) continue;
-    const prev = _batonTickets[e.issue];
-    const isDone = e.status === 'done' || e.role === 'consultant';
-    _batonTickets[e.issue] = {
-      activeRole: e.role, issue: e.issue,
+    if (!e.issue) continue;
+    const prev = _batonTickets[e.issue] || _ticketLog[e.issue];
+    const base = { issue: e.issue, _updated: now,
       title: e.title || prev?.title || '',
       epic: e.epic || prev?.epic || null,
-      status: isDone ? 'done' : (e.status || 'in-progress'),
-      agent: e.agent || '', model: e.model || prev?.model || '',
-      _updated: now
-    };
+      agent: e.agent || prev?.agent || '',
+      model: e.model || prev?.model || '' };
+    // Always update ticket log (full audit trail)
+    const logStatus = e.status || (e.type === 'ticket:created' ? 'backlog' : null)
+      || _ticketLog[e.issue]?.status || 'backlog';
+    _ticketLog[e.issue] = { ...base, status: logStatus,
+      activeRole: e.role || _ticketLog[e.issue]?.activeRole || null };
+    // Baton map: evict on close; skip if no role
+    if (e.status && CLOSED_STATUSES.has(e.status)) { delete _batonTickets[e.issue]; continue; }
+    if (!e.role) continue;
+    _batonTickets[e.issue] = { ...base, activeRole: e.role, status: e.status || 'in-progress' };
     if (!_batonHistory[e.issue]) _batonHistory[e.issue] = [];
     _batonHistory[e.issue].push({ role: e.role, ts: e.ts || new Date(now).toISOString() });
   }
-  // Expire done tickets beyond TTL
-  for (const [id, t] of Object.entries(_batonTickets)) {
-    if (t.status === 'done' && now - t._updated > BATON_TTL_MS) delete _batonTickets[id];
-  }
-  // Sort: active first (by issue# desc), then done
-  return Object.values(_batonTickets).sort((a, b) => {
-    if (a.status !== 'done' && b.status === 'done') return -1;
-    if (a.status === 'done' && b.status !== 'done') return 1;
-    return (b.issue || 0) - (a.issue || 0);
-  });
+  // Sort baton: by issue# desc (all active, no done tier)
+  return Object.values(_batonTickets).sort((a, b) => (b.issue || 0) - (a.issue || 0));
 }
 
 function getBatonState() { return Object.values(_batonTickets); }
+function getTicketLog() {
+  return Object.values(_ticketLog).sort((a, b) => (b.issue || 0) - (a.issue || 0));
+}
 function getTicketTimeline(issue) { return _batonHistory[issue] || []; }
 
 /** Detect governance gaps: skipped baton roles */
@@ -72,9 +74,8 @@ function detectMissingEvents(issue) {
   for (let i = 0; i < roles.length - 1; i++) {
     const from = expected.indexOf(roles[i]);
     const to = expected.indexOf(roles[i + 1]);
-    if (to > from + 1) {
+    if (to > from + 1)
       for (let j = from + 1; j < to; j++) gaps.push(expected[j]);
-    }
   }
   return gaps;
 }

--- a/dashboard/js/ticket-log.js
+++ b/dashboard/js/ticket-log.js
@@ -1,0 +1,48 @@
+// Ticket Log — full audit trail of all tickets (all statuses)
+// Separate from Agent Baton which shows only active-baton tickets
+
+const STATUS_META = {
+  backlog:      { icon: '📋', cls: 'tl-backlog' },
+  'in-progress':{ icon: '🔄', cls: 'tl-active'  },
+  closed:       { icon: '✅', cls: 'tl-closed'  },
+  cancelled:    { icon: '🚫', cls: 'tl-cancelled'},
+  done:         { icon: '✅', cls: 'tl-closed'  },
+};
+
+function renderTicketLog(tickets) {
+  if (!tickets || !tickets.length) {
+    return `<div class="tlog-empty">📋 No ticket history yet.<br>
+      <span style="font-size:0.75rem">Tickets appear once events are emitted.</span></div>`;
+  }
+  const open = tickets.filter(t => !['closed','cancelled','done'].includes(t.status));
+  const closed = tickets.filter(t =>  ['closed','cancelled','done'].includes(t.status));
+  let html = '';
+  if (open.length) html += renderTicketSection('Active / Backlog', open);
+  if (closed.length) html += `<details class="tlog-closed-group" open>
+    <summary>📁 ${closed.length} closed / cancelled</summary>
+    ${renderTicketSection(null, closed)}
+  </details>`;
+  return `<div class="tlog-wrap">${html}</div>`;
+}
+
+function renderTicketSection(heading, tickets) {
+  const rows = tickets.map(renderTicketRow).join('');
+  return heading
+    ? `<div class="tlog-section"><div class="tlog-heading">${heading}</div>${rows}</div>`
+    : `<div class="tlog-section">${rows}</div>`;
+}
+
+function renderTicketRow(t) {
+  const m = STATUS_META[t.status] || { icon: '❓', cls: 'tl-unknown' };
+  const title = t.title ? `<span class="tlog-title">${esc(t.title)}</span>` : '';
+  const epic = t.epic ? `<span class="tlog-epic">Epic #${t.epic}</span>` : '';
+  const role = t.activeRole
+    ? `<span class="tlog-role">${esc(t.activeRole)}</span>` : '';
+  const agent = t.agent ? `<span class="tlog-agent">🎭 ${esc(t.agent)}</span>` : '';
+  return `<div class="tlog-row ${m.cls}">
+    <span class="tlog-status">${m.icon}</span>
+    <span class="tlog-id">#${t.issue}</span>
+    ${epic}${title}
+    <span class="tlog-badges">${role}${agent}</span>
+  </div>`;
+}


### PR DESCRIPTION
## Summary

Agent Baton was showing closed tickets. This separates concerns cleanly.

## Changes

- **event-bus.js**: `_batonTickets` now only holds active-baton tickets. On `ticket:status{closed|cancelled|done}`, ticket is evicted. New `_ticketLog` map holds all tickets indefinitely. New `getTicketLog()` export.
- **ticket-log.js** *(new)*: Renders full audit trail panel — open/backlog section, collapsible closed section, status icons.
- **ticket-log.css** *(new)*: Row styles, status tiers (active/backlog/closed/cancelled).
- **app.js**: `ticketLog` state, refreshed each poll cycle.
- **index.html**: Ticket Log panel in Ops view.

## Ticket Lifecycle (enforced)

| Status | Agent Baton | Ticket Log |
|--------|-------------|------------|
| backlog | ❌ | ✅ |
| in-progress (any role) | ✅ | ✅ |
| closed / cancelled | ❌ | ✅ |

Closes #112, #113, #114, #115, #116