### PR TITLE
feat(hooks): anchor re-injection, closeout lint, corpus fix #542

### DIFF
--- a/.github/workflows/closeout-lint.yml
+++ b/.github/workflows/closeout-lint.yml
@@ -1,0 +1,57 @@
+name: Closeout Lint
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: closeout-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  closeout-schema:
+    name: closeout-schema
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const refsMatch = body.match(/Refs\s+#(\d+)/i);
+            if (!refsMatch) return; // no linked issue — baton-gates will catch missing Refs #N
+
+            const linkedIssue = parseInt(refsMatch[1]);
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: linkedIssue, per_page: 100,
+            });
+            const closeout = comments.find(c => c.body.includes('CONSULTANT_CLOSEOUT'));
+            if (!closeout) return; // not yet at closeout — baton-gates enforces existence
+
+            const text = closeout.body;
+            const violations = [];
+
+            // Required fields in CONSULTANT_CLOSEOUT
+            if (!text.includes('Signed-by:')) violations.push('Missing Signed-by field');
+            if (!text.includes('Team&Model:')) violations.push('Missing Team&Model field');
+            if (!text.includes('Role: consultant')) violations.push('Missing Role: consultant');
+
+            // Cross-team check: Team&Model in CONSULTANT_CLOSEOUT must differ from COLLABORATOR_HANDOFF
+            const collab = comments.find(c => c.body.includes('COLLABORATOR_HANDOFF'));
+            if (collab) {
+              const collabTeam = (collab.body.match(/Team&Model:\s*(\S+)/) || [])[1];
+              const closeoutTeam = (text.match(/Team&Model:\s*(\S+)/) || [])[1];
+              if (collabTeam && closeoutTeam && collabTeam === closeoutTeam) {
+                violations.push(
+                  `CONSULTANT_CLOSEOUT Team&Model (${closeoutTeam}) matches COLLABORATOR_HANDOFF — independent review requires a different team`
+                );
+              }
+            }
+
+            if (violations.length) {
+              core.warning(
+                `CONSULTANT_CLOSEOUT schema issues on issue #${linkedIssue}:\n` +
+                violations.map(v => `  - ${v}`).join('\n') +
+                '\nFix before claiming Consultant closeout complete.'
+              );
+            }

