### PR TITLE
feat(dashboard): prune stale baton tickets

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -10,7 +10,7 @@
     <script src="js/health-check.js"></script><script src="js/quota-tracker.js"></script>
     <script src="js/device-monitor.js"></script><script src="js/router-tracker.js"></script>
     <script src="js/live-stats.js"></script><script src="js/quota-live.js"></script>
-    <script src="js/fleet-topology.js"></script><script src="js/baton-flow.js"></script>
+    <script src="js/fleet-topology.js"></script><script src="js/baton-flow.js"></script><script src="js/baton-prune.js"></script>
     <script src="js/resource-monitor.js"></script><script src="js/activity-feed.js"></script>
     <script src="js/event-bus.js"></script><script src="js/render-panels.js"></script>
     <script src="js/config-panel.js"></script><script src="js/stress-test.js"></script>

--- a/dashboard/js/baton-flow.js
+++ b/dashboard/js/baton-flow.js
@@ -9,7 +9,8 @@ const BATON_ROLES = [
 ];
 
 function renderBatonFlow(batonState) {
-  const tickets = normalizeBaton(batonState);
+  let tickets = normalizeBaton(batonState);
+  if (typeof pruneStaleBaton === 'function') tickets = pruneStaleBaton(tickets, typeof getTicketLog === 'function' ? getTicketLog() : []);
   if (!tickets.length) {
     return `<div class="baton-flow"><div class="baton-empty">🎯 No active tickets<br>
       <small>Baton activates when issues are assigned to a role.</small></div></div>`;

--- a/dashboard/js/baton-prune.js
+++ b/dashboard/js/baton-prune.js
@@ -1,0 +1,9 @@
+// Baton Prune — filter done/cancelled tickets from baton display
+
+function pruneStaleBaton(batonTickets, ticketLog) {
+  if (!ticketLog || !ticketLog.length) return batonTickets;
+  const closedIds = new Set(ticketLog
+    .filter(t => ['done', 'cancelled'].includes(t.status))
+    .map(t => String(t.issue)));
+  return batonTickets.filter(t => !closedIds.has(String(t.issue)));
+}


### PR DESCRIPTION
Closes #251

- Baton does not render tickets with done/cancelled status
- pruneStaleBaton cross-references ticketLog
- Separated into baton-prune.js module