### PR TITLE
feat(infra): add stale and Epic staleness detectors #437 #439

### DIFF
--- a/.github/workflows/epic-staleness.yml
+++ b/.github/workflows/epic-staleness.yml
@@ -1,0 +1,72 @@
+name: Epic Staleness Detector
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  detect-stale-epics:
+    name: detect-stale-epics
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+
+            // Fetch all open epics
+            const epics = await github.paginate(
+              github.rest.issues.listForRepo,
+              { owner, repo, state: 'open', labels: 'type:epic', per_page: 100 }
+            );
+
+            for (const epic of epics) {
+              const epicLabels = epic.labels.map(l => l.name);
+              const epicStatus = epicLabels.find(l => l.startsWith('status:'));
+
+              // Fetch sub-issues via native sub-issues API (GA Dec 2024)
+              let subIssues = [];
+              try {
+                const res = await github.request(
+                  'GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                  { owner, repo, issue_number: epic.number }
+                );
+                subIssues = res.data;
+              } catch (e) {
+                core.info(`Epic #${epic.number}: sub-issues API error — ${e.message}`);
+                continue;
+              }
+
+              if (subIssues.length === 0) continue;
+
+              const allClosed = subIssues.every(si => si.state === 'closed');
+              const anyStarted = subIssues.some(si => {
+                const siLabels = (si.labels || []).map(l => l.name);
+                return siLabels.includes('status:in-progress') ||
+                  siLabels.includes('status:testing') ||
+                  siLabels.includes('status:review') ||
+                  si.state === 'closed';
+              });
+
+              let staleMsg = null;
+
+              if (allClosed && epicStatus !== 'status:review' && epicStatus !== 'status:done') {
+                staleMsg = `All ${subIssues.length} child tickets are closed but Epic is at \`${epicStatus}\`. ` +
+                  'Manager should advance to `status:review` and initiate Consultant closeout.';
+              } else if (anyStarted && epicStatus === 'status:backlog') {
+                staleMsg = `Child tickets are active but Epic remains at \`status:backlog\`. ` +
+                  'Manager should advance to `status:in-progress`.';
+              }
+
+              if (staleMsg) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: epic.number,
+                  body: `📊 **Epic Status Staleness Detected**\n\n${staleMsg}\n\n` +
+                    'This is an advisory notice — Manager retains authority to advance Epic status.'
+                });
+              }
+            }

--- a/.github/workflows/p1-ready-stall.yml
+++ b/.github/workflows/p1-ready-stall.yml
@@ -1,0 +1,67 @@
+name: P1 Ready-Stall Detector
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  detect-stall:
+    name: detect-stall
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+            // Fetch open issues with status:ready and priority:P1
+            const issues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                ...context.repo,
+                state: 'open',
+                labels: 'status:ready,priority:P1',
+                per_page: 100
+              }
+            );
+
+            for (const issue of issues) {
+              const updatedAt = new Date(issue.updated_at);
+              if (updatedAt > twentyFourHoursAgo) continue;
+
+              // Check for BLOCKER_NOTE in comments
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { ...context.repo, issue_number: issue.number, per_page: 100 }
+              );
+
+              const hasBlockerNote = comments.some(c =>
+                typeof c.body === 'string' && c.body.includes('BLOCKER_NOTE')
+              );
+
+              if (!hasBlockerNote) {
+                const hoursStalled = Math.floor(
+                  (Date.now() - updatedAt.getTime()) / (60 * 60 * 1000)
+                );
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: issue.number,
+                  body: [
+                    `⚠️ **P1 Ready-Stall Escalation** — stalled ${hoursStalled}h`,
+                    '',
+                    'This P1 ticket has been at `status:ready` for more than 24 hours',
+                    'without a `BLOCKER_NOTE` comment.',
+                    '',
+                    '**Manager must add one of**:',
+                    '1. `BLOCKER_NOTE` with `owner`, `unblock_condition`, `eta_or_review_time`',
+                    '2. Escalation comment linking a follow-up owner action',
+                    '',
+                    'See `instructions/ticket-driven-work.instructions.md` — Ready-SLA section.'
+                  ].join('\n')
+                });
+              }
+            }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    name: stale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-label: 'status:stale'
+          exempt-issue-labels: >-
+            status:in-progress,status:review,status:testing,
+            status:done,status:cancelled
+          days-before-issue-stale: 30
+          days-before-issue-close: -1
+          stale-issue-message: |
+            ⏰ **Stale Issue Detected**
+
+            This issue has had no activity for 30 days and has been labeled
+            `status:stale`. It will not be auto-closed — governance requires
+            explicit Consultant closeout before an issue can be closed.
+
+            To remove the stale label:
+            - Add a comment with a status update, or
+            - Transition to an active status label (`status:in-progress`, etc.)
+
+            See `instructions/ticket-driven-work.instructions.md` for the
+            full ticket lifecycle.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
## Summary

- **`stale.yml`** (#439): `actions/stale@v9` — labels issues `status:stale` after 30 days idle, never auto-closes, exempts active-status issues
- **`p1-ready-stall.yml`** (#439): Scheduled `github-script` cron (every 6h) — detects P1 issues at `status:ready` >24h without `BLOCKER_NOTE`, posts escalation comment
- **`epic-staleness.yml`** (#437): Daily `github-script` cron — uses native sub-issues API (GA Dec 2024) to detect Epic status/child mismatches, posts advisory comment

## Test plan

- [ ] Trigger `stale.yml` via `workflow_dispatch` → verify no issues affected yet (all exempted by active status)
- [ ] Trigger `p1-ready-stall.yml` via `workflow_dispatch` → verify it runs without error
- [ ] Trigger `epic-staleness.yml` via `workflow_dispatch` → verify it runs without error (sub-issues empty → skips gracefully)
- [ ] `npm run lint` passes (38, 67, 72 lines respectively)

Closes #437
Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)