### PR TITLE
feat(governance): share Team&Model alias registry (#449)

### DIFF
--- a/instructions/team-model-signing.instructions.md
+++ b/instructions/team-model-signing.instructions.md
@@ -18,6 +18,7 @@ applyTo: "**"
 
 - Structured `Team&Model` provenance is authoritative.
 - Human aliases are display-friendly and must remain deterministic from team + model + role.
+- `inventory/team-model-signatures.json` is the shared alias registry consumed by `scripts/global/agent-signature.js`.
 - Repo-local governance may extend or tighten the format, but may not remove team/model provenance.
 
 ## Required surfaces
@@ -37,6 +38,7 @@ applyTo: "**"
 ## Alias derivation
 
 - Given name derives from team + model family.
+- Match the first registry entry whose team/model pattern and optional device pattern fit.
 - Surname derives from active Agile role.
 - Current role surnames: Manager=`Mason`, Collaborator=`Harper`, Admin=`Reyes`, Consultant=`Vale`.
 - Use `node scripts/global/agent-signature.js` when you need deterministic output.

--- a/inventory/team-model-signatures.json
+++ b/inventory/team-model-signatures.json
@@ -1,0 +1,26 @@
+{
+  "lastUpdated": "2026-04-24",
+  "defaultAliasSeed": "Nova",
+  "roleSurnames": {
+    "manager": "Mason",
+    "collaborator": "Harper",
+    "admin": "Reyes",
+    "consultant": "Vale"
+  },
+  "registry": [
+    { "team": "codex", "modelPattern": "^gpt-5\\.4$", "aliasSeed": "Quill" },
+    { "team": "codex", "modelPattern": "gpt-5.*codex", "aliasSeed": "Caden" },
+    { "team": "copilot", "modelPattern": "sonnet", "aliasSeed": "Soren" },
+    { "team": "copilot", "modelPattern": "opus", "aliasSeed": "Orion" },
+    { "team": "copilot", "modelPattern": "gpt-5.*mini", "aliasSeed": "Milo" },
+    { "team": "claude-code", "modelPattern": "sonnet", "aliasSeed": "Clio" },
+    { "team": "claude-code", "modelPattern": "opus", "aliasSeed": "Orla" },
+    { "team": "openclaw", "modelPattern": "qwen", "aliasSeed": "Quinn", "devicePattern": "^windows-laptop$" },
+    { "team": "openclaw", "modelPattern": "mistral", "aliasSeed": "Mira", "devicePattern": "^windows-laptop$" },
+    { "team": "openclaw", "modelPattern": "phi", "aliasSeed": "Fia", "devicePattern": "^windows-laptop$" },
+    { "team": "*", "modelPattern": "qwen", "aliasSeed": "Quinn" },
+    { "team": "*", "modelPattern": "mistral", "aliasSeed": "Mira" },
+    { "team": "*", "modelPattern": "phi", "aliasSeed": "Fia" },
+    { "team": "*", "modelPattern": "gemma", "aliasSeed": "Gemma" }
+  ]
+}

--- a/scripts/global/agent-signature.js
+++ b/scripts/global/agent-signature.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 'use strict';
+const fs = require('fs');
+const path = require('path');
 
 const args = process.argv.slice(2);
 const opt = {};
@@ -7,33 +9,26 @@ for (let i = 0; i < args.length; i += 2) {
   if (args[i]?.startsWith('--')) opt[args[i].slice(2)] = args[i + 1] || '';
 }
 
+const registry = JSON.parse(fs.readFileSync(
+  path.join(__dirname, '..', '..', 'inventory', 'team-model-signatures.json'), 'utf8'
+));
 const team = (opt.team || 'codex').toLowerCase();
 const model = (opt.model || 'gpt-5.4').toLowerCase();
 const role = (opt.role || 'collaborator').toLowerCase();
 const substrate = (opt.substrate || 'local').toLowerCase();
-const device = opt.device ? `/${opt.device}` : '';
-const key = `${team}:${model}`;
-const surnames = {
-  manager: 'Mason', collaborator: 'Harper', admin: 'Reyes', consultant: 'Vale'
-};
+const deviceName = (opt.device || '').toLowerCase();
+const device = deviceName ? `/${deviceName}` : '';
 
-function firstName(value) {
-  if (/codex:gpt-5\.4/.test(value)) return 'Quill';
-  if (/codex:gpt-5.*codex/.test(value)) return 'Caden';
-  if (/copilot:.*sonnet/.test(value)) return 'Soren';
-  if (/copilot:.*opus/.test(value)) return 'Orion';
-  if (/copilot:.*gpt-5.*mini/.test(value)) return 'Milo';
-  if (/claude-code:.*sonnet/.test(value)) return 'Clio';
-  if (/claude-code:.*opus/.test(value)) return 'Orla';
-  if (/qwen/.test(value)) return 'Quinn';
-  if (/mistral/.test(value)) return 'Mira';
-  if (/phi/.test(value)) return 'Fia';
-  if (/gemma/.test(value)) return 'Gemma';
-  return 'Nova';
+function match(entry) {
+  const teamOk = entry.team === '*' || entry.team === team;
+  const modelOk = new RegExp(entry.modelPattern, 'i').test(model);
+  const deviceOk = !entry.devicePattern || new RegExp(entry.devicePattern, 'i').test(deviceName);
+  return teamOk && modelOk && deviceOk;
 }
 
 const payload = {
-  signedBy: `${firstName(key)} ${surnames[role] || 'Harper'}`,
+  signedBy: `${registry.registry.find(match)?.aliasSeed || registry.defaultAliasSeed} ` +
+    `${registry.roleSurnames[role] || registry.roleSurnames.collaborator}`,
   teamModel: `${team}:${model}@${substrate}${device}`,
   role
 };


### PR DESCRIPTION
## Summary

Move Team&Model alias derivation into shared inventory so Codex, Copilot, Claude Code, and fleet-hosted runtimes can resolve one governed provenance registry.

## Linked Issue

Closes #449

## Changes

- add `inventory/team-model-signatures.json` as the shared alias registry
- update `scripts/global/agent-signature.js` to resolve alias seeds and role surnames from inventory data
- update signing governance to name the shared registry as the alias source of truth

## Role Evidence

- **Manager**: issue #449 `MANAGER_HANDOFF` on branch `feat/449-shared-signature-registry`
- **Collaborator**: commit `ec0a1cd57ac3d7d74559048b0d14a87ee0bb657e`; live `#449` transition to `status:testing` completed without a new ADR-010 bot warning
- **Admin**: pending PR checks, push, and merge evidence
- **Consultant**: pending critique after gates

## Validation

- [x] `node scripts/global/agent-signature.js --team codex --model gpt-5.4 --role manager --substrate local --format text`
- [x] `node scripts/global/agent-signature.js --team openclaw --model qwen2.5:7b-instruct --role admin --substrate remote --device windows-laptop --format text`
- [x] `npm run lint` — clean in isolated worktree
- [x] `npm run lint:js` — passes with existing repo warnings only
- [x] `npm test` — 31/31 passed in isolated worktree
- [ ] CHANGELOG updated
- [ ] Docs synced to behavioral changes

## Risk

Low. The change centralizes existing naming rules without changing the canonical Team&Model provenance format.
