### PR TITLE
fix: panel height distribution from Playwright visual QA

### DIFF
--- a/dashboard/css/views.css
+++ b/dashboard/css/views.css
@@ -1,4 +1,4 @@
-/* Section help button — ? icon on panel h2 */
+/* Section help button */
 .shb {
   display: inline-flex; align-items: center; justify-content: center;
   width: 1.1rem; height: 1.1rem; border-radius: 50%;
@@ -69,19 +69,19 @@
 .help-category:first-child .help-cat-title { margin-top: 0; }
 .help-feedback { display: flex; gap: 1rem; padding: 0.5rem 0; }
 .help-empty { color: var(--text-muted); font-style: italic; }
-/* View grids + responsive */
 .view-live { grid-template-columns: 1fr 1fr; grid-template-rows: 1fr auto; }
-.view-logs, .view-fleet { grid-template-columns: 1fr 1fr; }
-.view-ops { grid-template-columns: 1fr 1fr; grid-template-rows: 2fr 1fr 1fr; }
-.view-wiki { grid-template-columns: 1fr 2fr; }
-.view-help { grid-template-columns: 1fr; }
-.log-scroll { overflow-y: scroll; max-height: calc(50dvh - 60px); }
+.view-logs { grid-template-columns: 1fr; grid-template-rows: 1fr 1fr; }
+.view-fleet { grid-template-columns: 1fr 1fr; }
+.view-ops { grid-template-columns: 1fr 1fr; grid-template-rows: repeat(3, 1fr); }
+.view-wiki { grid-template-columns: 1fr 2fr; } .view-help { grid-template-columns: 1fr; }
+.log-scroll { overflow-y: scroll; }
 .panel { overflow: hidden; display: flex; flex-direction: column;
   background: var(--surface); border: 1px solid var(--border);
   border-radius: 8px; padding: 0.5rem 0.6rem; }
 .panel:hover { border-color: color-mix(in srgb, var(--blue) 50%, var(--border)); }
 .panel > div { flex: 1; overflow-y: scroll; min-height: 0; }
-#panel-github, #panel-governance { grid-row: span 2; }
+#panel-github { grid-row: 1 / 3; }
+#panel-governance { grid-row: 2 / 4; grid-column: 2; }
 @media (max-width: 1023px) and (min-width: 641px) {
   .header { padding: 0.4rem 0.75rem; }
   .header-nav button { padding: 0.15rem 0.45rem; font-size: 0.78rem; }
@@ -91,10 +91,10 @@
   .header { flex-wrap: wrap; gap: 0.4rem; padding: 0.5rem 0.75rem; }
   .header-brand h1 { font-size: 0.95rem; }
   .header-nav, .header-actions { flex-wrap: wrap; }
-  .header-nav button { min-height: 44px; min-width: 44px; padding: 0.4rem 0.6rem; }
-  .header-actions button { min-height: 44px; min-width: 44px; padding: 0.4rem; }
+  .header-nav button, .header-actions button { min-height: 44px; min-width: 44px; }
+  .header-nav button { padding: 0.4rem 0.6rem; } .header-actions button { padding: 0.4rem; }
   .dashboard-grid { grid-template-columns: 1fr; height: auto; overflow-y: auto; }
   .view-wiki { grid-template-columns: 1fr; }
   .log-scroll { max-height: 40vh; }
-  #panel-github, #panel-governance { grid-row: span 1; }
+  #panel-github, #panel-governance { grid-row: auto; grid-column: auto; }
 }


### PR DESCRIPTION
## Summary
Fix critical panel clipping found during fleet-wide Playwright visual QA analysis.

### Changes
- **OPS view**: Equal row distribution `repeat(3, 1fr)` with explicit grid placement for GitHub (rows 1-3) and Governance (rows 2-4)
- **LOGS view**: Single-column stacked layout gives each log panel full viewport height
- **log-scroll**: Remove desktop max-height constraint
- **Mobile**: Reset explicit grid placements to `auto`

### Evidence
Playwright DOM analysis showed:
- LLM Context panel: 75% hidden (329px content in 81px container)
- Router panel: 29% hidden (114px in 81px)
- ticket-log: 71% hidden (1184px in 340px)

Closes #240