### PR TITLE
feat(governance): add Codex signing design #446

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -93,3 +93,7 @@ Install tools via CLI as needed. Don't ask permission.
 - **DO consult user**: Design decisions, architecture choices
 - **DO NOT ask user**: Git practices, lint fixes, test execution
 - **NEVER ask user to run tests**: Agent runs all automated checks
+
+## Team&Model Signing
+
+AI-authored baton artifacts, PR evidence, and governance docs must include human alias + structured `Team&Model` provenance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,12 @@ This repo is the **development workbench** for the entire `~/.copilot/` system:
 - **Branch before editing global resources**: `git checkout -b skill/<name>` or `feat/<topic>`
 - **Test before deploying**: verify agent behavior in a test chat session.
 
+## Team&Model signing
+
+- AI-authored governed artifacts must include human alias + structured `Team&Model` provenance.
+- Repo-local overrides may tighten the format, but must not remove provenance.
+- See `instructions/team-model-signing.instructions.md`.
+
 ## Development → Deploy workflow
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ and AI agent governance. All instructions below are binding for Claude Code sess
 @instructions/role-baton-routing.instructions.md
 @instructions/ticket-driven-work.instructions.md
 @instructions/operator-identity-context.instructions.md
+@instructions/team-model-signing.instructions.md
 @instructions/global-standards.instructions.md
 @instructions/global-task-router.instructions.md
 @instructions/github-governance.instructions.md

--- a/instructions/team-model-signing.instructions.md
+++ b/instructions/team-model-signing.instructions.md
@@ -1,0 +1,47 @@
+---
+name: Team & Model Signing Governance
+description: Require AI-authored governance artifacts to carry human alias plus structured team/model provenance across tickets, git, PRs, and documentation.
+applyTo: "**"
+---
+
+# Team & Model Signing Governance
+
+## Canonical rule
+
+- Every governed AI-authored artifact carries:
+  - `Signed-by: <human-alias>`
+  - `Team&Model: <team>:<model>@<substrate>[/<device>]`
+  - `Role: manager|collaborator|admin|consultant`
+- Use `Device` only when execution ran on a named fleet target or remote gateway.
+
+## Source of truth
+
+- Structured `Team&Model` provenance is authoritative.
+- Human aliases are display-friendly and must remain deterministic from team + model + role.
+- Repo-local governance may extend or tighten the format, but may not remove team/model provenance.
+
+## Required surfaces
+
+- GitHub issue comments for baton artifacts, blocker notes, and exception evidence.
+- PR descriptions and release/closeout evidence.
+- AI-authored governance, design, or research docs.
+- AI-authored commits should include structured trailers when the toolchain permits.
+
+## Git trailer contract
+
+- `AI-Signature: <human-alias>`
+- `AI-Team-Model: <team>:<model>@<substrate>[/<device>]`
+- `AI-Role: <role>`
+- Commit subject/body rules still follow repo commit policy; issue linkage `#N` remains mandatory.
+
+## Alias derivation
+
+- Given name derives from team + model family.
+- Surname derives from active Agile role.
+- Current role surnames: Manager=`Mason`, Collaborator=`Harper`, Admin=`Reyes`, Consultant=`Vale`.
+- Use `node scripts/global/agent-signature.js` when you need deterministic output.
+
+## Override rule
+
+- Repo-local governance may narrow or extend the global scheme.
+- When local rules differ, use the local alias/trailer format and keep canonical `Team&Model` provenance present.

