### PR TITLE
docs(governance): add concurrent agent worktree runbook (#458)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ Run `node scripts/global/fleet-config.js profile` for current state.
 - **JSON for structured data** (inventory/, config)
 - **Markdown for prose** (research/, ADRs, skills)
 - **No build step** — dashboard is static HTML/JS/CSS
-- **Branch before editing global resources**
+- **Branch before editing global resources** and keep one live worktree per agent; see `research/concurrent-agent-worktrees-2026-04-24.md`
 
 ## Commands
 
@@ -61,7 +61,7 @@ npm test               # E2E tests
 
 ## Git Workflow
 
-1. `git checkout -b skill/<name>` or `feat/<topic>`
+1. Use a dedicated agent worktree, then `git checkout -b skill/<name>` or `feat/<topic>`
 2. Make changes, test behavior in Copilot Chat
 3. `git checkout main && git merge feat/... --no-ff`
 4. `npm run deploy:apply` after merge

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,13 @@ This repo is the **development workbench** for the entire `~/.copilot/` system:
 - **Branch before editing global resources**: `git checkout -b skill/<name>` or `feat/<topic>`
 - **Test before deploying**: verify agent behavior in a test chat session.
 
+## Concurrent session safety
+
+- Never share one live checkout between Copilot, Claude Code, and Codex.
+- Give each agent its own worktree + branch, then merge through PRs.
+- Quarantine collisions in a rescue worktree instead of cleaning in place.
+- See `research/concurrent-agent-worktrees-2026-04-24.md`.
+
 ## Team&Model signing
 
 - AI-authored governed artifacts must include human alias + structured `Team&Model` provenance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,9 @@ and AI agent governance. All instructions below are binding for Claude Code sess
 - Hook scripts: `~/.claude/hooks/scripts/` (after deploy)
 - Deploy: `npm run deploy:claude` or `npm run deploy:apply` (both runtimes)
 - Lint: `npm run lint` — all files must be ≤ 100 lines
+
+## Concurrent session safety
+
+- Do not share this checkout with Copilot or Codex while Claude Code is active.
+- Use a dedicated worktree + branch for Claude Code work and merge via PR.
+- See `research/concurrent-agent-worktrees-2026-04-24.md`.

--- a/research/concurrent-agent-worktrees-2026-04-24.md
+++ b/research/concurrent-agent-worktrees-2026-04-24.md
@@ -1,0 +1,41 @@
+# Concurrent Agent Worktree Runbook
+
+This repo can support parallel AI teams, but not from the same live checkout.
+
+## Rules
+
+- One live agent family per worktree.
+- One active feature branch per worktree.
+- Keep `/home/curtisfranks/devenv-ops` as the clean integration checkout.
+- Merge work through PRs instead of letting agents share a branch.
+
+## Recommended layout
+
+- `/home/curtisfranks/devenv-ops` → clean `main`
+- `/home/curtisfranks/devenv-ops-codex` → Codex session
+- `/home/curtisfranks/devenv-ops-copilot` → Copilot session
+- `/home/curtisfranks/devenv-ops-claude-code` → Claude Code session
+- `/home/curtisfranks/devenv-ops-rescue` → quarantined mixed state when a collision happens
+
+## Setup
+
+```bash
+git fetch origin
+git worktree add -b sandbox/codex ../devenv-ops-codex origin/main
+git worktree add -b sandbox/copilot ../devenv-ops-copilot origin/main
+git worktree add -b sandbox/claude-code ../devenv-ops-claude-code origin/main
+```
+
+## Daily use
+
+1. Open one VS Code window per worktree.
+2. Start one agent family per window.
+3. Create the task branch inside that agent's worktree only.
+4. Merge reviewed work back through GitHub.
+
+## Recovery
+
+1. `git stash push -u -m "recovery: concurrent-agent-collision"`
+2. Create a rescue worktree from the current commit.
+3. Apply the stash inside the rescue worktree.
+4. Fast-forward the clean `main` checkout to `origin/main`.


### PR DESCRIPTION
## Summary
- add a short runbook for running Codex, Copilot, and Claude Code in parallel via isolated git worktrees
- surface the one-agent-per-worktree rule in Codex, Copilot, and Claude Code entry instructions
- document the local recovery pattern used to preserve collided state without losing work

## Validation
- `npm run lint`
- `npm test`

Closes #458

Signed-by: Quill Reyes
Team&Model: codex:gpt-5.4@local
Role: admin
