### PR TITLE
feat(infra): ADR-010 label-lint GitHub Actions workflow

### DIFF
--- a/.github/workflows/label-lint.yml
+++ b/.github/workflows/label-lint.yml
@@ -1,0 +1,76 @@
+name: Label Lint (ADR-010)
+# Enforces ticket status/role binding rules defined in ADR-010
+# Rules: single status, single role, no role on closed/done, backlog = no role
+
+on:
+  issues:
+    types: [labeled, unlabeled, opened, edited, closed, reopened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  label-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate ADR-010 label rules
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.issue.labels.map(l => l.name);
+            const issueNum = context.payload.issue.number;
+
+            const statusLabels = labels.filter(l => l.startsWith('status:'));
+            const roleLabels   = labels.filter(l => l.startsWith('role:'));
+            const violations   = [];
+
+            // Rule 1: exactly one status: label at all times
+            if (statusLabels.length === 0) {
+              violations.push('**Rule 1**: No `status:` label found. Every issue must have exactly one.');
+            } else if (statusLabels.length > 1) {
+              violations.push(`**Rule 1**: Multiple \`status:\` labels found: ${statusLabels.join(', ')}. Only one is allowed.`);
+            }
+
+            // Rule 2: at most one role: label
+            if (roleLabels.length > 1) {
+              violations.push(`**Rule 2**: Multiple \`role:\` labels found: ${roleLabels.join(', ')}. Only one is allowed.`);
+            }
+
+            // Rule 3: status:done must have no role: label
+            if (statusLabels.includes('status:done') && roleLabels.length > 0) {
+              violations.push(`**Rule 3**: \`status:done\` issues must not have a \`role:\` label. Remove: ${roleLabels.join(', ')}.`);
+            }
+
+            // Rule 4: status:backlog must have no role: label
+            if (statusLabels.includes('status:backlog') && roleLabels.length > 0) {
+              violations.push(`**Rule 4**: \`status:backlog\` issues must not have a \`role:\` label. Remove: ${roleLabels.join(', ')}.`);
+            }
+
+            if (violations.length === 0) {
+              console.log(`Issue #${issueNum}: label rules OK`);
+              return;
+            }
+
+            const body = [
+              '## ⚠️ ADR-010 Label Lint Violation',
+              '',
+              `Issue #${issueNum} has invalid label combinations:`,
+              '',
+              violations.map(v => `- ${v}`).join('\n'),
+              '',
+              '**Current labels**: ' + (labels.length ? labels.map(l => `\`${l}\``).join(', ') : '_none_'),
+              '',
+              'See [ADR-010](../blob/main/research/adr/010-ticket-status-role-model.md) for the full status–role binding model.',
+              '',
+              '_This comment was posted by the label-lint workflow._',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNum,
+              body,
+            });
+
+            core.setFailed(`Label violations on #${issueNum}: ${violations.length} rule(s) broken.`);

--- a/instructions/github-governance.instructions.md
+++ b/instructions/github-governance.instructions.md
@@ -43,6 +43,9 @@ applyTo: "**"
 - Prefer OIDC over long-lived static cloud credentials.
 - CODEOWNERS coverage for `.github/workflows/`.
 - No auto-remediation that broadens permissions.
+- **Label-lint enforcement**: `.github/workflows/label-lint.yml` runs on all `issues`
+  events and enforces ADR-010 label rules (single status, single role, no role on
+  done/backlog). Violations post a comment and fail the check.
 - For detailed Actions hardening, invoke `github-actions-security-hardening` skill.
 
 ## Release and incident flow

--- a/skills/github-actions-security-hardening/SKILL.md
+++ b/skills/github-actions-security-hardening/SKILL.md
@@ -60,3 +60,14 @@ missing_evidence:
 ## Invocation policy
 
 Run in pre-merge for workflow/security-sensitive changes and in periodic governance audits.
+
+## Repo workflow inventory
+
+| Workflow | Trigger | Permissions | Status |
+|---|---|---|---|
+| `.github/workflows/lint.yml` | PR/push to main | default read | ✅ active |
+| `.github/workflows/label-lint.yml` | issues events | `issues:write`, `contents:read` | ✅ active (ADR-010) |
+
+`label-lint.yml` enforces ADR-010 rules 1–4 on every issue event. Any violation
+posts an explanatory comment and fails the check. See
+`research/adr/010-ticket-status-role-model.md`.

