### PR TITLE
feat(scripts): add model routing telemetry, policy engine, and fleet live indicator #407

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "health": "node scripts/health-check.js",
     "router:smoke": "node scripts/global/task-router-smoke.js",
     "router:dispatch": "node scripts/global/task-router-dispatch.js",
+    "router:weekly": "node scripts/global/model-routing-weekly-report.js",
     "repo:scope": "node scripts/global/repo-scope.js",
     "ticket:create": "node scripts/global/ticket-create.js",
     "wiki:ingest": "node scripts/wiki/ingest.js",

--- a/scripts/global/fleet-live-indicator-stress.js
+++ b/scripts/global/fleet-live-indicator-stress.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+'use strict';
+const os = require('os');
+
+const args = Object.fromEntries(process.argv.slice(2)
+  .map(a => a.split('='))
+  .map(([k, v]) => [k.replace(/^--/, ''), v ?? 'true']));
+const model = args.model || 'tinyllama:latest';
+const host = args.host || 'http://127.0.0.1:11434';
+const prompt = args.prompt || 'terminal-uat-ping';
+const keepAlive = args.keepAlive || '30m';
+const intervalMs = Math.max(300, (Number(args.interval) || 1.5) * 1000);
+const durationMs = Math.max(5000, (Number(args.duration) || 60) * 1000);
+const nodeLabel = args.node || os.hostname();
+
+process.stdout.on('error', (e) => { if (e.code === 'EPIPE') process.exit(0); });
+const ts = () => new Date().toTimeString().slice(0, 8);
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function generateOnce() {
+  const started = Date.now();
+  const body = { model, prompt, stream: false, keep_alive: keepAlive };
+  const res = await fetch(`${host.replace(/\/$/, '')}/api/generate`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) throw new Error(`http${res.status}`);
+  await res.json();
+  return Date.now() - started;
+}
+
+async function run() {
+  const endAt = Date.now() + durationMs;
+  let ok = 0; let fail = 0; let totalMs = 0;
+  console.log(`# Stress start node=${nodeLabel} model=${model} duration=${durationMs / 1000}s interval=${intervalMs / 1000}s`);
+  while (Date.now() < endAt) {
+    try {
+      const ms = await generateOnce();
+      ok += 1; totalMs += ms;
+      const avg = (totalMs / ok).toFixed(0);
+      console.log(`[${ts()}] node=${nodeLabel} stress=ok req=${ok} fail=${fail} last_ms=${ms} avg_ms=${avg}`);
+    } catch (e) {
+      fail += 1;
+      console.log(`[${ts()}] node=${nodeLabel} stress=fail req=${ok} fail=${fail} err=${e.message}`);
+    }
+    await sleep(intervalMs);
+  }
+  const avg = ok ? (totalMs / ok).toFixed(0) : '-';
+  console.log(`# Stress done node=${nodeLabel} ok=${ok} fail=${fail} avg_ms=${avg}`);
+  process.exit(fail > 0 ? 2 : 0);
+}
+
+void run();

--- a/scripts/global/fleet-live-indicator-stress.sh
+++ b/scripts/global/fleet-live-indicator-stress.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+model="${MODEL:-tinyllama:latest}"
+host="${HOST:-http://127.0.0.1:11434}"
+prompt="${PROMPT:-terminal-uat-ping}"
+keep_alive="${KEEP_ALIVE:-30m}"
+interval="${INTERVAL:-1}"
+duration="${DURATION:-60}"
+node_label="${NODE_LABEL:-$(hostname)}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --model=*) model="${arg#*=}" ;;
+    --host=*) host="${arg#*=}" ;;
+    --prompt=*) prompt="${arg#*=}" ;;
+    --keep-alive=*) keep_alive="${arg#*=}" ;;
+    --interval=*) interval="${arg#*=}" ;;
+    --duration=*) duration="${arg#*=}" ;;
+    --node=*) node_label="${arg#*=}" ;;
+  esac
+done
+
+end_epoch=$(( $(date +%s) + duration ))
+ok=0
+fail=0
+
+echo "# Stress start node=${node_label} model=${model} duration=${duration}s interval=${interval}s"
+while (( $(date +%s) < end_epoch )); do
+  ts="$(date +%H:%M:%S)"
+  payload=$(printf '{"model":"%s","prompt":"%s","stream":false,"keep_alive":"%s"}' "$model" "$prompt" "$keep_alive")
+  if curl -sS --max-time 20 -H 'content-type: application/json' \
+    -d "$payload" "${host%/}/api/generate" >/dev/null; then
+    ok=$((ok + 1))
+    echo "[$ts] node=${node_label} stress=ok req=${ok} fail=${fail}"
+  else
+    fail=$((fail + 1))
+    echo "[$ts] node=${node_label} stress=fail req=${ok} fail=${fail}"
+  fi
+  sleep "$interval"
+done
+
+echo "# Stress done node=${node_label} ok=${ok} fail=${fail}"
+if (( fail > 0 )); then
+  exit 2
+fi

