### PR TITLE
feat(infra): add branch protection integrity canary #546

### DIFF
--- a/.github/workflows/branch-protection-canary.yml
+++ b/.github/workflows/branch-protection-canary.yml
@@ -1,0 +1,77 @@
+name: Branch Protection Canary
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  push:
+    branches: [main]
+    paths: ['.github/workflows/branch-protection-canary.yml']
+  workflow_dispatch:
+
+concurrency:
+  group: branch-protection-canary
+  cancel-in-progress: true
+
+jobs:
+  canary:
+    name: branch-protection-canary
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const REQUIRED = [
+              'collaborator-gate', 'admin-gate', 'consultant-gate',
+              'lint-required', 'pr-title-required',
+            ];
+            let protection;
+            try {
+              const r = await github.rest.repos.getBranchProtection({
+                owner: context.repo.owner, repo: context.repo.repo,
+                branch: 'main',
+              });
+              protection = r.data;
+            } catch (e) {
+              const msg = `Branch protection missing or inaccessible: ${e.message}`;
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title: '[CANARY ALERT] Branch protection absent on main',
+                body: `## Protection Regression Detected\n\n${msg}\n\nImmediate action required: re-enable via #537 procedure.`,
+                labels: ['priority:P1', 'area:infra'],
+              });
+              core.setFailed(msg);
+              return;
+            }
+            const violations = [];
+            if (!protection.enforce_admins?.enabled) {
+              violations.push('enforce_admins disabled — LLM Admin can self-approve through gates');
+            }
+            const contexts = protection.required_status_checks?.contexts ?? [];
+            const missing = REQUIRED.filter(c => !contexts.includes(c));
+            if (missing.length) {
+              violations.push(`Required checks missing: ${missing.join(', ')}`);
+            }
+            if (!protection.required_status_checks?.strict) {
+              violations.push('Branch not required to be up to date before merge');
+            }
+            if (!violations.length) {
+              console.log('Branch protection healthy. All required checks present.');
+              return;
+            }
+            const body = [
+              '## Branch Protection Regression',
+              '',
+              'The following violations were detected on `main`:',
+              '',
+              ...violations.map(v => `- ${v}`),
+              '',
+              'Restore configuration per #537 procedure immediately.',
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner, repo: context.repo.repo,
+              title: '[CANARY ALERT] Branch protection regression on main',
+              body, labels: ['priority:P1', 'area:infra'],
+            });
+            core.setFailed(`Protection violations: ${violations.join('; ')}`);


### PR DESCRIPTION
## Summary

- Adds scheduled daily canary workflow that validates `main` branch protection config
- Posts a sentinel P1 issue when protection is absent, `enforce_admins` is disabled, or required checks are missing
- Triggers on schedule (06:00 UTC), push to canary file, and manual dispatch

## Linked Issue

Refs #546

## Changes

- New `.github/workflows/branch-protection-canary.yml` — 77 lines, validates all 5 required checks

## Role Evidence

- **Manager**: MANAGER_HANDOFF posted on #546; scope from Epic #536
- **Collaborator**: COLLABORATOR_HANDOFF — all ACs for #546 satisfied; canary validates enforce_admins + all 5 required checks + strict mode; sentinel issue creation on any violation; 77 lines ≤ 100 limit
- **Admin**: ADMIN_HANDOFF — commit 45d708b; push to feat/546-branch-protection-canary; PR open; pending CI
- **Consultant**: pending

## Validation

- [ ] `npm run lint` — clean
- [ ] CI green on PR
- [ ] CHANGELOG updated

## Risk

medium — workflow file; no execution on merge; no permission escalation beyond issues:write