### PR TITLE
fix(dashboard): dense baton rows + context flow SVG visibility

### DIFF
--- a/dashboard/css/baton.css
+++ b/dashboard/css/baton.css
@@ -13,33 +13,31 @@
 }
 
 .baton-row {
-  border: 1px solid var(--border); border-radius: 6px;
-  padding: 0.4rem 0.6rem; background: var(--bg);
+  border: 1px solid var(--border); border-radius: 4px;
+  padding: 0.15rem 0.4rem; background: var(--bg);
+  display: flex; align-items: center; gap: 0.3rem; min-height: 0;
 }
 
-.baton-meta {
-  display: flex; align-items: center; gap: 0.4rem;
-  margin-bottom: 0.3rem; flex-wrap: wrap;
-}
+.baton-meta { display: contents; }
 
 .baton-issue { font-size: 0.9rem; font-weight: 700; color: var(--blue); }
-.baton-title { font-size: 0.78rem; color: var(--text); font-weight: 500;
-  max-width: 280px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: inline-block; vertical-align: middle; }
+.baton-title { font-size: 0.75rem; color: var(--text); font-weight: 500;
+  max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .baton-epic {
   font-size: 0.65rem; color: var(--text-muted); background: var(--surface);
   border: 1px solid var(--border); border-radius: 3px; padding: 0 0.3rem;
 }
-.baton-agent { font-size: 0.75rem; color: var(--text); margin-left: auto; }
+.baton-agent { font-size: 0.72rem; color: var(--text); }
 
 .baton-pipeline {
   display: flex; align-items: center; gap: 0;
-  flex-wrap: nowrap; overflow-x: auto;
+  flex-shrink: 0; margin-left: auto;
 }
 
 .baton-step {
-  text-align: center; padding: 0.15rem 0.25rem; border-radius: 4px;
-  border: 1.5px solid var(--border); background: var(--bg);
-  font-size: 0.72rem; opacity: 0.4; transition: all 0.3s ease;
+  text-align: center; padding: 0.1rem 0.2rem; border-radius: 3px;
+  border: 1px solid var(--border); background: var(--bg);
+  font-size: 0.65rem; opacity: 0.4; transition: all 0.3s ease;
   white-space: nowrap; flex-shrink: 0;
 }
 .baton-step.done { border-color: var(--green); opacity: 0.65; }
@@ -63,12 +61,7 @@
   background: color-mix(in srgb, var(--yellow) 10%, var(--bg));
   border: 1px solid var(--yellow); border-radius: 3px; padding: 0 0.3rem;
 }
-.baton-timeline {
-  display: flex; align-items: center; gap: 0.15rem;
-  font-size: 0.65rem; color: var(--text-muted);
-  margin-top: 0.2rem; padding: 0.15rem 0;
-  border-top: 1px dashed var(--border); flex-wrap: wrap;
-}
+.baton-timeline { display: none; }
 .tl-step {
   white-space: nowrap; font-size: 0.62rem; background: var(--bg);
   border: 1px solid var(--border); border-radius: 3px;

--- a/dashboard/css/context.css
+++ b/dashboard/css/context.css
@@ -7,7 +7,7 @@
   padding: 0.4rem;
 }
 
-.cf-svg { width: 100%; height: auto; max-height: 240px; }
+.cf-svg { width: 100%; height: 260px; display: block; }
 
 .cb-bar {
   display: flex; height: 8px; border-radius: 4px;

--- a/dashboard/js/context-flow.js
+++ b/dashboard/js/context-flow.js
@@ -36,8 +36,7 @@ function renderContextFlow(devices, fleetStats, isActive) {
     { from: 9, to: 5, label: 'host', tip: 'Windows laptop hosts the OpenClaw proxy locally' },
     { from: 0, to: 3, label: 'gh cli', tip: 'VS Code uses gh CLI for issue/PR operations' },
   ];
-  return `<div class="cf-wrap"><svg viewBox="0 0 ${W} ${H}"
-    class="cf-svg" role="img" aria-label="Context flow diagram">
+  return `<div class="cf-wrap"><svg viewBox="0 0 ${W} ${H}" height="${H}" class="cf-svg" role="img" aria-label="Context flow diagram">
     <defs>${cfDefs()}</defs>
     ${cfArrows(nodes, arrows)}${cfNodes(nodes, liveMap)}</svg>
     ${contextBudgetLegend()}</div>`;


### PR DESCRIPTION
## Summary

Fixes two Live view dashboard issues:

### #364 — Agent Baton: dense single-line ticket rows
- `baton.css`: `.baton-row` → flat `display: flex` row
- `.baton-meta` → `display: contents` (children flow inline with pipeline)
- Pipeline steps pushed right with `margin-left: auto`
- Timeline row hidden (not deleted — data preserved in DOM)
- Each active ticket now renders ~28px tall instead of ~80px

### #365 — Context Flow: blank SVG
- Root cause: SVG with only `viewBox` + CSS `height: auto` resolves to 0px when injected via Alpine.js `x-html` (innerHTML)
- `context-flow.js`: added explicit `height="260"` attribute to SVG element
- `context.css`: `height: auto` → `height: 260px; display: block`

## Validation
- Lint: ✅ all 302 files ≤100 lines

Closes #364
Closes #365