### PR TITLE
feat(plugin): add plugin.json manifest with 23 universal skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,1 @@
+/home/curtisfranks/devenv-ops/plugin.json

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,0 +1,1 @@
+/home/curtisfranks/devenv-ops/plugin.json

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "devenv-ops",
+  "description": "AI agent governance harness — skills, agents, hooks for structured development workflows",
+  "version": "3.0.0",
+  "author": "chf3198",
+  "skills": [
+    "skills/docs-drift-maintenance",
+    "skills/github-actions-security-hardening",
+    "skills/github-capability-resolver",
+    "skills/github-ops-excellence",
+    "skills/github-ops-tree-router",
+    "skills/github-projects-agile-linkage",
+    "skills/github-release-incident-flow",
+    "skills/github-review-merge-admin",
+    "skills/github-ruleset-architecture",
+    "skills/github-ticket-lifecycle-orchestrator",
+    "skills/manager-ticket-lifecycle",
+    "skills/release-version-integrity",
+    "skills/repo-onboarding-standards",
+    "skills/repo-profile-governance",
+    "skills/repo-standards-router",
+    "skills/repo-structure-conventions",
+    "skills/role-baton-orchestrator",
+    "skills/role-collaborator-execution",
+    "skills/role-consultant-critique",
+    "skills/role-manager-execution",
+    "skills/secret-exposure-prevention",
+    "skills/web-regression-governance",
+    "skills/workflow-self-anneal"
+  ],
+  "agents": "agents/"
+}


### PR DESCRIPTION
## Summary
Creates the VS Code Agent Plugin manifest (`plugin.json`) at repo root, exposing 23 universal skills and 8 custom agents for cross-tool consumption.

## Changes
- **plugin.json** (32 lines): Root manifest with name, description, version, author, 23 skill paths, agents directory
- **.claude-plugin/plugin.json**: Symlink → root manifest (Claude Code compatibility)
- **.github/plugin/plugin.json**: Symlink → root manifest (GitHub Copilot compatibility)

## Verification
- [x] Valid JSON (python3 -m json.tool)
- [x] 23 universal skills, 0 personal skills
- [x] Both symlinks resolve correctly
- [x] ≤100 lines (32 lines)
- [x] npm run lint passes (no new violations)

Closes #168