### PR TITLE
fix: align fleet proxy keys with credential store resource IDs

### DIFF
--- a/dashboard/fleet-config-migration.json
+++ b/dashboard/fleet-config-migration.json
@@ -40,7 +40,7 @@
     { "id": "chromebook-2-ollama", "name": "Chromebook-2 Ollama", "provider": "ollama", "tier": "local",
       "baseUrl": "http://100.87.216.75:11434",
       "apiFormat": "openai-compat", "healthEndpoint": "/api/tags", "modelsEndpoint": "/api/tags",
-      "auth": {"type":"none"}, "tags": ["local","chromebook","tbd"], "enabled": false,
+      "auth": {"type":"none"}, "tags": ["local","chromebook","slm"], "enabled": true,
       "meta": {"device":"chromebook-2","tailscaleIP":"100.87.216.75","status":"provisioning"} }
   ]
 }

--- a/dashboard/js/fleet-probe.js
+++ b/dashboard/js/fleet-probe.js
@@ -12,7 +12,7 @@ async function probeResource(resource) {
 }
 
 async function probeLocalResource(resource) {
-  const deviceId = resource.meta?.device || resource.id;
+  const deviceId = resource.id;
   const ep = resource.healthEndpoint || '/api/tags';
   const proxyUrl = `/api/fleet/${deviceId}${ep}`;
   try {

--- a/scripts/dashboard-server.js
+++ b/scripts/dashboard-server.js
@@ -4,9 +4,12 @@ const PORT = process.env.DASH_PORT || 8090; const ROOT = path.resolve(__dirname,
 const MIME = {'.html':'text/html','.css':'text/css','.js':'text/javascript','.json':'application/json'};
 const FLEET = {
   'penguin-1': process.env.DEVICE_PENGUIN1_URL || 'http://100.86.248.35:11434',
+  'penguin-1-ollama': process.env.DEVICE_PENGUIN1_URL || 'http://100.86.248.35:11434',
   'windows-laptop': process.env.DEVICE_WINDOWS_URL || 'http://100.78.22.13:11434',
+  'windows-laptop-ollama': process.env.DEVICE_WINDOWS_URL || 'http://100.78.22.13:11434',
   'openclaw-litellm': process.env.OPENCLAW_URL || 'http://100.78.22.13:4000',
-  'chromebook-2': process.env.DEVICE_CHROMEBOOK2_URL || 'http://100.87.216.75:11434'
+  'chromebook-2': process.env.DEVICE_CHROMEBOOK2_URL || 'http://100.87.216.75:11434',
+  'chromebook-2-ollama': process.env.DEVICE_CHROMEBOOK2_URL || 'http://100.87.216.75:11434'
 };
 const OPENCLAW = process.env.OPENCLAW_URL || 'http://100.78.22.13:4000';
 const { getWikiHealth, getWikiPages } = require('./dashboard-wiki');


### PR DESCRIPTION
Closes #209

## Problem
Health Check All showed OpenClaw as 'error' because fleet-probe resolved `meta.device = 'windows-laptop'` which mapped to Ollama (:11434), not LiteLLM (:4000).

## Fix
- Server FLEET map adds resource-ID aliases matching credential store IDs
- fleet-probe uses `resource.id` directly as the proxy key
- Chromebook-2 enabled in migration JSON

## Verification
- `curl /api/fleet/penguin-1-ollama/api/tags` → 200 (models returned)
- `curl /api/fleet/chromebook-2-ollama/api/tags` → 502 (offline, expected)
- Lint: only pre-existing SESSION_HANDOFF.md exceeds 100 lines