### PR TITLE
fix(dashboard): dynamic column heights

### DIFF
--- a/dashboard/css/app.css
+++ b/dashboard/css/app.css
@@ -63,7 +63,7 @@ body {
   display: grid; grid-template-columns: repeat(2, 1fr);
   gap: 0.5rem; padding: 0.5rem;
   height: calc(100dvh - 56px - 28px);
-  align-content: start; overflow: hidden;
+  align-content: stretch; overflow: hidden;
 }
 
 .panel h2 {

--- a/dashboard/css/views.css
+++ b/dashboard/css/views.css
@@ -73,7 +73,7 @@
 .view-logs { grid-template-columns: 1fr; grid-template-rows: 1fr 1fr; }
 .view-fleet { grid-template-columns: 1fr 1fr; }
 #panel-settings { grid-row: span 2; }
-#panel-devices > div, #panel-services > div { max-height: 12rem; }
+#panel-devices > div, #panel-services > div { max-height: none; flex: 1; min-height: 4rem; }
 .view-ops { grid-template-columns: 1fr 1fr; grid-template-rows: auto auto auto; }
 .view-wiki { grid-template-columns: 1fr; } .view-help { grid-template-columns: 1fr; }
 .view-settings { grid-template-columns: 1fr; }


### PR DESCRIPTION
Closes #255

- Panels in multi-column views stretch to fill column height
- Scroll-heavy panels (devices, services, fleet resources) expand
- No content clipped without scrollbar