### PR TITLE
fix(dashboard): cfArrows isActive scope, badge size, baton title

### DIFF
--- a/dashboard/css/baton.css
+++ b/dashboard/css/baton.css
@@ -28,6 +28,7 @@
   border: 1px solid var(--border); border-radius: 3px; padding: 0 0.3rem;
 }
 .baton-agent { font-size: 0.72rem; color: var(--text); }
+.baton-row .badge { font-size: 0.58rem; padding: 0.02rem 0.22rem; border-radius: 6px; line-height: 1.3; font-weight: 600; }
 
 .baton-pipeline {
   display: flex; align-items: center; gap: 0;

--- a/dashboard/js/baton-flow.js
+++ b/dashboard/js/baton-flow.js
@@ -1,6 +1,4 @@
 // Baton Flow — Multi-ticket parallel agent baton visualization
-// Shows Manager→Collaborator→Admin→Consultant per ticket
-
 const BATON_ROLES = [
   { id: 'manager', icon: '🎯', label: 'Mgr' },
   { id: 'collaborator', icon: '🔧', label: 'Collab' },
@@ -86,8 +84,8 @@ function renderTimeline(issue) {
     const r = BATON_ROLES.find(x => x.id === h.role);
     const t = h.ts ? new Date(h.ts).toLocaleTimeString() : '?';
     const ttl = `${roleDesc[h.role] || h.role} \u2014 at ${t}`;
-    return `<span class="tl-step" title="${esc(ttl)}" data-tip="tl-step">`
-      + `${r?.icon || '?'} ${t}</span>${i < tl.length - 1 ? ' → ' : ''}`;  }).join('');
+    return `<span class="tl-step" title="${esc(ttl)}">${r?.icon || '?'} ${t}</span>${i < tl.length - 1 ? ' → ' : ''}`;
+  }).join('');
   return `<div class="baton-timeline" title="Baton handoff history">${items}</div>`;
 }
 
@@ -95,6 +93,7 @@ function buildBatonState(routerLog) {
   if (!routerLog || !routerLog.length) return [];
   const last = routerLog[0];
   const roleMap = { router: 'manager', implementer: 'collaborator', quick: 'admin' };
+  const title = last.task ? last.task.replace(/#\d+\s*/g, '').trim() : '';
   return [{ activeRole: roleMap[last.agent] || 'manager',
-    issue: last.task?.match(/#(\d+)/)?.[1] || null, status: 'in-progress' }];
+    issue: last.task?.match(/#(\d+)/)?.[1] || null, status: 'in-progress', title }];
 }

--- a/dashboard/js/context-flow.js
+++ b/dashboard/js/context-flow.js
@@ -38,7 +38,7 @@ function renderContextFlow(devices, fleetStats, isActive) {
   ];
   return `<div class="cf-wrap"><svg viewBox="0 0 ${W} ${H}" height="${H}" class="cf-svg" role="img" aria-label="Context flow diagram">
     <defs>${cfDefs()}</defs>
-    ${cfArrows(nodes, arrows)}${cfNodes(nodes, liveMap)}</svg>
+    ${cfArrows(nodes, arrows, isActive)}${cfNodes(nodes, liveMap)}</svg>
     ${contextBudgetLegend()}</div>`;
 }
 function cfDefs() {
@@ -54,7 +54,7 @@ function cfDefs() {
   .cf-sub{font-size:7px;fill:var(--text-muted);pointer-events:none}
   .cf-lbl{font-size:7px;fill:var(--text-muted);font-style:italic}</style>`;
 }
-function cfArrows(nodes, arrows) {
+function cfArrows(nodes, arrows, isActive) {
   return arrows.map((a, i) => {
     const f = nodes[a.from], t = nodes[a.to];
     const cls = a.dashed ? 'cf-arrow dashed' : 'cf-arrow';


### PR DESCRIPTION
Closes #367\nCloses #368\n\n### #367 Context Flow blank\nRoot cause: `cfArrows()` references `isActive` from `renderContextFlow`'s param scope — top-level function, no closure. ReferenceError → Alpine x-html → empty string. Fix: `cfArrows(nodes, arrows, isActive)`.\n\n### #368 Badge too large / title missing\n- `.baton-row .badge` override for compact dense row styling\n- `buildBatonState` now extracts title from task string for fallback path\n\nLint: ✅ 302 files