### PR TITLE
docs(howto): HELP inventory and doc-update trigger matrix #522

### DIFF
--- a/docs/howto/doc-update-trigger-matrix.md
+++ b/docs/howto/doc-update-trigger-matrix.md
@@ -1,0 +1,59 @@
+# Doc-Update Trigger Matrix
+
+When code in a given area changes, the corresponding documentation surfaces
+**must** be updated in the same PR. This matrix is the enforcement spec for
+the CI doc-update gate (issue #641).
+
+Generated: 2026-04-30 | Refs #522 #335
+
+## Matrix
+
+| Changed path pattern | Required doc update (at least one) | Rationale |
+| --- | --- | --- |
+| `skills/**` | `docs/howto/`, `CONTRIBUTING.md`, or `CHANGELOG.md` | Skills are user-facing; gaps accumulate silently |
+| `instructions/**` | `docs/howto/`, `CHANGELOG.md`, or `README.md` | Instructions govern agent behavior; stale docs mislead |
+| `scripts/global/**` | `CHANGELOG.md` or `docs/howto/` | Global scripts affect routing, telemetry, cost |
+| `hooks/**` | `CHANGELOG.md` or `README.md` | Hook behavior is invisible unless documented |
+| `.github/workflows/**` | `CHANGELOG.md` or `.github/` doc | CI changes affect all contributors |
+| `inventory/**` | `CHANGELOG.md` or `research/` doc | Inventory changes reflect fleet topology shifts |
+| `package.json` (scripts) | `CHANGELOG.md` or `README.md` | New `npm run X` commands need surfacing |
+
+## Explicit Exclusions (gate must NOT fire)
+
+| Path pattern | Reason |
+| --- | --- |
+| `tests/**` | Test changes do not require doc updates |
+| `logs/**` | Generated/ephemeral data |
+| `research/**` | Research is self-documenting |
+| `wiki/**` | Wiki content is its own doc surface |
+| `model-compare/**` | Benchmark data; not user-facing |
+| `.github/ISSUE_TEMPLATE/**` | Templates are docs themselves |
+| `lint-configs/**` | Config only; behavior unchanged unless `npm run lint` output changes |
+
+## Escape Hatch
+
+Add `[skip-doc-gate]` to the PR description body when:
+
+- The change is a typo fix, formatting-only, or test-only within a covered path
+- The doc update would be trivial and is covered by the commit message
+- A linked issue provides the documentation artifact (add `Doc: #N` to PR body)
+
+The gate checks for the escape hatch token before failing.
+
+## Enforcement Implementation
+
+Gate: `.github/workflows/doc-update-gate.yml` (issue #641)
+
+Logic:
+1. Compute `changed_paths` from `git diff --name-only origin/main...HEAD`
+2. For each trigger pattern with a match in `changed_paths`, check if at least
+   one required doc path also appears in `changed_paths`
+3. If a trigger fires with no matching doc update AND no `[skip-doc-gate]` token
+   AND no `Doc: #N` reference → fail with actionable message
+4. If all triggers satisfied or no triggers fire → pass
+
+## Review Cadence
+
+This matrix should be reviewed whenever a new top-level directory is added to the repo,
+or when a new `scripts/global/` entry point is added. The CI gate enforces the matrix,
+so updates here must be accompanied by a gate config update.

--- a/docs/howto/help-inventory.md
+++ b/docs/howto/help-inventory.md
@@ -1,0 +1,124 @@
+# HELP Documentation Inventory
+
+Audit of all 36 skills in `skills/`. None currently have `HELP.md` files.
+
+Generated: 2026-04-30 | Refs #522 #335
+
+## Coverage Summary
+
+| Metric | Count |
+| --- | --- |
+| Total skills | 36 |
+| Have `HELP.md` | 0 |
+| Have `INSTALL-GLOBAL.md` | 8 |
+| Developer HOWTOs (`docs/howto/`) | 0 |
+| CI doc-update gate | none |
+
+## Skills by Category
+
+### Agile Baton Roles (5)
+
+| Skill | Files | HELP gap |
+| --- | --- | --- |
+| `role-manager-execution` | SKILL.md | No HOWTO for Manager phase entry/exit |
+| `role-collaborator-execution` | SKILL.md | No HOWTO for Collaborator evidence format |
+| `role-admin-execution` | SKILL.md | No HOWTO for Admin merge checklist |
+| `role-consultant-critique` | SKILL.md | No HOWTO for grading rubric in practice |
+| `role-baton-orchestrator` | SKILL.md | No HOWTO for end-to-end baton sequence |
+
+**Gap**: No single document shows a developer how to run a ticket start-to-finish.
+**Fix**: `docs/howto/baton-workflow.md` (#639)
+
+### Fleet Routing (3)
+
+| Skill | Files | HELP gap |
+| --- | --- | --- |
+| `global-task-router` | SKILL.md | No HOWTO for reading routing decisions |
+| `fleet-model-optimizer` | SKILL.md | No HOWTO for configuring thresholds |
+| `openrouter-free-failover` | SKILL.md | No HOWTO for fallback chain |
+
+**Gap**: No guide explains lane selection, complexity scoring, or `npm run cost-report`.
+**Fix**: `docs/howto/fleet-routing.md` (#640)
+
+### GitHub Governance (8)
+
+| Skill | Files | HELP gap |
+| --- | --- | --- |
+| `github-ticket-lifecycle-orchestrator` | SKILL.md | No HOWTO linking to label taxonomy |
+| `github-ops-tree-router` | SKILL.md references | No HOWTO for routing decisions |
+| `github-ops-excellence` | INSTALL-GLOBAL.md SKILL.md | INSTALL guide exists; no usage HOWTO |
+| `github-review-merge-admin` | SKILL.md | No HOWTO for merge gate checklist |
+| `github-projects-agile-linkage` | SKILL.md | No HOWTO for project field setup |
+| `github-release-incident-flow` | SKILL.md | No HOWTO for incident response |
+| `github-actions-security-hardening` | SKILL.md | No HOWTO for pin-to-SHA workflow |
+| `github-ruleset-architecture` | SKILL.md | No HOWTO for layered rulesets |
+| `github-capability-resolver` | SKILL.md | No HOWTO; used by router only |
+
+**Gap**: `github-review-merge-admin` and `github-release-incident-flow` are the most
+operator-facing but have no walkthrough documentation.
+
+### Repository Standards (5)
+
+| Skill | Files | HELP gap |
+| --- | --- | --- |
+| `repo-onboarding-standards` | SKILL.md | No HOWTO for new repo checklist |
+| `repo-profile-governance` | INSTALL-GLOBAL.md SKILL.md | Install guide only |
+| `repo-standards-router` | INSTALL-GLOBAL.md SKILL.md | Install guide only |
+| `repo-structure-conventions` | SKILL.md | No HOWTO for layout enforcement |
+| `web-regression-governance` | INSTALL-GLOBAL.md SKILL.md | Install guide only |
+
+### Operator Identity and Context (2)
+
+| Skill | Files | HELP gap |
+| --- | --- | --- |
+| `operator-identity-context` | INSTALL-GLOBAL.md SKILL.md | Install guide exists; no usage HOWTO |
+| `global-skills-bootstrap` | bin INSTALL-GLOBAL.md SKILL.md templates | Most complete; no HOWTO |
+
+### Documentation and Release (4)
+
+| Skill | Files | HELP gap |
+| --- | --- | --- |
+| `docs-drift-maintenance` | SKILL.md | No HOWTO for drift detection workflow |
+| `release-version-integrity` | SKILL.md | No HOWTO for pre-tag checklist |
+| `secret-exposure-prevention` | SKILL.md | No HOWTO for pre-publish scan |
+| `manager-ticket-lifecycle` | SKILL.md | No HOWTO for ticket creation ceremony |
+
+### LLM Wiki (2)
+
+| Skill | Files | HELP gap |
+| --- | --- | --- |
+| `llm-wiki-ops` | SKILL.md | No HOWTO for ingest/anneal/search |
+| `llm-wiki-ops-portable` | SKILL.md | No HOWTO for portable deployment |
+
+### Infrastructure and Platform (7)
+
+| Skill | Files | HELP gap |
+| --- | --- | --- |
+| `network-platform-resources` | SKILL.md | No HOWTO |
+| `mem-watchdog-ops` | SKILL.md watchdog-snapshot.sh | Script exists; no HOWTO |
+| `openclaw-availability-utilization` | SKILL.md | No HOWTO |
+| `openclaw-universal-system` | SKILL.md | No HOWTO |
+| `playwright-vision-low-resource` | INSTALL-GLOBAL.md scripts SKILL.md templates | Most complete |
+| `workflow-self-anneal` | INSTALL-GLOBAL.md SKILL.md | Install guide; no usage HOWTO |
+
+## Priority HELP Gaps
+
+These are the highest-impact gaps — used in every session, no documentation:
+
+| Priority | Gap | Blocking? |
+| --- | --- | --- |
+| P1 | End-to-end baton workflow (ticket → merged PR) | Yes — blocks new contributors |
+| P1 | Fleet routing: lane selection and cost-report | Yes — misrouting causes cost spiral |
+| P1 | Adding a new skill (CONTRIBUTING.md covers this but no HOWTO) | Partial |
+| P2 | Incident response flow | No — rarely needed |
+| P2 | Wiki ingest/search | No — power-user only |
+
+## Existing Doc Surfaces (Not Skills)
+
+| Surface | Location | Coverage |
+| --- | --- | --- |
+| Baton workflow rules | `instructions/role-baton-routing.instructions.md` | Complete but machine-readable |
+| Fleet routing policy | `instructions/global-task-router.instructions.md` | Complete but machine-readable |
+| Contributing guide | `CONTRIBUTING.md` | Covers skill creation; no baton HOWTO |
+| Research docs | `research/` | Ad-hoc; not indexed |
+| Runbooks | `research/ollama-keepalive-runbook.md` | Single runbook; no index |

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -15,7 +15,7 @@ const IGNORE = [
   'skills', 'hooks'
 ];
 
-const IGNORE_PATHS = ['scripts/global', 'instructions', 'research'];
+const IGNORE_PATHS = ['scripts/global', 'instructions', 'research', 'docs/howto'];
 const IGNORE_FILES = ['CHANGELOG.md', 'CHANGELOG-archive.md'];
 
 const EXTS = ['.js', '.html', '.css', '.md', '.sh', '.json'];


### PR DESCRIPTION
## Summary

Delivers research artifacts scoped in issue #522 (child of epic #335):

- `docs/howto/help-inventory.md` — full audit of all 36 skills; zero `HELP.md` coverage confirmed; priority gap table
- `docs/howto/doc-update-trigger-matrix.md` — maps 7 code-area patterns to required doc surfaces; spec for CI gate #641

Also includes #644 (config-only): adds `docs/howto` to `scripts/lint.js` IGNORE_PATHS so developer HOWTO files are not constrained to the 100-line code limit (same pattern as existing `instructions/` and `research/` exemptions).

Both docs pass `markdownlint-cli2` with 0 errors.

## Baton Artifacts

COLLABORATOR_HANDOFF: N/A — docs/research lane
ADMIN_HANDOFF: N/A — docs/research lane
CONSULTANT_CLOSEOUT: posted on issue #522 at 2026-04-30T07:22:43Z

Signed-by: Evelyn Vale
Team&Model: devenv-ops-consult:claude-sonnet-4-6@claude-code
Role: consultant

## Refs

Refs #522
Refs #644