### PR TITLE
feat(dashboard): dedicated Settings view

### DIFF
--- a/dashboard/css/views.css
+++ b/dashboard/css/views.css
@@ -76,6 +76,7 @@
 #panel-devices > div, #panel-services > div { max-height: 12rem; }
 .view-ops { grid-template-columns: 1fr 1fr; grid-template-rows: auto auto auto; }
 .view-wiki { grid-template-columns: 1fr; } .view-help { grid-template-columns: 1fr; }
+.view-settings { grid-template-columns: 1fr; }
 .log-scroll { overflow-y: scroll; }
 .panel { overflow: hidden; display: flex; flex-direction: column; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 0.5rem 0.6rem; }
 .panel:hover { border-color: color-mix(in srgb, var(--blue) 50%, var(--border)); }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -33,6 +33,7 @@
             <button @click="setView('ops')" :class="{active:isView('ops')}" data-tip="view-ops" title="Ops">📊</button>
             <button @click="setView('fleet')" :class="{active:isView('fleet')}" data-tip="view-fleet" title="Fleet">🌐</button>
             <button @click="setView('wiki')" :class="{active:isView('wiki')}" data-tip="view-wiki" title="Wiki">📚</button>
+            <button @click="setView('settings')" :class="{active:isView('settings')}" data-tip="view-settings" title="Settings">⚙️</button>
             <button @click="setView('help')" :class="{active:isView('help')}" data-tip="view-help" title="Help">📘</button>
         </nav>
         <div class="header-actions">
@@ -78,8 +79,6 @@
             <h2>⚡ Services <button class="shb" data-tip="services" aria-label="Help: Services">?</button></h2><div x-html="renderServiceCards(services)"></div></section></template>
         <template x-if="isView('fleet')"><section id="panel-settings" class="panel">
             <h2>⚙️ Fleet Resources <button class="shb" data-tip="settings" aria-label="Help: Resources">?</button></h2><div id="settings-content" x-html="renderSettingsPanel(loadFleetResources(), window._lastProbeResults, window._hostInfo)" x-init="fetchHostInfo().then(h=>{window._hostInfo=h;$el.innerHTML=renderSettingsPanel(loadFleetResources(),window._lastProbeResults,h);})"></div><div id="settings-form-container"></div></section></template>
-        <template x-if="isView('fleet')"><section id="panel-config" class="panel">
-            <h2>⚙️ Config <button class="shb" data-tip="config" aria-label="Help: Config">?</button></h2><div x-html="renderConfigPanel(config, autoRefreshEnabled, tooltipsEnabled)"></div></section></template>
         <template x-if="isView('fleet')"><section id="panel-test" class="panel">
             <h2>🧪 Stress Test <button class="shb" data-tip="test-panel" aria-label="Help: Test">?</button></h2><div x-html="renderStressPanel(testRun)"></div></section></template>
         <!-- WIKI: 2 panels -->
@@ -90,5 +89,8 @@
         <!-- HELP: 1 panel full-width -->
         <template x-if="isView('help')"><section id="panel-help" class="panel full-width">
             <h2>📘 Help Center</h2><div x-html="renderHelpPanel(helpDevMode)"></div></section></template>
+        <!-- SETTINGS: full-width config -->
+        <template x-if="isView('settings')"><section id="panel-config" class="panel full-width">
+            <h2>⚙️ Settings <button class="shb" data-tip="config" aria-label="Help: Settings">?</button></h2><div x-html="renderConfigPanel(config, autoRefreshEnabled, tooltipsEnabled)"></div></section></template>
     </main>
     <footer class="footer"><span>Last refresh: <span x-text="lastRefresh"></span></span><span>devenv-ops v3.0.0</span></footer><aside id="app-tip" class="app-tip" x-show="activeTip" x-html="activeTip" x-transition.opacity></aside></body></html>

--- a/dashboard/js/tooltips.js
+++ b/dashboard/js/tooltips.js
@@ -30,7 +30,8 @@ const TIP_COPY = {
   'wiki-reader': ['Wiki Reader', 'Browse and search research/ markdown pages.', 'wiki', 'use-wiki-reader'],
   devices: ['Fleet Devices', 'Device inventory: name, Tailscale IP, RAM, OS, role.', 'fleet', 'use-devices'],
   services: ['Services', 'API service cards: endpoint, status, last checked.', 'fleet', 'use-services'],
-  config: ['Settings', 'Dashboard preferences: refresh interval, contrast, tooltips.', 'fleet', 'use-config'],
+  config: ['Settings', 'Dashboard preferences: refresh interval, contrast, tooltips.', 'settings', 'use-config'],
+  'view-settings': ['Settings', 'Dashboard preferences and configuration.', 'settings', 'use-config'],
   'test-panel': ['Stress Test', 'Simulates 5 parallel tickets + mock events. ~60s.', 'fleet', 'use-stress'],
   'tl-step': ['Baton handoff', 'Role icon + time the baton was received. Hover for role description.', 'fleet', 'use-baton'],
 };


### PR DESCRIPTION
Closes #247

- Settings view accessible via ⚙️ nav icon
- Config panel renders full-width in Settings view
- Fleet view no longer contains Config panel
- Tooltip registered for view-settings