### PR TITLE
feat(codex): harden Codex-native governance runtime (#468)

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -2,6 +2,7 @@
 
 - Treat this file as the global DevEnv Ops baseline for Codex.
 - Repo-local `AGENTS.md` files override this baseline when they conflict.
+- Respect DevEnv Ops Codex governance from `~/.codex/config.toml`, `~/.codex/hooks.json`, and `~/.codex/rules/`.
 - Preserve Team&Model signing on governed issue, PR, commit, and doc artifacts.
-- Use installed DevEnv Ops skills from `$CODEX_HOME/skills/` when relevant.
+- Use installed DevEnv Ops skills from `$HOME/.agents/skills/` when relevant.
 - Always use the OpenAI developer documentation MCP server if you need to work with the OpenAI API, ChatGPT Apps SDK, Codex, or related docs without me having to explicitly ask.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,1 @@
-[mcp_servers.openaiDeveloperDocs]
-url = "https://developers.openai.com/mcp"
+project_doc_fallback_filenames = [".github/copilot-instructions.md", "CLAUDE.md"]

--- a/.codex/runtime-hooks.json
+++ b/.codex/runtime-hooks.json
@@ -1,0 +1,41 @@
+{
+  "hooks": {
+    "SessionStart": [{
+      "matcher": "startup|resume|clear",
+      "hooks": [{
+        "type": "command",
+        "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/session_context.py\"",
+        "timeout": 10,
+        "statusMessage": "Loading DevEnv Ops governance context"
+      }]
+    }],
+    "UserPromptSubmit": [{
+      "hooks": [
+        { "type": "command", "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/manager_ticket_gate.py\"", "timeout": 10 },
+        { "type": "command", "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/userprompt_gate.py\"", "timeout": 10 }
+      ]
+    }],
+    "PreToolUse": [{
+      "matcher": "Bash|apply_patch|Edit|Write",
+      "hooks": [
+        { "type": "command", "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/commit_ticket_gate.py\"", "timeout": 10 },
+        { "type": "command", "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/pretool_guard.py\"", "timeout": 10 }
+      ]
+    }],
+    "PostToolUse": [{
+      "matcher": "Bash|apply_patch|Edit|Write",
+      "hooks": [{
+        "type": "command",
+        "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/posttool_reminders.py\"",
+        "timeout": 10
+      }]
+    }],
+    "Stop": [{
+      "hooks": [{
+        "type": "command",
+        "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/stop_reminder.py\"",
+        "timeout": 10
+      }]
+    }]
+  }
+}

--- a/.codex/runtime-rules/default.rules
+++ b/.codex/runtime-rules/default.rules
@@ -1,0 +1,18 @@
+# Prompt before running risky history-rewriting Git commands outside the sandbox.
+prefix_rule(
+    pattern = ["git", "push", "--force"],
+    decision = "prompt",
+    justification = "Force pushes can rewrite shared history.",
+)
+
+prefix_rule(
+    pattern = ["git", "reset", "--hard"],
+    decision = "prompt",
+    justification = "Hard resets can discard governed work.",
+)
+
+prefix_rule(
+    pattern = ["gh", "issue", "close"],
+    decision = "prompt",
+    justification = "Issue closure must follow baton closeout evidence.",
+)

--- a/.codex/runtime.config.toml
+++ b/.codex/runtime.config.toml
@@ -1,0 +1,7 @@
+project_doc_fallback_filenames = [".github/copilot-instructions.md", "CLAUDE.md"]
+
+[features]
+codex_hooks = true
+
+[mcp_servers.openaiDeveloperDocs]
+url = "https://developers.openai.com/mcp"

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ This is a private development workbench. Contributions are by invitation only.
 2. Keep files ≤100 lines (lint-enforced)
 3. Run `npm run lint` and `npm test` before committing
 4. Merge to main via PR (or `--no-ff` for local work)
-5. Deploy: `npm run deploy:apply`
+5. Deploy the affected runtime: `npm run deploy:apply`, `npm run deploy:codex:apply`, or `npm run deploy:both:apply`
 
 ## Role Baton
 
@@ -20,4 +20,4 @@ Each role emits a named handoff artifact before the next begins.
 
 - JSON for structured data, Markdown for prose
 - Imperative commit messages: `type(scope): description`
-- Never edit `~/.copilot/` directly — all changes flow through this repo
+- Never edit deployed runtimes directly — all changes flow through this repo

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,92 +1,76 @@
 # Copilot Instructions — devenv-ops
 
-**devenv-ops**: Development workbench for `~/.copilot/` global resources (v0.1.0). Skills, instructions, hooks, scripts developed here. Fleet dashboard. Research archive.
+**devenv-ops**: Development workbench for the DevEnv Ops Harness runtime assets deployed to `~/.copilot/`, `~/.codex/`, and `~/.agents/skills/`.
 
 ## Execution Model
 
 Every task follows the **role baton sequence**: Manager → Collaborator → Admin → Consultant.
-See `role-baton-routing` instruction for rules. Local repos may override via `.github/copilot-instructions.md`.
+See `role-baton-routing` for rules. Local repos may override via `.github/copilot-instructions.md`.
 
 ## Repo Purpose
 
-This repo is the **source of truth** for all global Copilot resources:
-1. **skills/** → 33 skills, deployed to `~/.copilot/skills/`
-2. **instructions/** → 12 global instructions, deployed to `~/.copilot/instructions/`
-3. **hooks/** → Hook scripts, deployed to `~/.copilot/hooks/`
-4. **scripts/global/** → 17 bootstrap scripts, deployed to `~/.copilot/scripts/`
-5. **agents/** → 8 custom agents, deployed to `~/.copilot/agents/`
-6. **dashboard/** → Fleet monitoring web app (Alpine.js)
-7. **research/** → ADRs, service evaluations, hardware inventory
-8. **inventory/** → JSON device/service state
+This repo is the **source of truth** for the DevEnv Ops Harness:
+1. **skills/** → source skills for Copilot runtime and Codex user skill layer
+2. **instructions/** → global markdown instructions for the harness
+3. **hooks/** → shared hook logic and governance policies
+4. **scripts/global/** → bootstrap, routing, governance, and runtime utilities
+5. **.codex/** → Codex `AGENTS.md`, config, hooks, and rules install assets
+6. **agents/** → custom agent definitions
+7. **dashboard/** → fleet monitoring web app
+8. **research/** and **inventory/** → operational knowledge and state
 
 ## Architecture
 
-```
-This Repo (develop)          ~/.copilot/ (runtime)
-skills/          ──deploy──▶  skills/
-instructions/    ──deploy──▶  instructions/
-hooks/           ──deploy──▶  hooks/
-scripts/global/  ──deploy──▶  scripts/
-agents/          ──deploy──▶  agents/
+```text
+This Repo (develop)          Runtime targets
+skills/          ──deploy──▶  ~/.copilot/skills + ~/.agents/skills
+instructions/    ──deploy──▶  ~/.copilot/instructions
+hooks/           ──deploy──▶  ~/.copilot/hooks + ~/.codex/devenv-ops/hooks
+scripts/global/  ──deploy──▶  ~/.copilot/scripts + ~/.codex/devenv-ops/scripts
+.codex/          ──deploy──▶  ~/.codex/AGENTS.md + config.toml + hooks.json + rules/
+agents/          ──deploy──▶  ~/.copilot/agents
 ```
 
-**Rule**: Never edit `~/.copilot/` directly. All changes flow through this repo.
+**Rule**: Never edit deployed runtimes directly. All changes flow through this repo.
 
 ## Fleet Topology
 
-Auto-detected via `scripts/global/fleet-config.js`. Devices in `inventory/devices.json`.
-IPs resolved from `.env` overrides or Tailscale auto-discovery.
-Run `node scripts/global/fleet-config.js profile` for current state.
+Auto-detected via `scripts/global/fleet-config.js`. Devices live in `inventory/devices.json`.
+IPs resolve from `.env` overrides or Tailscale discovery.
 
 ## Constraints
 
 - **≤100 lines per file** (lint-enforced)
-- **JSON for structured data** (inventory/, config)
-- **Markdown for prose** (research/, ADRs, skills)
+- **JSON for structured data** and **Markdown for prose**
 - **No build step** — dashboard is static HTML/JS/CSS
-- **Branch before editing global resources** and keep one live worktree per agent; see `research/concurrent-agent-worktrees-2026-04-24.md`
+- **One live worktree per agent** — see `research/concurrent-agent-worktrees-2026-04-24.md`
 
 ## Commands
 
 ```bash
-npm start              # Dashboard on :8090
-npm run lint           # 100-line file check
-npm run sync           # Pull ~/.copilot/ → repo
-npm run sync:dry       # Preview sync
-npm run deploy         # Preview deploy (dry-run)
-npm run deploy:apply   # Deploy repo → ~/.copilot/
-npm run health         # Fleet health check
-npm test               # E2E tests
+npm start                   # Dashboard on :8090
+npm run lint                # 100-line file check
+npm run sync                # Pull default runtime → repo
+npm run sync:codex          # Pull Codex runtime → repo
+npm run deploy              # Preview deploy (dry-run)
+npm run deploy:apply        # Deploy repo → Copilot runtime
+npm run deploy:codex:apply  # Deploy repo → Codex runtime
+npm run deploy:both:apply   # Deploy repo → Copilot + Codex runtimes
+npm test                    # E2E tests
 ```
 
 ## Git Workflow
 
 1. Use a dedicated agent worktree, then `git checkout -b skill/<name>` or `feat/<topic>`
-2. Make changes, test behavior in Copilot Chat
+2. Make changes and test them in the target runtime
 3. `git checkout main && git merge feat/... --no-ff`
-4. `npm run deploy:apply` after merge
+4. Deploy the affected runtime(s) after merge
 5. Delete feature branch
-
-## File Organization
-
-| Path | Content | Format |
-|---|---|---|
-| `skills/<name>/SKILL.md` | Skill definition | Markdown |
-| `instructions/*.instructions.md` | Global instructions | Markdown |
-| `hooks/scripts/*.py` | Hook scripts | Python |
-| `hooks/*.json` | Hook config | JSON |
-| `scripts/global/*.js` | Bootstrap scripts | Node.js |
-| `scripts/*.sh` | Sync/deploy utilities | Bash |
-| `scripts/*.js` | Repo utilities | Node.js |
-| `agents/*.agent.md` | Custom agent definitions | Markdown |
-| `research/adr/NNN-title.md` | ADRs | Markdown |
-| `inventory/*.json` | Fleet state | JSON |
-| `dashboard/js/*.js` | Dashboard modules | JS |
 
 ## Environment
 
 Chromebook dev environment. Agent has root/sudo access.
-Install tools via CLI as needed. Don't ask permission.
+Install tools via CLI as needed. Don’t ask permission.
 
 ## User Interaction Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,20 +3,21 @@
 ## Agent startup protocol (required)
 
 1. Load `.github/copilot-instructions.md` before planning edits.
-2. Global skills, instructions, and hooks in this repo are the **development source**.
-3. `~/.copilot/` is the **deployed runtime**. Never edit runtime directly.
+2. Global skills, instructions, hooks, and Codex assets in this repo are the **development source**.
+3. Never edit deployed runtimes directly: `~/.copilot/`, `~/.codex/`, or `~/.agents/skills/`.
 4. Validate changes with lint and tests before claiming completion.
 
 ## Repo purpose
 
-This repo is the **development workbench** for the entire `~/.copilot/` system:
-- `skills/` → develop and test skill changes here, deploy to `~/.copilot/skills/`
+This repo is the **development workbench** for the DevEnv Ops Harness runtimes:
+- `skills/` → develop here, deploy to `~/.copilot/skills/` and `~/.agents/skills/`
 - `instructions/` → develop global instructions here, deploy to `~/.copilot/instructions/`
-- `hooks/` → develop hooks here, deploy to `~/.copilot/hooks/`
-- `scripts/global/` → develop scripts here, deploy to `~/.copilot/scripts/`
-- `agents/` → develop custom agents here, deploy to `~/.copilot/agents/`
+- `hooks/` → develop hook logic here, deploy to `~/.copilot/hooks/` and `~/.codex/devenv-ops/hooks/`
+- `scripts/global/` → develop runtime scripts here, deploy to `~/.copilot/scripts/` and `~/.codex/devenv-ops/scripts/`
+- `.codex/` → develop Codex `AGENTS.md`, config, hooks, and rules install assets here
+- `agents/` → develop custom Copilot agents here, deploy to `~/.copilot/agents/`
 - `dashboard/` is a standalone web app — treat with full web-app rigor.
-- `research/` docs are living — update when new services or hardware are evaluated.
+- `research/` docs are living — update them when runtime behavior changes.
 
 ## Edit discipline
 
@@ -25,7 +26,7 @@ This repo is the **development workbench** for the entire `~/.copilot/` system:
 - JSON for structured data (inventory/, config).
 - Markdown for prose (research/, ADRs).
 - **Branch before editing global resources**: `git checkout -b skill/<name>` or `feat/<topic>`
-- **Test before deploying**: verify agent behavior in a test chat session.
+- **Test before deploying**: verify behavior in the target runtime.
 
 ## Concurrent session safety
 
@@ -44,10 +45,10 @@ This repo is the **development workbench** for the entire `~/.copilot/` system:
 
 ```
 1. Branch:  git checkout -b skill/<name>-change
-2. Edit:    skills/<name>/SKILL.md (or instructions/, hooks/)
-3. Test:    Verify behavior in Copilot Chat
+2. Edit:    skills/<name>/SKILL.md (or instructions/, hooks/, `.codex/`)
+3. Test:    Verify behavior in the target runtime
 4. Merge:   git checkout main && git merge --no-ff
-5. Deploy:  npm run deploy:apply
+5. Deploy:  run the affected runtime deploy command
 ```
 
 ## Dashboard conventions

--- a/README.md
+++ b/README.md
@@ -1,98 +1,78 @@
 # devenv-ops
 
 [![License: PolyForm Noncommercial](https://img.shields.io/badge/License-PolyForm%20NC%201.0-purple.svg)](LICENSE)
-[![Agent Plugin](https://img.shields.io/badge/Agent%20Plugin-24%20skills-blue.svg)](plugin.json)
+[![Agent Plugin](https://img.shields.io/badge/Agent%20Plugin-governance%20harness-blue.svg)](plugin.json)
 [![Node ≥22](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
 
-**AI agent governance harness — skills, agents, hooks, and wiki.**
+**Governance-first AI agent harness for Copilot, Claude Code, and Codex.**
 
-Install as a VS Code Agent Plugin to get 24 governance skills,
-8 custom agents, and wiki seed content. No build step required.
+This repo is the development source for shared runtime assets deployed into `~/.copilot/`, `~/.codex/`, and `~/.agents/skills/`.
 
-## Install as Agent Plugin
+## Install
 
-In VS Code (with Copilot), run:
-> `Chat: Install Plugin From Source` → paste this repo's Git URL.
+Copilot plugin:
+- In VS Code, run `Chat: Install Plugin From Source` and paste this repo’s Git URL.
 
-Works in VS Code, Copilot CLI, and Claude Code.
+Codex runtime:
+- `npm run deploy:codex:apply`
+
+Both runtimes:
+- `npm run deploy:both:apply`
+
+## Runtime mapping
+
+| Source | Runtime target |
+|---|---|
+| `skills/` | `~/.copilot/skills/` and `~/.agents/skills/` |
+| `instructions/` | `~/.copilot/instructions/` |
+| `hooks/` | `~/.copilot/hooks/` and `~/.codex/devenv-ops/hooks/` |
+| `scripts/global/` | `~/.copilot/scripts/` and `~/.codex/devenv-ops/scripts/` |
+| `.codex/` | `~/.codex/AGENTS.md`, `config.toml`, `hooks.json`, and `rules/` |
+| `agents/` | `~/.copilot/agents/` |
+| `wiki/` | `~/.copilot/wiki/` and `~/.codex/devenv-ops/wiki/` |
 
 ## What You Get
 
-| Category | Count | Examples |
-|----------|-------|---------|
-| **Skills** | 24 | Role baton orchestration, GitHub governance, secret prevention, drift detection |
-| **Agents** | 8 | @architect, @implementer, @quick, @planner, @router, @governance-auditor |
-| **Wiki** | 15 seed articles | Agent drift, baton protocol, self-annealing, wiki pattern |
-| **Hooks** | 19 | Global standards enforcement, repo scoping |
-
-## How It Works
-
-```
- User Prompt ──▶ @router (Sonnet) ──▶ classifies ──┐
-                                                    │
-         ┌──────────────────────────────────────────┘
-         │
-         ├─▶ 🧠 @architect   (Opus 4.6)   complex / architecture
-         ├─▶ ⚡ @implementer (Sonnet 4.6)  standard coding
-         ├─▶ 🏎️ @quick       (GPT-5 mini)  fast lookups
-         └─▶ 📋 @planner     (Opus 4.6)   read-only research
-```
-
-Custom agents override VS Code Copilot AUTO model selection via
-`model` frontmatter — each pinned to the optimal model for its tier.
-
-## Tech Stack
-
-| Layer | Technology | Purpose |
-|-------|-----------|---------|
-| AI Runtime | VS Code Copilot + 8 custom agents | LLM task routing |
-| Dashboard | Alpine.js, vanilla JS/CSS | Fleet monitoring (≤50 MB) |
-| Fleet | Ollama, OpenClaw (LiteLLM) | Local/remote inference |
-| Network | Tailscale VPN mesh | Cross-device connectivity |
-| APIs | OpenRouter, Cloudflare AI, Google AI | Free-tier access |
-| QA | Playwright + Chrome DevTools Protocol | E2E + perf tests |
-| Deploy | Bash rsync scripts | `~/.copilot/` deployment |
-
-## Architecture
-
-```
-devenv-ops (source of truth)          ~/.copilot/ (runtime)
-  skills/          (35) ──deploy──▶   skills/
-  instructions/    (12) ──deploy──▶   instructions/
-  agents/           (8) ──deploy──▶   agents/
-  hooks/           (19) ──deploy──▶   hooks/
-  scripts/global/  (32) ──deploy──▶   scripts/
-```
+- Governance skills, role-baton instructions, routing, secret prevention, wiki knowledge, and dashboard tooling.
+- Custom Copilot agents plus Codex/Copilot deploy and sync tooling.
+- Shared Team&Model signing and GitHub ticket / PR governance.
 
 ## Develop the Harness
 
 ```bash
-npm run setup             # Install deps
-npm start                 # Dashboard on :8090
-npm run deploy:apply      # Deploy repo → ~/.copilot/
-npm run lint              # ≤100-line file check
-npm test                  # Playwright E2E tests
-npm run router:weekly     # Weekly model routing cost/quality scorecard
-node scripts/global/governance-verify.js        # Local ticket integrity check
-node scripts/global/fleet-live-indicator.js     # Real-time fleet status (CLI)
+npm run setup              # Install deps
+npm start                  # Dashboard on :8090
+npm run lint               # ≤100-line file check
+npm test                   # Playwright E2E tests
+npm run deploy:apply       # Deploy repo → Copilot runtime
+npm run deploy:codex:apply # Deploy repo → Codex runtime
+npm run deploy:both:apply  # Deploy repo → Copilot + Codex runtimes
 ```
 
-## Enable for Other Repos
+## Enable in Other Repos
 
 ```bash
 npm run repo:scope -- enable /path/to/repo
-npm run repo:scope -- disable /path/to/repo
+npm run repo:scope -- enable /path/to/repo --target=codex
 npm run repo:scope -- list
 ```
+
+By default the repo-scope tool updates both Copilot and Codex harness scope files.
+
+## Working Rules
+
+- Never share one live checkout between Copilot, Claude Code, and Codex.
+- Give each agent family its own worktree and branch.
+- Never edit deployed runtimes directly.
+- Validate with `npm run lint` and `npm test` before closeout.
 
 ## Help
 
 - [Bug reports](https://github.com/chf3198/devenv-ops/issues/new?template=bug-report.yml)
 - [Feature requests](https://github.com/chf3198/devenv-ops/issues/new?template=feature_request.md)
-- [Support guide](SUPPORT.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md)
+- [Contributing](.github/CONTRIBUTING.md)
+- [Security](.github/SECURITY.md)
 
 ## License
 
-[PolyForm Noncommercial 1.0.0](LICENSE) — free for personal,
-educational, nonprofit, and government use. Commercial use
-requires explicit permission.
+[PolyForm Noncommercial 1.0.0](LICENSE) — free for personal, educational, nonprofit, and government use. Commercial use requires explicit permission.

--- a/hooks/scripts/commit_ticket_gate.py
+++ b/hooks/scripts/commit_ticket_gate.py
@@ -55,7 +55,7 @@ def main() -> int:
         payload.get("tool_input"), dict) else [])
     joined = "\n".join(str(v) for v in values)
 
-    if tool not in {"run_in_terminal", "terminal"}:
+    if tool not in {"run_in_terminal", "terminal", "Bash"}:
         return 0
 
     if "git commit" not in joined:

--- a/hooks/scripts/posttool_reminders.py
+++ b/hooks/scripts/posttool_reminders.py
@@ -52,7 +52,7 @@ def main() -> int:
             "CHANGELOG(s), design docs, contribution/governance docs."
         )
 
-    if tool in {"run_in_terminal", "terminal", "runTerminalCommand"}:
+    if tool in {"run_in_terminal", "terminal", "runTerminalCommand", "Bash"}:
         if RE_GIT_PUSH.search(joined):
             messages.append(post_merge_checklist())
         elif RE_GIT_COMMIT.search(joined):

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -9,6 +9,7 @@ from admin_patterns import (  # noqa: E501
     RE_GIT_PUSH, RE_GIT_TAG, RE_PR_CHECKS, RE_PR_CREATE, RE_PR_MERGE,
     RE_RELEASE_INTEGRITY, RE_VSCE_PUBLISH, SECRET_FILE_RE, iter_strings)
 from governance_state import ensure_state
+from runtime_paths import runtime_hook_paths
 RE_ISSUE_REF = re.compile(r"#\d+")
 RE_BRANCH_CREATE = re.compile(r"git\s+(?:checkout\s+-b|switch\s+-c)\s+(\S+)")
 BRANCH_VALID = re.compile(r"^(feat|fix|hotfix)/\d+-|^(chore|skill)/[a-z0-9]|^main$|^develop$")
@@ -26,7 +27,7 @@ def check_terminal(joined: str, state: dict) -> int | None:
     m = RE_BRANCH_CREATE.search(joined)
     if m and not BRANCH_VALID.match(m.group(1)):
         return emit("deny",f"Branch '{m.group(1)}' violates naming. Use feat/<ticket#>-desc, fix/<ticket#>-desc, skill/<name>, or chore/<desc>.")
-    if ".copilot/hooks/scripts" in joined:
+    if any(marker in joined for marker in runtime_hook_paths()):
         return emit("ask","Hook script mutation detected. Manual approval required.","Review for policy weakening or bypass logic.")
     if RE_GIT_COMMIT.search(joined) and not RE_ISSUE_REF.search(joined):
         return emit("deny","Commit blocked: no issue ref (#N). Link a ticket first.")
@@ -67,7 +68,7 @@ def main() -> int:
     if tool in {"create_file","apply_patch","edit_notebook_file","create_new_jupyter_notebook","replace_string_in_file","multi_replace_string_in_file"}:
         if not state.get("active_ticket"):
             return emit("deny","File edit blocked: no active ticket. Manager must reference a ticket (#N) before edits.")
-    if tool in {"run_in_terminal","terminal","runTerminalCommand"}:
+    if tool in {"run_in_terminal","terminal","runTerminalCommand","Bash"}:
         result = check_terminal("\n".join(values), state)
         if result is not None: return result
     suspicious = [v for v in values if "/" in v or "." in v]

--- a/hooks/scripts/repo_scope.py
+++ b/hooks/scripts/repo_scope.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-CONFIG_PATH = Path.home() / ".copilot" / "hooks" / "repo-scope.json"
+from runtime_paths import repo_scope_candidates
 
 
 def _norm(path: str) -> str:
@@ -13,20 +13,18 @@ def _norm(path: str) -> str:
 
 
 def is_repo_enabled(cwd: str) -> bool:
-    try:
-        data = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-    except Exception:
-        return False
-
-    default_enabled = bool(data.get("default_enabled", False))
-    enabled = data.get("enabled_repos", [])
-    if not isinstance(enabled, list):
-        return default_enabled
-
     cur = _norm(cwd)
-    for item in enabled:
-        if not isinstance(item, str):
+    fallback = False
+    for cfg in repo_scope_candidates():
+        try:
+            data = json.loads(cfg.read_text(encoding="utf-8"))
+        except Exception:
             continue
-        if _norm(item) == cur:
-            return True
-    return default_enabled
+        enabled = data.get("enabled_repos", [])
+        fallback = fallback or bool(data.get("default_enabled", False))
+        if not isinstance(enabled, list):
+            continue
+        for item in enabled:
+            if isinstance(item, str) and _norm(item) == cur:
+                return True
+    return fallback

--- a/hooks/scripts/runtime_paths.py
+++ b/hooks/scripts/runtime_paths.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Shared runtime path helpers for Copilot/Codex hook parity."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _home(var: str, default: str) -> Path:
+    return Path(os.getenv(var) or default).expanduser()
+
+
+def runtime_name() -> str:
+    return (os.getenv("DEVENT_OPS_RUNTIME") or "copilot").strip().lower()
+
+
+def codex_home() -> Path:
+    return _home("CODEX_HOME", "~/.codex")
+
+
+def copilot_home() -> Path:
+    return _home("COPILOT_HOME", "~/.copilot")
+
+
+def codex_managed_root() -> Path:
+    return codex_home() / "devenv-ops"
+
+
+def _ordered(codex: Path, copilot: Path) -> list[Path]:
+    return [codex, copilot] if runtime_name() == "codex" else [copilot, codex]
+
+
+def repo_scope_candidates() -> list[Path]:
+    custom = os.getenv("DEVENT_OPS_REPO_SCOPE_PATH")
+    paths = _ordered(codex_managed_root() / "repo-scope.json",
+                     copilot_home() / "hooks" / "repo-scope.json")
+    return ([Path(custom).expanduser()] if custom else []) + paths
+
+
+def state_root() -> Path:
+    return codex_managed_root() / "state" if runtime_name() == "codex" else copilot_home() / "hooks" / "state"
+
+
+def script_candidates(name: str) -> list[Path]:
+    repo = Path(__file__).resolve().parents[2] / "scripts" / "global" / name
+    codex = codex_managed_root() / "scripts" / name
+    copilot = copilot_home() / "scripts" / name
+    return [repo] + _ordered(codex, copilot)
+
+
+def wiki_candidates() -> list[Path]:
+    repo = Path(__file__).resolve().parents[2] / "wiki"
+    extra = Path.home() / "devenv-ops" / "wiki"
+    return _ordered(codex_managed_root() / "wiki", copilot_home() / "wiki") + [repo, extra]
+
+
+def runtime_hook_paths() -> tuple[str, ...]:
+    return (str(codex_managed_root() / "hooks"), str(copilot_home() / "hooks" / "scripts"))

--- a/hooks/scripts/session_context.py
+++ b/hooks/scripts/session_context.py
@@ -22,7 +22,7 @@ def main() -> int:
 
     cwd = Path(payload.get("cwd") or os.getcwd())
     source = str(payload.get("source") or "")
-    if source == "new":
+    if source in {"new", "startup", "clear"}:
         state = reset_state(str(cwd))
     else:
         state = ensure_state(str(cwd))

--- a/hooks/scripts/state_store.py
+++ b/hooks/scripts/state_store.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Governance state persistence: load, save, ensure, reset."""
 from __future__ import annotations
-
 import hashlib
 import json
 import os
@@ -9,8 +8,9 @@ from pathlib import Path
 from typing import Any
 
 from repo_detection import detect_repo_type
+from runtime_paths import state_root
 
-STATE_ROOT = Path.home() / ".copilot" / "hooks" / "state"
+STATE_ROOT = state_root()
 
 
 def _repo_key(cwd: str) -> str:
@@ -18,40 +18,24 @@ def _repo_key(cwd: str) -> str:
 
 
 def state_path(cwd: str) -> Path:
-    return STATE_ROOT / f"repo-{_repo_key(cwd)}.json"
+    return state_root() / f"repo-{_repo_key(cwd)}.json"
 
 
 def _default_state(cwd: str) -> dict[str, Any]:
-    return {
-        "cwd": cwd,
-        "repo_type": detect_repo_type(cwd),
-        "routing": {
-            "lane": "free", "backend": "auto",
-            "recommended_model": "Auto",
-            "confidence": "medium", "rationale": "default",
-        },
-        "roles": {
-            "manager": False, "collaborator": False,
-            "admin": False, "consultant": False,
-        },
-        "flags": {
-            "code_touched": False, "docs_touched": False,
-            "extension_touched": False,
-        },
-        "admin_ops": {
-            "version_check": False, "commit": False,
-            "push": False, "pr_create": False,
-            "ci_green": False, "merge": False,
-            "publish": False, "release_integrity": False,
-            "gh_release": False, "issue_close": False,
-            "issue_linked": False, "visual_qa": False,
-        },
-        "drift": {
-            "commits": 0, "commits_with_ticket": 0,
-            "branches": 0, "branches_compliant": 0,
-            "edits_gated": 0, "edits_ungated": 0,
-        },
-    }
+    return {"cwd": cwd, "repo_type": detect_repo_type(cwd), "routing": {
+        "lane": "free", "backend": "auto", "recommended_model": "Auto",
+        "confidence": "medium", "rationale": "default"},
+        "roles": {"manager": False, "collaborator": False,
+                  "admin": False, "consultant": False},
+        "flags": {"code_touched": False, "docs_touched": False,
+                  "extension_touched": False},
+        "admin_ops": {"version_check": False, "commit": False, "push": False,
+                      "pr_create": False, "ci_green": False, "merge": False,
+                      "publish": False, "release_integrity": False,
+                      "gh_release": False, "issue_close": False,
+                      "issue_linked": False, "visual_qa": False},
+        "drift": {"commits": 0, "commits_with_ticket": 0, "branches": 0,
+                  "branches_compliant": 0, "edits_gated": 0, "edits_ungated": 0}}
 
 
 def load_state(cwd: str) -> dict[str, Any]:
@@ -62,10 +46,10 @@ def load_state(cwd: str) -> dict[str, Any]:
         data = json.loads(path.read_text(encoding="utf-8"))
         if not isinstance(data, dict):
             return _default_state(cwd)
-        defaults = _default_state(cwd)
+        defaults, keys = _default_state(cwd), ("routing", "roles", "flags", "admin_ops", "drift")
         data.setdefault("cwd", cwd)
         data.setdefault("repo_type", detect_repo_type(cwd))
-        for key in ("routing", "roles", "flags", "admin_ops", "drift"):
+        for key in keys:
             if key not in data:
                 data[key] = defaults[key]
             elif isinstance(defaults[key], dict):
@@ -80,9 +64,7 @@ def save_state(state: dict[str, Any]) -> None:
     cwd = str(state.get("cwd") or os.getcwd())
     path = state_path(cwd)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(state, indent=2, sort_keys=True), encoding="utf-8"
-    )
+    path.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
 
 
 def ensure_state(cwd: str) -> dict[str, Any]:

--- a/hooks/scripts/stop_reminder.py
+++ b/hooks/scripts/stop_reminder.py
@@ -63,11 +63,8 @@ def main() -> int:
 
     out = {"systemMessage": "\n\n".join(messages)}
     if block_reason:
-        out["hookSpecificOutput"] = {
-            "hookEventName": "Stop",
-            "decision": "block",
-            "reason": block_reason,
-        }
+        out["decision"] = "block"
+        out["reason"] = block_reason
 
     if not block_reason:
         roles["consultant"] = True

--- a/hooks/scripts/task_router.py
+++ b/hooks/scripts/task_router.py
@@ -2,13 +2,12 @@
 """Task router helpers for prompt classification and state persistence."""
 import json
 import subprocess
-from pathlib import Path
+
+from runtime_paths import script_candidates
 
 
 def _candidates() -> list[Path]:
-    repo = Path(__file__).resolve().parents[2] / "scripts" / "global" / "task-router.js"
-    runtime = Path.home() / ".copilot" / "scripts" / "task-router.js"
-    return [repo, runtime]
+    return script_candidates("task-router.js")
 
 
 def classify_prompt(prompt: str) -> dict | None:

--- a/hooks/scripts/tool_activity.py
+++ b/hooks/scripts/tool_activity.py
@@ -54,7 +54,7 @@ def mark_tool_activity(state: dict[str, Any], payload: dict[str, Any]) -> None:
             flags["code_touched"] = True
             roles["collaborator"] = True
 
-    if tool not in {"run_in_terminal", "terminal", "runTerminalCommand"}:
+    if tool not in {"run_in_terminal", "terminal", "runTerminalCommand", "Bash"}:
         return
 
     _match_ops = [

--- a/hooks/scripts/wiki_wisdom.py
+++ b/hooks/scripts/wiki_wisdom.py
@@ -6,6 +6,8 @@ Falls back to short defaults if wiki pages are missing.
 import re
 from pathlib import Path
 
+from runtime_paths import wiki_candidates
+
 _WIKI_ROOT = None
 
 
@@ -13,9 +15,7 @@ def _find_wiki() -> Path | None:
     global _WIKI_ROOT
     if _WIKI_ROOT is not None:
         return _WIKI_ROOT
-    for c in [Path.home() / ".copilot" / "wiki",
-              Path(__file__).resolve().parent.parent.parent / "wiki",
-              Path.home() / "devenv-ops" / "wiki"]:
+    for c in wiki_candidates():
         if c.is_dir():
             _WIKI_ROOT = c
             return c

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "devenv-ops",
   "version": "3.1.0",
-  "description": "AI agent governance harness — 24 skills, extensible agents, hooks, and wiki as a VS Code Agent Plugin",
+  "description": "AI agent governance harness — multi-runtime skills, hooks, agents, wiki, and Codex/Copilot install tooling",
   "private": true,
   "scripts": {
     "prepare": "cp hooks/scripts/validate-branch-name.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit",
@@ -12,8 +12,16 @@
     "lint:router": "node scripts/lint-router.js",
     "sync": "bash scripts/sync.sh",
     "sync:dry": "bash scripts/sync.sh --dry-run",
+    "sync:codex": "bash scripts/sync.sh --target codex",
+    "sync:codex:dry": "bash scripts/sync.sh --dry-run --target codex",
+    "sync:both": "bash scripts/sync.sh --target both",
+    "sync:both:dry": "bash scripts/sync.sh --dry-run --target both",
     "deploy": "bash scripts/deploy.sh",
     "deploy:apply": "bash scripts/deploy.sh --apply",
+    "deploy:codex": "bash scripts/deploy.sh --target codex",
+    "deploy:codex:apply": "bash scripts/deploy.sh --apply --target codex",
+    "deploy:both": "bash scripts/deploy.sh --target both",
+    "deploy:both:apply": "bash scripts/deploy.sh --apply --target both",
     "health": "node scripts/health-check.js",
     "router:smoke": "node scripts/global/task-router-smoke.js",
     "router:dispatch": "node scripts/global/task-router-dispatch.js",
@@ -40,6 +48,7 @@
   },
   "keywords": [
     "devops",
+    "codex",
     "copilot-skills",
     "monitoring",
     "dashboard"

--- a/research/codex-compatibility-and-team-model-signing-design-2026-04-24.md
+++ b/research/codex-compatibility-and-team-model-signing-design-2026-04-24.md
@@ -7,29 +7,31 @@ One DevEnv Ops init path should install a governance-first harness for Copilot, 
 ## Verified Codex surfaces
 
 - `$CODEX_HOME/AGENTS.md` and `AGENTS.override.md` for global instructions.
-- Repo-tree `AGENTS.md` files for local overrides.
-- `$CODEX_HOME/skills/` for reusable skills.
-- `~/.codex/config.toml` for model instructions, MCP, and extra tools.
-- Plugins/MCP as tool extensions.
-- Codex docs also expose Rules and Hooks as configuration areas; treat them as later installer targets once stable file paths are confirmed.
+- Repo-tree `AGENTS.md` files plus `project_doc_fallback_filenames` for local overrides.
+- `~/.agents/skills/` for user-level reusable skills.
+- `~/.codex/config.toml` plus trusted repo `.codex/config.toml` for config layers.
+- `~/.codex/hooks.json` / repo `.codex/hooks.json` for native hooks.
+- `~/.codex/rules/` / repo `.codex/rules/` for native command rules.
+- Plugins/MCP as tool extensions, with `.codex-plugin/plugin.json` as the local plugin manifest format.
 
 ## Runtime mapping
 
 | Concern | Copilot | Claude Code | Codex |
 |---|---|---|---|
 | Global baseline | `~/.copilot/instructions/` | `CLAUDE.md` + deployed hooks | `$CODEX_HOME/AGENTS.md` + `config.toml` |
-| Reusable skills | `~/.copilot/skills/` | `.claude/commands/` | `$CODEX_HOME/skills/` |
+| Reusable skills | `~/.copilot/skills/` | `.claude/commands/` | `~/.agents/skills/` |
 | Agents/subagents | `~/.copilot/agents/` | `.claude/agents/` | Codex subagents/future mapping |
-| Tool integration | hooks + scripts | `.claude/settings.json` hooks | MCP/plugins/config |
+| Tool integration | hooks + scripts | `.claude/settings.json` hooks | `hooks.json`, `rules/`, MCP, plugins, config |
 | Repo override | `.github/copilot-instructions.md` | `CLAUDE.md` + repo files | repo `AGENTS.md` |
 
 ## Codex init contract
 
 1. Install or merge the global baseline into `$CODEX_HOME/AGENTS.md`.
-2. Sync shared skills into `$CODEX_HOME/skills/`.
+2. Sync shared skills into `~/.agents/skills/`.
 3. Merge Codex MCP/config entries into `~/.codex/config.toml`.
-4. Create or update repo `AGENTS.md` with repo-local governance overlays.
-5. Keep ticket, PR, and git governance in the repo, not in the home directory.
+4. Install user-level hooks and rules into `~/.codex/hooks.json` and `~/.codex/rules/`.
+5. Keep managed support assets namespaced under `~/.codex/devenv-ops/`.
+6. Keep ticket, PR, and git governance in the repo, not in the home directory.
 
 ## Precedence
 
@@ -56,30 +58,9 @@ Examples:
 - `copilot:claude-sonnet-4.6@github-copilot`
 - `fleet:mistral@openclaw/windows-laptop`
 
-## Human alias convention
+## Implementation status after #468
 
-- Human alias is display-friendly; structured provenance is source of truth.
-- Given name derives from team + model family.
-- Surname derives from Agile role.
-- Role surnames: Manager=`Mason`, Collaborator=`Harper`, Admin=`Reyes`, Consultant=`Vale`.
-- Example: `Quill Mason | codex:gpt-5.4@local | role:manager`
-
-## Required signing surfaces
-
-- GitHub baton artifacts and exception notes
-- PR descriptions and review/closeout evidence
-- AI-authored governance/design docs
-- AI-authored commits via trailers when the toolchain permits
-
-## Git trailer contract
-
-- `AI-Signature: <human-alias>`
-- `AI-Team-Model: <team>:<model>@<substrate>[/<device>]`
-- `AI-Role: <role>`
-
-## Implementation next steps
-
-- Extend deploy/sync to manage Codex home targets.
-- Add repo-init scaffolding for Codex-aware `AGENTS.md`.
-- Add helpers or hooks that stamp commit/PR trailers and bodies.
-- Keep signing rules global, but let repos add stricter local variants.
+- Deploy/sync target `~/.agents/skills/`, `~/.codex/config.toml`, `~/.codex/hooks.json`, `~/.codex/rules/`, and namespaced support assets under `~/.codex/devenv-ops/`.
+- Shared governance hooks resolve runtime-sensitive state, wiki, task-router, and repo-scope paths for Codex as well as Copilot.
+- Repo docs and command surfaces expose Codex deploy/sync flows as first-class operations.
+- Plugin packaging remains a future enhancement, but the installer now uses currently documented Codex-native surfaces directly.

--- a/scripts/global/codex-runtime.js
+++ b/scripts/global/codex-runtime.js
@@ -5,7 +5,9 @@ const os = require('os');
 const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..', '..');
-const HOME = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+const CODEX_HOME = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+const MANAGED = path.join(CODEX_HOME, 'devenv-ops');
+const AGENTS_HOME = path.join(os.homedir(), '.agents');
 const MODE = process.argv[2];
 const APPLY = process.argv.includes('--apply');
 const DRY = process.argv.includes('--dry-run') || (MODE === 'deploy' && !APPLY);
@@ -15,58 +17,63 @@ const BLOCK = new RegExp(`${START}[\\s\\S]*?${END}\\n?`, 'm');
 
 function ensure(dir) { fs.mkdirSync(dir, { recursive: true }); }
 function read(file) { try { return fs.readFileSync(file, 'utf8'); } catch { return ''; } }
-function dirs(src) { return fs.existsSync(src) ? fs.readdirSync(src, { withFileTypes: true })
-  .filter(d => d.isDirectory() && !d.name.startsWith('.')).map(d => d.name) : []; }
 function wrap(text) { return `${START}\n${text.trim()}\n${END}\n`; }
-function logAction(write, action, name) {
-  console.log(write ? `  ✅ ${name}` : `  Would ${action}: ${name}`);
+function log(write, action, label) { console.log(write ? `  ✅ ${label}` : `  Would ${action}: ${label}`); }
+function tree(src, dest, write, label, action) {
+  console.log(`── ${label} ──`);
+  if (write && fs.existsSync(src)) { ensure(path.dirname(dest)); fs.cpSync(src, dest, { recursive: true, force: true }); }
+  log(write, action, path.basename(dest)); console.log('');
 }
-
-function syncSkills(src, dest, write, action) {
-  console.log('── Codex Skills ──');
-  let count = 0;
-  for (const name of dirs(src)) {
-    if (write) { ensure(dest); fs.cpSync(path.join(src, name), path.join(dest, name), { recursive: true, force: true }); }
-    logAction(write, action, name);
-    count++;
-  }
-  console.log(`  Total: ${count}\n`);
+function file(src, dest, write, label, action) {
+  console.log(`── ${label} ──`);
+  if (write && fs.existsSync(src)) { ensure(path.dirname(dest)); fs.copyFileSync(src, dest); }
+  log(write, action, path.basename(dest)); console.log('');
 }
-
 function mergeManaged(src, dest, write) {
   console.log(`── ${path.basename(dest)} ──`);
-  const current = read(dest);
-  const managed = wrap(read(src));
+  const current = read(dest), managed = wrap(read(src));
   const merged = BLOCK.test(current) ? current.replace(BLOCK, managed) :
     `${current.trim()}${current.trim() ? '\n\n' : ''}${managed}`;
   if (write) { ensure(path.dirname(dest)); fs.writeFileSync(dest, merged); }
-  logAction(write, 'merge', path.basename(dest));
-  console.log('');
+  log(write, 'merge', path.basename(dest)); console.log('');
 }
-
 function extractManaged(src, dest, write) {
   console.log(`── ${path.basename(src)} ──`);
   const match = read(src).match(new RegExp(`${START}\\n([\\s\\S]*?)\\n${END}`));
-  if (!match) return console.log('  Missing managed block\n');
-  if (write) { ensure(path.dirname(dest)); fs.writeFileSync(dest, `${match[1].trim()}\n`); }
-  logAction(write, 'extract', path.basename(dest));
-  console.log('');
+  if (write && match) { ensure(path.dirname(dest)); fs.writeFileSync(dest, `${match[1].trim()}\n`); }
+  console.log(match ? `  ${write ? '✅' : 'Would extract:'} ${path.basename(dest)}` : '  Missing managed block'); console.log('');
+}
+function initScope(write) {
+  const dest = path.join(MANAGED, 'repo-scope.json');
+  console.log('── repo-scope.json ──');
+  if (write && !fs.existsSync(dest)) { ensure(path.dirname(dest)); fs.writeFileSync(dest, '{\n  "default_enabled": true,\n  "enabled_repos": []\n}\n'); }
+  log(write, fs.existsSync(dest) ? 'preserve' : 'create', 'repo-scope.json'); console.log('');
 }
 
 if (!['deploy', 'sync'].includes(MODE)) {
   console.error('Usage: codex-runtime.js <deploy|sync> [--apply|--dry-run]'); process.exit(1);
 }
 
-console.log(`${MODE === 'deploy' ? 'Source' : 'Syncing from'}: ${MODE === 'deploy' ? ROOT : HOME}`);
-console.log(`${MODE === 'deploy' ? 'Target' : 'Into'}: ${MODE === 'deploy' ? HOME : ROOT}\n`);
+console.log(`${MODE === 'deploy' ? 'Source' : 'Syncing from'}: ${MODE === 'deploy' ? ROOT : CODEX_HOME}`);
+console.log(`${MODE === 'deploy' ? 'Target' : 'Into'}: ${MODE === 'deploy' ? CODEX_HOME : ROOT}\n`);
+if (DRY) console.log(`=== ${MODE === 'deploy' ? 'DRY RUN (pass --apply to write Codex runtime)' : 'DRY RUN — no Codex changes will be made'} ===\n`);
 if (MODE === 'deploy') {
-  if (DRY) console.log('=== DRY RUN (pass --apply to write Codex runtime) ===\n');
-  syncSkills(path.join(ROOT, 'skills'), path.join(HOME, 'skills'), !DRY, 'deploy');
-  mergeManaged(path.join(ROOT, '.codex', 'AGENTS.md'), path.join(HOME, 'AGENTS.md'), !DRY);
-  mergeManaged(path.join(ROOT, '.codex', 'config.toml'), path.join(HOME, 'config.toml'), !DRY);
+  tree(path.join(ROOT, 'skills'), path.join(AGENTS_HOME, 'skills'), !DRY, 'Codex User Skills', 'deploy');
+  tree(path.join(ROOT, 'scripts', 'global'), path.join(MANAGED, 'scripts'), !DRY, 'Codex Managed Scripts', 'deploy');
+  tree(path.join(ROOT, 'hooks', 'scripts'), path.join(MANAGED, 'hooks'), !DRY, 'Codex Managed Hooks', 'deploy');
+  tree(path.join(ROOT, 'wiki'), path.join(MANAGED, 'wiki'), !DRY, 'Codex Managed Wiki', 'deploy');
+  tree(path.join(ROOT, '.codex', 'runtime-rules'), path.join(CODEX_HOME, 'rules'), !DRY, 'Codex Rules', 'deploy');
+  mergeManaged(path.join(ROOT, '.codex', 'AGENTS.md'), path.join(CODEX_HOME, 'AGENTS.md'), !DRY);
+  mergeManaged(path.join(ROOT, '.codex', 'runtime.config.toml'), path.join(CODEX_HOME, 'config.toml'), !DRY);
+  file(path.join(ROOT, '.codex', 'runtime-hooks.json'), path.join(CODEX_HOME, 'hooks.json'), !DRY, 'Codex Hooks', 'deploy');
+  initScope(!DRY);
 } else {
-  if (DRY) console.log('=== DRY RUN — no Codex changes will be made ===\n');
-  syncSkills(path.join(HOME, 'skills'), path.join(ROOT, 'skills'), !DRY, 'sync');
-  extractManaged(path.join(HOME, 'AGENTS.md'), path.join(ROOT, '.codex', 'AGENTS.md'), !DRY);
-  extractManaged(path.join(HOME, 'config.toml'), path.join(ROOT, '.codex', 'config.toml'), !DRY);
+  tree(path.join(AGENTS_HOME, 'skills'), path.join(ROOT, 'skills'), !DRY, 'Codex User Skills', 'sync');
+  tree(path.join(MANAGED, 'scripts'), path.join(ROOT, 'scripts', 'global'), !DRY, 'Codex Managed Scripts', 'sync');
+  tree(path.join(MANAGED, 'hooks'), path.join(ROOT, 'hooks', 'scripts'), !DRY, 'Codex Managed Hooks', 'sync');
+  tree(path.join(MANAGED, 'wiki'), path.join(ROOT, 'wiki'), !DRY, 'Codex Managed Wiki', 'sync');
+  tree(path.join(CODEX_HOME, 'rules'), path.join(ROOT, '.codex', 'runtime-rules'), !DRY, 'Codex Rules', 'sync');
+  extractManaged(path.join(CODEX_HOME, 'AGENTS.md'), path.join(ROOT, '.codex', 'AGENTS.md'), !DRY);
+  extractManaged(path.join(CODEX_HOME, 'config.toml'), path.join(ROOT, '.codex', 'runtime.config.toml'), !DRY);
+  file(path.join(CODEX_HOME, 'hooks.json'), path.join(ROOT, '.codex', 'runtime-hooks.json'), !DRY, 'Codex Hooks', 'extract');
 }

--- a/scripts/global/global-skills-bootstrap-content.js
+++ b/scripts/global/global-skills-bootstrap-content.js
@@ -17,7 +17,7 @@ function skillRoutingBody() {
 
 1. Read .github/copilot-instructions.md first.
 2. Apply nearest AGENTS.md instructions.
-3. Prefer reusable global skills from ~/.copilot/skills before ad-hoc reasoning.
+3. Prefer reusable global skills from ~/.copilot/skills or ~/.agents/skills before ad-hoc reasoning.
 4. For every task, invoke \`role-baton-orchestrator\` first (Manager → Collaborator → Admin → Consultant).
 5. For repository workflow routing, invoke:
    - \`repo-standards-router\` for task classification and gates

--- a/scripts/global/repo-scope.js
+++ b/scripts/global/repo-scope.js
@@ -3,56 +3,79 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const cfgPath = path.join(os.homedir(), '.copilot', 'hooks', 'repo-scope.json');
+const homes = {
+  copilot: process.env.COPILOT_HOME || path.join(os.homedir(), '.copilot'),
+  codex: process.env.CODEX_HOME || path.join(os.homedir(), '.codex'),
+};
+const paths = {
+  copilot: path.join(homes.copilot, 'hooks', 'repo-scope.json'),
+  codex: path.join(homes.codex, 'devenv-ops', 'repo-scope.json'),
+};
 
-function loadCfg() {
+function loadCfg(file) {
   try {
-    return JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
   } catch {
     return { default_enabled: false, enabled_repos: [] };
   }
 }
 
-function saveCfg(cfg) {
-  fs.mkdirSync(path.dirname(cfgPath), { recursive: true });
-  fs.writeFileSync(cfgPath, `${JSON.stringify(cfg, null, 2)}\n`, 'utf8');
+function saveCfg(file, cfg) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(cfg, null, 2)}\n`, 'utf8');
 }
 
 function norm(p) { return path.resolve(p); }
 
 function main() {
-  const [cmd, arg] = process.argv.slice(2);
-  const cfg = loadCfg();
-  cfg.enabled_repos = Array.isArray(cfg.enabled_repos) ? cfg.enabled_repos : [];
+  const args = process.argv.slice(2);
+  const targetArg = args.find((x) => x.startsWith('--target=')) || '';
+  const target = (targetArg.split('=')[1] || 'both').toLowerCase();
+  const [cmd, arg] = args.filter((x) => !x.startsWith('--target='));
+  const targets = target === 'both' ? ['copilot', 'codex'] : [target];
+  if (!targets.every((x) => paths[x])) throw new Error('Invalid target. Use copilot, codex, or both.');
 
   if (cmd === 'list') {
-    console.log(JSON.stringify(cfg, null, 2));
+    console.log(JSON.stringify(Object.fromEntries(
+      targets.map((name) => [name, loadCfg(paths[name])])), null, 2));
     return;
+  }
+  const configs = Object.fromEntries(targets.map((name) => [name, loadCfg(paths[name])]));
+  for (const cfg of Object.values(configs)) {
+    cfg.enabled_repos = Array.isArray(cfg.enabled_repos) ? cfg.enabled_repos : [];
   }
   if (cmd === 'enable') {
     if (!arg) throw new Error('Missing repo path. Usage: repo-scope enable /abs/path');
     const p = norm(arg);
-    if (!cfg.enabled_repos.includes(p)) cfg.enabled_repos.push(p);
-    saveCfg(cfg);
-    console.log(`Enabled workflow for: ${p}`);
+    for (const name of targets) {
+      const cfg = configs[name];
+      if (!cfg.enabled_repos.includes(p)) cfg.enabled_repos.push(p);
+      saveCfg(paths[name], cfg);
+    }
+    console.log(`Enabled workflow for: ${p} (${targets.join(', ')})`);
     return;
   }
   if (cmd === 'disable') {
     if (!arg) throw new Error('Missing repo path. Usage: repo-scope disable /abs/path');
     const p = norm(arg);
-    cfg.enabled_repos = cfg.enabled_repos.filter((x) => x !== p);
-    saveCfg(cfg);
-    console.log(`Disabled workflow for: ${p}`);
+    for (const name of targets) {
+      const cfg = configs[name];
+      cfg.enabled_repos = cfg.enabled_repos.filter((x) => x !== p);
+      saveCfg(paths[name], cfg);
+    }
+    console.log(`Disabled workflow for: ${p} (${targets.join(', ')})`);
     return;
   }
   if (cmd === 'default-on' || cmd === 'default-off') {
-    cfg.default_enabled = cmd === 'default-on';
-    saveCfg(cfg);
-    console.log(`Default set to: ${cfg.default_enabled}`);
+    for (const name of targets) {
+      configs[name].default_enabled = cmd === 'default-on';
+      saveCfg(paths[name], configs[name]);
+    }
+    console.log(`Default set to: ${cmd === 'default-on'} (${targets.join(', ')})`);
     return;
   }
 
-  console.log('Usage: repo-scope <list|enable|disable|default-on|default-off> [repoPath]');
+  console.log('Usage: repo-scope <list|enable|disable|default-on|default-off> [repoPath] [--target=copilot|codex|both]');
   process.exit(2);
 }
 

--- a/scripts/global/router-metrics.js
+++ b/scripts/global/router-metrics.js
@@ -4,12 +4,17 @@ const os = require('os');
 
 function getRouterMetrics() {
   try {
-    const stateDir = path.join(os.homedir(), '.copilot', 'hooks', 'state');
-    const files = fs.existsSync(stateDir) ? fs.readdirSync(stateDir).filter(f => f.startsWith('repo-') && f.endsWith('.json')) : [];
+    const stateDirs = [
+      path.join(os.homedir(), '.copilot', 'hooks', 'state'),
+      path.join(process.env.CODEX_HOME || path.join(os.homedir(), '.codex'), 'devenv-ops', 'state'),
+    ];
+    const files = stateDirs.flatMap((dir) => fs.existsSync(dir)
+      ? fs.readdirSync(dir).filter((f) => f.startsWith('repo-') && f.endsWith('.json')).map((f) => path.join(dir, f))
+      : []);
     let free = 0, fleet = 0, premium = 0;
     for (const f of files) {
       try {
-        const data = JSON.parse(fs.readFileSync(path.join(stateDir, f), 'utf8'));
+        const data = JSON.parse(fs.readFileSync(f, 'utf8'));
         const lane = (data.routing && (data.routing.lane || data.routing.recommended_model)) || 'free';
         if (lane === 'fleet') fleet++; else if (lane === 'premium') premium++; else free++;
       } catch (e) { /* ignore malformed */ }

