### PR TITLE
fix: restore 2-col live view at 725px, fix node sub-text overflow (#384)

### DIFF
--- a/dashboard/css/views.css
+++ b/dashboard/css/views.css
@@ -88,5 +88,5 @@
 #panel-llm-context { grid-row: 3; grid-column: 1; }
 #panel-governance { grid-column: 2; }
 @media (max-width:1023px) and (min-width:641px) { .header{padding:0.4rem 0.75rem;} .header-nav button{padding:0.15rem 0.45rem;font-size:0.78rem;} .dashboard-grid{gap:0.35rem;padding:0.35rem;} }
-@media (max-width:800px) and (min-width:641px) { .view-live,.view-logs,.view-fleet,.view-ops{grid-template-columns:1fr;} #panel-github,#panel-llm-context,#panel-governance{grid-row:auto;grid-column:auto;} }
+@media (max-width:800px) and (min-width:641px) { .view-logs,.view-fleet,.view-ops{grid-template-columns:1fr;} #panel-github,#panel-llm-context,#panel-governance{grid-row:auto;grid-column:auto;} }
 @media (max-width: 640px) { .header{flex-wrap:wrap;gap:0.4rem;padding:0.5rem 0.75rem;} .header-brand h1{font-size:0.95rem;} .header-nav,.header-actions{flex-wrap:wrap;} .header-nav button,.header-actions button{min-height:44px;min-width:44px;} .header-nav button{padding:0.4rem 0.6rem;} .header-actions button{padding:0.4rem;} .dashboard-grid{grid-template-columns:1fr;height:auto;overflow-y:auto;} .view-wiki{grid-template-columns:1fr;} .log-scroll{max-height:40vh;} #panel-github,#panel-governance{grid-row:auto;grid-column:auto;} }

--- a/dashboard/js/context-topology.js
+++ b/dashboard/js/context-topology.js
@@ -57,9 +57,9 @@ function cfNodes(nodes, liveMap) {
     <rect x="${n.x-NW/2}" y="${n.y-NH/2}" width="${NW}" height="${NH}" rx="${ts.rx}" ${sd} fill="${ts.fill}" stroke="${ts.stroke}" stroke-width="${ts.sw}"/>
     <circle cx="${n.x+NW/2-8}" cy="${n.y-NH/2+9}" r="5" fill="${sc[st]||sc.unknown}"${hp}/>
     <text x="${n.x-NW/2+6}" y="${n.y-NH/2+12}" fill="${ts.stroke}" class="cf-tb">${CF_TYPE_LBL[n.type]||''}</text>
-    <text x="${n.x}" y="${n.y+2}" text-anchor="middle" style="font-size:14px;pointer-events:none">${n.icon}</text>
-    <text x="${n.x}" y="${n.y+16}" text-anchor="middle" class="cf-nm">${n.label}</text>
-    <text x="${n.x}" y="${n.y+28}" text-anchor="middle" class="cf-sb">${n.sub}</text></g>`;
+    <text x="${n.x}" y="${n.y}" text-anchor="middle" style="font-size:14px;pointer-events:none">${n.icon}</text>
+    <text x="${n.x}" y="${n.y+13}" text-anchor="middle" class="cf-nm">${n.label}</text>
+    <text x="${n.x}" y="${n.y+23}" text-anchor="middle" class="cf-sb">${n.sub}</text></g>`;
   }).join('');
 }
 function cfArrows(nodes,arrows,isActive){


### PR DESCRIPTION
Closes #384.

## Changes
- **views.css**: removed `view-live` from `max-width:800px` single-column collapse. This breakpoint was introduced in #381 and was wrong — live view must stay 2-column at 725px.
- **context-topology.js**: shifted node icon/name/sub-label up (y+2→y+0, y+16→y+13, y+28→y+23) so sub-label fits inside NH=50 box bottom (y+25).

## Verified at 725×642px
| Metric | Before | After |
|---|---|---|
| baton column position | x:6 (same as activity) | x:6 |
| activity column position | x:6 (stacked) | x:365 (side-by-side) ✅ |
| cfBottom vs grid bottom | 850 > 614 (clipped) | 592 < 614 ✅ |
| sub-label vs node box | 3px below bottom | within 2px ✅ |

31/31 tests. Lint clean.