### PR TITLE
docs(release): v3.1.0 CHANGELOG, README, and version bump #413

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [3.1.0] - 2026-04-24
+
+### Added — Model Routing Telemetry (#411)
+- `model-routing-engine.js`: policy-driven routing; classifies tasks, applies rollback logic
+- `model-routing-telemetry.js`: records per-dispatch events to `~/.copilot/logs/`
+- `model-routing-policy.json`: task-class → model-id + multiplier policy
+- `npm run router:weekly`: weekly cost/quality scorecard from telemetry log
+- `fleet-live-indicator.js`: real-time CLI system status (Ollama, memory, OpenClaw)
+
+### Added — Governance Verifier (#412)
+- `governance-verify.js`: scans `tickets/*.md` for ADR-010 violations; `--json` output
+
+### Changed — Governance Instructions (#409)
+- `ticket-driven-work.instructions.md`: GitHub evidence block, Ready-SLA contract, exception schema
+- `epic-governance.instructions.md`: re-scope-before-close rule
+- `workflow-resilience.instructions.md`: ready-stall blocker note minimum fields
+- CI workflows: `merge_group` trigger, stable job names, path filters, concurrency groups
+
+### Fixed — Dashboard JS ESLint Compliance (#410)
+- Added `/* global */` directives to 15 dashboard JS modules
+- Exported public APIs via `Object.assign(window, {})` in provider modules
+- Null-safety: strict equality guards in `render-panels.js`
+
 ## [3.0.2] - 2026-04-23
 
 ### Fixed — Agent Baton Filtering (#122)

--- a/README.md
+++ b/README.md
@@ -61,17 +61,20 @@ devenv-ops (source of truth)          ~/.copilot/ (runtime)
   instructions/    (12) ──deploy──▶   instructions/
   agents/           (8) ──deploy──▶   agents/
   hooks/           (19) ──deploy──▶   hooks/
-  scripts/global/  (17) ──deploy──▶   scripts/
+  scripts/global/  (32) ──deploy──▶   scripts/
 ```
 
 ## Develop the Harness
 
 ```bash
-npm run setup          # Install deps
-npm start              # Dashboard on :8090
-npm run deploy:apply   # Deploy repo → ~/.copilot/
-npm run lint           # ≤100-line file check
-npm test               # Playwright E2E tests
+npm run setup             # Install deps
+npm start                 # Dashboard on :8090
+npm run deploy:apply      # Deploy repo → ~/.copilot/
+npm run lint              # ≤100-line file check
+npm test                  # Playwright E2E tests
+npm run router:weekly     # Weekly model routing cost/quality scorecard
+node scripts/global/governance-verify.js        # Local ticket integrity check
+node scripts/global/fleet-live-indicator.js     # Real-time fleet status (CLI)
 ```
 
 ## Enable for Other Repos

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devenv-ops",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "AI agent governance harness — 24 skills, extensible agents, hooks, and wiki as a VS Code Agent Plugin",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
Post-merge governance remediation for PRs #409–412. Adds mandatory CHANGELOG entries, updates README for new scripts, and bumps package version to 3.1.0.

## Changes
- `CHANGELOG.md`: v3.1.0 section — model routing telemetry, governance verifier, instruction hardening, dashboard JS ESLint
- `README.md`: scripts count 17→32, new commands in Develop the Harness section
- `package.json`: version 3.0.0 → 3.1.0

## Visual QA Evidence
url: http://localhost:8090/ | capture: fullPage | verdict: pass | defects: none
Playwright dashboard spec: 6/6 passed

## Test Plan
- [x] `npm run lint` passes
- [x] `npm test` 31/31
- [x] Visual QA: full-page screenshot captured, all panels visible

Closes #413