### PR TITLE
fix(scripts): incident remediation #511

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,3 +95,5 @@ requires explicit approval before the next fires. **All baton sections require**
 `Team&Model:` / `Role:` (#485). Admin signer must differ from Collaborator (#494). PRs >10
 files or >500 LOC require a BLOCKER_NOTE (#492). Closure requires GitHub Evidence Block +
 CONSULTANT_CLOSEOUT (#493).
+
+**Admin must verify before merging**: (1) `pr-title-required` green (subject ≤60 chars, Conventional Commits); (2) `collaborator-gate` green; (3) all other required checks green. Merge with pending/failing checks is an Admin governance failure (#511).

--- a/scripts/global/cascade-dispatch.js
+++ b/scripts/global/cascade-dispatch.js
@@ -62,11 +62,12 @@ async function cascade(prompt, opts = {}) {
 
   // Layer 2: judge gate (semantic quality, independent model)
   const jcfg = policy.judge;
-  const j = jcfg?.enabled ? await judgeResponse(prompt, local.content, { threshold: jcfg.threshold }) : null;
+  const j = jcfg?.enabled ? await judgeResponse(prompt, local.content, { threshold: jcfg.threshold, judgeModel: jcfg.model }) : null;
   const judgePass = !j || !j.ok || j.decision === 'return';
   recordTelemetry({ lane: 'fleet', model, outcome: judgePass ? 'ok' : 'escalate',
     escalation: judgePass ? null : 'haiku', quality_reason: quality.reason,
-    ...(j?.ok && { judge_model: j.judge_model, judge_score: j.judge_score, judge_decision: j.decision }),
+    ...(j?.ok && { judge_model: j.judge_model, judge_score: j.judge_score,
+      judge_decision: j.decision, judge_latency_ms: j.latency_ms }),
     response_length: local.content.length, latency_ms: latency, execute: true });
   if (!judgePass)
     return { ok: true, content: local.content, tier: 'local', confidence: 'low',

--- a/scripts/global/litellm-client.js
+++ b/scripts/global/litellm-client.js
@@ -2,9 +2,13 @@
 'use strict';
 // Unified fleet client: LiteLLM gateway (preferred) → direct Ollama (fallback).
 // Activates when LITELLM_URL env var or fleet-config OpenClaw URL resolves.
+// Uses named LiteLLM route groups to trigger fallback chain from litellm-config.yaml.
 
 const { chatComplete: ollamaChat, healthCheck: ollamaHealth } = require('./ollama-direct');
 const { getOpenClawURL } = require('./fleet-config');
+
+// Map Ollama model IDs to LiteLLM named groups (triggers fallback chain).
+const NAMED_GROUPS = { 'qwen2.5:7b-instruct': 'fleet-primary', 'mistral:latest': 'fleet-fallback' };
 
 function getLiteLLMUrl() {
   return process.env.LITELLM_URL || getOpenClawURL();
@@ -13,7 +17,7 @@ function getLiteLLMUrl() {
 async function litellmChat(prompt, opts = {}) {
   const url = opts.url || getLiteLLMUrl();
   if (!url) return { ok: false, error: 'no_litellm_url' };
-  const model = opts.model ? `ollama/${opts.model}` : 'ollama/qwen2.5:7b-instruct';
+  const model = opts.litellmModel || NAMED_GROUPS[opts.model] || 'fleet-primary';
   const body = JSON.stringify({
     model,
     messages: [{ role: 'user', content: prompt }],


### PR DESCRIPTION
## Summary

- Fix 3 code bugs from Codex review of session 2026-04-26
- Harden Admin merge contract in CONTRIBUTING.md

## Code fixes

- **cascade-dispatch.js**: pass `judgeModel: jcfg.model` so policy config is honored (#512); emit `judge_latency_ms` in telemetry (#512)
- **litellm-client.js**: replace `ollama/<model>` bypass with `NAMED_GROUPS` mapping → defaults to `fleet-primary` named route group, enabling LiteLLM fallback chain (#513)

## Governance fixes (already applied directly, not in code)

- Removed stale `status:ready` from closed #506
- Created follow-up tickets #512 (judge bugs), #513 (litellm + deploy)
- Updated Admin merge contract in CONTRIBUTING.md
- Added memory: Admin must verify all required checks before merge

## Test plan

- [x] `cascade-dispatch.js` loads OK; 100 lines exactly ✅
- [x] `litellm-client.js` loads OK; 64 lines ✅
- [x] Bug fixes verified: judgeModel passed, judge_latency_ms emitted, NAMED_GROUPS present ✅
- [x] npm run lint: all files ≤100 lines ✅

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)