### PR TITLE
feat(dashboard): UX polish — layout, scrolling, tooltips, panel sizing

### DIFF
--- a/dashboard/css/settings.css
+++ b/dashboard/css/settings.css
@@ -11,6 +11,7 @@
 .settings-actions button:hover, .btn-label:hover { border-color: var(--accent, #58a6ff); }
 .settings-empty { padding: 24px; text-align: center; color: var(--muted); }
 .settings-form { padding: 16px; border: 1px solid var(--border); border-radius: 8px; margin: 12px 0; }
+#settings-form-container:empty { display: none; }
 .settings-form label { display: block; margin: 8px 0; font-size: 0.85rem; }
 .settings-form input, .settings-form select {
   display: block; width: 100%; padding: 6px 8px; margin-top: 4px;

--- a/dashboard/css/views.css
+++ b/dashboard/css/views.css
@@ -10,7 +10,6 @@
 .shb:hover { opacity: 1; border-color: var(--blue); }
 .shb:focus-visible { box-shadow: var(--focus-ring); }
 .panel h2 { display: flex; align-items: center; }
-/* Header nav */
 .header-nav { display: flex; gap: 0.25rem; }
 
 .header-nav button { background: var(--surface); color: var(--text);
@@ -21,9 +20,6 @@
   background: color-mix(in srgb, var(--blue) 10%, var(--surface)); }
 .header-nav button:focus-visible { box-shadow: var(--focus-ring); }
 .header-nav button.active { border-color: var(--blue); color: var(--blue); }
-
-.panel { content-visibility: auto;
-  contain-intrinsic-size: auto 180px; }
 
 .panel.full-width { grid-column: 1 / -1; }
 
@@ -73,14 +69,19 @@
 .help-category:first-child .help-cat-title { margin-top: 0; }
 .help-feedback { display: flex; gap: 1rem; padding: 0.5rem 0; }
 .help-empty { color: var(--text-muted); font-style: italic; }
-/* View-specific grids + responsive */
-.view-live, .view-logs { grid-template-rows: 1fr 1fr; }
-.view-ops { grid-template-rows: repeat(3, 1fr); }
+/* View grids + responsive */
+.view-live { grid-template-columns: 1fr 1fr; grid-template-rows: 1fr auto; }
+.view-logs, .view-fleet { grid-template-columns: 1fr 1fr; }
+.view-ops { grid-template-columns: 1fr 1fr; grid-template-rows: 2fr 1fr 1fr; }
 .view-wiki { grid-template-columns: 1fr 2fr; }
 .view-help { grid-template-columns: 1fr; }
-.log-scroll { overflow-y: auto; max-height: calc(50dvh - 60px); }
-.panel { overflow: hidden; display: flex; flex-direction: column; }
-.panel > div { flex: 1; overflow-y: auto; min-height: 0; }
+.log-scroll { overflow-y: scroll; max-height: calc(50dvh - 60px); }
+.panel { overflow: hidden; display: flex; flex-direction: column;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; padding: 0.5rem 0.6rem; }
+.panel:hover { border-color: color-mix(in srgb, var(--blue) 50%, var(--border)); }
+.panel > div { flex: 1; overflow-y: scroll; min-height: 0; }
+#panel-github, #panel-governance { grid-row: span 2; }
 @media (max-width: 1023px) and (min-width: 641px) {
   .header { padding: 0.4rem 0.75rem; }
   .header-nav button { padding: 0.15rem 0.45rem; font-size: 0.78rem; }
@@ -95,4 +96,5 @@
   .dashboard-grid { grid-template-columns: 1fr; height: auto; overflow-y: auto; }
   .view-wiki { grid-template-columns: 1fr; }
   .log-scroll { max-height: 40vh; }
+  #panel-github, #panel-governance { grid-row: span 1; }
 }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -49,14 +49,12 @@
             <h2>🔄 Agent Baton <button class="shb" data-tip="baton" aria-label="Help: Baton">?</button></h2><div x-html="renderBatonFlow(batonState)"></div></section></template>
         <template x-if="isView('live')"><section id="panel-activity" class="panel" data-tip="activity">
             <h2>📡 Live Activity <button class="shb" data-tip="activity" aria-label="Help: Activity">?</button></h2><div x-html="renderActivityFeed(activityLog)"></div></section></template>
-        <template x-if="isView('live')"><section id="panel-context-flow" class="panel full-width" data-tip="context-flow">
+        <template x-if="isView('live')"><section id="panel-context-flow" class="panel full-width">
             <h2>🧠 Context Flow <button class="shb" data-tip="context-flow" aria-label="Help: Context Flow">?</button></h2><div x-html="renderContextFlow()"></div></section></template>
-        <!-- LOGS: 3 panels (streaming chronological) -->
-        <template x-if="isView('logs')"><section id="panel-fleet-health" class="panel" data-tip="fleet-health">
-            <h2>🏥 Fleet Health <button class="shb" data-tip="fleet-health" aria-label="Help: Health">?</button></h2><div class="log-scroll" x-html="renderFleetHealthLog(fleetHealthLog)"></div></section></template>
+        <!-- LOGS: 2 panels (streaming chronological) -->
         <template x-if="isView('logs')"><section id="panel-router-log" class="panel" data-tip="router-log">
             <h2>📋 Router Log <button class="shb" data-tip="router-log" aria-label="Help: Router Log">?</button></h2><div class="log-scroll" x-html="renderRouterLog()"></div></section></template>
-        <template x-if="isView('logs')"><section id="panel-ticket-log" class="panel full-width" data-tip="ticket-log">
+        <template x-if="isView('logs')"><section id="panel-ticket-log" class="panel" data-tip="ticket-log">
             <h2>📋 Ticket Log <button class="shb" data-tip="ticket-log" aria-label="Help: Tickets">?</button></h2><div class="log-scroll" x-html="renderTicketLog(ticketLog)"></div></section></template>
         <!-- OPS: 6 panels (monitoring + analytics) -->
         <section id="panel-github" class="panel" x-show="isView('ops')" data-tip="github">
@@ -71,13 +69,15 @@
             <h2>📐 LLM Context <button class="shb" data-tip="llm-context" aria-label="Help: LLM">?</button></h2><div x-html="renderLLMContext()"></div></section>
         <section id="panel-wiki-health" class="panel" x-show="isView('ops')" data-tip="wiki">
             <h2>📚 Wiki Health <button class="shb" data-tip="wiki" aria-label="Help: Wiki">?</button></h2><div x-html="renderWikiPanel(wikiHealth)"></div></section>
-        <!-- FLEET: 5 panels (inventory + config) -->
+        <!-- FLEET: 6 panels (inventory + config + health) -->
+        <template x-if="isView('fleet')"><section id="panel-fleet-health" class="panel" data-tip="fleet-health">
+            <h2>🏥 Fleet Health <button class="shb" data-tip="fleet-health" aria-label="Help: Health">?</button></h2><div class="log-scroll" x-html="renderFleetHealthLog(fleetHealthLog)"></div></section></template>
         <template x-if="isView('fleet')"><section id="panel-devices" class="panel" data-tip="devices">
             <h2>🏗️ Devices <button class="shb" data-tip="devices" aria-label="Help: Devices">?</button></h2><div x-html="renderDeviceCards(devices)"></div></section></template>
         <template x-if="isView('fleet')"><section id="panel-services" class="panel" data-tip="services">
             <h2>⚡ Services <button class="shb" data-tip="services" aria-label="Help: Services">?</button></h2><div x-html="renderServiceCards(services)"></div></section></template>
-        <template x-if="isView('fleet')"><section id="panel-settings" class="panel full-width" data-tip="settings">
-            <h2>⚙️ Fleet Resources <button class="shb" data-tip="settings" aria-label="Help: Resources">?</button></h2><div id="settings-form-container"></div><div id="settings-content" x-html="renderSettingsPanel(loadFleetResources(), window._lastProbeResults, window._hostInfo)" x-init="fetchHostInfo().then(h=>{window._hostInfo=h;$el.innerHTML=renderSettingsPanel(loadFleetResources(),window._lastProbeResults,h);})"></div></section></template>
+        <template x-if="isView('fleet')"><section id="panel-settings" class="panel" data-tip="settings">
+            <h2>⚙️ Fleet Resources <button class="shb" data-tip="settings" aria-label="Help: Resources">?</button></h2><div id="settings-content" x-html="renderSettingsPanel(loadFleetResources(), window._lastProbeResults, window._hostInfo)" x-init="fetchHostInfo().then(h=>{window._hostInfo=h;$el.innerHTML=renderSettingsPanel(loadFleetResources(),window._lastProbeResults,h);})"></div><div id="settings-form-container"></div></section></template>
         <template x-if="isView('fleet')"><section id="panel-config" class="panel" data-tip="config">
             <h2>⚙️ Config <button class="shb" data-tip="config" aria-label="Help: Config">?</button></h2><div x-html="renderConfigPanel(config, autoRefreshEnabled, tooltipsEnabled)"></div></section></template>
         <template x-if="isView('fleet')"><section id="panel-test" class="panel" data-tip="test-panel">

--- a/dashboard/js/context-flow.js
+++ b/dashboard/js/context-flow.js
@@ -1,62 +1,70 @@
 // Context Flow — SVG diagram showing prompt → LLM → response chain
-// Renders in the Fleet view as a visual architecture map
+// Shows all fleet resources that send/receive context
 
 function renderContextFlow() {
-  const W = 500, H = 220;
+  const W = 620, H = 260;
   const nodes = [
-    { x: 55, y: 45, icon: '💻', label: 'VS Code', sub: 'Copilot Agent' },
-    { x: 185, y: 45, icon: '🧠', label: 'AUTO', sub: 'Model Select' },
-    { x: 325, y: 45, icon: '☁️', label: 'Cloud LLM', sub: 'Copilot API' },
-    { x: 325, y: 155, icon: '⚡', label: 'OpenClaw', sub: 'LiteLLM Proxy' },
-    { x: 460, y: 155, icon: '🤖', label: 'Ollama', sub: 'Local Models' },
+    { x: 60, y: 50, icon: '💻', label: 'VS Code', sub: 'Copilot Agent', tip: 'IDE sends prompts with file context, conversation history, and MCP tool results to the AUTO router.' },
+    { x: 200, y: 50, icon: '🧠', label: 'AUTO', sub: 'Model Select', tip: 'Routes prompts to Cloud LLM (primary) or OpenClaw (local fallback) based on model availability and rate limits.' },
+    { x: 370, y: 50, icon: '☁️', label: 'Cloud LLM', sub: 'Copilot API', tip: 'GitHub Copilot cloud models (GPT-4o, Claude). Primary route. Responses stream back to VS Code.' },
+    { x: 540, y: 50, icon: '🐙', label: 'GitHub', sub: 'API + Actions', tip: 'GitHub API: issues, PRs, commits. Actions CI/CD. Context flows bidirectionally via gh CLI and webhooks.' },
+    { x: 120, y: 150, icon: '🌐', label: 'Tailscale', sub: 'VPN Mesh', tip: 'Encrypted WireGuard mesh connecting all fleet devices. Routes traffic between Chromebooks and Windows laptop.' },
+    { x: 290, y: 150, icon: '⚡', label: 'OpenClaw', sub: 'LiteLLM :4000', tip: 'LiteLLM proxy on Windows laptop. Routes to local Ollama models. Fallback when cloud is rate-limited.' },
+    { x: 460, y: 150, icon: '🤖', label: 'Ollama', sub: 'Local 7B', tip: 'Local inference on Windows laptop (16GB RAM). Runs 7B models. Accessed via OpenClaw proxy over Tailscale.' },
+    { x: 60, y: 210, icon: '💻', label: 'CB-2', sub: 'This machine', tip: 'Chromebook-2 (penguin): primary dev workstation. 2.7GB RAM. Runs VS Code + dashboard.' },
+    { x: 200, y: 210, icon: '💻', label: 'CB-1', sub: 'SLM node', tip: 'Chromebook-1 (penguin-1): runs Ollama with tiny SLM models for lightweight local inference.' },
+    { x: 370, y: 210, icon: '🖥️', label: 'Win Laptop', sub: 'OpenClaw host', tip: 'Windows laptop (16GB). Hosts OpenClaw + Ollama. Primary fleet compute for local LLM inference.' },
   ];
   const arrows = [
-    { from: 0, to: 1, label: 'prompt + context' },
-    { from: 1, to: 2, label: 'cloud route' },
-    { from: 1, to: 3, label: 'local route', dashed: true },
-    { from: 3, to: 4, label: 'inference' },
+    { from: 0, to: 1, label: 'prompt', tip: 'User prompt + file context + conversation history sent to model router' },
+    { from: 1, to: 2, label: 'cloud', tip: 'Primary route: prompt sent to GitHub Copilot cloud API' },
+    { from: 1, to: 5, label: 'local', dashed: true, tip: 'Fallback route: prompt sent to OpenClaw LiteLLM proxy over Tailscale' },
+    { from: 5, to: 6, label: 'inference', tip: 'OpenClaw forwards to local Ollama for model inference' },
+    { from: 4, to: 5, label: 'mesh', dashed: true, tip: 'Tailscale VPN tunnels traffic between devices' },
+    { from: 7, to: 4, label: '', dashed: true, tip: 'CB-2 connects to Tailscale mesh' },
+    { from: 8, to: 4, label: '', dashed: true, tip: 'CB-1 connects to Tailscale mesh' },
+    { from: 9, to: 5, label: 'host', tip: 'Windows laptop hosts the OpenClaw proxy locally' },
+    { from: 0, to: 3, label: 'gh cli', tip: 'VS Code uses gh CLI for issue/PR operations' },
   ];
-
-  const arrowsSvg = arrows.map(a => {
+  return `<div class="cf-wrap"><svg viewBox="0 0 ${W} ${H}"
+    class="cf-svg" role="img" aria-label="Context flow diagram">
+    <defs>${cfDefs()}</defs>
+    ${cfArrows(nodes, arrows)}${cfNodes(nodes)}</svg>
+    ${contextBudgetLegend()}</div>`;
+}
+function cfDefs() {
+  return `<marker id="cfHead" markerWidth="6" markerHeight="4"
+    refX="6" refY="2" orient="auto">
+    <polygon points="0 0, 6 2, 0 4" fill="var(--green)"/></marker>
+  <style>.cf-arrow{stroke:var(--green);stroke-width:1.5;opacity:.7}
+  .cf-arrow.dashed{stroke-dasharray:4,3;stroke:var(--yellow)}
+  .cf-node{fill:var(--surface);stroke:var(--border);stroke-width:1;cursor:pointer}
+  .cf-node:hover{stroke:var(--blue);stroke-width:2}
+  .cf-icon{font-size:13px;fill:var(--text);pointer-events:none}
+  .cf-name{font-size:9px;fill:var(--text);font-weight:600;pointer-events:none}
+  .cf-sub{font-size:7px;fill:var(--text-muted);pointer-events:none}
+  .cf-lbl{font-size:7px;fill:var(--text-muted);font-style:italic}</style>`;
+}
+function cfArrows(nodes, arrows) {
+  return arrows.map(a => {
     const f = nodes[a.from], t = nodes[a.to];
     const cls = a.dashed ? 'cf-arrow dashed' : 'cf-arrow';
     const mx = (f.x + t.x) / 2, my = (f.y + t.y) / 2;
     return `<line x1="${f.x}" y1="${f.y}" x2="${t.x}" y2="${t.y}"
-      class="${cls}" marker-end="url(#cfHead)"/>
-      <text x="${mx}" y="${my - 5}" text-anchor="middle"
-        class="cf-lbl">${a.label}</text>`;
+      class="${cls}" marker-end="url(#cfHead)"><title>${a.tip}</title></line>
+      ${a.label ? `<text x="${mx}" y="${my - 4}" text-anchor="middle"
+        class="cf-lbl">${a.label}</text>` : ''}`;
   }).join('');
-
-  const nodesSvg = nodes.map(n => `
-    <rect x="${n.x - 38}" y="${n.y - 22}" width="76" height="44"
-      rx="6" class="cf-node"/>
-    <text x="${n.x}" y="${n.y - 5}" text-anchor="middle"
-      class="cf-icon">${n.icon}</text>
-    <text x="${n.x}" y="${n.y + 10}" text-anchor="middle"
-      class="cf-name">${n.label}</text>
-    <text x="${n.x}" y="${n.y + 22}" text-anchor="middle"
-      class="cf-sub">${n.sub}</text>`).join('');
-
-  return `<div class="cf-wrap"><svg viewBox="0 0 ${W} ${H}"
-    class="cf-svg" role="img" aria-label="Context flow diagram">
-    <defs>
-      <marker id="cfHead" markerWidth="6" markerHeight="4"
-        refX="6" refY="2" orient="auto">
-        <polygon points="0 0, 6 2, 0 4" fill="var(--green)"/>
-      </marker>
-      <style>
-        .cf-arrow{stroke:var(--green);stroke-width:1.5;opacity:.7}
-        .cf-arrow.dashed{stroke-dasharray:4,3;stroke:var(--yellow)}
-        .cf-node{fill:var(--surface);stroke:var(--border);stroke-width:1}
-        .cf-icon{font-size:14px;fill:var(--text)}
-        .cf-name{font-size:10px;fill:var(--text);font-weight:600}
-        .cf-sub{font-size:8px;fill:var(--text-muted)}
-        .cf-lbl{font-size:8px;fill:var(--text-muted);font-style:italic}
-      </style>
-    </defs>${arrowsSvg}${nodesSvg}</svg>
-    ${contextBudgetLegend()}</div>`;
 }
-
+function cfNodes(nodes) {
+  return nodes.map(n => `<g class="cf-node-g">
+    <rect x="${n.x - 36}" y="${n.y - 20}" width="72" height="40"
+      rx="6" class="cf-node"><title>${n.tip}</title></rect>
+    <text x="${n.x}" y="${n.y - 4}" text-anchor="middle" class="cf-icon">${n.icon}</text>
+    <text x="${n.x}" y="${n.y + 8}" text-anchor="middle" class="cf-name">${n.label}</text>
+    <text x="${n.x}" y="${n.y + 18}" text-anchor="middle" class="cf-sub">${n.sub}</text>
+  </g>`).join('');
+}
 function contextBudgetLegend() {
   const items = [
     { label: 'System prompt', pct: 10, color: 'var(--blue)' },


### PR DESCRIPTION
## Summary
Addresses 9 user-reported UX issues from Epic #229.

### Changes
1. **#230**: Fleet Health moved from Logs → Fleet view
2. **#231**: Context Flow section tooltip removed; per-node SVG `<title>` tooltips added
3. **#232**: All views enforce 2-column grid; only Context Flow spans full-width
4. **#233**: Context Flow now shows 10 nodes: VS Code, AUTO, Cloud LLM, GitHub, Tailscale, OpenClaw, Ollama, CB-2, CB-1, Win Laptop
5. **#234/#237**: GitHub + Governance panels span 2 grid rows on Ops view; Ops grid uses `2fr 1fr 1fr` rows
6. **#235**: Panels have visible border + border-radius + padding + hover highlight
7. **#236**: Scrollable panels use `overflow-y: scroll` (always-visible scrollbar)
8. **#238**: Fleet Resources form container hidden when empty; content div moved before form

### Tickets
Closes #230, #231, #232, #233, #234, #235, #236, #237, #238
Part of Epic #229