### PR TITLE
feat(ci): doc-update-gate requiring docs when skills change #641

### DIFF
--- a/.github/workflows/doc-update-gate.yml
+++ b/.github/workflows/doc-update-gate.yml
@@ -23,13 +23,15 @@ jobs:
 
       - name: Check doc update coverage
         id: check
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          CHANGED=$(git diff --name-only "origin/${BASE_REF}...HEAD")
           echo "Changed files:"
           echo "$CHANGED"
 
-          # Skip-gate escape hatches
-          PR_BODY="${{ github.event.pull_request.body }}"
+          # Skip-gate escape hatch
           if echo "$PR_BODY" | grep -qF '[skip-doc-gate]'; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/doc-update-gate.yml
+++ b/.github/workflows/doc-update-gate.yml
@@ -1,0 +1,66 @@
+name: doc-update-gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: doc-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  doc-update-gate:
+    name: Doc update required
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Check doc update coverage
+        id: check
+        run: |
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          # Skip-gate escape hatches
+          PR_BODY="${{ github.event.pull_request.body }}"
+          if echo "$PR_BODY" | grep -qF '[skip-doc-gate]'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Trigger patterns (paths that require a doc update)
+          TRIGGERS=$(echo "$CHANGED" | grep -E \
+            '^skills/|^instructions/|^scripts/global/|^hooks/|^\.github/workflows/|^inventory/|^package\.json')
+
+          if [ -z "$TRIGGERS" ]; then
+            echo "No trigger paths changed — gate passes."
+            exit 0
+          fi
+
+          echo "Trigger paths changed:"
+          echo "$TRIGGERS"
+
+          # Doc surfaces that satisfy the gate
+          DOC_CHANGED=$(echo "$CHANGED" | grep -E \
+            '^docs/|^CHANGELOG\.md$|^README\.md$|^\.github/.*\.md$')
+
+          if [ -n "$DOC_CHANGED" ]; then
+            echo "Doc update present:"
+            echo "$DOC_CHANGED"
+            exit 0
+          fi
+
+          echo ""
+          echo "❌ doc-update-gate: changes to skills/, instructions/, scripts/global/,"
+          echo "   hooks/, .github/workflows/, inventory/, or package.json require a"
+          echo "   corresponding update to docs/, CHANGELOG.md, or README.md."
+          echo ""
+          echo "   To bypass: add [skip-doc-gate] to the PR description body."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ Megingjord better positions the harness as a **governance-first** AI agent orche
 - **Governance-aligned semantics** (protection, guardrails, policy)
 - **Lower naming-conflict risk** after rejecting "Codex" due OpenAI brand collision and "Aegis" due broad prior use
 
+## [Unreleased] — HELP Docs and Doc Governance (Epic #335)
+
+### Added — HELP Documentation Infrastructure (#522 #639 #640 #641 #644)
+- `docs/howto/help-inventory.md`: full audit of all 36 skills; zero HELP.md coverage; priority gap table
+- `docs/howto/doc-update-trigger-matrix.md`: maps code-area patterns to required doc surfaces; CI gate spec
+- `docs/howto/baton-workflow.md`: end-to-end developer HOWTO for the Agile baton ticket lifecycle
+- `docs/howto/fleet-routing.md`: developer HOWTO for fleet routing lanes, complexity scoring, and cost-report
+- `.github/workflows/doc-update-gate.yml`: CI gate — fails PRs that modify skills/instructions/scripts without a doc update
+- `scripts/lint.js`: added `docs/howto` to 100-line exclusion list (same pattern as `instructions/` and `research/`)
+
 ## [Unreleased] — Self-Anneal Governance Infrastructure (Epic #416)
 
 ### Added — Fleet Capability Tagging (Epic #561)


### PR DESCRIPTION
## Summary

Adds `.github/workflows/doc-update-gate.yml` — a CI check that fails when a PR
modifies `skills/**`, `instructions/**`, `scripts/global/**`, `hooks/**`,
`.github/workflows/**`, `inventory/**`, or `package.json` without a corresponding
update to `docs/**`, `CHANGELOG.md`, or `README.md`.

Includes `[skip-doc-gate]` escape hatch in PR body. Implements the enforcement spec
from `docs/howto/doc-update-trigger-matrix.md`.

## Baton Artifacts

COLLABORATOR_HANDOFF: posted on issue #641 (Casey Harper / devenv-ops:claude-sonnet-4-6@claude-code)
ADMIN_HANDOFF: posted on issue #641 (Rio Reyes / devenv-ops:claude-sonnet-4-6@claude-code)
CONSULTANT_CLOSEOUT: posted on issue #641 (Evelyn Vale / devenv-ops-consult:claude-sonnet-4-6@claude-code)

Signed-by: Evelyn Vale
Team&Model: devenv-ops-consult:claude-sonnet-4-6@claude-code
Role: consultant

## Refs

Refs #641