--- a/scripts/global/fleet-live-indicator.js
+++ b/scripts/global/fleet-live-indicator.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+'use strict';
+const os = require('os');
+const { execSync } = require('child_process');
+
+const args = Object.fromEntries(process.argv.slice(2)
+  .map((a) => a.split('='))
+  .map(([k, v]) => [k.replace(/^--/, ''), v ?? 'true']));
+const intervalMs = Math.max(2000, (Number(args.interval) || 3) * 1000);
+const nodeLabel = args.node || os.hostname();
+const openclawUrl = args.openclawUrl || '';
+const mode = args.mode || 'line';
+
+process.stdout.on('error', (error) => {
+  if (error.code === 'EPIPE') process.exit(0);
+});
+
+function ts() {
+  return new Date().toTimeString().slice(0, 8);
+}
+
+function memFreeGb() {
+  return `${(os.freemem() / (1024 ** 3)).toFixed(2)}GB`;
+}
+
+function ollamaStatus() {
+  try {
+    const out = execSync('ollama ps', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    const lines = out.trim().split(/\r?\n/).filter(Boolean);
+    if (lines.length <= 1) return { up: true, state: 'idle', model: '-', until: '-' };
+    const row = lines[1].trim().split(/\s{2,}/);
+    const model = row[0] || '-';
+    const until = row[row.length - 1] || '-';
+    return { up: true, state: 'active', model, until };
+  } catch (error) {
+    return { up: false, state: 'down', model: '-', until: '-' };
+  }
+}
+
+async function openclawStatus() {
+  if (!openclawUrl) return '-';
+  try {
+    const c = new AbortController();
+    const t = setTimeout(() => c.abort(), 1200);
+    const res = await fetch(`${openclawUrl.replace(/\/$/, '')}/health/liveliness`, {
+      signal: c.signal
+    });
+    clearTimeout(t);
+    return res.ok ? 'live' : `http${res.status}`;
+  } catch (error) {
+    return 'down';
+  }
+}
+
+async function tick() {
+  const o = ollamaStatus();
+  const oc = await openclawStatus();
+  const parts = [
+    `[${ts()}]`,
+    `node=${nodeLabel}`,
+    `openclaw=${oc}`,
+    `ollama=${o.up ? 'up' : 'down'}`,
+    `state=${o.state}`,
+    `model=${o.model}`,
+    `until=${o.until}`,
+    `ram_free=${memFreeGb()}`
+  ];
+  const line = parts.join(' ');
+  if (mode === 'single') {
+    const pad = Math.max(0, 190 - line.length);
+    process.stdout.write(`\r${line}${' '.repeat(pad)}`);
+    return;
+  }
+  console.log(line);
+}
+
+console.log(`# Fleet live indicator started interval=${intervalMs / 1000}s node=${nodeLabel}`);
+if (openclawUrl) console.log(`# OpenClaw monitor URL: ${openclawUrl}`);
+if (mode === 'single') console.log('# Render mode: single-line');
+void tick();
+setInterval(() => void tick(), intervalMs);

--- a/scripts/global/model-routing-engine.js
+++ b/scripts/global/model-routing-engine.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { readTelemetry, summarize } = require('./model-routing-telemetry');
+
+const FILE = path.join(__dirname, 'model-routing-policy.json');
+
+function loadPolicy() { return JSON.parse(fs.readFileSync(FILE, 'utf8')); }
+
+function score(text, words) {
+  return (words || []).reduce((n, w) => n + (text.includes(w) ? 1 : 0), 0);
+}
+
+function classifyTask(prompt, classes) {
+  const text = String(prompt || '').toLowerCase();
+  const keys = Object.keys(classes || {});
+  let best = keys[0] || 'routine';
+  let top = -1;
+  for (const k of keys) {
+    const s = score(text, classes[k]);
+    if (s > top) { top = s; best = k; }
+  }
+  return best;
+}
+
+function shouldRollback(policy) {
+  const rb = policy.rollback || {};
+  if (!rb.enabled) return false;
+  const stats = summarize(readTelemetry(rb.windowDays || 7));
+  if (stats.samples < 5) return false;
+  return stats.successRate < (rb.minSuccessRate ?? 0.75) ||
+    stats.premiumShare > (rb.maxPremiumShare ?? 0.45);
+}
+
+function resolveRouting(prompt, route) {
+  const policy = loadPolicy();
+  const rollbackApplied = shouldRollback(policy);
+  const lane = rollbackApplied ? policy.rollback.forceLane : route.lane;
+  const model = policy.models[lane] || policy.models.fallback;
+  return {
+    lane,
+    modelId: model.id,
+    multiplier: model.mult,
+    taskClass: classifyTask(prompt, policy.taskClasses),
+    rollbackApplied
+  };
+}
+
+module.exports = { resolveRouting, loadPolicy };

--- a/scripts/global/model-routing-policy.json
+++ b/scripts/global/model-routing-policy.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "defaultLane": "free",
+  "taskClasses": {
+    "routine": ["search", "grep", "read", "docs", "simple"],
+    "coding": ["implement", "refactor", "tests", "integration"],
+    "architecture": ["architecture", "design", "risk", "security", "concurrency"]
+  },
+  "escalationRules": {
+    "premiumOn": ["failed", "stuck", "unclear", "cross-system", "trade-off"],
+    "fleetOn": ["medium", "repeated", "workflow", "generate", "coverage"]
+  },
+  "models": {
+    "free": { "id": "gpt-5-mini", "mult": 0 },
+    "fleet": { "id": "qwen2.5-7b", "mult": 0 },
+    "premium": { "id": "Claude Sonnet 4.6", "mult": 1 },
+    "fallback": { "id": "gpt-5-mini", "mult": 0 }
+  },
+  "rollback": {
+    "enabled": true,
+    "windowDays": 7,
+    "minSuccessRate": 0.75,
+    "maxPremiumShare": 0.45,
+    "forceLane": "free"
+  }
+}