--- a/hooks/scripts/posttool_reminders.py
+++ b/hooks/scripts/posttool_reminders.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""PostToolUse hook: governance reminders for docs/release hygiene."""
+"""PostToolUse hook: governance reminders for docs/release hygiene + context re-injection."""
 import json
 import re
 import sys
@@ -11,17 +11,13 @@ if str(SCRIPT_DIR) not in sys.path:
 
 from admin_patterns import RE_GIT_COMMIT, RE_GIT_PUSH, iter_strings
 from governance_state import ensure_state, mark_tool_activity, save_state
+from precompact_anchor import ANCHOR
 from wiki_wisdom import governance_enforcement, post_merge_checklist
 
-DOC_TRIGGER_RE = re.compile(
-    r"(^|/)(README\.md|CHANGELOG\.md|docs/|\.github/workflows/|"
-    r"\.github/CONTRIBUTING\.md|\.github/PULL_REQUEST_TEMPLATE\.md|"
-    r"package\.json|pyproject\.toml|Cargo\.toml|pom\.xml|\.vscodeignore)$"
-)
-CODE_TRIGGER_RE = re.compile(
-    r"(^|/)(mem-watchdog\.sh|install\.sh|mem-watchdog\.service|"
-    r"vscode-extension/.*\.(js|ts|json)|scripts/.*\.sh|tests/.*\.sh)$"
-)
+GOVERNANCE_ANCHOR_INTERVAL = 15
+
+DOC_TRIGGER_RE = re.compile(r"(^|/)(README\.md|CHANGELOG\.md|docs/|\.github/workflows/|\.github/CONTRIBUTING\.md|\.github/PULL_REQUEST_TEMPLATE\.md|package\.json|pyproject\.toml|Cargo\.toml|pom\.xml|\.vscodeignore)$")  # noqa: E501
+CODE_TRIGGER_RE = re.compile(r"(^|/)(mem-watchdog\.sh|install\.sh|mem-watchdog\.service|vscode-extension/.*\.(js|ts|json)|scripts/.*\.sh|tests/.*\.sh)$")  # noqa: E501
 
 
 def main() -> int:
@@ -37,12 +33,20 @@ def main() -> int:
     cwd = str(payload.get("cwd", "")) or str(Path.cwd())
     state = ensure_state(cwd)
     mark_tool_activity(state, payload)
-    save_state(state)
 
     flags = state.get("flags", {})
     ops = state.get("admin_ops", {})
     repo_type = state.get("repo_type", "generic")
     messages = []
+
+    # Periodic governance anchor re-injection every N bash calls
+    if tool in {"run_in_terminal", "terminal", "runTerminalCommand", "Bash"}:
+        ctr = state.get("bash_call_ctr", 0) + 1
+        state["bash_call_ctr"] = 0 if ctr >= GOVERNANCE_ANCHOR_INTERVAL else ctr
+        if ctr >= GOVERNANCE_ANCHOR_INTERVAL:
+            messages.insert(0, f"[GOVERNANCE ANCHOR — periodic reminder] {ANCHOR}")
+
+    save_state(state)
 
     if any(DOC_TRIGGER_RE.search(v) for v in values):
         messages.append(governance_enforcement())

--- a/instructions/feature-completion-governance.instructions.md
+++ b/instructions/feature-completion-governance.instructions.md
@@ -2,23 +2,9 @@
 applyTo: "**"
 ---
 
-When asked to "complete" a feature-add (or equivalent language), completion requires all four role batons:
-
-1) Manager complete → `MANAGER_HANDOFF` emitted, `status:ready` set
-2) Collaborator complete → `COLLABORATOR_HANDOFF` emitted, `status:testing` set
-3) Admin complete → `ADMIN_HANDOFF` emitted, `status:review` set
-4) Consultant closeout → `CONSULTANT_CLOSEOUT` emitted, `status:done` set, issue closed
-
-Each role must emit its named artifact before the next role begins.
-Do not stop at "tests pass". Tests passing only closes Collaborator.
-
-## Ticket-first requirement
-
-Before any implementation begins, a GitHub issue **must** exist:
-- Manager creates via `gh issue create` or links to an existing issue.
-- All commits reference the issue (`#N`).
-- PR links to the issue with `Refs #N` in the body (not `Closes #N`).
-- Issue is closed explicitly by Consultant via `gh issue close` after CONSULTANT_CLOSEOUT — never by PR auto-close.
+When asked to "complete" a feature-add (or equivalent language), all four baton roles are required.
+Do not stop at "tests pass" — tests passing only closes Collaborator.
+See `role-baton-routing.instructions.md` for the full sequence.
 
 ## Admin completion contract (required before claiming done)
 

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -69,13 +69,13 @@ Select the lane at ticket-creation based on work type. Label the ticket `lane:do
 - docs/research: PR changes only documentation/instruction/research files — no executable code.
 - config-only: single well-understood value change; if scoping or risk analysis needed, use code-change.
 
-**Reduced-lane baton-gate compliance**: `baton-gates.yml` checks for all three artifact strings.
-For skipped roles, include an explicit N/A marker in the PR body, e.g.:
+**Reduced-lane baton-gate compliance**: `baton-gates.yml` checks for all three artifact strings
+in the **linked issue comments** (the issue referenced by `Refs #N` in the PR body).
+For skipped roles, post an N/A marker as a comment on the linked issue, e.g.:
 `COLLABORATOR_HANDOFF: N/A — docs/research lane` and `ADMIN_HANDOFF: N/A — docs/research lane`.
-The string presence satisfies the gate; the N/A suffix preserves the audit trail.
 
 **Invariants across all lanes**: Every lane requires a GitHub issue, `Refs #N` in the PR body,
-`CONSULTANT_CLOSEOUT`, and explicit N/A markers for any skipped-role artifacts.
+`CONSULTANT_CLOSEOUT` as an issue comment, and explicit N/A comments for any skipped-role artifacts.
 
 ## Trivial-task escape
 


### PR DESCRIPTION
## Summary

- Periodic governance anchor re-injection every 15 Bash calls (counter in session state)
- `closeout-lint.yml` validates CONSULTANT_CLOSEOUT schema and warns on same-team cross-check
- Instruction N/A marker guidance corrected from PR body to linked issue (required after #538)
- Removed 14-line baton sequence duplication from `feature-completion-governance.instructions.md`

## Linked Issue

Refs #542

## Changes

- `hooks/scripts/posttool_reminders.py`: anchor counter logic, imports ANCHOR; 100 lines
- `.github/workflows/closeout-lint.yml`: schema + cross-team warning; 57 lines
- `instructions/role-baton-routing.instructions.md`: N/A marker wording corrected
- `instructions/feature-completion-governance.instructions.md`: 14-line dedup removed

## Role Evidence

- **Manager**: see MANAGER_HANDOFF comments on #542, #543, #544
- **Collaborator**: see COLLABORATOR_HANDOFF comments on #542, #543, #544
- **Admin**: commit 4bfe36e; pushed; PR open; pending CI
- **Consultant**: pending

## Validation

- [ ] `npm run lint` — clean
- [ ] CI green
- [ ] CHANGELOG updated

## Risk

low — posttool hook is additive; closeout-lint emits warnings not failures; instruction changes are correctness fixes