### PR TITLE
fix: resolve context-flow UAT layering and cloud path issues (#384)

### DIFF
--- a/dashboard/js/context-flow.js
+++ b/dashboard/js/context-flow.js
@@ -1,6 +1,6 @@
-// Context Flow — 700px canvas (#382 legibility fix)
+// Context Flow — 700px canvas (#384 label/cloud/z-order fix)
 function renderContextFlow(devices, fleetStats, isActive, liveQuotas) {
-  const W=700,H=284;
+  const W=700,H=298;
   const dm={}; (devices||[]).forEach(d=>{dm[d.id]=d.status;});
   const wl=dm['windows-laptop']||'unknown', sl=dm['penguin-1']||'unknown';
   const liveMap={
@@ -11,33 +11,33 @@ function renderContextFlow(devices, fleetStats, isActive, liveQuotas) {
     'OpenRouter':'online','Cloudflare':'online',
   };
   const zones=[
-    {x:5,  y:14,w:122,h:260,k:'l',label:'💻 CB-2 Dev Machine'},
-    {x:132,y:14,w:340,h:260,k:'t',label:'🌐 Tailscale VPN Mesh'},
-    {x:477,y:14,w:218,h:260,k:'c',label:'☁️ Cloud / Internet'},
+    {x:5,  y:28,w:122,h:260,k:'l',label:'💻 CB-2 Dev Machine'},
+    {x:132,y:28,w:340,h:260,k:'t',label:'🌐 Tailscale VPN Mesh'},
+    {x:477,y:28,w:218,h:260,k:'c',label:'☁️ Cloud / Internet'},
   ];
   const subs=[
-    {x:136,y:22,w:120,h:178,cls:'cf-sg',label:'🖥 CB-1 (2.7GB SLM)'},
-    {x:260,y:22,w:206,h:248,cls:'cf-sg',label:'🖥 Win Laptop (16GB)'},
-    {x:265,y:112,w:196,h:150,cls:'cf-oc',label:'⚡ OpenClaw :4000'},
+    {x:136,y:36,w:120,h:178,cls:'cf-sg',label:'🖥 CB-1 (2.7GB SLM)'},
+    {x:260,y:36,w:206,h:248,cls:'cf-sg',label:'🖥 Win Laptop (16GB)'},
+    {x:265,y:126,w:196,h:150,cls:'cf-oc',label:'⚡ OpenClaw :4000'},
   ];
   const nodes=[
-    {x:66, y:80, type:'SW', icon:'💻',label:'VS Code',    sub:'Copilot Agent',tip:'VS Code + Copilot Agent on CB-2'},
-    {x:66, y:192,type:'SW', icon:'🧠',label:'AUTO',       sub:'Router',       tip:'Model router on CB-2. Dispatches to cloud or OpenClaw.'},
-    {x:196,y:64, type:'HW', icon:'💻',label:'CB-1',       sub:'2.7GB RAM',    tip:'Chromebook-1: dedicated SLM inference node'},
-    {x:196,y:162,type:'LLM',icon:'🤖',label:'Ollama SLM', sub:'0.8b–1.2b',   tip:'Ollama on CB-1: qwen3.5:0.8b, gemma3:270m, tinyllama'},
-    {x:362,y:54, type:'HW', icon:'🖥️',label:'Win Laptop', sub:'16GB RAM',    tip:'Windows laptop: primary inference node'},
-    {x:362,y:144,type:'SW', icon:'⚡',label:'OpenClaw',   sub:'LiteLLM :4000',tip:'LiteLLM proxy on Win Laptop. Receives prompt from AUTO.'},
-    {x:310,y:240,type:'LLM',icon:'🤖',label:'mistral',    sub:'7.2B Q4',      tip:'ollama/mistral — general chat, 7.2B params'},
-    {x:362,y:240,type:'LLM',icon:'🤖',label:'qwen2.5:7b', sub:'7.6B Q4',     tip:'ollama/qwen2.5:7b-instruct — coding'},
-    {x:414,y:240,type:'LLM',icon:'🤖',label:'phi3:mini',  sub:'3.8B Q4',      tip:'ollama/phi3:mini — fast reasoning'},
-    {x:519,y:42, type:'SVC',icon:'☁️',label:'Copilot API',sub:'Claude/GPT',   tip:'GitHub Copilot cloud API — primary gateway'},
-    {x:519,y:104,type:'SVC',icon:'🔍',label:'Copilot RAG',sub:'context',      tip:'Copilot RAG: retrieves repo/wiki context'},
-    {x:519,y:166,type:'SVC',icon:'🐙',label:'GitHub',     sub:'API+Actions',  tip:'GitHub API + Actions via gh CLI from CB-2'},
-    {x:519,y:228,type:'SVC',icon:'🔀',label:'OpenRouter', sub:'free models',  tip:'OpenRouter: free model failover for OpenClaw'},
-    {x:614,y:42, type:'SVC',icon:'🔶',label:'Google AI',  sub:'Gemini 2.5',   tip:'Google AI Studio: Gemini 2.5 Pro/Flash'},
-    {x:614,y:104,type:'SVC',icon:'⚡',label:'Groq',       sub:'fast infer.',  tip:'Groq: ultra-fast LLM inference, free tier'},
-    {x:614,y:166,type:'SVC',icon:'🧠',label:'Cerebras',   sub:'120B OSS',     tip:'Cerebras: GPT-OSS-120B, Llama 3.1-8B'},
-    {x:614,y:228,type:'SVC',icon:'🌩️',label:'Cloudflare', sub:'Workers AI',  tip:'Cloudflare Workers AI: Llama vision, D1, R2'},
+    {x:66, y:94, type:'SW', icon:'💻',label:'VS Code',    sub:'Copilot Agent',tip:'VS Code + Copilot Agent on CB-2'},
+    {x:66, y:206,type:'SW', icon:'🧠',label:'AUTO',       sub:'Router',       tip:'Model router on CB-2. Dispatches to cloud or OpenClaw.'},
+    {x:196,y:78, type:'HW', icon:'💻',label:'CB-1',       sub:'2.7GB RAM',    tip:'Chromebook-1: dedicated SLM inference node'},
+    {x:196,y:176,type:'LLM',icon:'🤖',label:'Ollama SLM', sub:'0.8b–1.2b',   tip:'Ollama on CB-1: qwen3.5:0.8b, gemma3:270m, tinyllama'},
+    {x:362,y:68, type:'HW', icon:'🖥️',label:'Win Laptop', sub:'16GB RAM',    tip:'Windows laptop: primary inference node'},
+    {x:362,y:158,type:'SW', icon:'⚡',label:'OpenClaw',   sub:'LiteLLM :4000',tip:'LiteLLM proxy on Win Laptop. Receives prompt from AUTO.'},
+    {x:310,y:254,type:'LLM',icon:'🤖',label:'mistral',    sub:'7.2B Q4',      tip:'ollama/mistral — general chat, 7.2B params'},
+    {x:362,y:254,type:'LLM',icon:'🤖',label:'qwen2.5:7b', sub:'7.6B Q4',     tip:'ollama/qwen2.5:7b-instruct — coding'},
+    {x:414,y:254,type:'LLM',icon:'🤖',label:'phi3:mini',  sub:'3.8B Q4',      tip:'ollama/phi3:mini — fast reasoning'},
+    {x:519,y:56, type:'SVC',icon:'☁️',label:'Copilot API',sub:'Claude/GPT',   tip:'GitHub Copilot cloud API — primary gateway'},
+    {x:519,y:118,type:'SVC',icon:'🔍',label:'Copilot RAG',sub:'context',      tip:'Copilot RAG: retrieves repo/wiki context'},
+    {x:519,y:180,type:'SVC',icon:'🐙',label:'GitHub',     sub:'API+Actions',  tip:'GitHub API + Actions via gh CLI from CB-2'},
+    {x:519,y:242,type:'SVC',icon:'🔀',label:'OpenRouter', sub:'free models',  tip:'OpenRouter: free model failover for OpenClaw'},
+    {x:614,y:56, type:'SVC',icon:'🔶',label:'Google AI',  sub:'Gemini 2.5',   tip:'Google AI Studio: Gemini 2.5 Pro/Flash'},
+    {x:614,y:118,type:'SVC',icon:'⚡',label:'Groq',       sub:'fast infer.',  tip:'Groq: ultra-fast LLM inference, free tier'},
+    {x:614,y:180,type:'SVC',icon:'🧠',label:'Cerebras',   sub:'120B OSS',     tip:'Cerebras: GPT-OSS-120B, Llama 3.1-8B'},
+    {x:614,y:242,type:'SVC',icon:'🌩️',label:'Cloudflare', sub:'Workers AI',  tip:'Cloudflare Workers AI: Llama vision, D1, R2'},
   ];
   const arrows=[
     {from:0,to:1, type:'internal',tip:'VS Code passes prompt to AUTO Router'},
@@ -51,7 +51,7 @@ function renderContextFlow(devices, fleetStats, isActive, liveQuotas) {
     {from:0,to:11,type:'github',  label:'gh cli',  tip:'VS Code → GitHub via gh CLI'},
   ];
   const svg=`<svg viewBox="0 0 ${W} ${H}" width="100%" class="cf-svg" role="img" aria-label="Fleet topology">
-    <defs>${cfDefs()}</defs>${cfZones(zones)}${cfSubGroups(subs)}${cfNodes(nodes,liveMap)}${cfArrows(nodes,arrows,isActive)}</svg>`;
+    <defs>${cfDefs()}</defs>${cfZoneRects(zones)}${cfSubRects(subs)}${cfNodes(nodes,liveMap)}${cfArrows(nodes,arrows,isActive)}${cfSubLabels(subs)}${cfZoneLabels(zones)}</svg>`;
   return `<div class="cf-wrap">${svg}</div>`;
 }
 

--- a/dashboard/js/context-topology.js
+++ b/dashboard/js/context-topology.js
@@ -10,7 +10,7 @@ const CF_TYPE_LBL = {HW:'HW', SW:'SW', LLM:'LLM', SVC:'SVC', STORE:'DB'};
 const FLOW_TYPE = {
   internal: {color:'#4B5563',head:'cfHd', dash:false,dur:0,     op:0.5, sw:1.5,cls:''},
   hosts:    {color:'#4B5563',head:'cfHd', dash:true, dur:0,     op:0.35,sw:1.5,cls:''},
-  cloud:    {color:'#3B82F6',head:'cfHdB',dash:false,dur:'2s',  op:1.0, sw:5,  cls:'cf-cloud-path'},
+  cloud:    {color:'#3B82F6',head:'cfHdB',dash:false,dur:'2s',  op:0.9, sw:2,  cls:'cf-cloud-path'},
   local:    {color:'#F59E0B',head:'cfHdY',dash:true, dur:'3s',  op:0.9, sw:2,  cls:''},
   inference:{color:'#10B981',head:'cfHdG',dash:false,dur:'1.8s',op:0.9, sw:2,  cls:'cf-infer-path'},
   github:   {color:'#8B5CF6',head:'cfHdP',dash:false,dur:'3.5s',op:0.8, sw:2,  cls:''},
@@ -24,27 +24,33 @@ function cfDefs() {
 .cf-zl{stroke:#3B82F6;fill:rgba(59,130,246,0.15)}.cf-zt{stroke:#8B5CF6;fill:rgba(139,92,246,0.12)}
 .cf-zc{stroke:#F59E0B;fill:rgba(245,158,11,0.12)}.cf-sg{stroke:#4B5563;stroke-width:1.5;stroke-dasharray:4,2;fill:rgba(75,85,99,0.1)}
 .cf-oc{stroke:#F59E0B;stroke-width:1.5;stroke-dasharray:4,2;fill:rgba(245,158,11,0.1)}
-.cf-zlbl{font-size:11px;font-weight:700;pointer-events:none}
+.cf-zlbl{font-size:11px;font-weight:700;pointer-events:none;paint-order:stroke;stroke:#0d1117;stroke-width:3px}
 .cf-zlbl-l{fill:#3B82F6}.cf-zlbl-t{fill:#8B5CF6}.cf-zlbl-c{fill:#F59E0B}
-.cf-sglbl{font-size:9px;font-weight:600;fill:#9CA3AF;pointer-events:none}
+.cf-sglbl{font-size:9px;font-weight:600;fill:#9CA3AF;pointer-events:none;paint-order:stroke;stroke:#0d1117;stroke-width:2px}
 .cf-nm{font-size:13px;fill:#E6EDF3;font-weight:700;pointer-events:none}
 .cf-sb{font-size:10px;fill:#A3AEBF;pointer-events:none}
 .cf-tb{font-size:8px;font-weight:800;pointer-events:none}
 .cf-lbl2{font-size:9px;fill:#9CA3AF;font-style:italic}.cf-lbl2-bg{fill:#0d1117}
 .cf-cloud-path{filter:url(#cfGlowB)}.cf-infer-path{filter:url(#cfGlowG)}
-.cf-ng:hover rect{filter:brightness(1.5);transition:filter 0.15s}
+.cf-ng{cursor:pointer}.cf-ng:hover rect{filter:brightness(1.5);transition:filter 0.15s}
 @keyframes cfpulse{0%,100%{opacity:.3}50%{opacity:1}}
 circle.cfp{animation:cfpulse 1.4s ease-in-out 4;animation-fill-mode:forwards}
 .cfpkt{filter:drop-shadow(0 0 4px currentColor)}</style>`;
 }
-function cfZones(zones) {
-  return zones.map(z=>`<rect x="${z.x}" y="${z.y}" width="${z.w}" height="${z.h}" rx="8" class="cf-zone cf-z${z.k}"/>
-    <text x="${z.x+10}" y="${z.y+16}" class="cf-zlbl cf-zlbl-${z.k}">${z.label}</text>`).join('');
+function cfZoneRects(zones) {
+  return zones.map(z=>`<rect x="${z.x}" y="${z.y}" width="${z.w}" height="${z.h}" rx="8" class="cf-zone cf-z${z.k}"/>`).join('');
 }
-function cfSubGroups(groups) {
-  return (groups||[]).map(g=>`<rect x="${g.x}" y="${g.y}" width="${g.w}" height="${g.h}" rx="6" class="${g.cls||'cf-sg'}"/>
-    <text x="${g.x+8}" y="${g.y+13}" class="cf-sglbl">${g.label}</text>`).join('');
+function cfZoneLabels(zones) {
+  return zones.map(z=>`<text x="${z.x+6}" y="${z.y-4}" class="cf-zlbl cf-zlbl-${z.k}">${z.label}</text>`).join('');
 }
+function cfSubRects(groups) {
+  return (groups||[]).map(g=>`<rect x="${g.x}" y="${g.y}" width="${g.w}" height="${g.h}" rx="6" class="${g.cls||'cf-sg'}"/>`).join('');
+}
+function cfSubLabels(groups) {
+  return (groups||[]).map(g=>`<text x="${g.x+6}" y="${g.y-3}" class="cf-sglbl">${g.label}</text>`).join('');
+}
+function cfZones(z){return cfZoneRects(z)+cfZoneLabels(z);}
+function cfSubGroups(g){return cfSubRects(g)+cfSubLabels(g);}
 function cfNodes(nodes, liveMap) {
   const sc={healthy:'#22C55E',online:'#22C55E',degraded:'#EAB308',offline:'#EF4444',unknown:'#6B7280'};
   const NW=88,NH=50;
@@ -53,7 +59,7 @@ function cfNodes(nodes, liveMap) {
     const ts=CF_TYPE_STYLE[n.type]||CF_TYPE_STYLE.SW;
     const sd=n.type==='STORE'?'stroke-dasharray="3,2"':'';
     const hp=st==='healthy'||st==='online'?' class="cfp"':'';
-    return `<g class="cf-ng"><title>${n.tip}</title>
+    return `<g class="cf-ng" onclick="this.parentNode.appendChild(this)"><title>${n.tip}</title>
     <rect x="${n.x-NW/2}" y="${n.y-NH/2}" width="${NW}" height="${NH}" rx="${ts.rx}" ${sd} fill="${ts.fill}" stroke="${ts.stroke}" stroke-width="${ts.sw}"/>
     <circle cx="${n.x+NW/2-8}" cy="${n.y-NH/2+9}" r="5" fill="${sc[st]||sc.unknown}"${hp}/>
     <text x="${n.x-NW/2+6}" y="${n.y-NH/2+12}" fill="${ts.stroke}" class="cf-tb">${CF_TYPE_LBL[n.type]||''}</text>
@@ -75,8 +81,8 @@ function cfArrows(nodes,arrows,isActive){
     const mx=(f.x+t.x)/2, my=a.curve?Math.min(f.y,t.y)-72:(f.y+t.y)/2-6;
     const pkt=(isActive&&ft.dur)?`<circle r="3" fill="${ft.color}" class="cfpkt" opacity="0.95"><animateMotion dur="${ft.dur}" repeatCount="3"><mpath href="#${pid}"/></animateMotion></circle>`:'';
     const gp=ft.cls==='cf-cloud-path'
-      ?`<path d="${d}" fill="none" stroke="#1D4ED8" stroke-width="28" opacity="0.55"/><path d="${d}" fill="none" stroke="#93C5FD" stroke-width="12" opacity="0.7"/><path d="${d}" fill="none" stroke="#ffffff" stroke-width="3" opacity="0.6"/>`
-      :ft.cls==='cf-infer-path'?`<path d="${d}" fill="none" stroke="#065F46" stroke-width="12" opacity="0.5"/>` :'';
+      ?`<path d="${d}" fill="none" stroke="#3B82F6" stroke-width="8" opacity="0.25"/>`
+      :ft.cls==='cf-infer-path'?`<path d="${d}" fill="none" stroke="#065F46" stroke-width="6" opacity="0.4"/>` :'';
     return `${gp}<path id="${pid}" d="${d}" fill="none" stroke="${ft.color}" stroke-width="${ft.sw}" ${dk} opacity="${ft.op}" marker-end="url(#${ft.head})"><title>${a.tip||''}</title></path>${pkt}
     ${a.label?`<rect x="${mx-20}" y="${my-8}" width="40" height="13" rx="3" fill="#0d1117" opacity="0.75"/><text x="${mx}" y="${my+3}" text-anchor="middle" class="cf-lbl2">${a.label}</text>`:''}`;
   }).join('');


### PR DESCRIPTION
Closes #384.

## UAT failures addressed
- Zone titles moved outside and above their group borders
- Sub-group titles moved outside and above subgroup borders
- Group titles render last so nodes cannot hide them
- Overlapping LLM nodes now support click-to-front
- AUTO→Copilot API cloud path reduced from heavy multi-stroke band to slim line plus light halo

## Verification
- 725x642 split-window screenshot captured after patch
- Context Flow panel still fits in viewport
- DOM reorder verified: clicking phi3:mini moves it to the last painted node
- npm test: 31/31 passing
- node scripts/lint.js: clean