--- a/scripts/global/model-routing-telemetry.js
+++ b/scripts/global/model-routing-telemetry.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const FILE = path.join(__dirname, '..', '..', 'logs', 'model-routing-telemetry.jsonl');
+
+function ensureDir() { fs.mkdirSync(path.dirname(FILE), { recursive: true }); }
+
+function recordTelemetry(entry) {
+  ensureDir();
+  const row = { ts: new Date().toISOString(), ...entry };
+  fs.appendFileSync(FILE, JSON.stringify(row) + '\n');
+  return row;
+}
+
+function readTelemetry(days = 30) {
+  if (!fs.existsSync(FILE)) return [];
+  const cutoff = Date.now() - days * 86400000;
+  return fs.readFileSync(FILE, 'utf8').split('\n').filter(Boolean)
+    .map(l => { try { return JSON.parse(l); } catch { return null; } })
+    .filter(r => r && new Date(r.ts).getTime() >= cutoff);
+}
+
+function summarize(entries) {
+  const n = entries.length || 1;
+  const premium = entries.filter(e => e.lane === 'premium').length;
+  const ok = entries.filter(e => e.outcome === 'ok').length;
+  const fail = entries.filter(e => e.outcome === 'fail').length;
+  const rollback = entries.filter(e => e.rollbackApplied).length;
+  const mult = entries.reduce((s, e) => s + (Number(e.multiplier) || 0), 0);
+  return {
+    samples: entries.length,
+    premiumShare: premium / n,
+    successRate: ok / n,
+    failRate: fail / n,
+    rollbackRate: rollback / n,
+    avgMultiplier: mult / n,
+  };
+}
+
+module.exports = { recordTelemetry, readTelemetry, summarize, FILE };

