### PR TITLE
feat(#142): Global Wiki Availability

### DIFF
--- a/.github/SESSION_HANDOFF.md
+++ b/.github/SESSION_HANDOFF.md
@@ -1,0 +1,110 @@
+# Session Handoff — devenv-ops
+
+**Created**: 2026-04-17  
+**Reason**: Chat context limit reached — use this file to initialize a fresh chat.
+
+---
+
+## Repo Identity
+
+- **Repo**: `chf3198/devenv-ops` at `/home/curtisfranks/devenv-ops`
+- **Purpose**: Development workbench for `~/.copilot/` global Copilot resources (skills, instructions, hooks, scripts, agents). Also contains a static Alpine.js fleet monitoring dashboard.
+- **Branch**: `main` (HEAD: `854eca6`)
+- **No open issues** — all tickets closed as of this handoff.
+- **Deploy runtime**: `~/.copilot/` — never edit directly; use `npm run deploy:apply` after merge to main.
+
+---
+
+## What Was Just Completed
+
+### #137 — label-lint GitHub Actions workflow
+- `.github/workflows/label-lint.yml` — enforces ADR-010 label rules on all issue events
+- `skills/github-actions-security-hardening/SKILL.md` — workflow inventory table added
+- `instructions/github-governance.instructions.md` — label-lint bullet added
+- Merged PR #138
+
+### #136 — Code cleanup epic (5 ACs)
+- Named constants extracted: `STRESS_HARD_STOP_SEC`, `FETCH_TIMEOUT_MS`, `HEALTH_TIMEOUT_MS`, `DEDUP_WINDOW_MS`
+- README: badge row + sharpened pitch; GitHub topics set
+- `.nvmrc` (Node 22), `Dockerfile`, `compose.yaml`, `npm run setup`
+- `dashboard/README.md`: feature-based naming convention documented
+- Merged PR #139
+
+### #140 — Wire global-task-router fleet lane (OpenClaw HTTP dispatch)
+- `scripts/global/openclaw-chat.js` (new): OpenAI-compatible HTTP client for OpenClaw
+  - `chatComplete(prompt, opts)` — POST `/v1/chat/completions`
+  - `healthCheck()` — uses `/health/liveliness` (65ms, not the slow `/health` endpoint)
+  - Direct Tailscale HTTP: `http://100.78.22.13:4000` — no SSH tunnel needed
+  - 120s timeout via manual `setTimeout`+`AbortController` (NOT `AbortSignal.timeout()` — misfires in Node 22)
+  - Default 256 max_tokens (phi3-mini: ~17s/50 tokens)
+- `task-router-dispatch.js`: fleet lane now calls `chatComplete()` and returns live response
+- `task-router-policy.json`: model ID fixed `qwen2.5:7b` → `qwen2.5-7b`
+- Deployed to `~/.copilot/` via `npm run deploy:apply`
+- Merged PR #141
+
+---
+
+## Fleet Topology
+
+```
+chromebook-2 (this machine)     penguin-1 (SML)           windows-laptop (OpenClaw)
+  100.115.92.2                   100.86.248.35              100.78.22.13
+  primary dev / VS Code          qwen3.5:0.8b etc.          OpenClaw LiteLLM :4000
+  local=true                     Ollama :11434               Ollama :11434
+```
+
+**OpenClaw** is a LiteLLM proxy at `http://100.78.22.13:4000`. Reachable via direct Tailscale HTTP.  
+Available models (from `/v1/models`): `qwen2.5-7b`, `phi3-mini`, `mistral`  
+**Recommended for dispatch**: `phi3-mini` (fastest, ~6s for 5 tokens)  
+**Note**: `qwen2.5-7b` inference at 256 tokens likely exceeds 120s timeout — untested; follow-up ticket recommended.
+
+---
+
+## Known Good Commands
+
+```bash
+npm run lint              # ≤100-line file check (235 files, all passing)
+npm run router:smoke      # 3/3 classification cases pass
+npm run deploy:apply      # Deploy repo → ~/.copilot/ (auto-backup)
+npm run deploy            # Dry-run only
+
+# Test fleet dispatch
+node scripts/global/openclaw-chat.js --health
+node scripts/global/openclaw-chat.js --prompt "your prompt" --model phi3-mini
+node scripts/global/task-router-dispatch.js --prompt "implement multi-file refactor" --model phi3-mini --execute
+```
+
+---
+
+## Architecture Constraints
+
+- **≤100 lines per file** — hard lint gate (`npm run lint`)
+- **No build step** — dashboard is static HTML/CSS/JS served by `scripts/dashboard-server.js`
+- **Branch before any edit** to global resources (`skills/`, `instructions/`, `hooks/`, `scripts/global/`)
+- **Git workflow**: branch → implement → lint → commit → push → PR → squash merge → delete branch → `npm run deploy:apply`
+- **Ticket lifecycle**: `status:backlog` → `status:in-progress` (role:manager → role:collaborator → role:admin → role:consultant) → `status:done`
+
+---
+
+## Key File Locations
+
+| What | Path |
+|------|------|
+| OpenClaw HTTP client | `scripts/global/openclaw-chat.js` |
+| Task router dispatch | `scripts/global/task-router-dispatch.js` |
+| Task router policy | `scripts/global/task-router-policy.json` |
+| Lane usage log | `~/.copilot/openclaw-usage.log` |
+| Global skills (source) | `skills/<name>/SKILL.md` |
+| Global instructions (source) | `instructions/*.instructions.md` |
+| Dashboard entry | `dashboard/index.html` |
+| Dashboard JS docs | `dashboard/README.md` |
+| ADRs | `research/adr/` |
+| Fleet inventory | `inventory/devices.json`, `inventory/services.json` |
+
+---
+
+## Recommended Next Tickets
+
+1. **Characterize per-model inference latency** on OpenClaw (`phi3-mini`, `qwen2.5-7b`, `mistral`) and add per-model timeout config to `task-router-policy.json`
+2. **SLM dispatch to penguin-1** — same pattern as OpenClaw but targeting `http://100.86.248.35:11434/api/generate` (Ollama native API, not OpenAI-compat)
+3. **Router smoke test expansion** — add fleet/execute path to `task-router-smoke.js` with a mock for the HTTP call

--- a/hooks/scripts/wiki_wisdom.py
+++ b/hooks/scripts/wiki_wisdom.py
@@ -13,7 +13,8 @@ def _find_wiki() -> Path | None:
     global _WIKI_ROOT
     if _WIKI_ROOT is not None:
         return _WIKI_ROOT
-    for c in [Path(__file__).resolve().parent.parent.parent / "wiki",
+    for c in [Path.home() / ".copilot" / "wiki",
+              Path(__file__).resolve().parent.parent.parent / "wiki",
               Path.home() / "devenv-ops" / "wiki"]:
         if c.is_dir():
             _WIKI_ROOT = c

--- a/instructions/wiki-knowledge.instructions.md
+++ b/instructions/wiki-knowledge.instructions.md
@@ -1,0 +1,43 @@
+---
+applyTo: "**"
+---
+
+# Wiki Knowledge — Global Instruction
+
+## LLM Wiki Availability
+
+A compiled Karpathy LLM Wiki is deployed at `~/.copilot/wiki/`.
+This wiki contains cross-referenced knowledge about the fleet,
+skills, governance, architecture, and research.
+
+## Access Model
+
+| Operation | Where | Command |
+|---|---|---|
+| **Search** | Any repo | `node ~/.copilot/scripts/wiki-search.js "query"` |
+| **Read** | Any repo | Read `~/.copilot/wiki/index.md` then drill into pages |
+| **Ingest** | devenv-ops only | `npm run wiki:ingest -- raw/articles/<file>.md` |
+| **Lint** | devenv-ops only | `npm run wiki:lint` |
+| **Anneal** | devenv-ops only | `npm run wiki:anneal` |
+
+## When to Use the Wiki
+
+- Before research tasks: check if the wiki already has compiled knowledge
+- When answering questions about fleet topology, governance, or architecture
+- When cross-referencing skills, instructions, or ADR decisions
+- After completing significant work: suggest wiki updates in devenv-ops
+
+## Wiki Structure
+
+- `wiki/index.md` — read this first to find relevant pages
+- `wiki/entities/` — devices, services, tools
+- `wiki/concepts/` — patterns, protocols, decisions
+- `wiki/sources/` — digests of raw research documents
+- `wiki/syntheses/` — cross-cutting analysis
+
+## Rules
+
+- Wiki at `~/.copilot/wiki/` is **read-only** from non-devenv-ops repos
+- Never edit `~/.copilot/wiki/` directly — changes flow through devenv-ops
+- Cite wiki pages with `[[page-name]]` wikilink syntax
+- If wiki content is stale, note it for devenv-ops maintenance

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -66,6 +66,7 @@ if ! $APPLY; then
   deploy_files "$ROOT/instructions" "$COPILOT/instructions" "Instructions"
   deploy_files "$ROOT/scripts/global" "$COPILOT/scripts" "Global Scripts"
   deploy_files "$ROOT/agents" "$COPILOT/agents" "Agents"
+  deploy_dir "$ROOT/wiki" "$COPILOT/wiki" "Wiki (read-only)"
   echo "Re-run with --apply to deploy changes."
   exit 0
 fi
@@ -78,6 +79,12 @@ deploy_dir "$ROOT/skills" "$COPILOT/skills" "Skills"
 deploy_files "$ROOT/instructions" "$COPILOT/instructions" "Instructions"
 deploy_files "$ROOT/scripts/global" "$COPILOT/scripts" "Global Scripts"
 deploy_files "$ROOT/agents" "$COPILOT/agents" "Agents"
+deploy_dir "$ROOT/wiki" "$COPILOT/wiki" "Wiki (read-only)"
+
+# Deploy wiki index + log + schema
+for wf in "$ROOT/wiki/index.md" "$ROOT/wiki/log.md" "$ROOT/WIKI.md"; do
+  [[ -f "$wf" ]] && cp "$wf" "$COPILOT/wiki/$(basename "$wf")"
+done
 
 # Hooks: deploy excluding pycache/state
 rsync -a --exclude='__pycache__' \

--- a/scripts/global/wiki-search.js
+++ b/scripts/global/wiki-search.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+'use strict';
+// wiki-search.js — Global wiki search (works from any repo)
+// Deployed to ~/.copilot/scripts/wiki-search.js
+// Usage: node ~/.copilot/scripts/wiki-search.js "your question"
+
+const fs = require('fs');
+const path = require('path');
+
+const WIKI_DIR = process.env.WIKI_DIR
+  || path.join(process.env.HOME || '', '.copilot', 'wiki');
+
+function listPages() {
+  const dirs = ['entities', 'concepts', 'sources', 'syntheses'];
+  const pages = [];
+  for (const d of dirs) {
+    const dp = path.join(WIKI_DIR, d);
+    if (!fs.existsSync(dp)) continue;
+    for (const f of fs.readdirSync(dp).filter((x) => x.endsWith('.md'))) {
+      pages.push({ slug: f.replace('.md', ''), type: d, path: path.join(dp, f) });
+    }
+  }
+  return pages;
+}
+
+function searchPages(question, pages) {
+  const qWords = question.toLowerCase().split(/\s+/);
+  const scored = pages.map((p) => {
+    const content = fs.readFileSync(p.path, 'utf-8').toLowerCase();
+    const hits = qWords.filter((w) => content.includes(w)).length;
+    return { ...p, score: hits };
+  });
+  scored.sort((a, b) => b.score - a.score);
+  return scored.filter((p) => p.score > 0).slice(0, 5);
+}
+
+function main() {
+  const question = process.argv.slice(2).join(' ');
+  if (!question) {
+    console.log('Usage: node wiki-search.js "your question"');
+    process.exit(1);
+  }
+  if (!fs.existsSync(WIKI_DIR)) {
+    console.error(`❌ Wiki not found at ${WIKI_DIR}`);
+    console.error('Run: npm run deploy:apply (in devenv-ops)');
+    process.exit(1);
+  }
+  const pages = listPages();
+  if (pages.length === 0) {
+    console.log('📋 Wiki is empty.');
+    process.exit(0);
+  }
+  console.log(`🔍 Query: ${question}`);
+  console.log(`📚 Wiki: ${WIKI_DIR} (${pages.length} pages)\n`);
+  const relevant = searchPages(question, pages);
+  if (relevant.length === 0) {
+    console.log('No relevant pages found.');
+    process.exit(0);
+  }
+  console.log(`📄 ${relevant.length} match(es):\n`);
+  for (const p of relevant) {
+    console.log(`## [[${p.slug}]] (${p.type}, score: ${p.score})`);
+    const lines = fs.readFileSync(p.path, 'utf-8').split('\n');
+    const body = lines.filter((l) => !l.startsWith('---')).slice(0, 8);
+    console.log(body.join('\n') + '\n');
+  }
+}
+
+main();

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -68,6 +68,7 @@ sync_dir "$COPILOT/skills" "$ROOT/skills" "Skills"
 sync_files "$COPILOT/instructions" "$ROOT/instructions" "Instructions"
 sync_files "$COPILOT/scripts" "$ROOT/scripts/global" "Global Scripts"
 sync_files "$COPILOT/agents" "$ROOT/agents" "Agents"
+sync_dir "$COPILOT/wiki" "$ROOT/wiki" "Wiki"
 
 # Hooks: copy files, skip __pycache__ and state/
 echo "── Hooks ──"

--- a/skills/global-skills-bootstrap/SKILL.md
+++ b/skills/global-skills-bootstrap/SKILL.md
@@ -39,6 +39,7 @@ The generated instruction file must require this order:
 4. `web-regression-governance` when repo type is `website-static` or `web-app`
 5. `github-ops-tree-router` for rulesets/required checks/governance controls
 6. `workflow-self-anneal` only after failures/process drift
+7. `llm-wiki-ops` when querying compiled knowledge from `~/.copilot/wiki/`
 
 ## Hard constraints
 

--- a/skills/llm-wiki-ops/SKILL.md
+++ b/skills/llm-wiki-ops/SKILL.md
@@ -5,64 +5,59 @@ Operate and maintain the LLM Wiki knowledge system. Use this
 skill when ingesting sources, querying the wiki, diagnosing
 health issues, or planning knowledge graph expansion.
 
+## Global Access Model
+
+| Mode | Scope | Path |
+|---|---|---|
+| **Read** | Any repo | `~/.copilot/wiki/` (deployed runtime) |
+| **Write** | devenv-ops only | `wiki/` (source of truth) |
+| **Search** | Any repo | `node ~/.copilot/scripts/wiki-search.js` |
+| **Ingest** | devenv-ops only | `npm run wiki:ingest` |
+| **Lint** | devenv-ops only | `npm run wiki:lint` |
+
 ## Architecture
 ```
-raw/articles/     → Immutable human-curated sources
-wiki/             → LLM-compiled pages (sources/, entities/, concepts/, syntheses/)
-wiki/index.md     → Page catalog (updated on every ingest)
-wiki/log.md       → Append-only operation log
-scripts/wiki/     → CLI tools (ingest, lint, search)
-WIKI.md           → Governance schema
+devenv-ops/wiki/    ──deploy──▶  ~/.copilot/wiki/  (read-only)
+devenv-ops/raw/     (stays local, not deployed)
+scripts/wiki/       (dev tools, not deployed)
+scripts/global/wiki-search.js ──deploy──▶ ~/.copilot/scripts/
 ```
 
 ## Operations
 
-### Ingest
+### Search (any repo)
 ```bash
-node scripts/wiki/ingest.js raw/articles/<source>.md
-# or: npm run wiki:ingest -- raw/articles/<source>.md
+node ~/.copilot/scripts/wiki-search.js "your question"
 ```
-Reads raw source → calls OpenClaw LLM → writes wiki/sources/ page.
-Updates index.md and log.md. Marks raw source as ingested.
+Keyword scoring → top 5 pages → shows matches with excerpts.
 
-### Lint
+### Ingest (devenv-ops only)
 ```bash
-node scripts/wiki/lint.js
-# or: npm run wiki:lint
+npm run wiki:ingest -- raw/articles/<source>.md
 ```
-Checks: broken [[wikilinks]], orphan pages, missing frontmatter,
-index.md sync. Exit 0 = healthy, exit 1 = issues found.
+Raw → LLM summary → wiki/sources/ page → index + log update.
 
-### Search
+### Lint (devenv-ops only)
 ```bash
-node scripts/wiki/search.js "your question here"
-# or: npm run wiki:search -- "your question"
+npm run wiki:lint
 ```
-Keyword scoring → top 5 pages → LLM synthesis via OpenClaw.
-Graceful fallback: shows raw matches if LLM unavailable.
+Broken wikilinks, orphans, frontmatter, index sync.
 
 ## Fleet Routing
-- **Ingest**: Fleet lane → OpenClaw (mistral primary, qwen2.5 fallback)
-- **Lint**: Free lane → local only (no LLM needed)
-- **Search**: Fleet lane → OpenClaw for synthesis
-
-## Failover Chain
-OpenClaw(mistral) → OpenClaw(qwen2.5:7b) → Groq → Cerebras
+- **Ingest**: Fleet lane → OpenClaw (mistral → qwen2.5 fallback)
+- **Search (LLM)**: Fleet lane → OpenClaw for synthesis
+- **Lint**: Free lane → local only (no LLM)
 
 ## Troubleshooting
 | Symptom | Cause | Fix |
 |---|---|---|
-| Ingest timeout | Model cold start | Warm up: `curl OpenClaw/health` |
-| All LLMs fail | Network/Tailscale | Check `tailscale status` |
-| Orphan pages | No cross-refs | Expected for isolated topics |
-| Index drift | Manual wiki edits | Run `npm run wiki:lint` |
+| Wiki not found | Not deployed | `npm run deploy:apply` in devenv-ops |
+| Stale content | Not redeployed | Redeploy after wiki changes |
+| Ingest timeout | Model cold start | `curl OpenClaw/health` |
+| All LLMs fail | Network/Tailscale | `tailscale status` |
 
 ## Constraints
-- Raw sources are immutable after ingest (status: ingested)
-- Wiki pages are LLM-generated — human edits go in raw/
+- `~/.copilot/wiki/` is read-only from non-devenv-ops repos
+- Raw sources are immutable after ingest
 - All scripts ≤100 lines (lint-enforced)
-- Timeout: 300s per LLM call (model inference on 16GB RAM)
-
-## Dashboard
-Wiki Health panel in Ops view shows: page count, categories,
-structural issues. Backed by `/api/wiki-health` endpoint.
+- Changes flow: devenv-ops → merge → deploy → ~/.copilot/


### PR DESCRIPTION
## Summary

Makes the Karpathy LLM Wiki globally accessible to all DevEnv Ops-enabled repos.

### Changes

| File | Change |
|---|---|
| `scripts/deploy.sh` | Deploy wiki/ to `~/.copilot/wiki/` (read-only) |
| `scripts/sync.sh` | Sync wiki/ from runtime |
| `hooks/scripts/wiki_wisdom.py` | Resolve `~/.copilot/wiki/` first |
| `scripts/global/wiki-search.js` | **New** — portable wiki search from any repo |
| `instructions/wiki-knowledge.instructions.md` | **New** — global instruction for wiki access |
| `skills/global-skills-bootstrap/SKILL.md` | Add wiki routing to contract |
| `skills/llm-wiki-ops/SKILL.md` | Rewrite with global access model |

### Access Model
- **Read/Search**: Any repo via `~/.copilot/wiki/` and `wiki-search.js`
- **Write** (ingest/anneal/lint): devenv-ops only

Closes #142 #145 #146 #147 #148 #149 #150