### PR TITLE
feat(plugin): add skill triage manifest and validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "wiki:lint": "node scripts/wiki/lint.js",
     "wiki:anneal": "node scripts/wiki/anneal.js",
     "wiki:search": "node scripts/wiki/search.js",
+    "validate:triage": "node scripts/validate-plugin-triage.js",
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
     "test:quality": "npx playwright test tests/google-quality.spec.js",

--- a/scripts/validate-plugin-triage.js
+++ b/scripts/validate-plugin-triage.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// Validates plugin.json skills array matches .plugin-triage.json
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const root = path.resolve(__dirname, '..');
+
+const plugin = JSON.parse(fs.readFileSync(path.join(root, 'plugin.json'), 'utf8'));
+const triage = JSON.parse(fs.readFileSync(path.join(root, 'skills', '.plugin-triage.json'), 'utf8'));
+
+const pluginSkills = (plugin.skills || []).map(s => s.replace('skills/', ''));
+const universalSet = new Set(triage.universal);
+const personalNames = triage.personal.map(p => p.name);
+const personalSet = new Set(personalNames);
+let errors = 0;
+
+// Check: every plugin skill must be marked universal
+for (const skill of pluginSkills) {
+  if (!universalSet.has(skill)) {
+    console.error(`❌ plugin.json references "${skill}" not in triage universal list`);
+    errors++;
+  }
+}
+// Check: every universal skill must be in plugin.json
+for (const skill of triage.universal) {
+  if (!pluginSkills.includes(skill)) {
+    console.error(`❌ triage universal "${skill}" missing from plugin.json`);
+    errors++;
+  }
+}
+// Check: no personal skill in plugin.json
+for (const skill of pluginSkills) {
+  if (personalSet.has(skill)) {
+    console.error(`❌ personal skill "${skill}" found in plugin.json`);
+    errors++;
+  }
+}
+// Check: all skill dirs accounted for
+const allDirs = fs.readdirSync(path.join(root, 'skills'))
+  .filter(d => !d.startsWith('.') && fs.statSync(path.join(root, 'skills', d)).isDirectory());
+const triaged = new Set([...triage.universal, ...personalNames]);
+for (const dir of allDirs) {
+  if (!triaged.has(dir)) {
+    console.error(`❌ skill dir "${dir}" not in triage manifest`);
+    errors++;
+  }
+}
+
+if (errors > 0) {
+  console.error(`\n${errors} triage error(s) found.`);
+  process.exit(1);
+}
+console.log(`✅ Plugin triage valid: ${pluginSkills.length} universal, ${personalNames.length} personal, ${allDirs.length} total dirs`);

--- a/skills/.plugin-triage.json
+++ b/skills/.plugin-triage.json
@@ -1,0 +1,41 @@
+{
+  "_doc": "Canonical skill triage. 'universal' ships in plugin.json. 'personal' deploys only via deploy.sh.",
+  "universal": [
+    "docs-drift-maintenance",
+    "github-actions-security-hardening",
+    "github-capability-resolver",
+    "github-ops-excellence",
+    "github-ops-tree-router",
+    "github-projects-agile-linkage",
+    "github-release-incident-flow",
+    "github-review-merge-admin",
+    "github-ruleset-architecture",
+    "github-ticket-lifecycle-orchestrator",
+    "manager-ticket-lifecycle",
+    "release-version-integrity",
+    "repo-onboarding-standards",
+    "repo-profile-governance",
+    "repo-standards-router",
+    "repo-structure-conventions",
+    "role-baton-orchestrator",
+    "role-collaborator-execution",
+    "role-consultant-critique",
+    "role-manager-execution",
+    "secret-exposure-prevention",
+    "web-regression-governance",
+    "workflow-self-anneal"
+  ],
+  "personal": [
+    { "name": "global-skills-bootstrap", "reason": "repo-specific bootstrap wiring" },
+    { "name": "global-task-router", "reason": "fleet-specific lane routing" },
+    { "name": "llm-wiki-ops", "reason": "replaced by portable version in #171" },
+    { "name": "mem-watchdog-ops", "reason": "Crostini-specific memory management" },
+    { "name": "network-platform-resources", "reason": "personal fleet inventory" },
+    { "name": "openclaw-availability-utilization", "reason": "personal OpenClaw gateway" },
+    { "name": "openclaw-universal-system", "reason": "personal OpenClaw gateway" },
+    { "name": "openrouter-free-failover", "reason": "personal OpenRouter config" },
+    { "name": "operator-identity-context", "reason": "personal identity/authority model" },
+    { "name": "playwright-vision-low-resource", "reason": "hardware-specific constraints" },
+    { "name": "role-admin-execution", "reason": "personal admin workflow with deploy access" }
+  ]
+}


### PR DESCRIPTION
## Summary
Machine-readable triage manifest + validation script to prevent plugin/personal skill drift.

## Changes
- **skills/.plugin-triage.json** (41 lines): 23 universal + 11 personal with rationale
- **scripts/validate-plugin-triage.js** (53 lines): Bidirectional sync check
- **package.json**: Added `validate:triage` script

## Verification
- `npm run validate:triage` → ✅ 23 universal, 11 personal, 34 total
- Lint passes, both files ≤100 lines

Closes #169