### PR TITLE
chore(release): align plugin.json to v3.1.0 #413

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devenv-ops",
   "description": "AI agent governance harness — skills, agents, hooks for structured development workflows",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "chf3198",
   "skills": [
     "skills/docs-drift-maintenance",


### PR DESCRIPTION
## Summary
Consultant closeout finding on #413: plugin.json version (3.0.0) diverged from package.json and CHANGELOG (3.1.0). One-line fix.

Closes #413