### PR TITLE
feat(infra): add CONSULTANT_CLOSEOUT re-open gate #438

### DIFF
--- a/.github/workflows/closeout-gate.yml
+++ b/.github/workflows/closeout-gate.yml
@@ -1,0 +1,77 @@
+name: Closeout Gate
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: closeout-gate-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  verify-closeout:
+    name: verify-closeout
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+
+            // Exempt: cancelled (state_reason = not_planned)
+            if (issue.state_reason === 'not_planned') {
+              core.info('Issue closed as not_planned (cancelled) — exempt from closeout gate');
+              return;
+            }
+
+            // Exempt: epics (closeout lives on the epic's own comment thread)
+            const labels = issue.labels.map(l => l.name);
+            if (labels.includes('type:epic')) {
+              core.info('Epic issue — closeout gate exempt (CONSULTANT_CLOSEOUT on epic itself)');
+              return;
+            }
+
+            // Paginate all comments
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { ...context.repo, issue_number: issue.number, per_page: 100 }
+            );
+
+            const hasCloseout = comments.some(c =>
+              typeof c.body === 'string' && c.body.includes('CONSULTANT_CLOSEOUT')
+            );
+
+            if (!hasCloseout) {
+              // Re-open the issue
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: issue.number,
+                state: 'open'
+              });
+
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: [
+                  '🚫 **Governance Violation — Closeout Gate**',
+                  '',
+                  'This issue was closed without a `CONSULTANT_CLOSEOUT` comment.',
+                  'Issue has been re-opened automatically.',
+                  '',
+                  '**Required before closing**:',
+                  '1. Consultant emits `CONSULTANT_CLOSEOUT` comment',
+                  '2. Set `status:done` label',
+                  '3. Remove all `role:*` labels',
+                  '4. Then close the issue',
+                  '',
+                  'See `instructions/role-baton-routing.instructions.md` for closeout protocol.'
+                ].join('\n')
+              });
+
+              core.setFailed('Issue closed without CONSULTANT_CLOSEOUT — re-opened');
+            } else {
+              core.info('CONSULTANT_CLOSEOUT found — close permitted');
+            }


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/closeout-gate.yml` triggered on `issues: [closed]`
- Paginates all comments; checks for `CONSULTANT_CLOSEOUT` string
- Re-opens issue and posts governance violation comment if missing
- Exempts: `not_planned` closes (cancelled issues) and `type:epic` issues

## Test plan

- [ ] Close a test issue without CONSULTANT_CLOSEOUT → verify it re-opens and posts violation comment
- [ ] Close a `not_planned` issue → verify it stays closed
- [ ] Close an issue with valid CONSULTANT_CLOSEOUT → verify it stays closed
- [ ] `npm run lint` passes (77 lines, under 100-line limit)

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)