### PR TITLE
docs: refine project banner assets

### DIFF
--- a/.github/assets/megingjord-banner.svg
+++ b/.github/assets/megingjord-banner.svg
@@ -1,37 +1,55 @@
 <svg width="1600" height="420" viewBox="0 0 1600 420" fill="none" xmlns="http://www.w3.org/2000/svg">
 <defs>
-  <linearGradient id="bg" x1="120" y1="60" x2="1480" y2="360" gradientUnits="userSpaceOnUse">
-    <stop stop-color="#0B1020"/>
-    <stop offset="0.45" stop-color="#163C8C"/>
-    <stop offset="1" stop-color="#6C2BD9"/>
+  <linearGradient id="bg" x1="80" y1="40" x2="1500" y2="390" gradientUnits="userSpaceOnUse">
+    <stop stop-color="#08101F"/>
+    <stop offset="0.48" stop-color="#123A85"/>
+    <stop offset="1" stop-color="#5A27C7"/>
   </linearGradient>
-  <linearGradient id="belt" x1="320" y1="300" x2="1280" y2="300" gradientUnits="userSpaceOnUse">
-    <stop stop-color="#B78A2A"/>
-    <stop offset="0.5" stop-color="#F3D67A"/>
-    <stop offset="1" stop-color="#9C6B1F"/>
+  <linearGradient id="belt" x1="242" y1="308" x2="1360" y2="308" gradientUnits="userSpaceOnUse">
+    <stop stop-color="#7E5313"/>
+    <stop offset="0.24" stop-color="#C99738"/>
+    <stop offset="0.52" stop-color="#F4D880"/>
+    <stop offset="0.78" stop-color="#C08C2F"/>
+    <stop offset="1" stop-color="#75480F"/>
   </linearGradient>
-  <linearGradient id="bolt" x1="760" y1="86" x2="915" y2="247" gradientUnits="userSpaceOnUse">
-    <stop stop-color="#E8F3FF"/>
-    <stop offset="1" stop-color="#8ED0FF"/>
+  <linearGradient id="buckle" x1="734" y1="262" x2="866" y2="350" gradientUnits="userSpaceOnUse">
+    <stop stop-color="#FFF2B5"/>
+    <stop offset="1" stop-color="#C7932E"/>
   </linearGradient>
-  <filter id="glow" x="0" y="0" width="1600" height="420" filterUnits="userSpaceOnUse">
-    <feGaussianBlur stdDeviation="12" result="blur"/>
-    <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.65 0 0 0.12 0 0 1 0 0.45 0 0 0 1 0"/>
+  <linearGradient id="bolt" x1="1168" y1="92" x2="1296" y2="230" gradientUnits="userSpaceOnUse">
+    <stop stop-color="#F8FCFF"/>
+    <stop offset="1" stop-color="#8ACDFF"/>
+  </linearGradient>
+  <filter id="softGlow" x="0" y="0" width="1600" height="420" filterUnits="userSpaceOnUse">
+    <feGaussianBlur stdDeviation="10" result="blur"/>
+    <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.72 0 0 0.18 0 0 1 0 0.55 0 0 0 0.9 0"/>
   </filter>
 </defs>
 <rect width="1600" height="420" rx="36" fill="url(#bg)"/>
-<g opacity="0.28" filter="url(#glow)">
-  <path d="M136 90C285 55 348 157 496 128C643 99 663 29 843 51C1028 73 1085 170 1271 158C1386 150 1454 96 1516 62" stroke="#72C3FF" stroke-width="8" stroke-linecap="round"/>
-  <path d="M99 311C252 256 363 340 516 305C651 275 767 183 931 224C1081 261 1144 351 1303 320C1412 299 1484 238 1532 204" stroke="#C28BFF" stroke-width="6" stroke-linecap="round"/>
+<g opacity="0.3" filter="url(#softGlow)">
+  <path d="M86 106C227 58 350 159 489 123C633 85 722 47 879 72C1028 95 1095 182 1241 171C1360 161 1442 110 1510 72" stroke="#5AB8FF" stroke-width="7" stroke-linecap="round"/>
+  <path d="M98 274C244 232 348 312 495 282C646 250 768 167 923 204C1079 241 1139 322 1287 305C1388 293 1463 248 1524 206" stroke="#AD7DFF" stroke-width="5" stroke-linecap="round"/>
 </g>
