### PR TITLE
feat(scripts): Layer 2 local judge gate for cascade dispatch #501

### DIFF
--- a/scripts/global/cascade-dispatch.js
+++ b/scripts/global/cascade-dispatch.js
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 'use strict';
-// Cascade dispatch: Ollama (free) → quality gate → escalation signal.
-// Implements FrugalGPT-style adequacy scoring for 3-tier cost routing.
+// Cascade dispatch: Ollama → heuristic gate → judge gate → escalation signal.
 
 const { chatComplete: ollamaChat, healthCheck } = require('./ollama-direct');
 const { recordTelemetry } = require('./model-routing-telemetry');
 const { getProfile } = require('./fleet-config');
-
-const DEFAULTS = { minLength: 30, timeoutMs: 8000 };
+const { judgeResponse } = require('./local-judge');
+const policy = require('./model-routing-policy.json');
 
 function hints(prompt) {
   const t = prompt.toLowerCase();
@@ -19,8 +18,7 @@ function hints(prompt) {
 }
 
 function assessQuality(content, h) {
-  if (!content || content.trim().length < DEFAULTS.minLength)
-    return { pass: false, reason: 'too_short' };
+  if (!content || content.trim().length < 30) return { pass: false, reason: 'too_short' };
   if (h.expectsCode && !/`|function|def |class |=>|const |let |var /.test(content))
     return { pass: false, reason: 'no_code_structure' };
   if (h.expectsJson) {
@@ -31,7 +29,7 @@ function assessQuality(content, h) {
   return { pass: true, reason: 'ok' };
 }
 
-async function tryOllama(prompt, model, timeoutMs) {
+async function tryOllama(prompt, model) {
   const health = await healthCheck();
   if (!health.ok) return { ok: false, reason: 'ollama_unreachable', tier: 'local' };
   const result = await ollamaChat(prompt, { model, maxTokens: 1024 });
@@ -43,9 +41,7 @@ async function cascade(prompt, opts = {}) {
   const model = opts.model || 'qwen2.5:7b-instruct';
   const h = hints(prompt);
   const start = Date.now();
-
-  // Tier 1: local Ollama
-  const local = await tryOllama(prompt, model, opts.timeoutMs || DEFAULTS.timeoutMs);
+  const local = await tryOllama(prompt, model);
   const latency = Date.now() - start;
 
   if (!local.ok) {
@@ -56,16 +52,27 @@ async function cascade(prompt, opts = {}) {
   }
 
   const quality = assessQuality(local.content, h);
-  recordTelemetry({ lane: 'fleet', model, outcome: quality.pass ? 'ok' : 'escalate',
-    escalation: quality.pass ? null : 'haiku', quality_reason: quality.reason,
-    response_length: local.content.length, latency_ms: latency, execute: true });
-
   if (!quality.pass) {
+    recordTelemetry({ lane: 'fleet', model, outcome: 'escalate', escalation: 'haiku',
+      quality_reason: quality.reason, response_length: local.content.length,
+      latency_ms: latency, execute: true });
     return { ok: true, content: local.content, tier: 'local', confidence: 'low',
       escalation_needed: true, suggested_tier: 'haiku', quality_reason: quality.reason };
   }
-  return { ok: true, content: local.content, tier: 'local',
-    confidence: 'high', escalation_needed: false, model };
+
+  // Layer 2: judge gate (semantic quality, independent model)
+  const jcfg = policy.judge;
+  const j = jcfg?.enabled ? await judgeResponse(prompt, local.content, { threshold: jcfg.threshold }) : null;
+  const judgePass = !j || !j.ok || j.decision === 'return';
+  recordTelemetry({ lane: 'fleet', model, outcome: judgePass ? 'ok' : 'escalate',
+    escalation: judgePass ? null : 'haiku', quality_reason: quality.reason,
+    ...(j?.ok && { judge_model: j.judge_model, judge_score: j.judge_score, judge_decision: j.decision }),
+    response_length: local.content.length, latency_ms: latency, execute: true });
+  if (!judgePass)
+    return { ok: true, content: local.content, tier: 'local', confidence: 'low',
+      escalation_needed: true, suggested_tier: 'haiku', quality_reason: 'judge_low_score' };
+  return { ok: true, content: local.content, tier: 'local', confidence: 'high',
+    escalation_needed: false, model };
 }
 
 async function main() {
@@ -73,9 +80,7 @@ async function main() {
   const prompt = args[args.indexOf('--prompt') + 1] || '';
   const model = args[args.indexOf('--model') + 1] || undefined;
   const json = args.includes('--json');
-
   if (!prompt) { console.error('--prompt required'); process.exit(1); }
-
   const profile = getProfile();
   if (profile.mode === 'solo') {
     const r = { ok: false, tier: 'local', escalation_needed: true,
@@ -83,11 +88,11 @@ async function main() {
     console.log(json ? JSON.stringify(r) : `escalation_needed=true reason=fleet_unavailable`);
     return;
   }
-
   const result = await cascade(prompt, { model });
   if (json) { console.log(JSON.stringify(result, null, 2)); return; }
   if (result.ok) console.log(result.content);
-  if (result.escalation_needed) process.stderr.write(`[cascade] escalate→${result.suggested_tier}: ${result.reason || result.quality_reason}\n`);
+  if (result.escalation_needed)
+    process.stderr.write(`[cascade] escalate→${result.suggested_tier}: ${result.reason || result.quality_reason}\n`);
 }
 
 if (require.main === module) main().catch(e => { console.error(e.message); process.exit(1); });

--- a/scripts/global/local-judge.js
+++ b/scripts/global/local-judge.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+'use strict';
+// Layer 2 judge gate — semantic quality assessment using an independent local model.
+// Uses phi3:mini (Phi-3 family, architecturally independent from qwen2.5 generator).
+
+const { chatComplete } = require('./ollama-direct');
+
+const JUDGE_MODEL = process.env.JUDGE_MODEL || 'phi3:mini';
+const DEFAULT_THRESHOLD = 0.7;
+
+const RUBRIC = `You are a quality judge for AI responses. Score the response 0.0–1.0.
+Scoring guide: 1.0=complete and accurate; 0.7=adequate; 0.5=partial; 0.3=poor; 0.0=wrong/incoherent.
+Respond ONLY with JSON: {"score": 0.X, "reason": "one sentence"}
+
+Task: {TASK}
+Response: {RESPONSE}`;
+
+function buildPrompt(task, response) {
+  return RUBRIC
+    .replace('{TASK}', task.slice(0, 400))
+    .replace('{RESPONSE}', response.slice(0, 600));
+}
+
+function parseScore(content) {
+  const m = content.match(/\{[^}]*"score"\s*:\s*([\d.]+)[^}]*\}/);
+  if (!m) return null;
+  const s = parseFloat(m[1]);
+  return isNaN(s) ? null : Math.max(0, Math.min(1, s));
+}
+
+async function judgeResponse(task, response, opts = {}) {
+  const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
+  const start = Date.now();
+  const result = await chatComplete(buildPrompt(task, response), {
+    model: opts.judgeModel || JUDGE_MODEL,
+    maxTokens: 80,
+  });
+  const latency_ms = Date.now() - start;
+  if (!result.ok) return { ok: false, error: result.error, latency_ms };
+
+  const judge_score = parseScore(result.content);
+  if (judge_score === null)
+    return { ok: false, error: 'unparseable_score', raw: result.content.slice(0, 80), latency_ms };
+
+  const decision = judge_score >= threshold ? 'return' : 'escalate';
+  const rm = result.content.match(/"reason"\s*:\s*"([^"]+)"/);
+  return {
+    ok: true,
+    judge_model: opts.judgeModel || JUDGE_MODEL,
+    judge_score,
+    decision,
+    reason: rm?.[1] || '',
+    latency_ms,
+  };
+}
+
+module.exports = { judgeResponse, JUDGE_MODEL, DEFAULT_THRESHOLD };

--- a/scripts/global/model-routing-policy.json
+++ b/scripts/global/model-routing-policy.json
@@ -59,11 +59,12 @@
     }
   },
   "judge": {
-    "_doc": "Layer 2 local judge gate. phi3:mini as independent judge (Phi-3 family, different arch from qwen2.5 generator). Selene-1-Mini unavailable in Ollama registry as of 2026-04-26.",
-    "enabled": true,
+    "_doc": "Layer 2 judge gate. Disabled: CPU inference on windows-laptop yields ~10s latency (AC7 needs ≤800ms). Enable when GPU confirmed. phi3:mini is the model; llama3.1:8b is now also available.",
+    "enabled": false,
     "model": "phi3:mini",
     "threshold": 0.7,
-    "fallback_on_error": true
+    "fallback_on_error": true,
+    "requires_gpu": true
   },
   "rollback": {
     "enabled": true,

--- a/scripts/global/model-routing-policy.json
+++ b/scripts/global/model-routing-policy.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "defaultLane": "free",
   "taskClasses": {
     "routine": ["search", "grep", "read", "docs", "simple", "list", "find"],
@@ -57,6 +57,13 @@
       "structuralValidation": true,
       "confidenceLevels": { "high": "return", "low": "escalate_to_haiku" }
     }
+  },
+  "judge": {
+    "_doc": "Layer 2 local judge gate. phi3:mini as independent judge (Phi-3 family, different arch from qwen2.5 generator). Selene-1-Mini unavailable in Ollama registry as of 2026-04-26.",
+    "enabled": true,
+    "model": "phi3:mini",
+    "threshold": 0.7,
+    "fallback_on_error": true
   },
   "rollback": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- Add `scripts/global/local-judge.js`: phi3:mini judge module with structured rubric, score parsing (0.0–1.0), and configurable threshold
- Update `cascade-dispatch.js`: integrate Layer 2 judge after heuristic gate; log judge_model, judge_score, judge_decision in telemetry
- Update `model-routing-policy.json` v2.1.0: add `judge` config block

## Model selection decision (AC1)

Selene-1-Mini: NOT in Ollama registry (error: 'file does not exist').  
Selected: **phi3:mini** (already installed, 3.8B, architecturally independent from qwen2.5 generator).  
Also available after incidental background pulls: llama3.1:8b (potential upgrade).

## AC7 deviation

CPU inference on windows-laptop yields ~10s per judgment call (target: ≤800ms). Judge is implemented and tested but **disabled by default** (`judge.enabled=false`) until GPU acceleration is confirmed. Enable by setting `judge.enabled=true` in `model-routing-policy.json`.

## Test plan

- [x] `local-judge.js` require OK
- [x] `cascade-dispatch.js` exports correct (cascade, assessQuality, hints)
- [x] End-to-end judge test: capital-of-France query → score: 1.0, decision: return ✅
- [x] npm run lint: 321 files ≤100 lines ✅
- [x] JSON validation: model-routing-policy.json valid ✅

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-Signature: Clio Reyes
AI-Team-Model: claude-code:claude-sonnet-4-6@local
AI-Role: admin