### PR TITLE
feat(infra): governance compliance — templates, auto-label, visual QA

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a defect in dashboard, hooks, scripts, or agents
-labels: ["type:bug", "status:backlog", "area:dashboard", "priority:P2"]
+labels: ["type:bug", "status:backlog", "priority:P2"]
 body:
   - type: input
     id: summary

--- a/.github/ISSUE_TEMPLATE/task-request.yml
+++ b/.github/ISSUE_TEMPLATE/task-request.yml
@@ -1,6 +1,6 @@
 name: Task
 description: Request a feature, improvement, or work item
-labels: ["type:task", "status:backlog", "area:dashboard", "priority:P2"]
+labels: ["type:task", "status:backlog", "priority:P2"]
 body:
   - type: input
     id: summary

--- a/.github/workflows/auto-label-area.yml
+++ b/.github/workflows/auto-label-area.yml
@@ -1,0 +1,54 @@
+name: Auto-label area (ADR-010)
+# Parses the Area dropdown from issue body on open and applies the correct area:* label.
+# Removes any stale area:* labels left by templates before applying the correct one.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  auto-label-area:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply area label from form dropdown
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const num   = context.payload.issue.number;
+            const body  = context.payload.issue.body || '';
+
+            // Parse area dropdown — GitHub forms render: "### Area\n\n<value>"
+            const match = body.match(/###\s*Area\s*\n+([^\n#]+)/i);
+            const area  = match ? match[1].trim().toLowerCase() : null;
+
+            const areaMap = {
+              'dashboard':      'area:dashboard',
+              'hooks':          'area:hooks',
+              'skills':         'area:skills',
+              'instructions':   'area:instructions',
+              'agents':         'area:agents',
+              'scripts':        'area:scripts',
+              'infrastructure': 'area:infra',
+            };
+
+            const targetLabel = area ? areaMap[area] : null;
+            if (!targetLabel) {
+              console.log(`No area dropdown found or unrecognised value "${area}" — skipping`);
+              return;
+            }
+
+            // Remove stale area:* labels (e.g. area:dashboard hardcoded in old templates)
+            const issue = (await github.rest.issues.get({ owner, repo, issue_number: num })).data;
+            const stale = issue.labels.map(l => l.name).filter(l => l.startsWith('area:') && l !== targetLabel);
+            for (const l of stale) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: num, name: l }).catch(() => {});
+            }
+
+            await github.rest.issues.addLabels({ owner, repo, issue_number: num, labels: [targetLabel] });
+            console.log(`Applied ${targetLabel} to #${num}`);

--- a/.github/workflows/label-lint.yml
+++ b/.github/workflows/label-lint.yml
@@ -44,6 +44,12 @@ jobs:
             if (statusLabels.includes('status:triage') && !roleLabels.includes('role:manager')) {
               violations.push('**Rule 5**: `status:triage` issues must have `role:manager`. Epics always carry this label.');
             }
+            const areaLabels = labels.filter(l => l.startsWith('area:'));
+            if (areaLabels.length === 0) {
+              violations.push('**Rule 6**: No `area:` label found. Every issue must have exactly one `area:*` label (auto-label-area.yml applies it on open).');
+            } else if (areaLabels.length > 1) {
+              violations.push(`**Rule 6**: Multiple \`area:\` labels found: ${areaLabels.join(', ')}. Only one is allowed.`);
+            }
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number: issueNum, per_page: 100,
             });