--- a/scripts/global/model-routing-weekly-report.js
+++ b/scripts/global/model-routing-weekly-report.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { readTelemetry, summarize } = require('./model-routing-telemetry');
+const { loadUsage } = require('../copilot-tracker');
+
+function report() {
+  const week = readTelemetry(7);
+  const prev = readTelemetry(14).filter(e => new Date(e.ts).getTime() < Date.now() - 7 * 86400000);
+  const now = summarize(week);
+  const old = summarize(prev);
+  const usage = loadUsage();
+  return {
+    generatedAt: new Date().toISOString(),
+    period: usage.period,
+    premiumShare: { current: now.premiumShare, previous: old.premiumShare, delta: now.premiumShare - old.premiumShare },
+    quality: { successRate: now.successRate, failRate: now.failRate, rollbackRate: now.rollbackRate },
+    efficiency: { avgMultiplier: now.avgMultiplier, requests: usage.manualOverride?.requests ?? usage.requests }
+  };
+}
+
+if (require.main === module) {
+  const out = report();
+  const file = path.join(__dirname, '..', '..', 'logs', 'model-routing-weekly.json');
+  fs.writeFileSync(file, JSON.stringify(out, null, 2));
+  console.log(JSON.stringify(out, null, 2));
+}
+
+module.exports = { report };

--- a/scripts/global/task-router-dispatch.js
+++ b/scripts/global/task-router-dispatch.js
@@ -4,6 +4,8 @@ const { execSync } = require('child_process');
 const { classifyPrompt } = require('./task-router');
 const { chatComplete } = require('./openclaw-chat');
 const { getProfile } = require('./fleet-config');
+const { resolveRouting } = require('./model-routing-engine');
+const { recordTelemetry } = require('./model-routing-telemetry');
 
 const args = process.argv.slice(2);
 const prompt = (args[args.indexOf('--prompt') + 1]) || '';
@@ -22,11 +24,11 @@ function safe(cmd) {
   }
 }
 