-<path d="M808 72L742 195H822L774 329L920 163H839L882 72H808Z" fill="url(#bolt)"/>
-<rect x="282" y="278" width="1036" height="56" rx="28" fill="url(#belt)"/>
-<rect x="312" y="291" width="976" height="30" rx="15" fill="#6E4A12" fill-opacity="0.34"/>
-<circle cx="408" cy="306" r="15" fill="#FFF0B8" fill-opacity="0.9"/>
-<circle cx="1192" cy="306" r="15" fill="#FFF0B8" fill-opacity="0.9"/>
-<circle cx="512" cy="306" r="8" fill="#7A551B"/>
-<circle cx="1088" cy="306" r="8" fill="#7A551B"/>
-<text x="120" y="178" fill="#F8FBFF" font-family="Segoe UI, Arial, sans-serif" font-size="74" font-weight="800" letter-spacing="1.2">MEGINGJORD HARNESS</text>
-<text x="123" y="230" fill="#CFE4FF" font-family="Segoe UI, Arial, sans-serif" font-size="26" font-weight="600">Governance-first AI agent orchestration • Thor-forged belt motif • Lightning-backed runtime control</text>
-<text x="120" y="365" fill="#FFE39E" font-family="Segoe UI, Arial, sans-serif" font-size="22" font-weight="700" letter-spacing="4">COPILOT  •  CLAUDE CODE  •  CODEX</text>
+<path d="M1222 82L1166 179H1232L1193 282L1310 149H1254L1289 82H1222Z" fill="url(#bolt)"/>
+<rect x="90" y="86" width="928" height="100" rx="24" fill="#081225" fill-opacity="0.72" stroke="#9ED8FF" stroke-opacity="0.35"/>
+<text x="126" y="145" fill="#F8FBFF" font-family="Segoe UI, Arial, sans-serif" font-size="74" font-weight="800" letter-spacing="1.2">MEGINGJORD HARNESS</text>
+<rect x="120" y="206" width="770" height="44" rx="22" fill="#09182F" fill-opacity="0.84"/>
+<text x="150" y="235" fill="#DCEBFF" font-family="Segoe UI, Arial, sans-serif" font-size="28" font-weight="700">Governance-first AI agent orchestration • Thor-forged belt • Lightning-backed runtime control</text>
+<rect x="242" y="278" width="1118" height="60" rx="30" fill="url(#belt)" stroke="#FFD98A" stroke-opacity="0.35"/>
+<rect x="278" y="295" width="420" height="26" rx="13" fill="#5A340D" fill-opacity="0.34"/>
+<rect x="902" y="295" width="420" height="26" rx="13" fill="#5A340D" fill-opacity="0.34"/>
+<circle cx="340" cy="308" r="6" fill="#694314"/>
+<circle cx="384" cy="308" r="6" fill="#694314"/>
+<circle cx="428" cy="308" r="6" fill="#694314"/>
+<circle cx="472" cy="308" r="6" fill="#694314"/>
+<circle cx="516" cy="308" r="6" fill="#694314"/>
+<circle cx="1150" cy="308" r="6" fill="#694314"/>
+<circle cx="1194" cy="308" r="6" fill="#694314"/>
+<circle cx="1238" cy="308" r="6" fill="#694314"/>
+<circle cx="1282" cy="308" r="6" fill="#694314"/>
+<rect x="714" y="258" width="172" height="100" rx="18" fill="url(#buckle)" stroke="#FFF1B3" stroke-width="4"/>
+<rect x="754" y="281" width="92" height="54" rx="12" fill="#1E1710" fill-opacity="0.72" stroke="#FFF0B6" stroke-width="4"/>
+<rect x="798" y="281" width="24" height="54" rx="8" fill="#E4B85A"/>
+<rect x="550" y="346" width="500" height="42" rx="21" fill="#09182F" fill-opacity="0.86"/>
+<text x="586" y="374" fill="#FFE8A2" font-family="Segoe UI, Arial, sans-serif" font-size="26" font-weight="800" letter-spacing="1.5">COPILOT • CLAUDE CODE • CODEX</text>
 </svg>


### PR DESCRIPTION
## Summary
- improve Megingjord banner readability and belt silhouette
- sharpen subtitle/footer contrast and move lightning away from the title

## Validation
- npm run lint

Refs #614
