### PR TITLE
fix(dashboard): remove Fleet Resources scroll; expand to full width

### DIFF
--- a/dashboard/css/settings.css
+++ b/dashboard/css/settings.css
@@ -1,7 +1,14 @@
 /* Settings Panel — fleet resource management */
-.settings-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.settings-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; table-layout: fixed; }
 .settings-table th { text-align: left; padding: 6px 8px; border-bottom: 2px solid var(--border); }
-.settings-table td { padding: 6px 8px; border-bottom: 1px solid var(--border); }
+.settings-table th:nth-child(1) { width: 18%; }
+.settings-table th:nth-child(2) { width: 13%; }
+.settings-table th:nth-child(3) { width: 8%; }
+.settings-table th:nth-child(4) { width: 24%; }
+.settings-table th:nth-child(5) { width: 13%; }
+.settings-table th:nth-child(6) { width: 10%; }
+.settings-table th:nth-child(7) { width: 9%; }
+.settings-table td { padding: 6px 8px; border-bottom: 1px solid var(--border); overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 .settings-row:hover { background: var(--hover-bg, rgba(255,255,255,0.05)); }
 .settings-actions { display: flex; gap: 8px; margin-top: 12px; flex-wrap: wrap; }
 .settings-actions button, .btn-label {

--- a/dashboard/css/views.css
+++ b/dashboard/css/views.css
@@ -72,7 +72,7 @@
 .view-live { grid-template-columns: 1fr 1fr; grid-template-rows: 1fr auto; }
 .view-logs { grid-template-columns: 1fr; grid-template-rows: 1fr 1fr; }
 .view-fleet { grid-template-columns: 1fr 1fr; }
-#panel-settings { grid-row: span 2; }
+#panel-settings { grid-column: 1 / -1; }
 #panel-devices > div, #panel-services > div { max-height: 12rem; }
 .view-ops { grid-template-columns: 1fr 1fr; grid-template-rows: auto auto auto; }
 .view-wiki { grid-template-columns: 1fr 2fr; } .view-help { grid-template-columns: 1fr; }

--- a/dashboard/js/settings-panel.js
+++ b/dashboard/js/settings-panel.js
@@ -12,7 +12,7 @@ function renderSettingsPanel(resources, probeResults, hostInfo) {
     return `<tr class="settings-row">
       <td><span class="dot dot-${cls}"></span> ${esc(r.name)}</td>
       <td>${esc(r.provider)}</td><td>${esc(r.tier)}</td>
-      <td>${esc(r.baseUrl)}</td><td>${authBadge}</td><td>${st}</td>
+      <td title="${esc(r.baseUrl)}">${esc(r.baseUrl)}</td><td>${authBadge}</td><td>${st}</td>
       <td><button onclick="editResource('${r.id}')">✏️</button>
        <button onclick="removeResource('${r.id}')">🗑️</button></td>
     </tr>`;


### PR DESCRIPTION
## Summary

- **#332**: Add `table-layout: fixed` + explicit column-width `<th>` rules + `overflow:hidden; text-overflow:ellipsis; white-space:nowrap` on all `<td>` cells. URL column gets `title` attribute for full-value hover. Eliminates horizontal scrollbar at any viewport ≥640px.
- **#333**: Replace `#panel-settings { grid-row: span 2 }` with `grid-column: 1 / -1`. Panel now spans full dashboard width instead of one column (~50%). Other fleet panels (devices, services, config) auto-place correctly in the remaining rows.

## Validation evidence

```
npm run lint  → ✅ all files ≤100 lines
settings.css  → 36 lines
settings-panel.js → 78 lines
views.css     → 97 lines
```

## Baton artifacts

COLLABORATOR_HANDOFF: AC1-AC4 (#332) ✅; AC1-AC3 (#333) ✅; lint clean; URL title attr added
ADMIN_HANDOFF: lint ✅; PR created; CI pending
CONSULTANT_CLOSEOUT: N/A — see issue closeout comments

Refs #332
Refs #333
Refs #331

AI-Signature: Clio Reyes
AI-Team-Model: claude-code:claude-sonnet-4-6@local
AI-Role: admin