### PR TITLE
fix(governance): harden label-safe issue transitions (#450)

### DIFF
--- a/.github/workflows/label-lint.yml
+++ b/.github/workflows/label-lint.yml
@@ -18,41 +18,43 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const labels = context.payload.issue.labels.map(l => l.name);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
             const issueNum = context.payload.issue.number;
-
+            const marker = '<!-- adr-010-label-lint -->';
+            const issue = (await github.rest.issues.get({ owner, repo, issue_number: issueNum })).data;
+            const labels = issue.labels.map(label => label.name);
             const statusLabels = labels.filter(l => l.startsWith('status:'));
             const roleLabels   = labels.filter(l => l.startsWith('role:'));
             const violations   = [];
-
-            // Rule 1: exactly one status: label at all times
             if (statusLabels.length === 0) {
               violations.push('**Rule 1**: No `status:` label found. Every issue must have exactly one.');
             } else if (statusLabels.length > 1) {
               violations.push(`**Rule 1**: Multiple \`status:\` labels found: ${statusLabels.join(', ')}. Only one is allowed.`);
             }
-
-            // Rule 2: at most one role: label
             if (roleLabels.length > 1) {
               violations.push(`**Rule 2**: Multiple \`role:\` labels found: ${roleLabels.join(', ')}. Only one is allowed.`);
             }
-
-            // Rule 3: status:done must have no role: label
             if (statusLabels.includes('status:done') && roleLabels.length > 0) {
               violations.push(`**Rule 3**: \`status:done\` issues must not have a \`role:\` label. Remove: ${roleLabels.join(', ')}.`);
             }
-
-            // Rule 4: status:backlog must have no role: label
             if (statusLabels.includes('status:backlog') && roleLabels.length > 0) {
               violations.push(`**Rule 4**: \`status:backlog\` issues must not have a \`role:\` label. Remove: ${roleLabels.join(', ')}.`);
             }
-
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: issueNum, per_page: 100,
+            });
+            const lintComment = comments.find(comment => comment.body?.includes(marker));
             if (violations.length === 0) {
+              if (lintComment) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: lintComment.id });
+              }
               console.log(`Issue #${issueNum}: label rules OK`);
               return;
             }
-
             const body = [
+              marker,
+              '',
               '## ⚠️ ADR-010 Label Lint Violation',
               '',
               `Issue #${issueNum} has invalid label combinations:`,
@@ -65,12 +67,11 @@ jobs:
               '',
               '_This comment was posted by the label-lint workflow._',
             ].join('\n');
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNum,
-              body,
-            });
-
+            if (lintComment?.body !== body) {
+              if (lintComment) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: lintComment.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: issueNum, body });
+              }
+            }
             core.setFailed(`Label violations on #${issueNum}: ${violations.length} rule(s) broken.`);

--- a/scripts/global/issue-transition.js
+++ b/scripts/global/issue-transition.js
@@ -1,49 +1,61 @@
 #!/usr/bin/env node
 'use strict';
-// Atomic baton label transition — single gh issue edit to prevent ADR-010 race.
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 const TRANSITIONS = {
-  triage:      ['ready'],
-  ready:       ['in-progress'],
-  'in-progress':['testing'],
-  testing:     ['review'],
-  review:      ['done'],
+  backlog: ['ready', 'in-progress'],
+  triage: ['ready'],
+  ready: ['in-progress'],
+  'in-progress': ['testing'],
+  testing: ['review'],
+  review: ['done'],
 };
 const ROLE_FOR = {
-  triage: 'manager', 'in-progress': 'collaborator',
-  testing: 'admin', review: 'consultant',
+  'in-progress': 'collaborator',
+  testing: 'admin',
+  review: 'consultant',
 };
 
-const [,, issue, fromStatus, toStatus, extra] = process.argv;
+const [,, issue, fromStatus, toStatus, ...extras] = process.argv;
+const force = extras.includes('--force');
+const dryRun = extras.includes('--dry-run');
 if (!issue || !fromStatus || !toStatus) {
-  console.error('Usage: issue-transition.js <issue#> <from-status> <to-status> [--force]');
+  console.error('Usage: issue-transition.js <issue#> <from-status> <to-status> [--force] [--dry-run]');
   process.exit(1);
 }
 
