### PR TITLE
fix(hooks): upgrade commit_ticket_gate from ask to deny (#259)

### DIFF
--- a/hooks/scripts/commit_ticket_gate.py
+++ b/hooks/scripts/commit_ticket_gate.py
@@ -69,7 +69,7 @@ def main() -> int:
     commit_issue = extract_issue_num(joined)
     if not commit_issue:
         return emit(
-            "ask",
+            "deny",
             f"Branch #{branch_issue} requires ticket reference in commit. "
             f"Use: git commit -m \"...(closes #{branch_issue})\"",
         )


### PR DESCRIPTION
Closes #259

Changes commit_ticket_gate.py to return deny instead of ask for missing ticket references. 1-line change addressing 50.6% ticketless commit rate from harness drift analysis #257.

Parent Epic: #256