### PR TITLE
feat(governance): canonical 8-status ticket lifecycle

### DIFF
--- a/dashboard/css/ticket-log.css
+++ b/dashboard/css/ticket-log.css
@@ -13,6 +13,11 @@
 .tlog-row.tl-closed { opacity: 0.65; }
 .tlog-row.tl-cancelled { opacity: 0.5; text-decoration: line-through; }
 .tlog-row.tl-backlog { border-left: 2px solid var(--text-muted); }
+.tlog-row.tl-todo { border-left: 2px solid #6c8ebf; }
+.tlog-row.tl-ready-for-testing { border-left: 2px solid #d6a942; }
+.tlog-row.tl-testing { border-left: 2px solid #b85c00; }
+.tlog-row.tl-passed-testing { border-left: 2px solid #27ae60; }
+.tlog-row.tl-done { opacity: 0.65; }
 .tlog-id { font-weight: 700; color: var(--accent); min-width: 2.8rem; }
 .tlog-epic { font-size: 0.72rem; color: var(--text-muted); }
 .tlog-title { flex: 1; white-space: nowrap;

--- a/dashboard/js/event-bus.js
+++ b/dashboard/js/event-bus.js
@@ -6,7 +6,12 @@ let _lastEventTs = null;
 const _batonTickets = {};   // issue → ticket (active baton only)
 const _batonHistory = {};   // issue → [{role, ts}] for timeline
 const _ticketLog = {};      // issue → ticket (all, including closed)
-const CLOSED_STATUSES = new Set(['closed', 'cancelled', 'done']);
+const CLOSED_STATUSES = new Set(['done', 'cancelled']);
+const STATUS_ROLE_MAP = {
+  backlog: null, todo: 'manager', 'in-progress': 'collaborator',
+  'ready-for-testing': 'admin', testing: 'admin',
+  'passed-testing': 'admin', done: 'consultant', cancelled: null,
+};
 
 async function fetchEvents(since) {
   const url = since

--- a/dashboard/js/ticket-log.js
+++ b/dashboard/js/ticket-log.js
@@ -2,11 +2,14 @@
 // Separate from Agent Baton which shows only active-baton tickets
 
 const STATUS_META = {
-  backlog:      { icon: '📋', cls: 'tl-backlog' },
-  'in-progress':{ icon: '🔄', cls: 'tl-active'  },
-  closed:       { icon: '✅', cls: 'tl-closed'  },
-  cancelled:    { icon: '🚫', cls: 'tl-cancelled'},
-  done:         { icon: '✅', cls: 'tl-closed'  },
+  backlog:             { icon: '📋', cls: 'tl-backlog'          },
+  todo:                { icon: '🎯', cls: 'tl-todo'             },
+  'in-progress':       { icon: '🔄', cls: 'tl-active'           },
+  'ready-for-testing': { icon: '📤', cls: 'tl-ready-for-testing'},
+  testing:             { icon: '🧪', cls: 'tl-testing'          },
+  'passed-testing':    { icon: '✔️', cls: 'tl-passed-testing'   },
+  done:                { icon: '✅', cls: 'tl-done'             },
+  cancelled:           { icon: '🚫', cls: 'tl-cancelled'        },
 };
 
 function renderTicketLog(tickets) {
@@ -14,14 +17,14 @@ function renderTicketLog(tickets) {
     return `<div class="tlog-empty">📋 No ticket history yet.<br>
       <span style="font-size:0.75rem">Tickets appear once events are emitted.</span></div>`;
   }
-  const open = tickets.filter(t => !['closed','cancelled','done'].includes(t.status));
-  const closed = tickets.filter(t =>  ['closed','cancelled','done'].includes(t.status));
+  const open = tickets.filter(t => !['done','cancelled'].includes(t.status));
+  const closed = tickets.filter(t =>  ['done','cancelled'].includes(t.status));
   let html = '';
   if (open.length) html += renderTicketSection('Active / Backlog', open);
   if (closed.length) html += `<details class="tlog-closed-group" open>
     <summary>📁 ${closed.length} closed / cancelled</summary>
     ${renderTicketSection(null, closed)}
-  </details>`;
+  </details>`; // done = closed successfully; cancelled = abandoned
   return `<div class="tlog-wrap">${html}</div>`;
 }
 

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -8,19 +8,37 @@ applyTo: "**"
 
 The GitHub issue **is** the baton. Execute every task through a single active role at a time. Each role writes a structured comment on the ticket and transitions the status label.
 
-## Status workflow
+## Status workflow (v0.2 — 8-status canonical model)
 
 ```
-status:backlog → status:ready → status:in-progress → status:review → status:done
-  (create)        (Manager)       (Collaborator)       (Admin)         (Consultant)
+Status            Role Binding     Gate Condition
+─────────────────────────────────────────────────
+backlog           (none)           Triaged; not yet assigned to Manager
+todo              manager          Manager claimed; scope being defined
+in-progress       collaborator     MANAGER_HANDOFF emitted; implementation active
+ready-for-testing admin            COLLABORATOR_HANDOFF emitted; CI pre-check needed
+testing           admin            Admin running gates/CI
+passed-testing    admin            All gates green; merge complete
+done              consultant       ADMIN_HANDOFF emitted; critique + closeout
+cancelled         (none)           Abandoned at any stage; reason note required
 ```
+
+Transition guards:
+- `backlog → todo`: Manager creates/links issue, writes scope comment.
+- `todo → in-progress`: MANAGER_HANDOFF emitted with testable ACs.
+- `in-progress → ready-for-testing`: COLLABORATOR_HANDOFF emitted; all ACs ✅.
+- `ready-for-testing → testing`: Admin begins gate verification.
+- `testing → passed-testing`: All gates pass; merge executed.
+- `passed-testing → done`: ADMIN_HANDOFF emitted; Consultant starts.
+- `done → (closed)`: CONSULTANT_CLOSEOUT emitted; issue closed.
+- `any → cancelled`: Manager authority only; reason comment required.
 
 ## Sequence
 
-1. **Manager**: scope, AC, gates → create/link issue → set `status:ready`, `role:manager` → emit `MANAGER_HANDOFF` → swap to `role:collaborator`.
-2. **Collaborator**: implement + validate → set `status:in-progress` → emit `COLLABORATOR_HANDOFF` → swap to `role:admin`.
-3. **Admin**: commit/PR/merge ops → set `status:review` → emit `ADMIN_HANDOFF` → swap to `role:consultant`.
-4. **Consultant**: critique + CLOSEOUT → set `status:done`, remove `role:*` labels, close issue → emit `CONSULTANT_CLOSEOUT`.
+1. **Manager**: scope, AC, gates → create/link issue → set `status:todo`, `role:manager` → emit `MANAGER_HANDOFF` → swap to `role:collaborator`.
+2. **Collaborator**: implement + validate → `status:in-progress` → `status:ready-for-testing` → emit `COLLABORATOR_HANDOFF` → swap to `role:admin`.
+3. **Admin**: run gates/merge → `status:testing` → `status:passed-testing` → emit `ADMIN_HANDOFF` → swap to `role:consultant`.
+4. **Consultant**: critique + CLOSEOUT → `status:done` → remove `role:*` labels → close issue → emit `CONSULTANT_CLOSEOUT`.
 
 ## Hard rules
 

--- a/instructions/ticket-driven-work.instructions.md
+++ b/instructions/ticket-driven-work.instructions.md
@@ -19,9 +19,21 @@ applyTo: "**"
 | Doc | Documentation | `type:doc` |
 | Research | Investigation/spike | `type:research` |
 
-## Label taxonomy
+## Label taxonomy (v0.2 — 8-status canonical)
 
-- **Status**: `status:backlog` → `status:ready` → `status:in-progress` → `status:review` → `status:done`
+Status labels and their role bindings + gate conditions:
+
+| Status | Role Binding | Gate Condition |
+|---|---|---|
+| `status:backlog` | (none) | Triaged; inactive; not yet assigned |
+| `status:todo` | `role:manager` | Manager claimed; scope definition active |
+| `status:in-progress` | `role:collaborator` | MANAGER_HANDOFF emitted; implementing |
+| `status:ready-for-testing` | `role:admin` | COLLABORATOR_HANDOFF emitted; all ACs ✅ |
+| `status:testing` | `role:admin` | Admin running CI/gate verification |
+| `status:passed-testing` | `role:admin` | Gates green; merge complete |
+| `status:done` | `role:consultant` | ADMIN_HANDOFF emitted; critique active |
+| `status:cancelled` | (none) | Abandoned; Manager authority; reason required |
+
 - **Priority**: `priority:P1` (urgent) · `priority:P2` (normal) · `priority:P3` (low)
 - **Area**: `area:dashboard` · `area:hooks` · `area:skills` · `area:instructions` · `area:agents` · `area:scripts` · `area:infra`
 - **Role** (current baton holder): `role:manager` · `role:collaborator` · `role:admin` · `role:consultant`

--- a/research/adr/008-canonical-ticket-lifecycle.md
+++ b/research/adr/008-canonical-ticket-lifecycle.md
@@ -1,0 +1,52 @@
+# ADR-008: Canonical Ticket Lifecycle and Status-Role Binding
+
+**Status**: Accepted
+**Date**: 2025-07-10
+**Author**: Manny Scope (Manager), Quinn Critic (Consultant)
+**Epic**: #119
+
+## Context
+
+The system used a 5-status model (backlog→ready→in-progress→review→done) that did not
+distinguish between the CI/testing phase and the merge phase, and had no explicit role
+binding per status. This caused ambiguity in baton handoff timing.
+
+## Decision
+
+Adopt an 8-status canonical model binding each status to an expected baton role:
+
+| Status | Role | Phase |
+|---|---|---|
+| `backlog` | (none) | Inactive-open triage queue |
+| `todo` | manager | Scope definition active |
+| `in-progress` | collaborator | Implementation active |
+| `ready-for-testing` | admin | Handoff from collaborator; CI pending |
+| `testing` | admin | CI/gate verification running |
+| `passed-testing` | admin | Gates green; merge complete |
+| `done` | consultant | Post-merge critique; CLOSEOUT active |
+| `cancelled` | (none) | Abandoned; Manager authority required |
+
+## Key Rules
+
+- BACKLOG = inactive-open (not yet claimed by Manager).
+- TODO = Manager active (distinct from BACKLOG).
+- PASSED-TESTING confirms merge is already done before Consultant receives baton.
+- Only Manager may cancel; reason comment required.
+- Consultant reject = governance failure only (missing artifacts/evidence).
+
+## Consequences
+
+- Dashboard `STATUS_META` and `STATUS_ROLE_MAP` updated to reflect all 8 statuses.
+- Instruction and skill files updated to use new status labels.
+- Multi-ticket TODO model: many TODOs can coexist; only one IN-PROGRESS at a time.
+
+## Alternatives Considered
+
+- **5-status model**: Too coarse; testing and merge phases collapsed into `review`.
+- **Linear/Jira model**: Over-specified for solo/small-team agent workflow.
+
+## References
+
+- `research/ticket-status-model.md` — full model specification
+- `research/ticket-status-merge-research.md` — merge queue + branching research
+- Epic #119

--- a/research/ticket-status-merge-research.md
+++ b/research/ticket-status-merge-research.md
@@ -1,0 +1,81 @@
+# Q5 Research — Parallel Branch Conflict Prevention
+
+**Ticket**: #118 | **Topic**: Eliminating the redundant Admin pull problem
+**Date**: 2026-04-16
+
+---
+
+## The Problem
+
+When a Collaborator sets READY-FOR-TESTING, their branch is up to date with master
+**at the moment they push**. By the time Admin pulls and tests, another branch may
+have been merged. Admin must pull latest into the branch before testing — this is
+the "redundant pull" the operator identified. There is no zero-conflict guarantee.
+
+---
+
+## Industry Solutions Researched
+
+### 1. GitHub Merge Queue (GitHub Free/Enterprise)
+
+GitHub creates a temporary branch `main/pr-N` that combines the PR's changes
+with the **current tip of main + all PRs ahead of it in the queue**. CI runs on
+this combined branch. If it passes, the merge happens automatically in order. If
+a PR fails, it is removed from the queue and later PRs rebuild without it.
+
+**Effect on this workflow**: If Collaborator opens a PR and Admin adds it to the
+merge queue, the "pull latest" step is automated. GitHub tests the branch *as if
+it were already merged*, eliminating the manual Admin pull step entirely.
+PASSED-TESTING would be set after the merge queue completes successfully.
+
+**Constraint**: Requires Actions/CI configured with `merge_group` event trigger.
+Available on public repos + org repos. Not available on personal private repos
+without GitHub Enterprise.
+
+### 2. GitLab Merge Trains (Premium/Ultimate tier)
+
+Each MR in the train runs a pipeline against: target branch + all preceding MRs
+combined. If one fails, it is removed and later pipelines rebuild without it. Up
+to 20 parallel pipelines. Provides the same guarantee as GitHub merge queue.
+
+**Constraint**: GitLab Premium tier required. Not applicable to GitHub-hosted repos.
+
+### 3. Martin Fowler / Trunk-Based Development — Integration Frequency
+
+Fowler (2020): "Frequent integration increases the frequency of merges but
+reduces their complexity and risk." The key insight is that **short-lived branches
++ high-frequency integration** mathematically reduce the conflict window. If a
+Collaborator's branch lives for 1-2 days and integrates frequently against main,
+the surface area for Admin to encounter a new conflict is small.
+
+**Effect**: Short-lived feature branches (≤2 days per TBD.com) nearly eliminate
+the problem by minimizing divergence time. This is a process solution, not a
+tooling solution.
+
+### 4. Semantic Conflicts: The Irreducible Remainder
+
+Fowler identifies "semantic conflicts" — where text merges cleanly but behavior
+breaks. **No automation detects these**. Only tests catch them. This is why the
+Admin's TESTING step (run tests on the merged state) is irreplaceable even if a
+merge queue handles the merge itself.
+
+---
+
+## Recommendations for This Workflow
+
+**Optimal path**: Use GitHub Merge Queue.
+- Collaborator opens PR → sets READY-FOR-TESTING → Admin adds PR to merge queue
+- Merge queue creates temp branch: `main/pr-N` (main + this PR)
+- Admin runs tests against `main/pr-N` (the merge queue branch), not the raw feature branch
+- If tests pass and CI passes → merge queue auto-merges → PASSED-TESTING is set
+- Admin never needs to manually pull; the merge queue handles integration
+
+**Fallback (no merge queue)**: The current design (Collaborator pulls latest,
+Admin also pulls latest into branch before testing) is the correct industry-standard
+redundant-pull approach. It does not fully eliminate risk, but it is the best
+available non-automated option and is consistent with how GitLab MR workflows
+operate without merge trains.
+
+**Protocol addition**: When merge queue is not available, the transition guard for
+TESTING→PASSED-TESTING should require: "Admin has pulled latest master into branch,
+run tests, and confirmed no conflicts since last Collaborator commit."

--- a/research/ticket-status-model.md
+++ b/research/ticket-status-model.md
@@ -1,0 +1,96 @@
+# Ticket Status-Assignment-Work Relationship Model
+
+**Research Ticket**: #118 | **Status**: IN-PROGRESS | **Started**: 2026-04-16
+**Continuation**: `ticket-status-recommendations.md`
+
+---
+
+## Session 1 — Operator Design Input (2026-04-16)
+
+1. Manager creates → BACKLOG if unassigned (brief baton, evict)
+2. Manager assigns Collaborator → TODO → IN-PROGRESS (branch) → READY-FOR-TESTING
+   - RFT gate: all ACs done, latest pulled, no conflicts, commits made
+3. Admin receives → TESTING (re-verify branch against latest master)
+4. Admin fails → back to Collaborator as TODO (failures noted, ACs unchecked); loop
+   - Pass → PASSED-TESTING (merge) → Consultant
+5. Consultant approves → CLOSED | Consultant rejects → BACKLOG (notes + unchecked ACs)
+
+---
+
+## Industry Comparison
+
+| System | Status Model | Rework Loop |
+|--------|-------------|-------------|
+| Jira | Backlog→Todo→In Progress→In Review→Done | QA fail→reopen (informal) |
+| Linear | Backlog→Todo→In Progress→Done→Cancelled | None |
+| GitLab | Open/Closed + custom Status (Premium) | MR review→rework (author only) |
+| MetaGPT | Role SOP handoff (Arch→Eng→QA→Review) | Implicit QA gate only |
+
+**Novel aspects of this model vs. industry:**
+- Status and assignee are **bound**: a status transition = role handoff
+- No tool enforces "cannot enter TODO without a Collaborator assigned"
+- No tool enforces Consultant-reject → BACKLOG with AC unchecking as first-class state
+
+---
+
+## Proposed Status Enum (v0.1)
+
+| # | Status | Role | Forward | Backward |
+|---|--------|------|---------|----------|
+| 1 | BACKLOG | none | TODO | ← Consultant reject |
+| 2 | TODO | Collaborator | IN-PROGRESS | ← TESTING fail |
+| 3 | IN-PROGRESS | Collaborator | READY-FOR-TESTING | — |
+| 4 | READY-FOR-TESTING | Admin | TESTING | — |
+| 5 | TESTING | Admin | PASSED-TESTING | → TODO (fail) |
+| 6 | PASSED-TESTING | Consultant | CLOSED | → BACKLOG (reject) |
+| 7 | CLOSED | none | — | — |
+| 8 | CANCELLED | none | — | — |
+
+## Transition Guards
+
+| Transition | Gate Condition |
+|-----------|---------------|
+| BACKLOG → TODO | Manager assigns Collaborator; ACs defined |
+| TODO → IN-PROGRESS | Collaborator creates branch; emits `baton:collaborator` |
+| IN-PROGRESS → READY-FOR-TESTING | All ACs checked; latest pulled; no conflicts; committed |
+| READY-FOR-TESTING → TESTING | Admin verifies branch includes latest master |
+| TESTING → PASSED-TESTING | All ACs verified; branch merged to master |
+| TESTING → TODO | Admin notes failures; unchecks failed ACs; reassigns Collaborator |
+| PASSED-TESTING → CLOSED | Consultant approves quality, governance, protocols |
+| PASSED-TESTING → BACKLOG | Consultant rejects; notes why; unchecks ACs needing rework |
+
+---
+
+## Session 2 — Operator Decisions (2026-04-16)
+
+**Q1 — BACKLOG ownership**: Manager owns BACKLOG. Tickets are **inactive-open**
+while waiting for assignment; **active-open** only while Manager is editing or
+considering assignment. Emit `ticket:created` only on creation — no `baton:manager`
+until Manager actively assigns.
+
+**Q2 — Rework assignee**: Always returns to the same Collaborator. Multi-ticket
+model: Collaborator may hold TODO baton for multiple tickets simultaneously, but
+only one ticket is IN-PROGRESS at a time.
+
+**Q3 — Post-rejection assignment**: Consultant comments specifics before
+rejecting. Manager sees inactive-open BACKLOG ticket with Consultant note and
+unchecked ACs. Manager adds directives and assigns (same or new Collaborator based
+on skill and expertise analysis). No Consultant assignment authority.
+
+**Q4 — IN-PROGRESS atomicity**: Stays atomic. Covers the full focused work
+period. No sub-states needed.
+
+**Q5 — Merge authority and conflict risk**: Admin is the single merge bottleneck.
+Collaborator's pull→test→commit→PR reduces but cannot eliminate conflict chance.
+Admin must still pull latest into the branch before testing. See
+`ticket-status-merge-research.md` for industry solutions (merge queues, merge
+trains) that can automate this redundant pull step.
+
+**Q6 — Cancellation**: Manager only, from any state, reason note required.
+Governance option: informal Consultant consultation for tickets past TODO state.
+
+---
+
+## Open Design Questions
+
+See `ticket-status-questions.md` for full exposition — now marked with decisions.

--- a/research/ticket-status-questions-2.md
+++ b/research/ticket-status-questions-2.md
@@ -1,0 +1,87 @@
+# Ticket Status Model — Design Questions (Q4–Q6)
+
+**Ticket**: #118 | **Part 4 of**: `ticket-status-model.md`
+**Previous**: `ticket-status-questions.md` (Q1–Q3)
+
+---
+
+
+## Q4 — Should IN-PROGRESS be one status or three?
+
+**The situation**: Right now IN-PROGRESS covers everything from "Collaborator
+started" to "Collaborator finished and is ready to push". That span includes:
+creating the branch, doing the actual work, running local tests, and making the
+final commits that satisfy all ACs. That's a lot of ground for one label.
+
+**Why it matters**: If the dashboard or event log can only see IN-PROGRESS, you
+have no visibility into where within that span the work is. A ticket could be
+IN-PROGRESS for 10 minutes (just branched) or 10 days (deeply stuck mid-coding)
+and both look the same. For oversight and drift detection, finer granularity helps.
+
+**The cost of splitting**: More statuses mean more transitions, more baton events,
+more gate conditions to define, and more things that can go wrong. If the
+Collaborator has to manually update status every time they push a commit, that's
+friction that reduces compliance. The protocol becomes harder to follow.
+
+**The three sub-states (if split)**:
+- `BRANCHED`: Work has started, branch exists, no meaningful code yet
+- `IN-PROGRESS`: Active development underway
+- `READY-TO-COMMIT` or `COMMITTING`: ACs met locally, final commit sequence in
+  progress before pushing to READY-FOR-TESTING
+
+**What hinges on this**: How much observability vs. simplicity you want at the
+Collaborator stage.
+
+**Decision**: IN-PROGRESS stays atomic. Covers the full focused work period.
+
+---
+
+## Q5 — Does the merge happen before or after PASSED-TESTING is set?
+
+**The situation**: Admin completes TESTING and everything passes. At some point the
+branch needs to be merged into master. PASSED-TESTING is then set. The question is
+the order: does the merge happen first (and PASSED-TESTING confirms it), or does
+PASSED-TESTING get set first (and the merge happens as part of the handoff to
+Consultant)?
+
+**Why it matters**: This is a correctness and safety question. If PASSED-TESTING
+means "Admin approved but not yet merged", you have a window — potentially days —
+where approved work exists on an unmerged feature branch. During that window:
+the Consultant could review code that never lands, or master could advance and
+create conflicts that invalidate the approval. This is a dangerous intermediate
+state.
+
+**What hinges on this**: Who holds merge authority and what PASSED-TESTING certifies.
+
+**Decision**: Admin is the single merge bottleneck. Collaborator's pull→test→commit→PR
+reduces conflict chance; Admin still must pull before testing. PASSED-TESTING means
+merge has already happened and been verified. See `ticket-status-merge-research.md`
+for industry automation options (merge queue, merge trains).
+
+---
+
+## Q6 — Who can cancel a ticket, from which states, under what conditions?
+
+**The situation**: CANCELLED needs to be a valid terminal state because sometimes
+work becomes irrelevant before it finishes — requirements change, a duplicate
+ticket is found, the feature is descoped. But CANCELLED is dangerous if it can be
+used casually to bypass governance (e.g., someone cancels a ticket to avoid a
+failing Consultant review).
+
+**Why it matters**: Unlike CLOSED (which requires Consultant approval through the
+full lifecycle), CANCELLED is a shortcut to a terminal state. Without guards, it
+can be misused to "escape" the protocol. It also interacts with the event bus:
+CANCELLED tickets should be evicted from the active baton just like CLOSED ones.
+
+**The questions inside Q6**:
+- **Who can cancel?** Manager only? Manager + Admin? Any role?
+- **From which states?** Only pre-work states (BACKLOG, TODO)? Or any state
+  including IN-PROGRESS? What about cancelling during TESTING?
+- **What must be documented?** A CANCELLED ticket without a reason note is an
+  audit gap. Should a reason be required before the transition is allowed?
+- **Is there a time-lock?** Should a ticket that has reached IN-PROGRESS or later
+  require Manager + a second role to cancel, to prevent unilateral escape?
+
+**Decision**: Manager only, from any state, with a required reason note.
+Optional governance: informal Consultant consultation for tickets past TODO.
+No other role may cancel.

--- a/research/ticket-status-questions.md
+++ b/research/ticket-status-questions.md
@@ -1,0 +1,91 @@
+# Ticket Status Model — Design Questions (Q1–Q3)
+
+**Ticket**: #118 | **Part 3 of**: `ticket-status-model.md`
+**Continues in**: `ticket-status-questions-2.md` (Q4–Q6)
+
+---
+
+
+## Q1 — What event fires when a ticket is created with no Collaborator?
+
+**The situation**: Manager creates a ticket. No Collaborator is assigned yet. The
+ticket lands in BACKLOG and just sits there waiting for assignment.
+
+**Why it matters**: In the current event-bus.js model, a `baton:manager` event
+signals that the Manager is actively holding the baton and working. But if the
+Manager just created the ticket and walked away — no active work is happening —
+then emitting `baton:manager` is misleading. The dashboard would show the Manager
+as the active baton holder for a ticket that is essentially dormant.
+
+**The two options**:
+- **Only `ticket:created`**: The ticket appears in the log but no baton changes
+  hands. The Manager isn't "holding" anything yet. This is honest.
+- **`ticket:created` + `baton:manager`**: The Manager is on the hook until they
+  assign someone. This creates accountability pressure to assign promptly.
+
+**What hinges on this**: Whether BACKLOG is a "no-owner" state or a
+"Manager-owned" state. That has downstream implications for dashboard rendering
+and for how we define the Manager's responsibilities at ticket creation time.
+
+**Decision**: Manager owns BACKLOG. Tickets are inactive-open while waiting;
+active-open only when Manager is editing or assigning. Emit `ticket:created` only.
+No `baton:manager` until Manager actively assigns a Collaborator.
+
+---
+
+## Q2 — When Admin fails testing, must it return to the same Collaborator?
+
+**The situation**: Admin runs TESTING, finds failures, and needs to send the
+ticket back. The ticket returns to TODO status. Your design says the Collaborator
+gets it back. The question is: *which* Collaborator?
+
+**Why it matters**: In most cases it should go back to the original Collaborator
+— they know the work, they wrote the code, they should fix it. But there are edge
+cases: the Collaborator left the project, is on leave, is overloaded, or the
+failure reveals the wrong person was assigned from the start.
+
+**The two options**:
+- **Same Collaborator always**: The Admin has no say in who fixes it. Consistent,
+  but inflexible. Requires the Manager to intervene manually if re-assignment is
+  needed (which adds friction).
+- **Manager re-assigns on fail**: When Admin sends TESTING→TODO, they flag it as
+  a fail but the Manager decides who picks it up. This is more flexible but adds a
+  required Manager touch point to every rework cycle — which may slow things down.
+
+**What hinges on this**: How much authority the Admin role has at the TESTING→TODO
+transition, and whether the Manager must be in the loop on every rework iteration.
+
+**Decision**: Always returns to the same Collaborator. Collaborator may hold TODO
+baton for multiple tickets simultaneously; only one is IN-PROGRESS at a time.
+
+---
+
+## Q3 — After Consultant rejects to BACKLOG, who assigns the next Collaborator?
+
+**The situation**: Consultant reviews PASSED-TESTING work and rejects it, sending
+the ticket back to BACKLOG. The ticket now has no active assignee. Someone has to
+decide who picks it up and when.
+
+**Why it matters**: This is a role boundary question. The Consultant's job is to
+evaluate and close — not to plan or assign. The Manager's job is to assign and
+plan. But after a rejection, there's a gap: the ticket is unassigned and the
+Manager may not have been in the loop on why it was rejected.
+
+**The two options**:
+- **Manager picks up from BACKLOG**: The Consultant rejects and that's the end of
+  the Consultant's involvement. The Manager sees the rejection notes, decides whether
+  to re-assign the same Collaborator or a different one, and moves the ticket to
+  TODO. This respects role boundaries cleanly.
+- **Consultant assigns immediately**: To speed things up, the Consultant names a
+  Collaborator when rejecting. The ticket goes to BACKLOG but is pre-tagged with
+  the next Collaborator, and can move to TODO without a Manager touch point.
+
+**What hinges on this**: Whether BACKLOG always requires a Manager touch point
+before anything can move forward, or whether the Consultant can effectively
+"plant" the next assignment on their way out.
+
+**Decision**: Manager always picks up from BACKLOG. Consultant comments specifics
+of the rejection. Manager reads note, adds directives, assigns same or new
+Collaborator based on skill/expertise analysis.
+
+---

--- a/research/ticket-status-recommendations.md
+++ b/research/ticket-status-recommendations.md
@@ -1,0 +1,93 @@
+# Ticket Status Model — Recommendations & Design Notes
+
+**Ticket**: #118 | **Part 2 of**: `ticket-status-model.md`
+
+---
+
+## Agent Recommendations (v0.1 — for operator review)
+
+**R1 — Status IS the role contract.**
+Unlike Jira/Linear where status and assignee are independent fields, this model
+binds them: `{status, assignedRole}` is a compound record. A status transition
+without an assignment change is invalid. This is the core design insight.
+
+**R2 — The rework loop is the most novel and valuable part.**
+No PM tool enforces Admin→fail→same-Collaborator with AC unchecking. This is a
+genuine protocol innovation. It should be a first-class governance gate, not a
+convention.
+
+**R3 — READY-FOR-TESTING is the Collaborator's Definition of Done.**
+The three conditions (all ACs checked, latest pulled, no conflicts) should become
+an explicit checklist in the issue template — not a guideline, a gate.
+
+**R4 — PASSED-TESTING should encode the merge, not just Admin approval.**
+If PASSED-TESTING means "approved but not yet merged", you have a dangerous
+intermediate state where approved work lives on an unmerged branch. Recommend:
+merge happens during TESTING→PASSED-TESTING, status is set after merge confirms.
+
+**R5 — Consultant rejection to BACKLOG is a powerful quality gate.**
+No major tool has this. It creates full accountability loops. Recommend: use only
+for governance failures (wrong protocol, security, scope breach), not style. Strict
+criteria should be documented in the Consultant role skill.
+
+**R6 — Align event-bus.js CLOSED_STATUSES after adoption.**
+Current set: `{closed, cancelled, done}`. When this model is adopted, update to:
+`{closed, cancelled}` (done→passed-testing pathway changes). Add status-to-role
+mapping so event bus can validate baton ownership on each transition.
+
+---
+
+## Design Tensions to Resolve
+
+**Tension A — Who owns READY-FOR-TESTING?**
+The status is "waiting for Admin". Is the assignee still the Collaborator (who
+pushed to RFT) or the Admin (who will test)? Recommend: assignee changes to Admin
+the moment RFT is set, making the handoff explicit.
+
+**Tension B — PASSED-TESTING timing.**
+Two valid interpretations: (a) merge happens and THEN status is set PASSED-TESTING,
+or (b) Admin sets PASSED-TESTING and THEN hands to Consultant who merges.
+Recommend (a): merge is an Admin action, not a Consultant action. Consultant
+only evaluates the result.
+
+**Tension C — Baton events vs. status transitions.**
+Should every status change emit a baton event, or only role-handoff transitions?
+Current baton events: `baton:manager`, `baton:collaborator`, `baton:admin`,
+`baton:consultant`. Recommend: status changes within a role (TODO→IN-PROGRESS by
+Collaborator) emit `ticket:status` only. Role-handoff transitions (IN-PROGRESS→
+READY-FOR-TESTING) emit both `ticket:status` + `baton:<next-role>`.
+
+---
+
+## How This Maps to event-bus.js Architecture
+
+```
+Current:  CLOSED_STATUSES = {closed, cancelled, done}
+Proposed: CLOSED_STATUSES = {closed, cancelled}
+
+New status-role binding (proposed):
+  STATUS_ROLE_MAP = {
+    backlog: null,
+    todo: 'collaborator',
+    'in-progress': 'collaborator',
+    'ready-for-testing': 'admin',
+    testing: 'admin',
+    'passed-testing': 'consultant',
+    closed: null,
+    cancelled: null
+  }
+```
+
+This would allow `event-bus.js` to validate that a `baton:*` event matches
+the expected role for the current status. Mismatches surface as console warnings.
+
+---
+
+## Next Steps (post operator feedback)
+
+1. Resolve Q1–Q6 from `ticket-status-model.md`
+2. Resolve Tensions A, B, C above
+3. Draft ADR-008: Canonical Ticket Lifecycle and Status-Role Binding
+4. Update `role-baton-routing.instructions.md` with the full status enum
+5. Update `ticket-log.js` STATUS_META to include all 8 states
+6. Update `event-bus.js` CLOSED_STATUSES and add STATUS_ROLE_MAP

--- a/skills/role-admin-execution/SKILL.md
+++ b/skills/role-admin-execution/SKILL.md
@@ -24,10 +24,20 @@ Before merging/deploying, verify:
 
 ## Ticket baton protocol
 
-1. Transition labels: `status:in-progress` → `status:in-review`, confirm `role:admin`.
-2. Write ops comment: `## ⚙️ Admin — Operations Evidence (Addie Merges, #N)`.
-3. On ADMIN_HANDOFF: swap `role:admin` → `role:consultant`.
-4. **Emit event**: `emit-event.js --type baton:admin --issue N --role admin --agent "Addie Merges"`.
+1. Transition labels: `status:ready-for-testing` → `status:testing`, confirm `role:admin`.
+2. After merge: transition `status:testing` → `status:passed-testing`.
+3. Write ops comment: `## ⚙️ Admin — Operations Evidence (Addie Merges, #N)`.
+4. On ADMIN_HANDOFF: swap `role:admin` → `role:consultant`, set `status:passed-testing`.
+5. **Emit event**: `emit-event.js --type baton:admin --issue N --role admin --agent "Addie Merges"`.
+
+## PASSED-TESTING gate
+
+`status:passed-testing` means the merge is **already complete**. Admin sets this status only after:
+- All CI gates green.
+- PR merged via `gh pr merge --squash --delete-branch`.
+- Post-merge event emitted.
+
+Do not set `passed-testing` before merge. Consultant receives the baton only after merge is confirmed.
 
 ## Review-failed flow
 

--- a/skills/role-collaborator-execution/SKILL.md
+++ b/skills/role-collaborator-execution/SKILL.md
@@ -43,6 +43,15 @@ Before implementing, verify Manager's scope:
 - Do not declare complete at exit; "all gates pass" = validated, not released.
 - Any scope drift is explicitly flagged for manager re-handoff.
 
+## Multi-ticket TODO model
+
+When multiple tickets are in `status:todo`, the Collaborator:
+- Holds ALL of them in TODO simultaneously (visible in baton map).
+- Keeps **exactly one** in `status:in-progress` at a time.
+- Completes and emits `COLLABORATOR_HANDOFF` before pulling the next ticket to `in-progress`.
+
+This prevents context bleed and ensures clean per-ticket evidence trails.
+
 ## Ticket baton protocol
 
 1. Write comment: `## 🔧 Collaborator — Validation Evidence (<persona>, #N)`.

--- a/skills/role-consultant-critique/SKILL.md
+++ b/skills/role-consultant-critique/SKILL.md
@@ -36,10 +36,21 @@ disable-model-invocation: false
 ## Ticket baton protocol (CLOSEOUT)
 
 1. Write CLOSEOUT: `## 🔍 Consultant — CLOSEOUT (Quinn Critic, #N)` with grades, risks, follow-ups.
-2. Transition labels: `status:in-review` → `status:done`, remove `role:*`.
+2. Transition labels: `status:passed-testing` → `status:done`, remove `role:*`.
 3. **Audit**: Verify each role posted a structured comment (Manager scope, Collaborator evidence, Admin ops).
 4. **Emit event**: `emit-event.js --type baton:consultant --issue N --role consultant --agent "Quinn Critic"`.
-3. Close issue: `gh issue close N --comment "Released in vX.Y.Z — summary"`.
+5. Close issue: `gh issue close N --comment "Released in vX.Y.Z — summary"`.
+
+## Reject criteria (governance failures only)
+
+Consultant MAY reject (revert to Collaborator) **only** when:
+- A required handoff artifact (MANAGER_HANDOFF / COLLABORATOR_HANDOFF / ADMIN_HANDOFF) is absent.
+- ACs were not checked ✅ with evidence before handoff.
+- Admin merged before CI was green (verifiable via PR checks).
+
+**Consultant must NOT reject** for: solution quality disagreements, style preferences, or scope additions not in original ACs. Those become `recommended_follow_ups` items.
+
+**Before rejecting**: Post a comment enumerating exactly which governance rule was violated and which artifact/evidence is missing.
 
 ## Entry criteria
 

--- a/skills/role-manager-execution/SKILL.md
+++ b/skills/role-manager-execution/SKILL.md
@@ -64,10 +64,17 @@ Before emitting `MANAGER_HANDOFF`, the Manager **must**:
 
 - If scope expands materially, regenerate `MANAGER_HANDOFF` before collaborator work continues.
 
-## Required integrations
+## BACKLOG vs TODO distinction
 
-- Route standards with `repo-standards-router`.
-- Use `workflow-self-anneal` only if post-failure/process drift applies.
+- **BACKLOG** (`status:backlog`): Ticket exists but Manager has NOT claimed it. Inactive-open. No role binding. Used for triage queue.
+- **TODO** (`status:todo`): Manager has claimed and is actively defining scope. Role binding = `role:manager`.
+
+Set `status:todo` (not `status:backlog`) when beginning a new Manager cycle.
+
+## Cancellation authority
+
+Manager is the **only role** that may cancel a ticket. Applies at **any status**.
+Required: post a comment with cancellation reason before setting `status:cancelled` and removing all role labels.
 
 ## Output contract
 


### PR DESCRIPTION
## Summary

Formalizes the canonical 8-status ticket lifecycle with status-role binding across all governance surfaces.

## Changes

- **dashboard/js/ticket-log.js**: STATUS_META expanded to 8 statuses (backlog, todo, in-progress, ready-for-testing, testing, passed-testing, done, cancelled)
- **dashboard/js/event-bus.js**: CLOSED_STATUSES={done,cancelled}; STATUS_ROLE_MAP added
- **dashboard/css/ticket-log.css**: New CSS classes for 4 new statuses
- **instructions/role-baton-routing.instructions.md**: Full 8-status workflow with gate conditions
- **instructions/ticket-driven-work.instructions.md**: Label taxonomy v0.2
- **4 role skills**: BACKLOG/TODO distinction, multi-ticket TODO, PASSED-TESTING gate, reject criteria
- **research/adr/008-canonical-ticket-lifecycle.md**: ADR documenting the decision
- **5 research files**: Committed from prior sessions

## Validation

- ✅ npm run lint: 222 files, all ≤100 lines

Closes #119