### PR TITLE
feat(infra): add GitHub Environments baton gate chain #423

### DIFF
--- a/.github/workflows/baton-gates.yml
+++ b/.github/workflows/baton-gates.yml
@@ -1,0 +1,33 @@
+name: Baton Gates
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: baton-gates-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  collaborator-gate:
+    name: collaborator-gate
+    runs-on: ubuntu-latest
+    environment: collaborator-gate
+    steps:
+      - run: echo "COLLABORATOR_HANDOFF acknowledged — work validated"
+
+  admin-gate:
+    name: admin-gate
+    needs: [collaborator-gate]
+    runs-on: ubuntu-latest
+    environment: admin-gate
+    steps:
+      - run: echo "ADMIN_HANDOFF acknowledged — CI gates verified"
+
+  consultant-gate:
+    name: consultant-gate
+    needs: [admin-gate]
+    runs-on: ubuntu-latest
+    environment: consultant-gate
+    steps:
+      - run: echo "CONSULTANT_CLOSEOUT acknowledged — ready to merge"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,3 +77,15 @@ Use the appropriate template when opening issues:
 - **Feature request** → `feature_request.md`
 - **Epic** → `epic.yml`
 - **Research** → `research.yml`
+
+## Baton Gate Chain (CI enforcement)
+
+Every PR runs the `baton-gates.yml` workflow with three sequential environment gates:
+
+| Gate | Environment | Approves |
+|---|---|---|
+| `collaborator-gate` | `collaborator-gate` | COLLABORATOR_HANDOFF — work validated |
+| `admin-gate` | `admin-gate` | ADMIN_HANDOFF — CI gates verified |
+| `consultant-gate` | `consultant-gate` | CONSULTANT_CLOSEOUT — ready to merge |
+
+Each gate pauses for explicit operator approval before the next fires. The chain cannot be bypassed — admin-gate cannot run until collaborator-gate is approved, and consultant-gate cannot run until admin-gate is approved.


### PR DESCRIPTION
## Summary

- Creates three GitHub Environments via API: `collaborator-gate`, `admin-gate`, `consultant-gate` — each with Required Reviewer (operator) and `prevent_self_review: false` (single-operator setup)
- Adds `.github/workflows/baton-gates.yml` — three chained environment jobs; each pauses for explicit operator approval before the next fires; `cancel-in-progress: false` to prevent race conditions
- Documents the gate chain in `CONTRIBUTING.md` with a table mapping gate → environment → baton handoff artifact

## How it works

On every PR to `main`: `collaborator-gate` fires and pauses. Operator approves → `admin-gate` fires and pauses. Operator approves → `consultant-gate` fires and pauses. Operator approves → merge is unblocked. The chain cannot be short-circuited: later gates have `needs:` dependencies on earlier ones.

## Test plan

- [ ] CI `lint-required`, `danger-required`, `pr-title-required` all pass on this PR
- [ ] Baton gate jobs appear in the Actions run for this PR
- [ ] Approving `collaborator-gate` unblocks `admin-gate` job
- [ ] Approving `admin-gate` unblocks `consultant-gate` job

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)