### PR TITLE
feat(codex): add runtime deploy and sync targets (#451)

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,7 @@
+# DevEnv Ops — Codex Global Harness
+
+- Treat this file as the global DevEnv Ops baseline for Codex.
+- Repo-local `AGENTS.md` files override this baseline when they conflict.
+- Preserve Team&Model signing on governed issue, PR, commit, and doc artifacts.
+- Use installed DevEnv Ops skills from `$CODEX_HOME/skills/` when relevant.
+- Always use the OpenAI developer documentation MCP server if you need to work with the OpenAI API, ChatGPT Apps SDK, Codex, or related docs without me having to explicitly ask.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[mcp_servers.openaiDeveloperDocs]
+url = "https://developers.openai.com/mcp"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,20 +1,21 @@
 #!/usr/bin/env bash
-# Deploy resources to ~/.copilot/. Default: dry-run. Pass --apply to deploy.
 set -euo pipefail
-
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 COPILOT="$HOME/.copilot"
 BACKUP="$HOME/.copilot-backup-$(date +%Y%m%d-%H%M%S)"
 APPLY=false
-
-if [[ "${1:-}" == "--apply" ]]; then
-  APPLY=true
-fi
-
-echo "Source: $ROOT"
-echo "Target: $COPILOT"
-echo ""
-
+TARGET="copilot"
+CODEX_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) APPLY=true ;;
+    --target) TARGET="${2:-copilot}"; shift ;;
+    *) echo "Usage: deploy.sh [--apply] [--target copilot|codex|both]"; exit 1 ;;
+  esac
+  shift
+done
+[[ "$TARGET" =~ ^(copilot|codex|both)$ ]] || { echo "Invalid target: $TARGET"; exit 1; }
+$APPLY && CODEX_ARGS+=(--apply)
 deploy_dir() {
   local src="$1" dest="$2" label="$3"
   echo "── $label ──"
@@ -27,11 +28,7 @@ deploy_dir() {
       cp -r "$item"* "$dest/$name/"
       echo "  ✅ $name"
     else
-      if [[ -d "$dest/$name" ]]; then
-        echo "  Would update: $name"
-      else
-        echo "  Would create: $name"
-      fi
+      [[ -d "$dest/$name" ]] && echo "  Would update: $name" || echo "  Would create: $name"
     fi
     count=$((count + 1))
   done
@@ -58,6 +55,14 @@ deploy_files() {
   echo ""
 }
 
+if [[ "$TARGET" == "codex" || "$TARGET" == "both" ]]; then
+  node "$ROOT/scripts/global/codex-runtime.js" deploy "${CODEX_ARGS[@]}"
+fi
+[[ "$TARGET" == "codex" ]] && exit 0
+
+echo "Source: $ROOT"
+echo "Target: $COPILOT"
+echo ""
 if ! $APPLY; then
   echo "=== DRY RUN (pass --apply to deploy) ==="
   echo ""
@@ -74,14 +79,11 @@ fi
 echo "Backing up $COPILOT → $BACKUP"
 cp -r "$COPILOT" "$BACKUP"
 echo ""
-
 deploy_dir "$ROOT/skills" "$COPILOT/skills" "Skills"
 deploy_files "$ROOT/instructions" "$COPILOT/instructions" "Instructions"
 deploy_files "$ROOT/scripts/global" "$COPILOT/scripts" "Global Scripts"
 deploy_files "$ROOT/agents" "$COPILOT/agents" "Agents"
 deploy_dir "$ROOT/wiki" "$COPILOT/wiki" "Wiki (read-only)"
-
-# Dashboard: static assets (HTML + css/ + js/)
 echo "── Dashboard ──"
 mkdir -p "$COPILOT/dashboard/css" "$COPILOT/dashboard/js"
 cp "$ROOT/dashboard/index.html" "$COPILOT/dashboard/"
@@ -89,7 +91,6 @@ cp "$ROOT"/dashboard/css/*.css "$COPILOT/dashboard/css/"
 cp "$ROOT"/dashboard/js/*.js "$COPILOT/dashboard/js/"
 echo "  ✅ Dashboard deployed"
 echo ""
-
 for wf in "$ROOT/wiki/index.md" "$ROOT/wiki/log.md" "$ROOT/WIKI.md"; do
   [[ -f "$wf" ]] && cp "$wf" "$COPILOT/wiki/$(basename "$wf")"
 done

--- a/scripts/global/codex-runtime.js
+++ b/scripts/global/codex-runtime.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const HOME = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+const MODE = process.argv[2];
+const APPLY = process.argv.includes('--apply');
+const DRY = process.argv.includes('--dry-run') || (MODE === 'deploy' && !APPLY);
+const START = '# >>> devenv-ops managed block >>>';
+const END = '# <<< devenv-ops managed block <<<';
+const BLOCK = new RegExp(`${START}[\\s\\S]*?${END}\\n?`, 'm');
+
+function ensure(dir) { fs.mkdirSync(dir, { recursive: true }); }
+function read(file) { try { return fs.readFileSync(file, 'utf8'); } catch { return ''; } }
+function dirs(src) { return fs.existsSync(src) ? fs.readdirSync(src, { withFileTypes: true })
+  .filter(d => d.isDirectory() && !d.name.startsWith('.')).map(d => d.name) : []; }
+function wrap(text) { return `${START}\n${text.trim()}\n${END}\n`; }
+function logAction(write, action, name) {
+  console.log(write ? `  ✅ ${name}` : `  Would ${action}: ${name}`);
+}
+
+function syncSkills(src, dest, write, action) {
+  console.log('── Codex Skills ──');
+  let count = 0;
+  for (const name of dirs(src)) {
+    if (write) { ensure(dest); fs.cpSync(path.join(src, name), path.join(dest, name), { recursive: true, force: true }); }
+    logAction(write, action, name);
+    count++;
+  }
+  console.log(`  Total: ${count}\n`);
+}
+
+function mergeManaged(src, dest, write) {
+  console.log(`── ${path.basename(dest)} ──`);
+  const current = read(dest);
+  const managed = wrap(read(src));
+  const merged = BLOCK.test(current) ? current.replace(BLOCK, managed) :
+    `${current.trim()}${current.trim() ? '\n\n' : ''}${managed}`;
+  if (write) { ensure(path.dirname(dest)); fs.writeFileSync(dest, merged); }
+  logAction(write, 'merge', path.basename(dest));
+  console.log('');
+}
+
+function extractManaged(src, dest, write) {
+  console.log(`── ${path.basename(src)} ──`);
+  const match = read(src).match(new RegExp(`${START}\\n([\\s\\S]*?)\\n${END}`));
+  if (!match) return console.log('  Missing managed block\n');
+  if (write) { ensure(path.dirname(dest)); fs.writeFileSync(dest, `${match[1].trim()}\n`); }
+  logAction(write, 'extract', path.basename(dest));
+  console.log('');
+}
+
+if (!['deploy', 'sync'].includes(MODE)) {
+  console.error('Usage: codex-runtime.js <deploy|sync> [--apply|--dry-run]'); process.exit(1);
+}
+
+console.log(`${MODE === 'deploy' ? 'Source' : 'Syncing from'}: ${MODE === 'deploy' ? ROOT : HOME}`);
+console.log(`${MODE === 'deploy' ? 'Target' : 'Into'}: ${MODE === 'deploy' ? HOME : ROOT}\n`);
+if (MODE === 'deploy') {
+  if (DRY) console.log('=== DRY RUN (pass --apply to write Codex runtime) ===\n');
+  syncSkills(path.join(ROOT, 'skills'), path.join(HOME, 'skills'), !DRY, 'deploy');
+  mergeManaged(path.join(ROOT, '.codex', 'AGENTS.md'), path.join(HOME, 'AGENTS.md'), !DRY);
+  mergeManaged(path.join(ROOT, '.codex', 'config.toml'), path.join(HOME, 'config.toml'), !DRY);
+} else {
+  if (DRY) console.log('=== DRY RUN — no Codex changes will be made ===\n');
+  syncSkills(path.join(HOME, 'skills'), path.join(ROOT, 'skills'), !DRY, 'sync');
+  extractManaged(path.join(HOME, 'AGENTS.md'), path.join(ROOT, '.codex', 'AGENTS.md'), !DRY);
+  extractManaged(path.join(HOME, 'config.toml'), path.join(ROOT, '.codex', 'config.toml'), !DRY);
+}

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,24 +1,27 @@
 #!/usr/bin/env bash
-# Sync all global resources from ~/.copilot/ into this repo
-# Usage: bash scripts/sync.sh [--dry-run]
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 COPILOT="$HOME/.copilot"
 DRY_RUN=false
+TARGET="copilot"
+CODEX_ARGS=()
 
-if [[ "${1:-}" == "--dry-run" ]]; then
-  DRY_RUN=true
-  echo "=== DRY RUN — no changes will be made ==="
-  echo ""
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true ;;
+    --target) TARGET="${2:-copilot}"; shift ;;
+    *) echo "Usage: sync.sh [--dry-run] [--target copilot|codex|both]"; exit 1 ;;
+  esac
+  shift
+done
+
+[[ "$TARGET" =~ ^(copilot|codex|both)$ ]] || { echo "Invalid target: $TARGET"; exit 1; }
+$DRY_RUN && CODEX_ARGS+=(--dry-run)
 
 sync_dir() {
   local src="$1" dest="$2" label="$3"
-  if [[ ! -d "$src" ]]; then
-    echo "⚠️  Source not found: $src"
-    return
-  fi
+  [[ -d "$src" ]] || { echo "⚠️  Source not found: $src"; return; }
   echo "── $label ──"
   local count=0
   for item in "$src"/*/; do
@@ -39,10 +42,7 @@ sync_dir() {
 
 sync_files() {
   local src="$1" dest="$2" label="$3"
-  if [[ ! -d "$src" ]]; then
-    echo "⚠️  Source not found: $src"
-    return
-  fi
+  [[ -d "$src" ]] || { echo "⚠️  Source not found: $src"; return; }
   echo "── $label ──"
   local count=0
   for file in "$src"/*; do
@@ -60,17 +60,20 @@ sync_files() {
   echo ""
 }
 
+if [[ "$TARGET" == "codex" || "$TARGET" == "both" ]]; then
+  node "$ROOT/scripts/global/codex-runtime.js" sync "${CODEX_ARGS[@]}"
+fi
+[[ "$TARGET" == "codex" ]] && exit 0
+
+$DRY_RUN && echo "=== DRY RUN — no changes will be made ===" && echo ""
 echo "Syncing from: $COPILOT"
 echo "Into:         $ROOT"
 echo ""
-
 sync_dir "$COPILOT/skills" "$ROOT/skills" "Skills"
 sync_files "$COPILOT/instructions" "$ROOT/instructions" "Instructions"
 sync_files "$COPILOT/scripts" "$ROOT/scripts/global" "Global Scripts"
 sync_files "$COPILOT/agents" "$ROOT/agents" "Agents"
 sync_dir "$COPILOT/wiki" "$ROOT/wiki" "Wiki"
-
-# Dashboard: sync static assets back
 echo "── Dashboard ──"
 if [[ -d "$COPILOT/dashboard" ]]; then
   if $DRY_RUN; then
@@ -84,11 +87,14 @@ if [[ -d "$COPILOT/dashboard" ]]; then
   fi
 fi
 echo ""
-
 echo "── Hooks ──"
 if [[ -d "$COPILOT/hooks" ]]; then
-  if $DRY_RUN; then echo "  Would sync: hooks/"
-  else rsync -a --exclude='__pycache__' --exclude='state/' "$COPILOT/hooks/" "$ROOT/hooks/"; echo "  ✅ Hooks synced"; fi
+  if $DRY_RUN; then
+    echo "  Would sync: hooks/"
+  else
+    rsync -a --exclude='__pycache__' --exclude='state/' "$COPILOT/hooks/" "$ROOT/hooks/"
+    echo "  ✅ Hooks synced"
+  fi
 fi
 echo ""
 echo "Done. Review changes with: git diff --stat"


### PR DESCRIPTION
## Summary

Add executable Codex runtime deploy/sync support so DevEnv Ops can install and retrieve shared Codex assets from user-level locations without hand-editing `~/.codex`.

## Linked Issue

Closes #451

## Changes

- add repo-owned Codex runtime source files at `.codex/AGENTS.md` and `.codex/config.toml`
- add `scripts/global/codex-runtime.js` to manage Codex skills plus managed-block merge/extract for runtime files
- extend `scripts/deploy.sh` and `scripts/sync.sh` with `--target codex|both`
- preserve current Copilot deploy/sync behavior while enabling shared `both` mode

## Role Evidence

- **Manager**: issue #451 `MANAGER_HANDOFF` on branch `feat/451-codex-runtime-targets`
- **Collaborator**: commit `e21d0f785ce4c8ec86f68da14378e9270412141d`; isolated-worktree validation passed
- **Admin**: pending PR checks, push, and merge evidence
- **Consultant**: pending critique after gates

## Validation

- [x] `npm run lint` — clean in isolated worktree
- [x] `npm run lint:sh` — clean in isolated worktree
- [x] `npm test` — 31/31 passed in isolated worktree
- [ ] CHANGELOG updated
- [ ] Docs synced to behavioral changes
- [x] `CODEX_HOME=$(mktemp -d) bash scripts/deploy.sh --apply --target codex`
- [x] `CODEX_HOME=<temp> bash scripts/sync.sh --dry-run --target codex`
- [x] `bash scripts/deploy.sh --target both`
- [x] `bash scripts/sync.sh --dry-run --target both`

## Risk

Low. Changes are localized to new Codex source files plus deploy/sync wrappers, and managed blocks avoid clobbering existing user Codex configuration.
