### PR TITLE
feat: polish Megingjord public presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,92 +1,68 @@
-# Megingjord
+# Megingjord Harness
 
-[![License: PolyForm Noncommercial](https://img.shields.io/badge/License-PolyForm%20NC%201.0-purple.svg)](LICENSE)
-[![Agent Plugin](https://img.shields.io/badge/Agent%20Plugin-Megingjord%20Harness-blue.svg)](plugin.json)
-[![Node ≥22](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
+![Megingjord Banner](https://capsule-render.vercel.app/api?type=waving&height=180&text=Megingjord%20Harness&fontSize=44&fontColor=ffffff&color=0:1f6feb,100:5f2c82&desc=Governance-first%20AI%20agent%20orchestration%20for%20Copilot%20%7C%20Claude%20Code%20%7C%20Codex&descAlignY=68)
 
-**Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex.**
+[![License: PolyForm NC](https://img.shields.io/badge/License-PolyForm%20NC%201.0-blue.svg)](LICENSE)
+[![Node >=22](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
+[![Plugin](https://img.shields.io/badge/Agent%20Plugin-Megingjord%20Harness-0a66c2.svg)](plugin.json)
+[![Runtime](https://img.shields.io/badge/runtime-Copilot%20%2B%20Codex%20%2B%20Claude-7c3aed.svg)](AGENTS.md)
 
-> **Formerly DevEnv Ops** — Rebranded to Megingjord. (Codex rejected due OpenAI product-name conflict; Aegis rejected as too common.)
+**Megingjord** is a governance-first AI agent harness with skills, hooks, agents, runtime scripts, and a Karpathy-style LLM wiki.
 
-This repo is the development source for shared runtime assets deployed into `~/.copilot/`, `~/.codex/`, and `~/.agents/skills/`.
+## Architecture at a glance
 
-## Install
+```mermaid
+flowchart LR
+	A[Repo Source] --> B[skills/ instructions/ hooks/ scripts]
+	B --> C[~/.copilot runtime]
+	B --> D[~/.codex/megingjord-harness runtime]
+	B --> E[~/.agents/skills runtime]
+	C --> F[Governed agent execution]
+	D --> F
+	E --> F
+```
 
-Copilot plugin:
-- In VS Code, run `Chat: Install Plugin From Source` and paste this repo’s Git URL.
+## Why it is robust
 
-Codex runtime:
-- `npm run deploy:codex:apply`
+- Multi-runtime deployment model with dry-run/apply scripts
+- Governance baton model: Manager → Collaborator → Admin → Consultant
+- Fleet-aware routing, telemetry, and policy enforcement
+- Static dashboard with operations + governance visibility
+- LLM wiki integration for reusable institutional knowledge
 
-Both runtimes:
-- `npm run deploy:both:apply`
+## Quick start
+
+```bash
+npm run setup
+npm start
+npm run lint
+npm test
+npm run deploy:both:apply
+```
+
+## Public trust surfaces
+
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Security Policy](SECURITY.md)
+- [Support](SUPPORT.md)
+- [License](LICENSE)
 
 ## Runtime mapping
 
 | Source | Runtime target |
 |---|---|
-| `skills/` | `~/.copilot/skills/` and `~/.agents/skills/` |
-| `instructions/` | `~/.copilot/instructions/` |
-| `hooks/` | `~/.copilot/hooks/` and `~/.codex/devenv-ops/hooks/` |
-| `scripts/global/` | `~/.copilot/scripts/` and `~/.codex/devenv-ops/scripts/` |
-| `.codex/` | `~/.codex/AGENTS.md`, `config.toml`, `hooks.json`, and `rules/` |
-| `agents/` | `~/.copilot/agents/` |
-| `wiki/` | `~/.copilot/wiki/` and `~/.codex/devenv-ops/wiki/` |
+| skills/ | ~/.copilot/skills + ~/.agents/skills |
+| instructions/ | ~/.copilot/instructions |
+| hooks/ | ~/.copilot/hooks + ~/.codex/megingjord-harness/hooks |
+| scripts/global/ | ~/.copilot/scripts + ~/.codex/megingjord-harness/scripts |
+| .codex/ | ~/.codex/AGENTS.md + config.toml + hooks.json + rules/ |
+| wiki/ | ~/.copilot/wiki + ~/.codex/megingjord-harness/wiki |
 
-## What You Get
+## Issue flows
 
-- Governance skills, role-baton instructions, routing, secret prevention, wiki knowledge, and dashboard tooling.
-- Custom Copilot agents plus Codex/Copilot deploy and sync tooling.
-- Shared Team&Model signing and GitHub ticket / PR governance.
+- [Bug report](https://github.com/chf3198/megingjord-harness/issues/new?template=bug-report.yml)
+- [Feature request](https://github.com/chf3198/megingjord-harness/issues/new?template=feature_request.md)
+- [Discussions](https://github.com/chf3198/megingjord-harness/discussions)
 
-## Develop the Harness
-
-```bash
-npm run setup              # Install deps
-npm start                  # Dashboard on :8090
-npm run lint               # ≤100-line file check
-npm test                   # Playwright E2E tests
-npm run deploy:apply       # Deploy repo → Copilot runtime
-npm run deploy:codex:apply # Deploy repo → Codex runtime
-npm run deploy:both:apply  # Deploy repo → Copilot + Codex runtimes
-```
-
-## Enable in Other Repos
-
-```bash
-npm run repo:scope -- enable /path/to/repo
-npm run repo:scope -- enable /path/to/repo --target=codex
-npm run repo:scope -- list
-```
-
-By default the repo-scope tool updates both Copilot and Codex harness scope files.
-
-## Working Rules
-
-- Never share one live checkout between Copilot, Claude Code, and Codex.
-- Give each agent family its own worktree and branch.
-- Never edit deployed runtimes directly.
-- Validate with `npm run lint` and `npm test` before closeout.
-
-## Help
-
-- [Bug reports](https://github.com/chf3198/devenv-ops/issues/new?template=bug-report.yml)
-- [Feature requests](https://github.com/chf3198/devenv-ops/issues/new?template=feature_request.md)
-- [Contributing](.github/CONTRIBUTING.md)
-- [Security](.github/SECURITY.md)
-
-## Label Taxonomy (ADR-010)
-
-Every issue must carry one label from each dimension:
-
-| Dimension | Values |
-|---|---|
-| `status:` | `backlog` · `triage` · `ready` · `in-progress` · `testing` · `review` · `done` · `cancelled` |
-| `type:` | `epic` · `story` · `task` · `bug` · `doc` · `research` |
-| `area:` | `dashboard` · `hooks` · `skills` · `instructions` · `agents` · `scripts` · `infra` · `knowledge` |
-| `priority:` | `P1` (critical) · `P2` (normal) · `P3` (low) |
-| `role:` | `manager` · `collaborator` · `admin` · `consultant` (active baton only) |
-
-## License
-
-[PolyForm Noncommercial 1.0.0](LICENSE) — free for personal, educational, nonprofit, and government use. Commercial use requires explicit permission.
+> Formerly DevEnv Ops. Codex name rejected due product conflict; Aegis rejected due broad name reuse.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ report it responsibly. **Do not open a public issue.**
 
 ### Preferred: GitHub Private Vulnerability Reporting
 
-1. Go to the [Security tab](https://github.com/chf3198/devenv-ops/security)
+1. Go to the [Security tab](https://github.com/chf3198/megingjord-harness/security)
 2. Click **Report a vulnerability**
 3. Provide a description, steps to reproduce, and impact assessment
 
@@ -24,7 +24,7 @@ Contact the maintainer via the information listed on
 
 ## Scope
 
-This policy covers the devenv-ops repository, including:
+This policy covers the megingjord-harness repository, including:
 
 - Skills, agents, hooks, and instructions
 - Dashboard (Alpine.js web app)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,21 +4,21 @@
 
 ### 🐛 Bug Reports
 
-Found a bug? [Open an issue](https://github.com/chf3198/devenv-ops/issues/new?template=bug-report.yml)
+Found a bug? [Open an issue](https://github.com/chf3198/megingjord-harness/issues/new?template=bug-report.yml)
 using the bug report template.
 
 ### 💡 Feature Requests
 
-Have an idea? [Open a feature request](https://github.com/chf3198/devenv-ops/issues/new?template=feature_request.md).
+Have an idea? [Open a feature request](https://github.com/chf3198/megingjord-harness/issues/new?template=feature_request.md).
 
 ### ❓ Questions
 
-For general questions about using devenv-ops as an Agent Plugin:
+For general questions about using Megingjord Harness as an Agent Plugin:
 
 1. Check the [README](README.md) for install and usage instructions
 2. Check [CONTRIBUTING](CONTRIBUTING.md) for development workflow
-3. Search [existing issues](https://github.com/chf3198/devenv-ops/issues)
-4. If still stuck, [open a discussion](https://github.com/chf3198/devenv-ops/discussions)
+3. Search [existing issues](https://github.com/chf3198/megingjord-harness/issues)
+4. If still stuck, [open a discussion](https://github.com/chf3198/megingjord-harness/discussions)
 
 ## Plugin Installation Help
 

--- a/research/epic-607-marketing-brief.md
+++ b/research/epic-607-marketing-brief.md
@@ -1,0 +1,37 @@
+# Epic 607 Marketing Brief Megingjord
+Date: 2026-04-29
+
+| Message Pillar | Audience | Proof Point | CTA |
+|---|---|---|---|
+| Governance-first orchestration | AI operators | Baton workflow + enforced evidence gates | Read README + AGENTS |
+| Multi-runtime portability | Copilot/Codex users | deploy:both:apply + runtime mapping | Install plugin |
+| Operational trust | Maintainers/security reviewers | CoC/Contributing/Security/License surfaces | Open issue or discussion |
+
+## Positioning
+Megingjord is the professional harness for organizations that want AI-agent speed without governance drift. It combines policy, routing, deployment, and knowledge operations into one source-controlled system.
+
+## Narrative blocks
+- Hero claim: Governance-first AI agent orchestration.
+- Differentiator: Single source deployed to Copilot, Codex, and agent skill runtimes.
+- Confidence layer: Explicit policy docs and security intake path.
+- Proof layer: Fleet-aware and wiki-integrated operations.
+
+## Visual direction
+- Banner-led top section for immediate identity.
+- Short badge stack for runtime, license, and plugin context.
+- One architecture diagram for deployment topology comprehension.
+
+Last-updated: 2026-04-29T00:00:00Z
+
+## Actionable Next Steps
+1. Keep README top section stable for brand recall.
+2. Reuse the same hero line in profile README and release notes.
+3. Add one screenshot/GIF in next pass (dashboard or deploy flow).
+4. Track inbound issue quality after the polish release.
+
+## Team&Model Provenance
+- Human Alias: chf3198
+- Team: DevEnv Ops
+- Agent: GitHub Copilot
+- Model: GPT-5.3-Codex
+- Artifact Role: Marketing brief (Epic #607)

--- a/research/epic-607-public-presence-research.md
+++ b/research/epic-607-public-presence-research.md
@@ -1,0 +1,37 @@
+# Epic 607 Public Presence Research
+Date: 2026-04-29
+
+| Area | Current State | Target State | Gap |
+|---|---|---|---|
+| Repo landing | Functional README | Premium visual + architecture clarity | High |
+| Policy surfaces | Present but stale links | Fully aligned + visible links | Medium |
+| Support funnels | Legacy URLs remained | Megingjord issue/discussion flows | Medium |
+| Profile promotion | Low Megingjord visibility | Primary profile spotlight | High |
+
+## Summary
+Megingjord release quality is strong internally, but public trust/marketing surfaces were behind. The benchmark standard is a polished hero-first repository landing, explicit governance value proposition, and no stale brand traces.
+
+## Findings with sources
+1. Benchmark visual style shows strong first-screen identity and concise value framing.
+   - Source: https://github.com/chf3198/crostini-mem-watchdog
+2. Repository had stale support/security URL traces pointing to the old repo name.
+   - Source: README, SUPPORT.md, SECURITY.md inspection in this branch
+3. Policy docs are already present (CoC, Contributing, Security, License), enabling immediate trust-surface uplift.
+   - Source: CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md, LICENSE
+4. Fleet and wiki readiness already exists, enabling a stronger narrative for operational credibility.
+   - Source: inventory/devices.json and wiki search evidence in Epic #607 notes
+
+Last-updated: 2026-04-29T00:00:00Z
+
+## Actionable Next Steps
+1. Ship a hero-first README with architecture diagram and trust-surface links.
+2. Normalize all public links to megingjord-harness.
+3. Update profile README to feature Megingjord with direct links.
+4. Attach collaborator/admin/consultant governance evidence to Epic #607.
+
+## Team&Model Provenance
+- Human Alias: chf3198
+- Team: DevEnv Ops
+- Agent: GitHub Copilot
+- Model: GPT-5.3-Codex
+- Artifact Role: Research evidence (Epic #607)


### PR DESCRIPTION
## Summary
- modernized repository landing experience with a premium-style README
- corrected public support/security funnels to `megingjord-harness`
- added epic research and marketing evidence artifacts
- updated GitHub profile README to feature Megingjord prominently

## Validation
- npm run lint
- npm test

Refs #607
