### PR TITLE
fix(dashboard): wiki metrics fallback on API failure

### DIFF
--- a/dashboard/js/wiki-metrics.js
+++ b/dashboard/js/wiki-metrics.js
@@ -2,11 +2,19 @@
 
 let _wikiMetrics = null;
 
+function _fallbackMetrics() {
+  return { totalAccess: 0, sections: {},
+    grade: '?', score: 0, gradeReasons: ['Metrics API unavailable'] };
+}
+
 async function fetchWikiMetrics() {
   try {
     const r = await fetch('/api/wiki-metrics');
     if (r.ok) _wikiMetrics = await r.json();
-  } catch { /* keep stale */ }
+    else if (!_wikiMetrics) _wikiMetrics = _fallbackMetrics();
+  } catch {
+    if (!_wikiMetrics) _wikiMetrics = _fallbackMetrics();
+  }
   return _wikiMetrics;
 }
 
@@ -20,7 +28,7 @@ function gradeColor(g) {
 }
 
 function renderWikiMetrics(m, health) {
-  if (!m) return '<div class="wiki-metrics-empty">Loading usage metrics…</div>';
+  if (!m) return '<div class="wiki-metrics-empty">📊 No metrics available — browse wiki pages to generate usage data.</div>';
   const grade = m.grade || '?';
   const cls = gradeColor(grade);
   const total = m.totalAccess || 0;


### PR DESCRIPTION
Closes #249

- fetchWikiMetrics returns fallback object on failure
- Empty state shows actionable message instead of 'Loading...'
- Panel renders without errors when API unavailable