### PR TITLE
feat(scripts): local-first routing + complexity gates #575

### DIFF
--- a/scripts/global/model-routing-engine.js
+++ b/scripts/global/model-routing-engine.js
@@ -36,14 +36,18 @@ function shouldRollback(policy) {
 function resolveRouting(prompt, route) {
   const policy = loadPolicy();
   const rollbackApplied = shouldRollback(policy);
-  const lane = rollbackApplied ? policy.rollback.forceLane : route.lane;
+  let lane = rollbackApplied ? policy.rollback.forceLane : route.lane;
+  const cx = route.complexity ?? 0.5;
+  const thresh = policy.complexityThresholds || {};
+  if (lane === 'premium' && cx < (thresh.premium ?? 0.7)) lane = cx < (thresh.haiku ?? 0.3) ? 'fleet' : 'haiku';
   const model = policy.models[lane] || policy.models.fallback;
   return {
     lane,
     modelId: model.id,
     multiplier: model.mult,
     taskClass: classifyTask(prompt, policy.taskClasses),
-    rollbackApplied
+    rollbackApplied,
+    complexity: cx
   };
 }
 

--- a/scripts/global/model-routing-policy.json
+++ b/scripts/global/model-routing-policy.json
@@ -1,6 +1,11 @@
 {
-  "version": "2.1.0",
-  "defaultLane": "free",
+  "version": "2.2.0",
+  "defaultLane": "fleet",
+  "complexityThresholds": {
+    "_doc": "Numeric complexity score gates. fleet=[0,0.3), haiku=[0.3,0.7), premium=[0.7,1.0]",
+    "haiku": 0.3,
+    "premium": 0.7
+  },
   "taskClasses": {
     "routine": ["search", "grep", "read", "docs", "simple", "list", "find"],
     "coding": ["implement", "refactor", "tests", "integration", "generate", "config"],

--- a/scripts/global/task-router.js
+++ b/scripts/global/task-router.js
@@ -7,6 +7,7 @@ const policyPath = path.join(__dirname, 'task-router-policy.json');
 const inventoryPath = path.join(__dirname, '..', '..', 'inventory', 'devices.json');
 const policy = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
 const inventory = JSON.parse(fs.readFileSync(inventoryPath, 'utf8'));
+const aiRules = require('../../inventory/ai-models.json').optimizationStrategy || {};
 
 function score(prompt, list) {
   const text = String(prompt || '').toLowerCase();
@@ -56,11 +57,15 @@ function classifyPrompt(prompt) {
   if (totals.premium >= 2 && totals.premium >= totals.fleet) lane = 'premium';
   else if (totals.fleet >= fleetMin) lane = 'fleet';
   else if (totals.free >= 2) lane = 'free';
+  const totalScore = Object.values(totals).reduce((s, v) => s + v, 0) + 0.01;
+  const complexity = +(Math.min(1.0, totals.premium / totalScore)).toFixed(2);
+  if (aiRules.rule3 && complexity < 0.7 && lane === 'premium') lane = 'fleet';
   const selected = policy.lanes[lane];
   const target = lane === 'fleet' ? pickFleetTarget(prompt) : null;
   const confidence = lane === 'free' && free < 2 ? 'medium' : 'high';
   return {
     lane,
+    complexity,
     backend: selected.backend,
     recommendedModel: selected.recommendedModel,
     targetDevice: target?.targetDevice || null,

--- a/tests/routing-policy.spec.js
+++ b/tests/routing-policy.spec.js
@@ -1,0 +1,73 @@
+// Complexity threshold boundary tests — #575
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const { resolveRouting } = require(path.join(__dirname, '../scripts/global/model-routing-engine'));
+const { classifyPrompt } = require(path.join(__dirname, '../scripts/global/task-router'));
+
+// AC2: complexityThresholds present and configurable in model-routing-policy.json
+test('model-routing-policy has configurable complexityThresholds', () => {
+  const policy = require(path.join(__dirname, '../scripts/global/model-routing-policy.json'));
+  expect(typeof policy.complexityThresholds).toBe('object');
+  expect(typeof policy.complexityThresholds.haiku).toBe('number');
+  expect(typeof policy.complexityThresholds.premium).toBe('number');
+  expect(policy.complexityThresholds.haiku).toBeLessThan(policy.complexityThresholds.premium);
+});
+
+// AC1: default lane is fleet
+test('model-routing-policy defaultLane is fleet', () => {
+  const policy = require(path.join(__dirname, '../scripts/global/model-routing-policy.json'));
+  expect(policy.defaultLane).toBe('fleet');
+});
+
+// AC3: classifyPrompt emits complexity: 0.0–1.0
+test('classifyPrompt emits numeric complexity in [0, 1]', () => {
+  const r = classifyPrompt('implement a function to parse JSON');
+  expect(typeof r.complexity).toBe('number');
+  expect(r.complexity).toBeGreaterThanOrEqual(0);
+  expect(r.complexity).toBeLessThanOrEqual(1);
+});
+
+// AC4: ai-models.json rule3 enforced — low-complexity tasks do not route to premium
+test('rule3: low-complexity task forced from premium to fleet', () => {
+  const route = { lane: 'premium', complexity: 0.1 };
+  const resolved = resolveRouting('search for files', route);
+  expect(resolved.lane).not.toBe('premium');
+  expect(['fleet', 'free']).toContain(resolved.lane);
+});
+
+// AC5 boundary: complexity < 0.3 → fleet
+test('complexity 0.29 routes to fleet (below haiku threshold)', () => {
+  const route = { lane: 'premium', complexity: 0.29 };
+  const resolved = resolveRouting('read docs', route);
+  expect(resolved.lane).toBe('fleet');
+});
+
+// AC5 boundary: complexity in [0.3, 0.7) → haiku
+test('complexity 0.35 routes to haiku (above haiku threshold, below premium)', () => {
+  const route = { lane: 'premium', complexity: 0.35 };
+  const resolved = resolveRouting('refactor a module', route);
+  expect(resolved.lane).toBe('haiku');
+});
+
+// AC5 boundary: complexity 0.69 → haiku (just below premium threshold)
+test('complexity 0.69 routes to haiku (just below premium threshold)', () => {
+  const route = { lane: 'premium', complexity: 0.69 };
+  const resolved = resolveRouting('implement feature', route);
+  expect(resolved.lane).toBe('haiku');
+});
+
+// AC5 boundary: complexity >= 0.7 → premium
+test('complexity 0.71 routes to premium (above premium threshold)', () => {
+  const route = { lane: 'premium', complexity: 0.71 };
+  const resolved = resolveRouting('architecture design risk security', route);
+  expect(resolved.lane).toBe('premium');
+});
+
+// AC4: ai-models.json optimization rules imported by task-router
+test('task-router imports ai-models.json optimization rules', () => {
+  const aiModels = require(path.join(__dirname, '../inventory/ai-models.json'));
+  expect(aiModels.optimizationStrategy).toBeDefined();
+  expect(typeof aiModels.optimizationStrategy.rule1).toBe('string');
+  expect(typeof aiModels.optimizationStrategy.rule3).toBe('string');
+});


### PR DESCRIPTION
## Summary

Sets local/fleet as the default routing tier. Adds a numeric complexity score (0.0–1.0) to routing decisions and enforces complexity thresholds — Sonnet only for tasks scoring ≥0.7.

## Changes

- \`model-routing-policy.json\`: v2.2.0, defaultLane=fleet, complexityThresholds (haiku=0.3, premium=0.7)
- \`task-router.js\`: emit complexity score; import ai-models.json optimizationStrategy; enforce rule3 gate
- \`model-routing-engine.js\`: resolveRouting enforces thresholds — premium→haiku/fleet when cx<0.7
- \`tests/routing-policy.spec.js\`: 9 boundary/policy tests

## Test Results

58/58 passing (1 skipped). Lint clean.

## Role Evidence

- **Manager**: see MANAGER_HANDOFF on #575
- **Collaborator**: see COLLABORATOR_HANDOFF on #575
- **Admin**: pending
- **Consultant**: pending

Refs #575