### PR TITLE
feat: harden readability hook install for worktrees #594

### DIFF
--- a/scripts/global/install-readability-toolchain.js
+++ b/scripts/global/install-readability-toolchain.js
@@ -14,6 +14,8 @@ const assets = [
   ['lint-configs/eslint.config.devenv.js', 'lint-configs/eslint.config.devenv.js'],
   ['lint-configs/ruff.devenv.toml', 'lint-configs/ruff.devenv.toml'],
   ['lint-configs/ci-lint.yml', '.github/workflows/ci-lint.yml'],
+  ['hooks/scripts/pre-push-readability.sh', 'hooks/scripts/pre-push-readability.sh'],
+  ['scripts/install-git-hooks.sh', 'scripts/install-git-hooks.sh'],
 ];
 
 const timestamp = new Date().toISOString();

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -2,7 +2,13 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-HOOKS_DIR="$ROOT/.git/hooks"
+GIT_COMMON_DIR="$(git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null || true)"
+if [[ -z "$GIT_COMMON_DIR" ]]; then
+  echo "⚠️  Unable to resolve git common dir for hooks"
+  exit 0
+fi
+[[ "$GIT_COMMON_DIR" = /* ]] || GIT_COMMON_DIR="$ROOT/$GIT_COMMON_DIR"
+HOOKS_DIR="$GIT_COMMON_DIR/hooks"
 
 if [[ ! -d "$HOOKS_DIR" ]]; then
   echo "⚠️  Git hooks directory not found: $HOOKS_DIR"


### PR DESCRIPTION
## Summary
Completes remaining #594 wiring gaps for local readability governance in sandbox/worktree setups.

## Changes
- scripts/install-git-hooks.sh
  - resolve hooks path from git common dir (worktree-safe)
- scripts/global/install-readability-toolchain.js
  - include readability hook assets for install bootstrapping

## Validation
- bash scripts/install-git-hooks.sh (sandbox worktree): pre-commit + pre-push installed
- npm run toolchain:readability:install: hook assets listed in dry-run
- npm run lint:readability:ci: passes (baseline 389 warnings)

Refs #594