### PR TITLE
feat(hooks): baton_gate.py PreToolUse commit gate for Claude Code #420

### DIFF
--- a/.claude/settings.json.template
+++ b/.claude/settings.json.template
@@ -1,0 +1,44 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 hooks/scripts/baton_gate.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 hooks/scripts/pretool_guard.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 hooks/scripts/posttool_reminders.py"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 hooks/scripts/stop_checks.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 hooks/scripts/stop_reminder.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/scripts/baton_gate.py
+++ b/hooks/scripts/baton_gate.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""PreToolUse: block git commit when no GitHub issue reference present.
+Extends commit_ticket_gate.py with Claude Code Bash tool support."""
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from repo_scope import is_repo_enabled
+
+ISSUE_RE = re.compile(r'#(\d+)')
+BRANCH_ISSUE_RE = re.compile(r'(?:feat|fix|chore|docs|style|test|refactor|perf)/(\d+)-')
+
+
+def get_branch() -> str:
+    try:
+        import subprocess
+        return subprocess.check_output(
+            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+            text=True, stderr=subprocess.DEVNULL).strip()
+    except Exception:
+        return ''
+
+
+def block(reason: str) -> int:
+    print(json.dumps({'decision': 'block', 'reason': reason}))
+    return 0
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    tool = str(payload.get('tool_name', ''))
+    cwd = str(payload.get('cwd') or os.getcwd())
+
+    # Only active in scoped repos
+    if not is_repo_enabled(cwd):
+        return 0
+
+    # Only intercept Bash tool (Claude Code runtime)
+    if tool != 'Bash':
+        return 0
+
+    cmd = str(payload.get('tool_input', {}).get('command', ''))
+    if 'git commit' not in cmd:
+        return 0
+
+    # Extract -m message
+    msg_match = re.search(r'-m\s+["\']([^"\']+)["\']', cmd)
+    if not msg_match:
+        return 0
+    message = msg_match.group(1)
+
+    if not ISSUE_RE.search(message):
+        branch = get_branch()
+        branch_issue = BRANCH_ISSUE_RE.search(branch)
+        hint = f' (branch suggests #{branch_issue.group(1)})' if branch_issue else ''
+        return block(
+            f'Commit message must reference a GitHub issue #N{hint}.\n'
+            f'Example: feat(scope): description #123'
+        )
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- `baton_gate.py`: PreToolUse hook for Claude Code's `Bash` tool — blocks `git commit` calls without `#N` issue reference in message
- `.claude/settings.json.template`: documents required hook registration (apply via update-config skill; not auto-applied due to agent self-modification policy)

## Test Plan
- [x] `npm run lint` passes
- [x] `npm test` 31/31
- [ ] Manual: commit without #N blocked with hint; commit with #N passes

Closes #420