### PR TITLE
feat(hooks): add global wiki root fallback to wiki_router

### DIFF
--- a/hooks/scripts/wiki_router.py
+++ b/hooks/scripts/wiki_router.py
@@ -1,6 +1,24 @@
 #!/usr/bin/env python3
 """Task-adaptive wiki context snippets for SessionStart hooks."""
+import sys
 from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from runtime_paths import wiki_candidates
+
+
+def _resolve_wiki(cwd: Path) -> Path | None:
+    """Return first valid wiki dir: local cwd/wiki, then global candidates."""
+    local = cwd / "wiki"
+    if local.is_dir():
+        return local
+    for candidate in wiki_candidates():
+        if candidate.is_dir():
+            return candidate
+    return None
 
 
 def _read(path: Path) -> str:
@@ -39,8 +57,8 @@ def _recent_from_index(index_text: str, limit: int = 3) -> str:
 
 def route_wiki_context(cwd: Path, repo_type: str, signals: list[str]) -> list[str]:
     """Return small, high-value wiki snippets based on repo signals."""
-    wiki = cwd / "wiki"
-    if not wiki.is_dir():
+    wiki = _resolve_wiki(cwd)
+    if wiki is None:
         return []
     msgs = []
     index_text = _read(wiki / "index.md")


### PR DESCRIPTION
## Summary

- `hooks/scripts/wiki_router.py`: introduces `_resolve_wiki(cwd)` helper that checks `cwd/wiki` first, then falls back to `wiki_candidates()` from `runtime_paths` — the same resolution chain used by `wiki_wisdom._find_wiki()`
- `route_wiki_context()` now returns meaningful snippets from the global wiki when no local wiki dir exists, enabling cross-repo harness usage

## Closes

Closes #404

## AC Checklist

- [x] AC1: Router resolves wiki root using same strategy as `wiki_wisdom` — uses `wiki_candidates()` from `runtime_paths`
- [x] AC2: SessionStart adaptive snippets work when cwd has no wiki dir — validated with temp dir, returns global wiki content
- [x] AC3: Existing behavior for local wiki repos is preserved — local `cwd/wiki` checked first
- [x] AC4: lint passes — `npm run lint` green, 287 files, file is 83 lines (≤100)

## Risk

Low. Additive change only — no existing call sites modified. Falls back gracefully when all candidates are absent (returns `None` → empty list).