--- a/research/codex-compatibility-and-team-model-signing-design-2026-04-24.md
+++ b/research/codex-compatibility-and-team-model-signing-design-2026-04-24.md
@@ -1,0 +1,85 @@
+# Codex Compatibility and Team&Model Signing Design — 2026-04-24
+
+## Goal
+
+One DevEnv Ops init path should install a governance-first harness for Copilot, Claude Code, and Codex.
+
+## Verified Codex surfaces
+
+- `$CODEX_HOME/AGENTS.md` and `AGENTS.override.md` for global instructions.
+- Repo-tree `AGENTS.md` files for local overrides.
+- `$CODEX_HOME/skills/` for reusable skills.
+- `~/.codex/config.toml` for model instructions, MCP, and extra tools.
+- Plugins/MCP as tool extensions.
+- Codex docs also expose Rules and Hooks as configuration areas; treat them as later installer targets once stable file paths are confirmed.
+
+## Runtime mapping
+
+| Concern | Copilot | Claude Code | Codex |
+|---|---|---|---|
+| Global baseline | `~/.copilot/instructions/` | `CLAUDE.md` + deployed hooks | `$CODEX_HOME/AGENTS.md` + `config.toml` |
+| Reusable skills | `~/.copilot/skills/` | `.claude/commands/` | `$CODEX_HOME/skills/` |
+| Agents/subagents | `~/.copilot/agents/` | `.claude/agents/` | Codex subagents/future mapping |
+| Tool integration | hooks + scripts | `.claude/settings.json` hooks | MCP/plugins/config |
+| Repo override | `.github/copilot-instructions.md` | `CLAUDE.md` + repo files | repo `AGENTS.md` |
+
+## Codex init contract
+
+1. Install or merge the global baseline into `$CODEX_HOME/AGENTS.md`.
+2. Sync shared skills into `$CODEX_HOME/skills/`.
+3. Merge Codex MCP/config entries into `~/.codex/config.toml`.
+4. Create or update repo `AGENTS.md` with repo-local governance overlays.
+5. Keep ticket, PR, and git governance in the repo, not in the home directory.
+
+## Precedence
+
+1. Global DevEnv Ops baseline
+2. Runtime-specific global config
+3. Repo-local governance
+4. Deeper repo-local override
+
+Repo-local rules may narrow or extend the baseline, but must keep issue linkage, role baton evidence, and Team&Model provenance.
+
+## Team&Model signing
+
+Required fields:
+- `Signed-by`
+- `Team&Model`
+- `Role`
+- `Device` when non-local or fleet-hosted
+
+Canonical format:
+- `Team&Model: <team>:<model>@<substrate>[/<device>]`
+
+Examples:
+- `codex:gpt-5.4@local`
+- `copilot:claude-sonnet-4.6@github-copilot`
+- `fleet:mistral@openclaw/windows-laptop`
+
+## Human alias convention
+
+- Human alias is display-friendly; structured provenance is source of truth.
+- Given name derives from team + model family.
+- Surname derives from Agile role.
+- Role surnames: Manager=`Mason`, Collaborator=`Harper`, Admin=`Reyes`, Consultant=`Vale`.
+- Example: `Quill Mason | codex:gpt-5.4@local | role:manager`
+
+## Required signing surfaces
+
+- GitHub baton artifacts and exception notes
+- PR descriptions and review/closeout evidence
+- AI-authored governance/design docs
+- AI-authored commits via trailers when the toolchain permits
+
+## Git trailer contract
+
+- `AI-Signature: <human-alias>`
+- `AI-Team-Model: <team>:<model>@<substrate>[/<device>]`
+- `AI-Role: <role>`
+
+## Implementation next steps
+
+- Extend deploy/sync to manage Codex home targets.
+- Add repo-init scaffolding for Codex-aware `AGENTS.md`.
+- Add helpers or hooks that stamp commit/PR trailers and bodies.
+- Keep signing rules global, but let repos add stricter local variants.

--- a/scripts/global/agent-signature.js
+++ b/scripts/global/agent-signature.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+'use strict';
+
+const args = process.argv.slice(2);
+const opt = {};
+for (let i = 0; i < args.length; i += 2) {
+  if (args[i]?.startsWith('--')) opt[args[i].slice(2)] = args[i + 1] || '';
+}
+
+const team = (opt.team || 'codex').toLowerCase();
+const model = (opt.model || 'gpt-5.4').toLowerCase();
+const role = (opt.role || 'collaborator').toLowerCase();
+const substrate = (opt.substrate || 'local').toLowerCase();
+const device = opt.device ? `/${opt.device}` : '';
+const key = `${team}:${model}`;
+const surnames = {
+  manager: 'Mason', collaborator: 'Harper', admin: 'Reyes', consultant: 'Vale'
+};
+
+function firstName(value) {
+  if (/codex:gpt-5\.4/.test(value)) return 'Quill';
+  if (/codex:gpt-5.*codex/.test(value)) return 'Caden';
+  if (/copilot:.*sonnet/.test(value)) return 'Soren';
+  if (/copilot:.*opus/.test(value)) return 'Orion';
+  if (/copilot:.*gpt-5.*mini/.test(value)) return 'Milo';
+  if (/claude-code:.*sonnet/.test(value)) return 'Clio';
+  if (/claude-code:.*opus/.test(value)) return 'Orla';
+  if (/qwen/.test(value)) return 'Quinn';
+  if (/mistral/.test(value)) return 'Mira';
+  if (/phi/.test(value)) return 'Fia';
+  if (/gemma/.test(value)) return 'Gemma';
+  return 'Nova';
+}
+
+const payload = {
+  signedBy: `${firstName(key)} ${surnames[role] || 'Harper'}`,
+  teamModel: `${team}:${model}@${substrate}${device}`,
+  role
+};
+
+if (opt.format === 'text') {
+  console.log(`Signed-by: ${payload.signedBy}`);
+  console.log(`Team&Model: ${payload.teamModel}`);
+  console.log(`Role: ${payload.role}`);
+} else {
+  console.log(JSON.stringify(payload, null, 2));
+}


### PR DESCRIPTION
## Summary

- adds a Codex compatibility and precedence design artifact
- adds Team&Model signing governance for AI-authored artifacts
- adds a deterministic `agent-signature.js` helper
- wires the signing rule into Copilot, Claude Code, and Codex repo entrypoints

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [x] `node scripts/global/agent-signature.js --team codex --model gpt-5.4 --role manager --substrate local --format text`

## Governance

Signed-by: Quill Reyes
Team&Model: codex:gpt-5.4@local
Role: admin

Closes #446