--- a/scripts/global/wiki-search.js
+++ b/scripts/global/wiki-search.js
@@ -1,14 +1,16 @@
 #!/usr/bin/env node
 'use strict';
 // wiki-search.js — Global wiki search (works from any repo)
-// Deployed to ~/.copilot/scripts/wiki-search.js
-// Usage: node ~/.copilot/scripts/wiki-search.js "your question"
+// Deployed to ~/.copilot/scripts/wiki-search.js and ~/.codex/devenv-ops/scripts/wiki-search.js
 
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 
-const WIKI_DIR = process.env.WIKI_DIR
-  || path.join(process.env.HOME || '', '.copilot', 'wiki');
+const WIKI_DIR = process.env.WIKI_DIR || [
+  path.join(process.env.HOME || '', '.copilot', 'wiki'),
+  path.join(process.env.CODEX_HOME || path.join(os.homedir(), '.codex'), 'devenv-ops', 'wiki'),
+].find((dir) => fs.existsSync(dir));
 
 function listPages() {
   const dirs = ['entities', 'concepts', 'sources', 'syntheses'];
@@ -42,7 +44,7 @@ function main() {
   }
   if (!fs.existsSync(WIKI_DIR)) {
     console.error(`❌ Wiki not found at ${WIKI_DIR}`);
-    console.error('Run: npm run deploy:apply (in devenv-ops)');
+    console.error('Run: npm run deploy:apply or npm run deploy:codex:apply (in devenv-ops)');
     process.exit(1);
   }
   const pages = listPages();


### PR DESCRIPTION
## Summary

Harden the DevEnv Ops Harness so Codex support is native, deployable, and governance-enforced rather than just design-documented.

## Linked Issue

Closes #468

## Changes

- correct Codex user skill install target to `~/.agents/skills/`
- expand Codex deploy/sync to manage `~/.codex/config.toml`, `~/.codex/hooks.json`, `~/.codex/rules/`, and namespaced assets under `~/.codex/devenv-ops/`
- make shared governance helpers runtime-aware for Codex repo scope, state, task-router, wiki lookup, and Bash tool gating
- update dashboard/router observability and wiki-search utilities to see Codex runtime state
- refresh repo docs and commands so Codex is first-class in install, contributing, and research guidance

## Role Evidence

- **Manager**: issue #468 MANAGER_HANDOFF defines scope, constraints, and acceptance checks
- **Collaborator**: implemented on `feat/468-codex-governance-hardening`; live Codex runtime deployed and smoke-tested locally
- **Admin**: pending PR merge + closeout
- **Consultant**: pending critique + terminal closeout

## Validation

- [x] `npm run lint` — clean
- [x] `npm test` — 31/31 pass
- [x] `bash scripts/deploy.sh --target codex` — dry-run clean
- [x] `bash scripts/sync.sh --dry-run --target codex` — dry-run clean
- [x] `npm run deploy:codex:apply` — live Codex runtime updated
- [x] Codex hook smoke for `session_context.py`
- [x] Repo-scope CLI smoke for `--target=both`
- [x] Docs synced to behavioral changes

## Risk

Medium: this changes the Codex install surface and shared governance helpers, but the work is isolated to Codex runtime plumbing, shared path resolution, and docs.
