### PR TITLE
feat(dashboard): Context Flow hardware sub-groupings + full cloud inventory #374

### DIFF
--- a/dashboard/css/context.css
+++ b/dashboard/css/context.css
@@ -7,7 +7,7 @@
   padding: 0.4rem;
 }
 
-.cf-svg { width: 100%; height: 260px; display: block; }
+.cf-svg { width: 100%; height: 420px; display: block; overflow-x: auto; }
 
 .cb-bar {
   display: flex; height: 8px; border-radius: 4px;

--- a/dashboard/js/context-flow.js
+++ b/dashboard/js/context-flow.js
@@ -1,43 +1,65 @@
-// Context Flow — fleet topology: zones (CB-2 Local | Tailscale VPN | Cloud)
+// Context Flow — fleet topology with hardware sub-groupings #374
 function renderContextFlow(devices, fleetStats, isActive, liveQuotas) {
-  const W=900,H=315;
+  const W=1050,H=460;
   const dm={}; (devices||[]).forEach(d=>{dm[d.id]=d.status;});
+  const wl=dm['windows-laptop']||'unknown', sl=dm['penguin-1']||'unknown';
   const liveMap={
-    'VS Code':'healthy','AUTO':'healthy','Wiki':'healthy',
-    'CB-1':dm['penguin-1']||'unknown','Ollama SLM':dm['penguin-1']||'unknown',
-    'Win Laptop':dm['windows-laptop']||'unknown',
-    'OpenClaw':dm['windows-laptop']||'unknown',
-    'Ollama 7B':fleetStats?.['windows-laptop']?.online?'healthy':'offline',
-    'Copilot API':'healthy','GitHub':'healthy',
+    'VS Code':'online','AUTO':'online','Wiki':'online',
+    'CB-1':sl,'Ollama SLM':sl,'Win Laptop':wl,
+    'OpenClaw':wl,'mistral':wl,'qwen2.5:7b':wl,'phi3:mini':wl,
+    'Copilot API':'online','Copilot RAG':'online','GitHub':'online',
+    'Google AI':'online','Groq':'online','Cerebras':'online',
+    'OpenRouter':'online','Cloudflare AI':'online',
   };
   const zones=[
-    {x:8,  y:22,w:188,h:285,k:'l',label:'💻 CB-2 Dev Machine (local)'},
-    {x:204,y:22,w:368,h:285,k:'t',label:'🌐 Tailscale VPN Mesh'},
-    {x:580,y:22,w:312,h:285,k:'c',label:'☁️ Cloud / Internet'},
+    {x:8,  y:22,w:182,h:420,k:'l',label:'💻 CB-2 Dev Machine (local)'},
+    {x:196,y:22,w:492,h:420,k:'t',label:'🌐 Tailscale VPN Mesh'},
+    {x:694,y:22,w:350,h:420,k:'c',label:'☁️ Cloud / Internet'},
   ];
+  const subs=[
+    {x:204,y:35, w:200,h:210,cls:'cf-sg', label:'🖥 CB-1 (2.7GB SLM)'},
+    {x:412,y:35, w:268,h:400,cls:'cf-sg', label:'🖥 Win Laptop (16GB)'},
+    {x:420,y:175,w:252,h:248,cls:'cf-oc', label:'⚡ OpenClaw :4000'},
+  ];
+  // nodes indexed 0-17
   const nodes=[
-    {x:102,y:95, type:'SW',    icon:'💻',label:'VS Code',    sub:'Copilot Agent',tip:'VS Code + Copilot Agent on CB-2. Sends prompts to AUTO Router.'},
-    {x:102,y:195,type:'SW',    icon:'🧠',label:'AUTO',       sub:'Router',       tip:'Model router software on CB-2. Dispatches to cloud (primary) or OpenClaw (fallback).'},
-    {x:102,y:278,type:'STORE', icon:'📖',label:'Wiki',       sub:'local files',  tip:'Local wiki files on CB-2. Loaded as context by Copilot Agent.'},
-    {x:293,y:90, type:'HW',    icon:'💻',label:'CB-1',       sub:'SLM node 2.7GB',tip:'Chromebook-1: 2.7GB RAM. Hosts Ollama with tiny SLM models.'},
-    {x:293,y:205,type:'LLM',   icon:'🤖',label:'Ollama SLM', sub:'0.8b-1.2b',   tip:'Ollama on CB-1: qwen3.5:0.8b, gemma3:270m, tinyllama, lfm2.5:1.2b.'},
-    {x:468,y:90, type:'HW',    icon:'🖥️',label:'Win Laptop', sub:'16GB',         tip:'Windows laptop: primary inference node. 16GB RAM. Hosts OpenClaw + Ollama.'},
-    {x:468,y:185,type:'SW',    icon:'⚡',label:'OpenClaw',   sub:'LiteLLM :4000',tip:'LiteLLM proxy on Win Laptop. Receives prompt from AUTO via Tailscale VPN.'},
-    {x:468,y:278,type:'LLM',   icon:'🤖',label:'Ollama 7B',  sub:'mistral/qwen', tip:'Ollama on Win Laptop: mistral:latest, qwen2.5:7b-instruct, phi3:mini.'},
-    {x:736,y:110,type:'SVC',   icon:'☁️',label:'Copilot API',sub:'Claude/GPT/Gemini',tip:'GitHub Copilot cloud API. Primary inference. Routes to best available model.'},
-    {x:736,y:220,type:'SVC',   icon:'🐙',label:'GitHub',     sub:'API + Actions', tip:'GitHub API + Actions CI/CD. Accessed via gh CLI from VS Code on CB-2.'},
+    // CB-2 (0-2)
+    {x:98, y:95, type:'SW',  icon:'💻',label:'VS Code',    sub:'Copilot Agent',  tip:'VS Code + Copilot Agent on CB-2'},
+    {x:98, y:210,type:'SW',  icon:'🧠',label:'AUTO',       sub:'Router',         tip:'Model router on CB-2. Dispatches to cloud or OpenClaw.'},
+    {x:98, y:360,type:'STORE',icon:'📖',label:'Wiki',      sub:'local files',    tip:'Local wiki/context files on CB-2'},
+    // CB-1 sub-group (3-4)
+    {x:304,y:95, type:'HW',  icon:'💻',label:'CB-1',       sub:'2.7GB RAM',      tip:'Chromebook-1: dedicated SLM inference node'},
+    {x:304,y:180,type:'LLM', icon:'🤖',label:'Ollama SLM', sub:'0.8b–1.2b',     tip:'Ollama on CB-1: qwen3.5:0.8b, gemma3:270m, tinyllama, lfm2.5:1.2b'},
+    // Win Laptop sub-group (5)
+    {x:546,y:85, type:'HW',  icon:'🖥️',label:'Win Laptop', sub:'16GB RAM',       tip:'Windows laptop: primary inference node. Hosts OpenClaw + Ollama.'},
+    // OpenClaw sub-group (6-9)
+    {x:490,y:240,type:'SW',  icon:'⚡',label:'OpenClaw',   sub:'LiteLLM :4000',  tip:'LiteLLM proxy on Win Laptop. Receives prompt from AUTO via Tailscale.'},
+    {x:460,y:335,type:'LLM', icon:'🤖',label:'mistral',    sub:'7.2B Q4',        tip:'ollama/mistral:latest — general chat, 7.2B params'},
+    {x:546,y:380,type:'LLM', icon:'🤖',label:'qwen2.5:7b', sub:'7.6B Q4',        tip:'ollama/qwen2.5:7b-instruct — coding/instruction'},
+    {x:632,y:335,type:'LLM', icon:'🤖',label:'phi3:mini',  sub:'3.8B Q4',        tip:'ollama/phi3:mini — fast/lightweight reasoning'},
+    // Cloud nodes (10-17)
+    {x:800,y:65, type:'SVC', icon:'☁️',label:'Copilot API',sub:'Claude/GPT/Gemini',tip:'GitHub Copilot cloud API — primary inference gateway'},
+    {x:800,y:150,type:'SVC', icon:'🔍',label:'Copilot RAG',sub:'context retrieval',tip:'Copilot RAG pipeline: retrieves repo/wiki context for grounding'},
+    {x:800,y:235,type:'SVC', icon:'🐙',label:'GitHub',     sub:'API + Actions',  tip:'GitHub API + Actions. Accessed via gh CLI from CB-2.'},
+    {x:900,y:65, type:'SVC', icon:'🔶',label:'Google AI',  sub:'Gemini 2.5',     tip:'Google AI Studio: Gemini 2.5 Pro/Flash, free tier + $10 credit'},
+    {x:900,y:150,type:'SVC', icon:'⚡',label:'Groq',       sub:'fast inference', tip:'Groq: ultra-fast LLM inference, free tier'},
+    {x:900,y:235,type:'SVC', icon:'🧠',label:'Cerebras',   sub:'GPT-OSS-120B',   tip:'Cerebras: GPT-OSS-120B, Llama 3.1-8B, Qwen3-235B — free tier'},
+    {x:850,y:320,type:'SVC', icon:'🔀',label:'OpenRouter', sub:'free models',    tip:'OpenRouter: free model failover gateway for OpenClaw'},
+    {x:850,y:400,type:'SVC', icon:'🌩️',label:'Cloudflare', sub:'Workers AI',    tip:'Cloudflare Workers AI: Llama vision, D1, R2 — $10/mo'},
   ];
   const arrows=[
-    {from:0,to:1,type:'internal',label:'',           tip:'VS Code passes prompt to AUTO Router on CB-2'},
-    {from:1,to:8,type:'cloud',   label:'prompt',     tip:'PRIMARY: prompt dispatched to GitHub Copilot cloud API'},
-    {from:1,to:6,type:'local',   label:'via Tailscale VPN',curve:true,tip:'FALLBACK: AUTO routes over Tailscale mesh to OpenClaw on Win Laptop'},
-    {from:6,to:7,type:'inference',label:'inference', tip:'OpenClaw dispatches prompt to Ollama 7B on Win Laptop'},
-    {from:3,to:4,type:'hosts',   label:'runs',       tip:'CB-1 hardware hosts Ollama SLM service'},
-    {from:5,to:6,type:'hosts',   label:'hosts',      tip:'Win Laptop hosts OpenClaw LiteLLM proxy'},
-    {from:0,to:9,type:'github',  label:'gh cli',     tip:'VS Code uses gh CLI for issues, PRs, commits'},
+    {from:0,to:1,type:'internal',tip:'VS Code passes prompt to AUTO Router'},
+    {from:1,to:10,type:'cloud',label:'prompt',curve:true,tip:'PRIMARY: prompt → Copilot API cloud'},
+    {from:1,to:6,type:'local',label:'fallback',curve:true,tip:'FALLBACK: AUTO → OpenClaw via Tailscale'},
+    {from:6,to:7,type:'inference',tip:'OpenClaw → mistral'},
+    {from:6,to:8,type:'inference',tip:'OpenClaw → qwen2.5:7b'},
+    {from:6,to:9,type:'inference',tip:'OpenClaw → phi3:mini'},
+    {from:3,to:4,type:'hosts',label:'runs',tip:'CB-1 hosts Ollama SLM'},
+    {from:5,to:6,type:'hosts',label:'hosts',tip:'Win Laptop hosts OpenClaw'},
+    {from:0,to:12,type:'github',label:'gh cli',tip:'VS Code → GitHub via gh CLI'},
   ];
-  const svg=`<svg viewBox="0 0 ${W} ${H}" height="${H}" class="cf-svg" role="img" aria-label="Fleet topology diagram">
-    <defs>${cfDefs()}</defs>${cfZones(zones)}${cfArrows(nodes,arrows,isActive)}${cfNodes(nodes,liveMap)}</svg>`;
+  const svg=`<svg viewBox="0 0 ${W} ${H}" height="${H}" class="cf-svg" role="img" aria-label="Fleet topology">
+    <defs>${cfDefs()}</defs>${cfZones(zones)}${cfSubGroups(subs)}${cfArrows(nodes,arrows,isActive)}${cfNodes(nodes,liveMap)}</svg>`;
   return `<div class="cf-wrap">${svg}${cfTypeLegend()}${contextBudgetLegend()}${typeof cfResourcePills==='function'?cfResourcePills(liveQuotas):''}</div>`;
 }
 function cfTypeLegend() {

--- a/dashboard/js/context-topology.js
+++ b/dashboard/js/context-topology.js
@@ -1,4 +1,4 @@
-// Context Topology — SVG zones, type-differentiated nodes, and flow arrows
+// Context Topology — SVG zones, sub-groups, type-differentiated nodes, and flow arrows
 const CF_TYPE_STYLE = {
   HW:    {rx:4,  sw:2,   stroke:'var(--text-muted)', fill:'var(--surface)'},
   SW:    {rx:8,  sw:1.5, stroke:'var(--blue)',        fill:'color-mix(in srgb,var(--blue) 8%,var(--bg))'},
@@ -22,7 +22,10 @@ function cfDefs() {
     .cf-zl{stroke:var(--blue);fill:color-mix(in srgb,var(--blue) 4%,transparent)}
     .cf-zt{stroke:var(--yellow);fill:color-mix(in srgb,var(--yellow) 3%,transparent)}
     .cf-zc{stroke:var(--text-muted);fill:color-mix(in srgb,var(--text-muted) 3%,transparent)}
+    .cf-sg{stroke:var(--text-muted);stroke-width:1;stroke-dasharray:3,2;fill:color-mix(in srgb,var(--text-muted) 5%,transparent);rx:6}
+    .cf-oc{stroke:var(--yellow);stroke-width:1;stroke-dasharray:3,2;fill:color-mix(in srgb,var(--yellow) 6%,transparent)}
     .cf-zlbl{font-size:8px;font-weight:700;fill:var(--text-muted);pointer-events:none}
+    .cf-sglbl{font-size:7px;font-weight:600;fill:var(--text-muted);pointer-events:none}
     .cf-nm{font-size:8.5px;fill:var(--text);font-weight:700;pointer-events:none}
     .cf-sb{font-size:6.5px;fill:var(--text-muted);pointer-events:none}
     .cf-tb{font-size:6px;font-weight:800;pointer-events:none}
@@ -36,14 +39,18 @@ function cfZones(zones) {
   return zones.map(z=>`<rect x="${z.x}" y="${z.y}" width="${z.w}" height="${z.h}" rx="8" class="cf-zone cf-z${z.k}"/>
     <text x="${z.x+8}" y="${z.y+13}" class="cf-zlbl">${z.label}</text>`).join('');
 }
+function cfSubGroups(groups) {
+  return (groups||[]).map(g=>`<rect x="${g.x}" y="${g.y}" width="${g.w}" height="${g.h}" rx="6" class="${g.cls||'cf-sg'}"/>
+    <text x="${g.x+6}" y="${g.y+11}" class="cf-sglbl">${g.label}</text>`).join('');
+}
 function cfNodes(nodes, liveMap) {
-  const sc={healthy:'var(--green)',degraded:'var(--yellow)',offline:'var(--red)',unknown:'var(--text-muted)'};
-  const NW=76,NH=44;
+  const sc={healthy:'var(--green)',online:'var(--green)',degraded:'var(--yellow)',offline:'var(--red)',unknown:'var(--text-muted)'};
+  const NW=72,NH=42;
   return nodes.map(n=>{
     const st=(liveMap||{})[n.label]||'unknown';
     const ts=CF_TYPE_STYLE[n.type]||CF_TYPE_STYLE.SW;
     const sd=n.type==='STORE'?'stroke-dasharray="3,2"':'';
-    const hp=st==='healthy'?' class="cfp"':'';
+    const hp=st==='healthy'||st==='online'?' class="cfp"':'';
     return `<g class="cf-ng"><title>${n.tip}</title>
     <rect x="${n.x-NW/2}" y="${n.y-NH/2}" width="${NW}" height="${NH}" rx="${ts.rx}" ${sd} fill="${ts.fill}" stroke="${ts.stroke}" stroke-width="${ts.sw}"/>
     <circle cx="${n.x+NW/2-6}" cy="${n.y-NH/2+7}" r="4" fill="${sc[st]||sc.unknown}"${hp}/>


### PR DESCRIPTION
Closes #374\n\n## Changes\n- **context-topology.js**: Added `cfSubGroups()` for inner hardware group rects (CF-1, Win Laptop, OpenClaw nested boxes with distinct styles)\n- **context-flow.js**: Expanded canvas to W=1050 H=460; CB-1 sub-group with Ollama SLM; Win Laptop sub-group with OpenClaw sub-group containing mistral/qwen2.5:7b/phi3:mini LLM nodes; Cloud zone with 8 service nodes (Copilot API, Copilot RAG, GitHub, Google AI, Groq, Cerebras, OpenRouter, Cloudflare AI)\n- **context.css**: SVG height 260px → 420px to accommodate expanded canvas\n- 4-state status enum support in node rendering (online/degraded/offline/unknown)\n\n## Note\nArrow connectivity to OpenClaw pending deep-dive with user.\n\nLint: ✅ 310 files, 0 violations