### PR TITLE
feat(infra): add issue governance workflows #434 #435 #436

### DIFF
--- a/.github/workflows/epic-role-guard.yml
+++ b/.github/workflows/epic-role-guard.yml
@@ -1,0 +1,59 @@
+name: Epic Role Guard
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: epic-role-guard-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard-epic-role:
+    name: guard-epic-role
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.issue.labels.map(l => l.name);
+            const issueNum = context.payload.issue.number;
+
+            // Only applies to Epics
+            if (!labels.includes('type:epic')) {
+              core.info('Not an Epic — skipping Epic role guard');
+              return;
+            }
+
+            // Epic invariant: role:manager must always be present
+            if (labels.includes('role:manager')) {
+              core.info('Epic has role:manager — invariant satisfied');
+              return;
+            }
+
+            // Re-add role:manager
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: issueNum,
+              labels: ['role:manager']
+            });
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: issueNum,
+              body: [
+                '🔒 **Epic `role:manager` Invariant Enforced**',
+                '',
+                '`role:manager` was removed from this Epic and has been automatically re-added.',
+                '',
+                '**Rule**: Epics always carry `role:manager` regardless of status.',
+                'The active execution role lives on the **child ticket**, not the Epic.',
+                '',
+                'See `instructions/epic-governance.instructions.md` for details.'
+              ].join('\n')
+            });
+
+            core.setFailed('Epic role:manager invariant violated — label re-added automatically');

--- a/.github/workflows/issue-title-lint.yml
+++ b/.github/workflows/issue-title-lint.yml
@@ -1,0 +1,59 @@
+name: Issue Title Lint
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: issue-title-lint-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-title:
+    name: lint-title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.issue.title;
+            const violations = [];
+
+            if (title.length > 72) {
+              violations.push(`Title is ${title.length} characters (limit: 72)`);
+            }
+
+            if (/^(feat|fix|chore|refactor|docs|style|test|perf|content)\s*(\([^)]*\))?\s*:/i.test(title)) {
+              violations.push('Conventional Commits format is forbidden on issue titles (`feat(scope):` belongs on commits/PRs)');
+            }
+
+            if (/^\[(BUG|FEATURE|EPIC|TASK|DOC|RESEARCH|STORY)\]/i.test(title)) {
+              violations.push('Bracket type tags are forbidden (`[BUG]`, `[EPIC]`, etc.) — use `type:*` labels instead');
+            }
+
+            if (violations.length === 0) {
+              core.info('Issue title format is valid');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.payload.issue.number,
+              body: [
+                '⚠️ **Issue Title Governance Violation**',
+                '',
+                violations.map(v => `- ${v}`).join('\n'),
+                '',
+                '**Required format**: Plain imperative sentence ≤72 characters',
+                '> ✅ `Fix header nav contrast on dark backgrounds`',
+                '> ❌ `feat(nav): fix header nav contrast #123`',
+                '> ❌ `[BUG] Header nav contrast broken`',
+                '',
+                'Edit the issue title to resolve this check.'
+              ].join('\n')
+            });
+
+            core.setFailed(`Issue title violations: ${violations.join('; ')}`);

--- a/.github/workflows/label-completeness.yml
+++ b/.github/workflows/label-completeness.yml
@@ -1,0 +1,57 @@
+name: Label Completeness
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: label-completeness-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-labels:
+    name: check-labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.issue.labels.map(l => l.name);
+            const missing = [];
+
+            if (!labels.some(l => l.startsWith('type:'))) missing.push('`type:*`');
+            if (!labels.some(l => l.startsWith('status:'))) missing.push('`status:*`');
+            if (!labels.some(l => l.startsWith('priority:'))) missing.push('`priority:*`');
+            if (!labels.some(l => l.startsWith('area:'))) missing.push('`area:*`');
+
+            if (missing.length === 0) {
+              core.info('All required label categories present');
+              return;
+            }
+
+            const issueNum = context.payload.issue.number;
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: issueNum,
+              body: [
+                '⚠️ **Label Governance Violation — Missing Required Labels**',
+                '',
+                `Missing categories: ${missing.join(', ')}`,
+                '',
+                '**Required label set** (ADR-010):',
+                '| Category | Examples |',
+                '|---|---|',
+                '| `type:*` | `type:task` `type:bug` `type:epic` `type:story` |',
+                '| `status:*` | `status:backlog` `status:triage` `status:in-progress` |',
+                '| `priority:*` | `priority:P1` `priority:P2` `priority:P3` |',
+                '| `area:*` | `area:infra` `area:dashboard` `area:scripts` |',
+                '',
+                'Add the missing labels to resolve this check.'
+              ].join('\n')
+            });
+
+            core.setFailed(`Missing required label categories: ${missing.join(', ')}`);


### PR DESCRIPTION
## Summary

Adds three GitHub Actions workflows for issue governance enforcement (all using `actions/github-script@v7`, no external trust surface):

- **`label-completeness.yml`** (#434): Validates `type:*`, `status:*`, `priority:*`, `area:*` present on all issues. Posts violation comment on `issues: [opened, labeled, unlabeled]`.
- **`issue-title-lint.yml`** (#435): Validates issue title ≤72 chars, no Conventional Commits prefix, no bracket tags. Posts violation comment on `issues: [opened, edited]`.
- **`epic-role-guard.yml`** (#436): Enforces `type:epic` issues always carry `role:manager`. Auto-re-adds if removed. Posts invariant explanation comment.

All three are advisory enforcement (comment + failing check) — GitHub has no hard API gate on issue creation/edit.

## Test plan

- [ ] Create issue without all 4 label categories → label-completeness check fails with violation comment
- [ ] Create issue with title `feat(infra): add something` → title-lint check fails
- [ ] Create issue with title `[BUG] something` → title-lint check fails
- [ ] Remove `role:manager` from an Epic → epic-role-guard re-adds it and posts comment
- [ ] `npm run lint` passes (57, 59, 59 lines respectively)

Closes #434
Closes #435
Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)