### PR TITLE
feat(infra): DangerJS PR governance enforcer — ticket-first and CC gate #418

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,29 @@
+name: Danger (PR Governance)
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+concurrency:
+  group: danger-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  danger_required:
+    name: danger-required
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install Danger
+        run: npm install --no-save danger
+      - name: Run Danger
+        run: npx danger ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dangerfile.js
+++ b/Dangerfile.js
@@ -1,0 +1,50 @@
+// Dangerfile.js — PR governance enforcer
+// Validates ticket-first, branch naming, and Conventional Commits on PRs.
+/* global danger, warn, fail, message */
+
+const pr = danger.github.pr;
+const body = pr.body || '';
+const title = pr.title || '';
+const branch = pr.head.ref || '';
+
+// Rule 1: PR body must reference a closing issue
+const closesRef = /closes?\s+#\d+/i;
+if (!closesRef.test(body)) {
+  fail(
+    '**Ticket-first violation**: PR body must contain `Closes #N` to link ' +
+    'a GitHub issue. Every change requires a pre-existing ticket.'
+  );
+}
+
+// Rule 2: Branch must follow <type>/<issue#>-<slug> naming
+const branchPattern = /^(feat|fix|chore|docs|style|test|refactor|perf)\/\d+-/;
+if (!branchPattern.test(branch)) {
+  warn(
+    `**Branch naming**: \`${branch}\` does not match ` +
+    '`<type>/<issue#>-<slug>` (e.g. `feat/42-my-feature`). ' +
+    'See github-governance.instructions.md.'
+  );
+}
+
+// Rule 3: PR title must follow Conventional Commits
+const ccPattern = /^(feat|fix|chore|docs|style|test|refactor|perf)(\([^)]+\))?!?: .+/;
+if (!ccPattern.test(title)) {
+  fail(
+    `**PR title**: \`${title}\` does not match Conventional Commits format. ` +
+    'Required: `type(scope): description` (e.g. `feat(hooks): add gate #42`).'
+  );
+}
+
+// Rule 4: PR title should end with issue reference
+if (!/\s#\d+$/.test(title)) {
+  warn(
+    '**PR title**: convention is to end with the issue reference `#N` ' +
+    `(e.g. \`${title} #42\`).`
+  );
+}
+
+// Summary
+message(
+  '**Danger**: ticket-first, branch, and title checks complete. ' +
+  'Failures block merge; warnings are advisory.'
+);


### PR DESCRIPTION
## Summary
Adds DangerJS as a PR governance enforcer. `Dangerfile.js` enforces ticket-first (`Closes #N` in body), branch naming, Conventional Commits title format, and issue reference in title. Runs as `danger-required` check on all PRs.

## Test Plan
- [x] `npm run lint` passes (Dangerfile.js: 50 lines, danger.yml: 29 lines)
- [x] `npm test` 31/31
- [ ] CI: `danger-required` check appears and validates this PR

Closes #418