### PR TITLE
docs: add plugin install path and CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to devenv-ops
+
+## Universal vs Personal Skills
+
+Skills are categorized in `skills/.plugin-triage.json`:
+- **Universal** (24): Ship in `plugin.json` for all consumers
+- **Personal** (11): Deploy only via `deploy.sh` to `~/.copilot/`
+
+## Adding a Universal Skill
+
+1. Create `skills/<name>/SKILL.md` with YAML frontmatter
+2. Add to `plugin.json` `skills` array
+3. Add to `skills/.plugin-triage.json` `universal` list
+4. Run `npm run validate:triage` to verify sync
+5. Branch → PR → squash merge → `npm run deploy:apply`
+
+## Adding a Personal Skill
+
+1. Create `skills/<name>/SKILL.md`
+2. Add to `skills/.plugin-triage.json` `personal` list
+3. Do NOT add to `plugin.json`
+4. Run `npm run validate:triage`
+
+## Skill Format
+
+```markdown
+---
+name: skill-name
+description: One-line description
+---
+# skill-name — Title
+## Purpose
+## Scope
+## Constraints
+## Instructions
+## Verification
+```
+
+## Testing Plugin Installation
+
+1. Push changes to a branch
+2. In VS Code: `Chat: Install Plugin From Source`
+3. Paste the branch Git URL
+4. Verify skills appear in chat suggestions
+
+## Cross-Tool Compatibility
+
+| Tool | Detection Path |
+|------|---------------|
+| VS Code Copilot | `plugin.json` (root) |
+| Claude Code | `.claude-plugin/plugin.json` (symlink) |
+| GitHub Copilot | `.github/plugin/plugin.json` (symlink) |
+
+Symlinks auto-resolve to root `plugin.json`.
+
+## Constraints
+
+- **≤100 lines** per file (lint-enforced)
+- **Branch before editing**: `feat/<issue>-<slug>`
+- **Conventional commits**: `feat(scope):`, `fix(scope):`
+- Run `npm run lint` before pushing

--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@
 [![Node ≥22](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
 [![Lint: ≤100 lines](https://img.shields.io/badge/lint-%E2%89%A4100%20lines-blue)](#)
 
-**Copilot workbench for a personal AI-augmented dev environment.**
-Routes prompts across 8 custom agents, monitors an Ollama fleet,
-and deploys global skills/instructions to `~/.copilot/` via one command.
+**AI agent governance harness — skills, agents, hooks, and wiki.**
+24 universal skills ship as a VS Code Agent Plugin. Install via Git
+URL or develop the harness itself for personal fleet deployment.
+
+## Install as Agent Plugin
+
+In VS Code (with Copilot), run:
+> `Chat: Install Plugin From Source` → paste this repo's Git URL.
+
+You get: 24 governance skills, 8 custom agents, wiki seed content.
+No build step. No configuration. Works in VS Code, Copilot CLI,
+and Claude Code (via `.claude-plugin/` symlink).
 
 ## How It Works
 
@@ -40,7 +49,7 @@ Custom agents override VS Code Copilot AUTO model selection via
 
 ```
 devenv-ops (source of truth)          ~/.copilot/ (runtime)
-  skills/          (33) ──deploy──▶   skills/
+  skills/          (35) ──deploy──▶   skills/
   instructions/    (12) ──deploy──▶   instructions/
   agents/           (8) ──deploy──▶   agents/
   hooks/           (19) ──deploy──▶   hooks/


### PR DESCRIPTION
README adds plugin install section. CONTRIBUTING.md covers skill triage workflow and cross-tool compat.

Closes #172