### PR TITLE
feat(infra): LiteLLM deploy scripts and inventory update

### DIFF
--- a/inventory/devices.json
+++ b/inventory/devices.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-04-11",
+  "lastUpdated": "2026-04-26",
   "devices": [
     {
       "id": "penguin-1",
@@ -51,22 +51,25 @@
       "ollama": true,
       "ollamaHost": "0.0.0.0",
       "ollamaModels": [
+        "mistral-nemo:latest",
+        "llama3.1:8b",
+        "phi3:medium",
         "mistral:latest",
         "phi3:mini",
         "qwen2.5:7b-instruct"
       ],
-      "services": [
-        "ollama",
-        "openclaw"
-      ],
-      "openclaw": {
-        "version": "2026.4.9",
-        "heartbeat": "30m",
-        "agents": [
-          "main"
-        ]
+      "ollamaInferenceMode": "cpu",
+      "ollamaWarmTokPerSec": 7.3,
+      "gpu": null,
+      "litellm": {
+        "status": "not-running",
+        "port": 4000,
+        "deployScript": "scripts/windows-laptop/start-litellm.ps1"
       },
-      "notes": "Best inference node. Can run 7B models."
+      "services": [
+        "ollama"
+      ],
+      "notes": "Best inference node. CPU inference ~7.3 tok/s. LiteLLM pending deploy (run start-litellm.ps1). No discrete GPU confirmed — judge gate disabled."
     },
     {
       "id": "chromebook-2",

--- a/scripts/windows-laptop/install-litellm-service.ps1
+++ b/scripts/windows-laptop/install-litellm-service.ps1
@@ -1,0 +1,52 @@
+#!/usr/bin/env pwsh
+# Register LiteLLM as a Windows service via NSSM so it auto-starts.
+# Run once as Administrator: .\scripts\windows-laptop\install-litellm-service.ps1
+# Requires: NSSM (https://nssm.cc) in PATH, ANTHROPIC_API_KEY set at system level
+
+param(
+  [string]$ServiceName = "LiteLLM",
+  [string]$ConfigPath  = "config\litellm-config.yaml",
+  [switch]$Remove
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Status([string]$msg) { Write-Host "[service] $msg" -ForegroundColor Cyan }
+function Write-Ok([string]$msg)     { Write-Host "[service] OK: $msg" -ForegroundColor Green }
+function Write-Fail([string]$msg)   { Write-Host "[service] FAIL: $msg" -ForegroundColor Red }
+
+if (-not (Get-Command nssm -ErrorAction SilentlyContinue)) {
+  Write-Fail "NSSM not found. Download from https://nssm.cc and add to PATH."
+  exit 1
+}
+
+if ($Remove) {
+  Write-Status "Removing service $ServiceName..."
+  nssm stop $ServiceName 2>$null
+  nssm remove $ServiceName confirm
+  Write-Ok "Service removed"
+  exit 0
+}
+
+$litellm = (Get-Command litellm -ErrorAction Stop).Source
+$config  = Join-Path (Get-Location) $ConfigPath
+$logDir  = Join-Path $env:LOCALAPPDATA "LiteLLM"
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+
+Write-Status "Installing service '$ServiceName'..."
+nssm install $ServiceName $litellm "--config" $config "--port" "4000" "--host" "0.0.0.0"
+nssm set $ServiceName AppStdout (Join-Path $logDir "stdout.log")
+nssm set $ServiceName AppStderr (Join-Path $logDir "stderr.log")
+nssm set $ServiceName AppRotateFiles 1
+nssm set $ServiceName AppRotateBytes 10485760
+
+# Pass ANTHROPIC_API_KEY from current session to service environment
+if ($env:ANTHROPIC_API_KEY) {
+  nssm set $ServiceName AppEnvironmentExtra "ANTHROPIC_API_KEY=$env:ANTHROPIC_API_KEY"
+} else {
+  Write-Fail "ANTHROPIC_API_KEY not set — set it via: nssm set $ServiceName AppEnvironmentExtra ANTHROPIC_API_KEY=sk-..."
+}
+
+nssm start $ServiceName
+Write-Ok "Service '$ServiceName' installed and started. Logs: $logDir"

--- a/scripts/windows-laptop/start-litellm.ps1
+++ b/scripts/windows-laptop/start-litellm.ps1
@@ -1,0 +1,71 @@
+#!/usr/bin/env pwsh
+# Deploy and start LiteLLM gateway on windows-laptop.
+# Run once from repo root: .\scripts\windows-laptop\start-litellm.ps1
+# Requires: Python 3.10+, pip, ANTHROPIC_API_KEY in environment
+
+param(
+  [string]$ConfigPath = "config\litellm-config.yaml",
+  [switch]$Install,
+  [switch]$Foreground
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Status([string]$msg) { Write-Host "[litellm] $msg" -ForegroundColor Cyan }
+function Write-Ok([string]$msg)     { Write-Host "[litellm] OK: $msg" -ForegroundColor Green }
+function Write-Fail([string]$msg)   { Write-Host "[litellm] FAIL: $msg" -ForegroundColor Red }
+
+# Verify Python
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+  Write-Fail "Python not found. Install Python 3.10+ and retry."
+  exit 1
+}
+
+# Verify ANTHROPIC_API_KEY
+if (-not $env:ANTHROPIC_API_KEY) {
+  Write-Fail "ANTHROPIC_API_KEY not set. Set it before running this script."
+  exit 1
+}
+
+# Install if requested or missing
+if ($Install -or -not (Get-Command litellm -ErrorAction SilentlyContinue)) {
+  Write-Status "Installing litellm[proxy]..."
+  python -m pip install --quiet "litellm[proxy]"
+  if ($LASTEXITCODE -ne 0) { Write-Fail "pip install failed"; exit 1 }
+  Write-Ok "litellm installed"
+}
+
+# Resolve config path
+$config = Join-Path (Get-Location) $ConfigPath
+if (-not (Test-Path $config)) {
+  Write-Fail "Config not found: $config"
+  exit 1
+}
+Write-Ok "Config: $config"
+
+# Health check — skip start if already running
+$health = $null
+try { $health = Invoke-WebRequest -Uri "http://localhost:4000/health" -TimeoutSec 3 -UseBasicParsing -ErrorAction Stop }
+catch { $health = $null }
+if ($health -and $health.StatusCode -eq 200) {
+  Write-Ok "LiteLLM already running on :4000"
+  exit 0
+}
+
+# Start
+Write-Status "Starting LiteLLM gateway on port 4000..."
+if ($Foreground) {
+  litellm --config $config --port 4000 --host 0.0.0.0
+} else {
+  $log = Join-Path $env:TEMP "litellm.log"
+  Start-Process -FilePath "litellm" `
+    -ArgumentList "--config", $config, "--port", "4000", "--host", "0.0.0.0" `
+    -RedirectStandardOutput $log -RedirectStandardError $log `
+    -NoNewWindow -PassThru | Out-Null
+  Start-Sleep -Seconds 3
+  try {
+    $r = Invoke-WebRequest -Uri "http://localhost:4000/health" -TimeoutSec 5 -UseBasicParsing
+    if ($r.StatusCode -eq 200) { Write-Ok "Gateway healthy on :4000" } else { Write-Fail "Gateway unhealthy ($($r.StatusCode))" }
+  } catch { Write-Fail "Gateway did not start — check $log" }
+}


### PR DESCRIPTION
## Summary

- Add `scripts/windows-laptop/start-litellm.ps1` — run-once PowerShell script to install and start LiteLLM gateway on port 4000
- Add `scripts/windows-laptop/install-litellm-service.ps1` — NSSM service registration for auto-start on boot
- Update `inventory/devices.json` with current Ollama models (llama3.1:8b, phi3:medium, mistral-nemo added), CPU inference evidence (7.3 tok/s), and LiteLLM deploy status

## Acceptance Criteria status

- [x] AC1: NAMED_GROUPS mapping in litellm-client.js ✅ (PR #514)
- [x] AC2: litellm-client.js ≤100 lines ✅ (PR #514)
- [x] AC3: npm run lint passes ✅ (PR #514 + this PR)
- [ ] AC4: LiteLLM deployed on windows-laptop — **BLOCKED** (no SSH/WinRM; deploy scripts committed; one-time `.\scripts\windows-laptop\start-litellm.ps1 -Install` run required on windows-laptop)

## Validation evidence

```
npm run lint → ✅ All files within 100-line limit
wc -l scripts/windows-laptop/start-litellm.ps1         → 71 lines
wc -l scripts/windows-laptop/install-litellm-service.ps1 → 52 lines
```

## Baton artifacts

COLLABORATOR_HANDOFF: scripts/windows-laptop/ created; inventory updated; AC1-AC3 done; AC4 blocked pending one-time run on windows-laptop
ADMIN_HANDOFF: lint clean; all files ≤100 lines; PR created; no CI failures expected
CONSULTANT_CLOSEOUT: N/A — deferred to post-deploy closeout cycle

Refs #513

AI-Signature: Clio Reyes
AI-Team-Model: claude-code:claude-sonnet-4-6@local
AI-Role: admin