### PR TITLE
feat(hooks): add real-time drift scoreboard (#267)

### DIFF
--- a/hooks/scripts/commit_ticket_gate.py
+++ b/hooks/scripts/commit_ticket_gate.py
@@ -13,6 +13,7 @@ if str(SCRIPT_DIR) not in sys.path:
 
 from repo_scope import is_repo_enabled
 from ticket_helpers import extract_issue_num, extract_from_branch
+from governance_state import ensure_state, save_state
 
 
 def get_current_branch() -> str:
@@ -81,6 +82,11 @@ def main() -> int:
             f"Branch and commit must reference the same ticket.",
         )
 
+    state = ensure_state(cwd)
+    d = state.setdefault("drift", {})
+    d["commits"] = d.get("commits", 0) + 1
+    d["commits_with_ticket"] = d.get("commits_with_ticket", 0) + 1
+    save_state(state)
     return 0
 
 

--- a/hooks/scripts/state_store.py
+++ b/hooks/scripts/state_store.py
@@ -46,6 +46,11 @@ def _default_state(cwd: str) -> dict[str, Any]:
             "gh_release": False, "issue_close": False,
             "issue_linked": False, "visual_qa": False,
         },
+        "drift": {
+            "commits": 0, "commits_with_ticket": 0,
+            "branches": 0, "branches_compliant": 0,
+            "edits_gated": 0, "edits_ungated": 0,
+        },
     }
 
 
@@ -60,7 +65,7 @@ def load_state(cwd: str) -> dict[str, Any]:
         defaults = _default_state(cwd)
         data.setdefault("cwd", cwd)
         data.setdefault("repo_type", detect_repo_type(cwd))
-        for key in ("routing", "roles", "flags", "admin_ops"):
+        for key in ("routing", "roles", "flags", "admin_ops", "drift"):
             if key not in data:
                 data[key] = defaults[key]
             elif isinstance(defaults[key], dict):

--- a/hooks/scripts/stop_reminder.py
+++ b/hooks/scripts/stop_reminder.py
@@ -50,6 +50,12 @@ def main() -> int:
 
     messages.extend(post_merge_messages(signals, bool(messages)))
 
+    drift = state.get("drift", {})
+    total_c = drift.get("commits", 0)
+    if total_c > 0:
+        rate = (total_c - drift.get("commits_with_ticket", 0)) / total_c * 100
+        messages.append(f"📊 Drift score: {rate:.0f}% ticketless ({total_c} commits this session).")
+
     out = {"systemMessage": "\n\n".join(messages)}
     if block_reason:
         out["hookSpecificOutput"] = {


### PR DESCRIPTION
Closes #267

Adds drift counters to governance state and reports drift score at session end. Parent: #256