### PR TITLE
feat(instructions): add CLAUDE.md instruction entry point for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# devenv-ops — Claude Code Governance
+
+This project uses a structured Agile baton workflow, GitHub ticketing standards,
+and AI agent governance. All instructions below are binding for Claude Code sessions.
+
+## Instructions
+
+@instructions/role-baton-routing.instructions.md
+@instructions/ticket-driven-work.instructions.md
+@instructions/operator-identity-context.instructions.md
+@instructions/global-standards.instructions.md
+@instructions/global-task-router.instructions.md
+@instructions/github-governance.instructions.md
+@instructions/epic-governance.instructions.md
+@instructions/feature-completion-governance.instructions.md
+@instructions/workflow-resilience.instructions.md
+@instructions/release-docs-hygiene.instructions.md
+@instructions/repo-health-onboarding.instructions.md
+@instructions/visual-qa-governance.instructions.md
+@instructions/playwright-mcp-low-resource.instructions.md
+@instructions/wiki-knowledge.instructions.md
+
+## Runtime Context
+
+- Skills (slash commands): `.claude/commands/`
+- Agents: `.claude/agents/`
+- Hook scripts: `~/.claude/hooks/scripts/` (after deploy)
+- Deploy: `npm run deploy:claude` or `npm run deploy:apply` (both runtimes)
+- Lint: `npm run lint` — all files must be ≤ 100 lines


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` at repo root as the Claude Code instruction entry point
- Imports all 14 existing `instructions/*.instructions.md` files by reference
- Documents `.claude/` scaffold and deploy commands for Runtime Context section

## Test plan
- [x] `npm run lint` passes (312 files, all ≤ 100 lines)
- [x] All 14 instruction files referenced by exact filename
- [x] No instruction content duplicated
- [x] File is 29 lines (≤ 100)
- [x] No secrets

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)