### PR TITLE
fix(dashboard): wiki view single-column layout

### DIFF
--- a/dashboard/css/views.css
+++ b/dashboard/css/views.css
@@ -75,7 +75,7 @@
 #panel-settings { grid-row: span 2; }
 #panel-devices > div, #panel-services > div { max-height: 12rem; }
 .view-ops { grid-template-columns: 1fr 1fr; grid-template-rows: auto auto auto; }
-.view-wiki { grid-template-columns: 1fr 2fr; } .view-help { grid-template-columns: 1fr; }
+.view-wiki { grid-template-columns: 1fr; } .view-help { grid-template-columns: 1fr; }
 .log-scroll { overflow-y: scroll; }
 .panel { overflow: hidden; display: flex; flex-direction: column; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 0.5rem 0.6rem; }
 .panel:hover { border-color: color-mix(in srgb, var(--blue) 50%, var(--border)); }


### PR DESCRIPTION
Closes #248

- Wiki Metrics panel stacks above Research Wiki
- Both panels take full width
- Lint passes (≤100 lines)