--- a/tests/visual-governance.spec.js
+++ b/tests/visual-governance.spec.js
@@ -1,0 +1,96 @@
+const { test, expect } = require('@playwright/test');
+
+const BATON_STUB = {
+  tickets: [{
+    issue: 42, title: 'Test ticket', status: 'in-progress',
+    agent: 'Clio Harper', model: 'claude-sonnet-4-6',
+    steps: [{ id: 'manager', label: 'Manager', done: true },
+            { id: 'collaborator', label: 'Collaborator', active: true }],
+  }],
+};
+
+async function goLive(page) {
+  await page.route('**/api/baton', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(BATON_STUB) })
+  );
+  await page.goto('/');
+  const btn = page.locator('button[title="Live"]');
+  if (await btn.count() > 0) await btn.click();
+  await page.waitForTimeout(400);
+}
+
+test.describe('Visual governance — baton rows', () => {
+  test('rows have positive height (not clipped)', async ({ page }) => {
+    await goLive(page);
+    const rows = page.locator('.baton-row');
+    const count = await rows.count();
+    for (let i = 0; i < count; i++) {
+      const box = await rows.nth(i).boundingBox();
+      expect(box).not.toBeNull();
+      expect(box.height).toBeGreaterThan(0);
+      expect(box.width).toBeGreaterThan(0);
+    }
+  });
+
+  test('rows are within viewport bounds', async ({ page }) => {
+    await goLive(page);
+    const rows = page.locator('.baton-row');
+    const count = await rows.count();
+    const vp = page.viewportSize();
+    for (let i = 0; i < count; i++) {
+      const box = await rows.nth(i).boundingBox();
+      if (!box) continue;
+      expect(box.y).toBeGreaterThanOrEqual(0);
+      expect(box.x + box.width).toBeLessThanOrEqual(vp.width + 1);
+    }
+  });
+});
+
+test.describe('Visual governance — context flow layout', () => {
+  test('SVG renders with positive dimensions', async ({ page }) => {
+    await goLive(page);
+    const svg = page.locator('.cf-svg');
+    await expect(svg).toBeVisible();
+    const box = await svg.boundingBox();
+    expect(box.width).toBeGreaterThan(100);
+    expect(box.height).toBeGreaterThan(50);
+  });
+
+  test('node rects are ≥5px inside SVG viewBox border', async ({ page }) => {
+    await goLive(page);
+    const rects = await page.locator('.cf-svg .cf-node-g rect').evaluateAll(ns =>
+      ns.map(n => ({
+        x: parseFloat(n.getAttribute('x') || '0'),
+        y: parseFloat(n.getAttribute('y') || '0'),
+        w: parseFloat(n.getAttribute('width') || '0'),
+        h: parseFloat(n.getAttribute('height') || '0'),
+      }))
+    );
+    expect(rects.length).toBeGreaterThan(0);
+    for (const r of rects) {
+      expect(r.x).toBeGreaterThanOrEqual(5);
+      expect(r.y).toBeGreaterThanOrEqual(5);
+      expect(r.x + r.w).toBeLessThanOrEqual(620);
+      expect(r.y + r.h).toBeLessThanOrEqual(260);
+    }
+  });
+
+  test('cf-sub labels are within parent node rect Y range', async ({ page }) => {
+    await goLive(page);
+    const groups = await page.locator('.cf-svg').evaluateHandle(svg => {
+      return [...svg.querySelectorAll('.cf-node-g')].map(g => {
+        const rect = g.querySelector('rect');
+        const rectY = parseFloat(rect?.getAttribute('y') || '0');
+        const rectH = parseFloat(rect?.getAttribute('height') || '0');
+        const subYs = [...g.querySelectorAll('.cf-sub')].map(s => parseFloat(s.getAttribute('y') || '0'));
+        return { rectY, rectH, subYs };
+      });
+    });
+    for (const g of await groups.jsonValue()) {
+      for (const sy of g.subYs) {
+        expect(sy).toBeGreaterThanOrEqual(g.rectY - 2);
+        expect(sy).toBeLessThanOrEqual(g.rectY + g.rectH + 2);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

**Child #A (#528)** — Issue template area label fix:
- Remove hardcoded `area:dashboard` from `task-request.yml` and `bug-report.yml` default labels
- Add `auto-label-area.yml` workflow: parses area dropdown on `issues: [opened]`, applies correct `area:*` label, removes stale defaults
- Add Rule 6 to `label-lint.yml`: every issue must have exactly one `area:*` label

**Child #B (#529)** — Playwright visual governance tests:
- Add `tests/visual-governance.spec.js` with 5 assertions:
  - Baton rows have `height > 0` (not clipped)
  - Baton rows within viewport bounds
  - Context flow SVG renders with positive dimensions
  - Node rects are ≥5px from SVG viewBox border (620×260)
  - `.cf-sub` label Y positions are within parent rect Y range

## Validation evidence

```
npm run lint → ✅ All files within 100-line limit
wc -l tests/visual-governance.spec.js → 97 lines
wc -l .github/workflows/auto-label-area.yml → 54 lines
wc -l .github/workflows/label-lint.yml → 86 lines
```

## Acceptance Criteria status

### #528
- [x] AC1: area:dashboard removed from task and bug template labels
- [x] AC2: auto-label-area.yml added — parses area dropdown, applies area:* on open
- [x] AC3: label-lint.yml Rule 6 added — exactly one area:*
- [x] AC4: npm run lint passes; all files ≤100 lines

### #529
- [x] AC1: visual-governance.spec.js with baton row, SVG border, cf-sub assertions
- [x] AC2: Tests use mocked baton stub via route interception
- [x] AC3: npm run lint passes; file ≤100 lines

## Baton artifacts

COLLABORATOR_HANDOFF: all ACs implemented; lint clean; templates fixed; workflow added; tests added
ADMIN_HANDOFF: lint ✅; all files ≤100 lines; PR created; ready for merge
CONSULTANT_CLOSEOUT: N/A — see Consultant closeout comments on tickets

Refs #528
Refs #529
Refs #397

AI-Signature: Clio Reyes
AI-Team-Model: claude-code:claude-sonnet-4-6@local
AI-Role: admin