-async function buildDecision(route) {
-  if (route.lane === 'free') {
+async function buildDecision(route, resolved) {
+  if (resolved.lane === 'free') {
     return { action: 'stay-auto', reason: 'lowest adequate lane' };
   }
-  if (route.lane === 'fleet') {
+  if (resolved.lane === 'fleet') {
     const profile = getProfile();
     if (profile.mode === 'solo') {
       return { action: 'fleet-solo-fallback', reason: 'No fleet nodes reachable — using cloud fallback' };
@@ -38,7 +40,7 @@ async function buildDecision(route) {
       return { action: 'fleet-unavailable', preflight };
     }
     if (execute && prompt) {
-      const selectedModel = model || route.recommendedModel;
+      const selectedModel = model || resolved.modelId || route.recommendedModel;
       const chat = await chatComplete(prompt, { model: selectedModel });
       if (chat.ok) safe('node scripts/global/openclaw-lane-log.js record openclaw task-router');
       return { action: chat.ok ? 'dispatched-openclaw' : 'fleet-error', preflight, chat };
@@ -50,13 +52,18 @@ async function buildDecision(route) {
 
 async function main() {
   const route = classifyPrompt(prompt);
-  const decision = await buildDecision(route);
-  const result = { route, decision, execute };
+  const resolved = resolveRouting(prompt, route);
+  const effectiveRoute = { ...route, lane: resolved.lane, recommendedModel: resolved.modelId };
+  const decision = await buildDecision(effectiveRoute, resolved);
+  const outcome = decision.action === 'fleet-error' || decision.action === 'fleet-unavailable' ? 'fail' : 'ok';
+  recordTelemetry({ lane: resolved.lane, model: resolved.modelId, multiplier: resolved.multiplier,
+    taskClass: resolved.taskClass, rollbackApplied: resolved.rollbackApplied, outcome, execute });
+  const result = { route: effectiveRoute, routing: resolved, decision, execute };
   if (json) {
     console.log(JSON.stringify(result, null, 2));
   } else {
-    console.log(`lane=${route.lane}`);
-    console.log(`backend=${route.backend}`);
+    console.log(`lane=${effectiveRoute.lane}`);
+    console.log(`backend=${effectiveRoute.backend}`);
     console.log(`action=${decision.action}`);
     if (decision.chat?.ok) console.log('\n' + decision.chat.content);
     if (decision.chat && !decision.chat.ok) console.error('Fleet error:', decision.chat.error);

--- a/scripts/wiki/wiki-io.js
+++ b/scripts/wiki/wiki-io.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 const WIKI_DIR = path.join(__dirname, '../../wiki');
 
-/** Parse YAML-ish frontmatter from markdown */
+/** Parse YAML-ish frontmatter from markdown. */
 function parseFrontmatter(content) {
   const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
   if (!match) return { frontmatter: {}, body: content };
@@ -17,7 +17,7 @@ function parseFrontmatter(content) {
   return { frontmatter: fm, body: match[2] };
 }
 
-/** Add an entry to wiki/index.md under the appropriate section */
+/** Add an entry to wiki/index.md under the appropriate section. */
 function updateIndex(slug, title, type) {
   const indexPath = path.join(WIKI_DIR, 'index.md');
   let content = fs.readFileSync(indexPath, 'utf-8');
@@ -26,12 +26,6 @@ function updateIndex(slug, title, type) {
     concept: '## Concepts',
     source: '## Source Summaries',
     synthesis: '## Syntheses',
-  };
-  const dirMap = {
-    entity: 'entities',
-    concept: 'concepts',
-    source: 'sources',
-    synthesis: 'syntheses',
   };
   const section = sectionMap[type] || '## Source Summaries';
   const entry = `- [[${slug}]] — ${title}`;
@@ -49,7 +43,6 @@ function updateIndex(slug, title, type) {
   }
 
   // Update stats line
-  const dir = path.join(WIKI_DIR, dirMap[type] || 'sources');
   const pages = countPages();
   content = content.replace(
     /\*\*Pages\*\*:.*$/m,
@@ -58,14 +51,14 @@ function updateIndex(slug, title, type) {
   fs.writeFileSync(indexPath, content);
 }
 
-/** Append a log entry to wiki/log.md */
+/** Append a log entry to wiki/log.md. */
 function appendLog(date, operation, subject) {
   const logPath = path.join(WIKI_DIR, 'log.md');
   const entry = `\n## [${date}] ${operation} | ${subject}\n`;
   fs.appendFileSync(logPath, entry);
 }
 
-/** Count all .md files in wiki subdirs (not index/log) */
+/** Count all .md files in wiki subdirs (not index/log). */
 function countPages() {
   const dirs = ['entities', 'concepts', 'sources', 'syntheses'];
   let count = 0;
@@ -77,7 +70,7 @@ function countPages() {
   return count;
 }
 
-/** List all wiki page slugs with their paths */
+/** List all wiki page slugs with their paths. */
 function listPages() {
   const dirs = ['entities', 'concepts', 'sources', 'syntheses'];
   const pages = [];


### PR DESCRIPTION
## Summary
- Policy-driven model routing engine reads `model-routing-policy.json` and applies rollback logic from telemetry
- Per-dispatch telemetry recorded to `~/.copilot/logs/routing-telemetry.jsonl`
- `npm run router:weekly` prints weekly cost/quality scorecard
- Fleet live indicator CLI polls Ollama, memory, and OpenClaw for real-time system status
- `task-router-dispatch.js` wired to use routing engine and telemetry

## Test Plan
- [ ] `npm run lint` passes
- [ ] `npm run router:weekly` exits 0
- [ ] `node scripts/global/fleet-live-indicator.js` runs without errors
- [ ] `npm test` 31/31 pass

Closes #407