### PR TITLE
docs: add Megingjord banner asset

### DIFF
--- a/.github/assets/megingjord-banner.svg
+++ b/.github/assets/megingjord-banner.svg
@@ -1,0 +1,37 @@
+<svg width="1600" height="420" viewBox="0 0 1600 420" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs>
+  <linearGradient id="bg" x1="120" y1="60" x2="1480" y2="360" gradientUnits="userSpaceOnUse">
+    <stop stop-color="#0B1020"/>
+    <stop offset="0.45" stop-color="#163C8C"/>
+    <stop offset="1" stop-color="#6C2BD9"/>
+  </linearGradient>
+  <linearGradient id="belt" x1="320" y1="300" x2="1280" y2="300" gradientUnits="userSpaceOnUse">
+    <stop stop-color="#B78A2A"/>
+    <stop offset="0.5" stop-color="#F3D67A"/>
+    <stop offset="1" stop-color="#9C6B1F"/>
+  </linearGradient>
+  <linearGradient id="bolt" x1="760" y1="86" x2="915" y2="247" gradientUnits="userSpaceOnUse">
+    <stop stop-color="#E8F3FF"/>
+    <stop offset="1" stop-color="#8ED0FF"/>
+  </linearGradient>
+  <filter id="glow" x="0" y="0" width="1600" height="420" filterUnits="userSpaceOnUse">
+    <feGaussianBlur stdDeviation="12" result="blur"/>
+    <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.65 0 0 0.12 0 0 1 0 0.45 0 0 0 1 0"/>
+  </filter>
+</defs>
+<rect width="1600" height="420" rx="36" fill="url(#bg)"/>
+<g opacity="0.28" filter="url(#glow)">
+  <path d="M136 90C285 55 348 157 496 128C643 99 663 29 843 51C1028 73 1085 170 1271 158C1386 150 1454 96 1516 62" stroke="#72C3FF" stroke-width="8" stroke-linecap="round"/>
+  <path d="M99 311C252 256 363 340 516 305C651 275 767 183 931 224C1081 261 1144 351 1303 320C1412 299 1484 238 1532 204" stroke="#C28BFF" stroke-width="6" stroke-linecap="round"/>
+</g>
+<path d="M808 72L742 195H822L774 329L920 163H839L882 72H808Z" fill="url(#bolt)"/>
+<rect x="282" y="278" width="1036" height="56" rx="28" fill="url(#belt)"/>
+<rect x="312" y="291" width="976" height="30" rx="15" fill="#6E4A12" fill-opacity="0.34"/>
+<circle cx="408" cy="306" r="15" fill="#FFF0B8" fill-opacity="0.9"/>
+<circle cx="1192" cy="306" r="15" fill="#FFF0B8" fill-opacity="0.9"/>
+<circle cx="512" cy="306" r="8" fill="#7A551B"/>
+<circle cx="1088" cy="306" r="8" fill="#7A551B"/>
+<text x="120" y="178" fill="#F8FBFF" font-family="Segoe UI, Arial, sans-serif" font-size="74" font-weight="800" letter-spacing="1.2">MEGINGJORD HARNESS</text>
+<text x="123" y="230" fill="#CFE4FF" font-family="Segoe UI, Arial, sans-serif" font-size="26" font-weight="600">Governance-first AI agent orchestration • Thor-forged belt motif • Lightning-backed runtime control</text>
+<text x="120" y="365" fill="#FFE39E" font-family="Segoe UI, Arial, sans-serif" font-size="22" font-weight="700" letter-spacing="4">COPILOT  •  CLAUDE CODE  •  CODEX</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Megingjord Harness
 
-![Megingjord Banner](https://capsule-render.vercel.app/api?type=waving&height=180&text=Megingjord%20Harness&fontSize=44&fontColor=ffffff&color=0:1f6feb,100:5f2c82&desc=Governance-first%20AI%20agent%20orchestration%20for%20Copilot%20%7C%20Claude%20Code%20%7C%20Codex&descAlignY=68)
+![Megingjord Banner](.github/assets/megingjord-banner.svg)
 
 [![License: PolyForm NC](https://img.shields.io/badge/License-PolyForm%20NC%201.0-blue.svg)](LICENSE)
 [![Node >=22](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)


### PR DESCRIPTION
## Summary
- add a Thor-inspired Megingjord banner asset under `.github/assets/`
- switch the repo README to use the new local banner image
- support the refreshed GitHub profile featured-project layout

## Validation
- npm run lint

Refs #611
