### PR TITLE
fix(hooks): require active_ticket for file edits (#264)

### DIFF
--- a/hooks/scripts/manager_ticket_gate.py
+++ b/hooks/scripts/manager_ticket_gate.py
@@ -37,6 +37,7 @@ def main() -> int:
 
     if issue_num:
         state.setdefault("roles", {})["manager"] = True
+        state["active_ticket"] = issue_num
         save_state(state)
         return 0
 

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -62,9 +62,9 @@ def main() -> int:
     values = list(iter_strings(payload.get("tool_input",{})))
     cwd = str(payload.get("cwd","")) or str(Path.cwd())
     state = ensure_state(cwd)
-    if tool in {"create_file","apply_patch","edit_notebook_file","create_new_jupyter_notebook","replace_string_in_file"}:
-        if not state.get("roles", {}).get("manager"):
-            return emit("deny","File edit blocked: Manager handoff required before editing repository files. Create and reference a ticket first.")
+    if tool in {"create_file","apply_patch","edit_notebook_file","create_new_jupyter_notebook","replace_string_in_file","multi_replace_string_in_file"}:
+        if not state.get("active_ticket"):
+            return emit("deny","File edit blocked: no active ticket. Manager must reference a ticket (#N) before edits.")
     if tool in {"run_in_terminal","terminal","runTerminalCommand"}:
         result = check_terminal("\n".join(values), state)
         if result is not None: return result


### PR DESCRIPTION
Closes #264

Manager gate now stores ticket number as active_ticket. Pretool guard checks active_ticket instead of boolean manager flag. Prevents helpfulness-bias bypass. Parent: #256