### PR TITLE
feat(governance): add epic lifecycle governance rules

### DIFF
--- a/instructions/epic-governance.instructions.md
+++ b/instructions/epic-governance.instructions.md
@@ -1,0 +1,59 @@
+---
+name: Epic Governance
+description: Rules governing epic lifecycle — status advancement, role label, progress tracking, and close conditions.
+applyTo: "**"
+---
+
+# Epic Governance
+
+## Epic vs. Child Ticket — Role Boundary
+
+- Epic always carries `role:manager`. This never changes during the epic's lifecycle.
+- The active agent role lives on the **child ticket**, not the epic.
+- Agent Baton: the child ticket at `status:in-progress` is the active work item; the epic is context only.
+
+## Epic Status Advancement Rules
+
+| Epic Status | Condition to Enter |
+|---|---|
+| `backlog` | Created; no children started |
+| `triage` | Manager scoping children; at least one child exists |
+| `in-progress` | First child ticket moves to `status:in-progress` |
+| `review` | All children are terminal (closed); epic-level closeout pending |
+| `done` + closed | CONSULTANT_CLOSEOUT emitted on epic; all children confirmed terminal |
+| `cancelled` | Manager authority; all children must be cancelled or closed first |
+
+Epic status is advanced by the Manager agent at each gate — it does **not** auto-advance.
+
+## Epic Progress Comment Protocol
+
+When any child ticket is closed, the Manager posts a progress update to the epic:
+
+```
+## Epic Progress Update — #<child-number> Complete
+
+- Ticket: #N — <title>
+- Closed: <date>
+- Deliverables: <brief summary>
+- Remaining children: #X, #Y, #Z
+```
+
+## Epic Close Conditions
+
+An epic may close **only when ALL of these are true**:
+
+1. All child tickets are in terminal state (`done`/`cancelled`, issue `CLOSED`)
+2. Epic is at `status:review` with `role:consultant`
+3. CONSULTANT_CLOSEOUT comment posted on the epic
+4. Epic-level resolution label applied (`resolution:released` or `resolution:cancelled`)
+
+## Branch Naming
+
+Branches are created for **child tickets**, never for epics directly.
+Format: `<type>/<child-issue-number>-<slug>`
+
+## Forbidden
+
+- Epic carrying any role other than `role:manager`
+- Epic closing while any child is still open
+- Child ticket branch named after the epic number

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -80,3 +80,4 @@ When global and local instructions conflict, local wins for that workspace.
 - `operator-identity-context` defines authority and automation mandate.
 - Role skills define per-role execution contracts.
 - Domain skills (`repo-standards-router`, `workflow-self-anneal`, release/security/docs skills) remain source of truth for specialized procedures.
+- Epic lifecycle overlay rules: see `epic-governance.instructions.md`.

--- a/instructions/ticket-driven-work.instructions.md
+++ b/instructions/ticket-driven-work.instructions.md
@@ -82,3 +82,7 @@ Each status names the active agent type. One glance = who owns it now.
 - Branch: `feat/11-ticket-baton-system`
 - Commit: `feat(skills): implement ticket-as-baton governance #11`
 - PR: Body must include `Closes #11` + validation evidence
+
+## Epic Rules
+
+See `epic-governance.instructions.md` for epic status advancement, role label, progress tracking, and close conditions.

--- a/wiki/concepts/epic-governance.md
+++ b/wiki/concepts/epic-governance.md
@@ -1,0 +1,56 @@
+# Epic Governance
+
+## Summary
+
+Rules for epic ticket lifecycle: role ownership, status advancement, progress tracking,
+and close conditions. Epics are parent containers; all active work happens in child tickets.
+
+## Role Boundary
+
+- Epic always carries `role:manager`. Never reassigned during active child work.
+- Child tickets carry the active agent's role label (`role:collaborator`, etc.).
+- The Agent Baton displayed on child tickets reflects current execution; epic label is constant.
+
+## Status Advancement Table
+
+| Epic Status     | Condition to Advance             |
+|-----------------|----------------------------------|
+| `triage`        | Scope defined, children created  |
+| `ready`         | All children triaged              |
+| `in-progress`   | ≥1 child `in-progress`           |
+| `review`        | All children `done` or terminal  |
+| `done`/closed   | See close conditions below       |
+
+## Progress Comment Protocol
+
+Post a progress comment to the epic when:
+1. A child ticket reaches `done` (closed)
+2. A child ticket is cancelled (`status:cancelled`)
+3. A new child is added after triage
+
+Format: `Progress: #NNN <title> → done/cancelled. Children: X/Y complete.`
+
+## Close Conditions (all required)
+
+1. All child tickets are terminal (`done`, `cancelled`, or `wont-fix`)
+2. CONSULTANT_CLOSEOUT comment posted on epic
+3. Resolution label set (`resolution:completed` or appropriate variant)
+4. Epic closed with `stateReason: COMPLETED`
+
+## Branch Naming
+
+- Child ticket work: `feat/<child-issue-number>-<slug>`
+- **Never** name a branch after the epic number
+
+## Related
+
+- `instructions/epic-governance.instructions.md` — authoritative rule set
+- `instructions/ticket-driven-work.instructions.md` — full ticket lifecycle
+- `instructions/role-baton-routing.instructions.md` — baton handoff protocol
+- `wiki/concepts/ticket-lifecycle-v1.md`
+- `wiki/concepts/baton-protocol.md`
+
+## Sources
+
+- Epic #353: Ticket governance normalization (source task)
+- ADR: Agent-typed status vocabulary v1.0

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -22,6 +22,7 @@ The LLM updates this on every ingest operation.
 
 - [[baton-protocol]] — Baton Protocol (Role Handoff) [v1.0]
 - [[ticket-lifecycle-v1]] — Ticket Lifecycle v1.0 — Agent-Typed Model
+- [[epic-governance]] — Epic Lifecycle Governance Rules
 - [[agent-drift]] — Agent Drift
 - [[self-annealing]] — Self-Annealing Protocol
 - [[wiki-pattern]] — Karpathy LLM Wiki Pattern


### PR DESCRIPTION
## Summary

Adds formal epic governance rules to prevent the drift observed in #353 (epics worked without defined lifecycle protocol).

## Changes
- `instructions/epic-governance.instructions.md` — new 59-line file: status advancement table, role boundary (`role:manager` always), progress comment protocol, close conditions, branch naming rules
- `instructions/ticket-driven-work.instructions.md` — added Epic Rules section cross-reference
- `instructions/role-baton-routing.instructions.md` — added epic overlay cross-reference
- `wiki/concepts/epic-governance.md` — wiki concept page
- `wiki/index.md` — index entry added

## Validation
- Lint: ✅ 302 files, all ≤100 lines
- All AC items in #361 MANAGER_HANDOFF satisfied

Closes #361
Part of #353