-const allowed = TRANSITIONS[fromStatus];
-if (!allowed?.includes(toStatus) && extra !== '--force') {
+const allowed = TRANSITIONS[fromStatus] || [];
+if (!allowed.includes(toStatus) && !force) {
   console.error(`Invalid transition: ${fromStatus} → ${toStatus}`);
-  console.error(`Allowed from ${fromStatus}: ${allowed?.join(', ') || 'none'}`);
+  console.error(`Allowed from ${fromStatus}: ${allowed.join(', ') || 'none'}`);
   process.exit(1);
 }
 
-const adds = [`status:${toStatus}`];
-const removes = [`status:${fromStatus}`];
+function gh(args, input) {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    input: input ? JSON.stringify(input) : undefined,
+  }).trim();
+}
 
-const fromRole = ROLE_FOR[fromStatus];
-const toRole = ROLE_FOR[toStatus];
-if (fromRole) removes.push(`role:${fromRole}`);
-if (toRole) adds.push(`role:${toRole}`);
-
-const addFlags = adds.map(l => `--add-label "${l}"`).join(' ');
-const removeFlags = removes.map(l => `--remove-label "${l}"`).join(' ');
-const cmd = `gh issue edit ${issue} ${addFlags} ${removeFlags}`;
-
-try {
-  execSync(cmd, { stdio: 'inherit' });
-  console.log(`#${issue}: ${fromStatus}(${fromRole||'-'}) → ${toStatus}(${toRole||'-'})`);
-} catch (e) {
-  console.error('Transition failed:', e.message);
+const repo = gh(['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner']);
+const data = JSON.parse(gh(['api', `repos/${repo}/issues/${issue}`]));
+const labels = data.labels.map(label => label.name);
+const current = labels.filter(label => label.startsWith('status:')).map(label => label.slice(7));
+if (!force && !current.includes(fromStatus)) {
+  console.error(`Issue #${issue} is not currently at status:${fromStatus}`);
+  console.error(`Current status labels: ${current.join(', ') || 'none'}`);
   process.exit(1);
 }
+
+const next = labels.filter(label => !label.startsWith('status:') && !label.startsWith('role:'));
+next.push(`status:${toStatus}`);
+if (ROLE_FOR[toStatus]) next.push(`role:${ROLE_FOR[toStatus]}`);
+
+if (dryRun) {
+  console.log(JSON.stringify({ issue: Number(issue), repo, labels: next }, null, 2));
+  process.exit(0);
+}
+
+gh(['api', `repos/${repo}/issues/${issue}/labels`, '-X', 'PUT', '--input', '-'], { labels: next });
+console.log(`#${issue}: ${fromStatus}(${ROLE_FOR[fromStatus] || '-'}) → ${toStatus}(${ROLE_FOR[toStatus] || '-'})`);


### PR DESCRIPTION
## Summary

Harden the baton transition path so valid status/role moves do not trigger misleading ADR-010 label-lint noise.

## Linked Issue

Closes #450

## Changes

- replace governed status/role labels in `issue-transition.js` with a single issue-label set operation
- add `--dry-run` output for auditable transition previews
- have label-lint validate the live current issue state instead of the event payload
- make label-lint maintain one managed comment and delete it once the violation is resolved

## Role Evidence

- **Manager**: issue #450 `MANAGER_HANDOFF` on branch `fix/450-label-transition-races`
- **Collaborator**: commit `6c33e1b3fa1c8d6875d2e91b548f2d0250abc518`; live `#450` transition to `status:testing` completed without a new ADR-010 bot warning
- **Admin**: pending PR checks, push, and merge evidence
- **Consultant**: pending critique after gates

## Validation

- [x] `node scripts/global/issue-transition.js 450 in-progress testing --dry-run`
- [x] `node scripts/global/issue-transition.js 449 backlog ready --dry-run`
- [x] `npm run lint` — clean in isolated worktree
- [x] `npm run lint:sh` — clean in isolated worktree
- [x] `npm run lint:js` — passes with existing repo warnings only
- [x] `npm test` — 31/31 passed in isolated worktree
- [ ] CHANGELOG updated
- [ ] Docs synced to behavioral changes
- [ ] `npm run lint:all` — blocked by pre-existing `hooks/scripts/baton_gate.py` docstring lint outside this PR

## Risk

Low. Changes are limited to governance automation and were dogfooded on issue #450 before PR creation.