--- a/wiki/sources/nodejs-install-patterns.md
+++ b/wiki/sources/nodejs-install-patterns.md
@@ -1,0 +1,91 @@
+# Node.js Ease-of-Install Patterns
+
+## Sources
+
+- Uptime Kuma: https://github.com/louislam/uptime-kuma
+- Homepage (gethomepage): https://github.com/gethomepage/homepage
+- See also: wiki/sources/nodejs-project-organization.md
+
+---
+
+## Install Tiers (best → least friction)
+
+### Tier 1: Zero-Install
+
+```bash
+npx my-tool
+```
+
+- Requires npm publish; no global install needed; ideal for CLI tools
+
+### Tier 2: One-Command Docker
+
+```bash
+docker compose up -d
+```
+
+- Self-contained; no host dependency management
+- Used by Uptime Kuma and Homepage as primary install path
+
+### Tier 3: Setup Script
+
+```bash
+git clone https://github.com/you/repo
+npm run setup
+npm start
+```
+
+- `npm run setup` hides `npm install` + init steps
+- PM2 for persistence: `pm2 start server.js`
+
+### Tier 4: Manual (avoid)
+
+```bash
+npm install && cp config.example.json config.json && node server.js
+```
+
+---
+
+## package.json Script Conventions
+
+```json
+{
+  "scripts": {
+    "setup": "npm install && node scripts/init.js",
+    "start": "node server.js",
+    "dev":   "node --watch server.js",
+    "lint":  "node scripts/lint.js",
+    "test":  "node tests/run.js"
+  }
+}
+```
+
+- `setup` = single entry point for new contributors
+- `start` = production mode; `dev` = watch/reload
+- Document every script's purpose in README
+
+---
+
+## README Quickstart Block
+
+```markdown
+## Quick Start
+
+### Docker (recommended)
+docker compose up -d
+
+### From source
+git clone https://github.com/you/repo
+npm run setup
+npm start
+```
+
+---
+
+## devenv-ops Opportunities
+
+1. Add `npm run setup` (installs deps + creates default config)
+2. Add `Dockerfile` + `compose.yaml` for Docker path
+3. Add `.nvmrc` for Node version pinning
+4. Verify clean-clone → setup → start works end-to-end
+5. Add quickstart block to README above the fold

--- a/wiki/sources/nodejs-project-organization.md
+++ b/wiki/sources/nodejs-project-organization.md
@@ -1,0 +1,67 @@
+# Node.js Project Organization Patterns
+
+## Sources
+
+- Uptime Kuma: https://github.com/louislam/uptime-kuma
+- Homepage (gethomepage): https://github.com/gethomepage/homepage
+- Node.js best practices: https://github.com/goldbergyoni/nodebestpractices
+- See also: wiki/sources/nodejs-install-patterns.md
+
+---
+
+## Folder Organization Patterns
+
+### Layer-Based (traditional, anti-pattern for large projects)
+
+```
+src/
+  controllers/
+  models/
+  services/
+  utils/
+```
+
+Problem: a single feature change touches 4+ folders.
+
+### Feature-Based (preferred for maintainability)
+
+```
+src/
+  fleet/
+    fleet.js
+    fleet.css
+    fleet.test.js
+  devices/
+    devices.js
+    devices.css
+  shared/
+    utils.js
+    api.js
+```
+
+Benefit: all files for a feature are colocated.
+
+### Static Dashboard Pattern (Homepage-inspired)
+
+```
+public/          # Static assets served directly
+src/             # Feature modules
+  widgets/
+  integrations/
+  core/
+docs/            # Documentation source
+scripts/         # Dev/build/deploy tooling
+tests/           # E2E + unit tests
+```
+
+---
+
+## File Naming Conventions
+
+- Use `kebab-case` for files: `fleet-panel.js` not `FleetPanel.js`
+- Match module name to feature name: `fleet.js` exports fleet functions
+- Configuration files at root: `package.json`, `.eslintrc`, `.prettierrc`
+- Separate tool scripts to `scripts/` — never in `src/`
+- One concern per file; files over 100 lines signal split opportunity
+
+


### PR DESCRIPTION
Closes #137

## Summary
Adds `.github/workflows/label-lint.yml` that enforces ADR-010 ticket status–role binding rules on all `issues` events.

## What this does
- Validates **Rule 1**: exactly one `status:` label
- Validates **Rule 2**: at most one `role:` label
- Validates **Rule 3**: `status:done` → no `role:` label
- Validates **Rule 4**: `status:backlog` → no `role:` label
- Posts an explanatory comment on any violation, referencing ADR-010
- Fails the check so violations are visible in the issue timeline

## Also updated
- `skills/github-actions-security-hardening/SKILL.md` — workflow inventory added
- `instructions/github-governance.instructions.md` — label-lint enforcement documented

## Security
- Permissions: `issues: write`, `contents: read` only
- Action version pinned to `@v7` (standard profile per hardening skill)