### PR TITLE
docs(howto): baton workflow and fleet routing HOWTOs #639 #640

### DIFF
--- a/docs/howto/baton-workflow.md
+++ b/docs/howto/baton-workflow.md
@@ -1,0 +1,213 @@
+# Developer HOWTO: End-to-End Baton Workflow
+
+Step-by-step guide for taking a task from user request to closed ticket.
+Refs #639 #335
+
+## Overview
+
+Every change in Megingjord goes through a single-threaded baton sequence. One role is
+active at a time per ticket. The GitHub issue IS the baton — whoever holds the active
+`role:*` label owns the current step.
+
+```
+Manager → Collaborator → Admin → Consultant → done + closed
+```
+
+## 1. Manager Phase
+
+**Entry**: User request or backlog item.
+
+**Create the ticket first — never code first.**
+
+```bash
+gh issue create \
+  --title "Verb phrase describing the change" \
+  --body "## Problem\n...\n## Acceptance Criteria\n- [ ] AC1\n- [ ] AC2" \
+  --label "type:task,status:triage,priority:P2,area:scripts"
+```
+
+Title rules: plain imperative ≤72 chars. No `feat(scope):` prefix on issue titles.
+
+**Post scope comment** with objective, ACs, and constraints. End it with:
+
+```
+MANAGER_HANDOFF
+
+Signed-by: <alias>
+Team&Model: devenv-ops:<model>@<substrate>
+Role: manager
+```
+
+**Transition labels**:
+
+```bash
+gh issue edit N --remove-label "status:triage,role:manager" --add-label "status:ready"
+```
+
+## 2. Collaborator Phase
+
+**Entry**: Issue at `status:ready`.
+
+```bash
+# Pick up the ticket
+gh issue edit N --remove-label "status:ready" --add-label "status:in-progress,role:collaborator"
+
+# Create branch in your worktree
+git checkout -b feat/N-short-slug
+
+# Implement, then validate every AC with evidence
+```
+
+**When all ACs are checked ✅**, post the handoff:
+
+```
+COLLABORATOR_HANDOFF
+
+Signed-by: <alias>
+Team&Model: devenv-ops:<model>@<substrate>
+Role: collaborator
+
+AC evidence:
+- AC1: <test output or command result>
+- AC2: <file path or CI link>
+```
+
+Wait at least 60 seconds, then create the PR:
+
+```bash
+gh pr create \
+  --title "feat(scope): imperative description #N" \
+  --body "... COLLABORATOR_HANDOFF ... ADMIN_HANDOFF ... CONSULTANT_CLOSEOUT ... Refs #N"
+```
+
+PR title: `type(scope): description #N` ≤60 chars. Use `Refs #N`, never `Closes #N`.
+
+**Transition**:
+
+```bash
+gh issue edit N --remove-label "status:in-progress,role:collaborator" --add-label "status:testing,role:admin"
+```
+
+## 3. Admin Phase
+
+**Entry**: Issue at `status:testing`. PR exists with all gates pending.
+
+Verify all required CI checks are green:
+
+- `collaborator-gate` — COLLABORATOR_HANDOFF confirmed on linked issue
+- `admin-gate` — ADMIN_HANDOFF confirmed on linked issue
+- `consultant-gate` — CONSULTANT_CLOSEOUT confirmed on linked issue
+- `evidence-completeness` — COLLABORATOR_HANDOFF predates PR creation by ≥60 s
+- `lint-required` — markdownlint + eslint + shellcheck pass
+- `pr-title-required` — title ≤60 chars
+
+Post the ADMIN_HANDOFF on the issue (not the PR body):
+
+```
+ADMIN_HANDOFF
+
+Signed-by: <alias>
+Team&Model: devenv-ops:<model>@<substrate>
+Role: admin
+
+CI evidence:
+- collaborator-gate: pass (run #...)
+- lint-required: pass
+- All required checks green
+```
+
+Rerun any failed gates after posting:
+
+```bash
+gh run rerun <run-id> --failed
+```
+
+**Transition**:
+
+```bash
+gh issue edit N --remove-label "status:testing,role:admin" --add-label "status:review,role:consultant"
+```
+
+## 4. Consultant Phase
+
+**Entry**: Issue at `status:review`. All CI gates green.
+
+Post an independent critique and closeout on the **issue** (not the PR):
+
+```
+CONSULTANT_CLOSEOUT
+
+Signed-by: <alias>
+Team&Model: devenv-ops-consult:<model>@<substrate>
+Role: consultant
+
+[independent review — Team&Model must differ from Collaborator's]
+```
+
+Then merge the PR:
+
+```bash
+gh pr merge N --squash --delete-branch
+```
+
+Close the issue atomically with status:done:
+
+```bash
+gh issue edit N --remove-label "status:review,role:consultant" --add-label "status:done"
+gh issue close N
+```
+
+## Reduced Lanes
+
+### docs/research lane (Manager → Consultant only)
+
+For PRs that only change `.md` files, instructions, or research docs:
+
+Post these N/A markers on the issue before creating the PR:
+
+```
+COLLABORATOR_HANDOFF: N/A — docs/research lane
+ADMIN_HANDOFF: N/A — docs/research lane
+```
+
+The CI `baton-gates.yml` reads the issue comments for these strings. N/A markers satisfy
+the gate while still enforcing the ≥60 s timing check against their timestamps.
+
+### config-only lane (Admin → Consultant only)
+
+For trivial single-value config changes with no design decision:
+
+```
+COLLABORATOR_HANDOFF: N/A — config-only lane
+```
+
+## Label Reference
+
+| Status | Active role | Meaning |
+| --- | --- | --- |
+| `status:triage` | `role:manager` | Manager scoping |
+| `status:ready` | none | Awaiting Collaborator |
+| `status:in-progress` | `role:collaborator` | Implementation active |
+| `status:testing` | `role:admin` | CI gates running |
+| `status:review` | `role:consultant` | Critique and closeout |
+| `status:done` | none | Closed — terminal |
+
+## Forbidden Combinations
+
+- `status:done` on an open issue — done must coincide with `gh issue close`
+- Any `role:*` label on a closed issue
+- `status:backlog` or `status:done` with any `role:*` label
+- Skipping a role without posting an explicit N/A marker
+
+## Quick Reference
+
+```bash
+# Check what the baton-gates CI expects
+gh issue view N --json comments -q '[.comments[].body | select(contains("HANDOFF") or contains("CLOSEOUT"))]'
+
+# See all checks on a PR
+gh pr checks <PR-number>
+
+# Rerun only failed checks
+gh run rerun <run-id> --failed
+```

--- a/docs/howto/fleet-routing.md
+++ b/docs/howto/fleet-routing.md
@@ -1,0 +1,155 @@
+# Developer HOWTO: Fleet Routing Cascade
+
+How task routing works in Megingjord, how to test it, and how to read cost reports.
+Refs #640 #335 #573
+
+## Overview
+
+Every task is routed through a four-lane cost-ascending cascade. The goal is to use
+the cheapest capable model — local Ollama first, Sonnet only when complexity requires it.
+
+```
+free → fleet → haiku → premium
+  $0      $0    $0.08x    1.0x
+```
+
+The routing pipeline has three stages:
+
+1. **classify** (`task-router.js`) — assigns a lane and computes a complexity score
+2. **resolve** (`model-routing-engine.js`) — applies complexity thresholds and rollback policy
+3. **dispatch** (`task-router-dispatch.js`) — executes against the resolved backend
+
+## Lanes
+
+| Lane | Backend | Cost | Use when |
+| --- | --- | --- | --- |
+| `free` | Claude auto-tier | $0 | Lookups, Q&A, docs, boilerplate |
+| `fleet` | Ollama (qwen2.5:7b-instruct) | $0 | Medium implementation, config gen, log analysis |
+| `haiku` | claude-haiku-4-5-20251001 | ~$0.08x | Single-file refactors, test gen, code review |
+| `premium` | claude-sonnet-4-6 | 1.0x | Multi-file architecture, security, ambiguous debugging |
+
+## Complexity Scoring
+
+The classifier emits a `complexity` score in `[0.0, 1.0]` based on the ratio of
+premium-tier keywords to total keyword weight in the prompt.
+
+| Score range | Lane assigned |
+| --- | --- |
+| `[0.0, 0.3)` | fleet |
+| `[0.3, 0.7)` | haiku |
+| `[0.7, 1.0]` | premium |
+
+These thresholds are configurable in `scripts/global/model-routing-policy.json`:
+
+```json
+"complexityThresholds": {
+  "haiku": 0.3,
+  "premium": 0.7
+}
+```
+
+## Testing a Routing Decision
+
+```bash
+# Route a prompt and see the decision (no execution)
+node scripts/global/task-router-dispatch.js --prompt "write unit tests for auth.js" --json
+
+# Route and execute against fleet (Ollama must be reachable)
+node scripts/global/task-router-dispatch.js --prompt "write unit tests for auth.js"
+
+# Override the model
+node scripts/global/task-router-dispatch.js --prompt "..." --model qwen2.5:14b-instruct
+```
+
+Output fields:
+- `route.lane` — lane selected by classifier
+- `routing.lane` — lane after threshold and rollback enforcement
+- `routing.complexity` — 0.0–1.0 score
+- `decision.action` — what actually happened (`route-fleet`, `recommend-haiku`, `fleet-unavailable`, etc.)
+
+## Reading the Cost Report
+
+```bash
+npm run cost-report
+```
+
+Sample output:
+
+```
+=== Routing Cost Report ===
+Samples (last 30 days): 47
+
+Tier distribution:
+  free     ████████████         60.0%
+  fleet    ████████             38.0%
+  haiku                          1.0%
+  premium                        1.0%
+
+Estimated monthly cost: $0.54
+  (based on 1090 req/mo baseline)
+Premium share: 1.0%
+Avg multiplier: 0.012
+Success rate: 97.9%
+```
+
+A warning fires when premium share exceeds 20%. If you see it, run
+`npm run routing:report` to see the 7-day trend and check whether rollback
+policy has already engaged.
+
+## Fleet Node Requirements
+
+Fleet dispatch requires a reachable Ollama instance. The primary target is
+`36gbwinresource` (GPU node, `100.91.113.16:11434`). The fallback is
+`windows-laptop` (`100.94.84.232:11434`).
+
+**Critical**: Set `OLLAMA_KEEP_ALIVE=24h` as a Windows system environment variable
+on any fleet node running Ollama. Without this, Ollama evicts models after 1 minute
+of idle time, causing every fleet dispatch to wait for a cold reload (~30 s).
+
+See `research/ollama-keepalive-runbook.md` for the full setup procedure.
+
+## Rollback Policy
+
+If premium share exceeds 20% over the last 7 days, `model-routing-engine.js`
+automatically forces all tasks to fleet lane until the share drops.
+
+```bash
+# Check current distribution
+npm run routing:report
+
+# Check 7-day rolling baseline
+npm run routing:baseline
+```
+
+The rollback threshold and force-lane are configured in `model-routing-policy.json`
+under `rollback`.
+
+## Adjusting Routing Thresholds
+
+Edit `scripts/global/model-routing-policy.json`:
+
+```json
+"complexityThresholds": {
+  "haiku": 0.3,   // raise to send more tasks to fleet
+  "premium": 0.7  // raise to send more tasks to haiku
+}
+```
+
+After editing, run the routing policy tests to verify boundary behavior:
+
+```bash
+npx playwright test tests/routing-policy.spec.js
+```
+
+## Policy Files
+
+Two policy files govern routing — they must stay consistent:
+
+| File | Controls |
+| --- | --- |
+| `scripts/global/task-router-policy.json` | Keyword weights, lane classification, `defaultLane` |
+| `scripts/global/model-routing-policy.json` | Model IDs, complexity thresholds, rollback, fleet targets |
+
+Both set `defaultLane: "fleet"`. If they diverge, `resolveRouting()` in
+`model-routing-engine.js` applies `model-routing-policy.json`'s threshold logic
+on top of the classifier's lane from `task-router-policy.json`.


### PR DESCRIPTION
## Summary

Adds two developer HOWTOs under `docs/howto/` (exempted from 100-line limit per #644):

- **`baton-workflow.md`** — end-to-end ticket lifecycle: all four roles, exact handoff artifact formats, label transition table, reduced lanes with N/A examples, quick-reference commands
- **`fleet-routing.md`** — lane selection, complexity scoring (0.0–1.0 scale, thresholds at 0.3/0.7), cost-report interpretation, fleet node OLLAMA_KEEP_ALIVE requirement, rollback policy, threshold adjustment

Both files pass `markdownlint-cli2` with 0 errors and `npm run lint`.

[skip-doc-gate] — docs/howto changes do not require additional doc updates

## Baton Artifacts

COLLABORATOR_HANDOFF: N/A — docs/research lane
ADMIN_HANDOFF: N/A — docs/research lane
CONSULTANT_CLOSEOUT: posted on issue #639 (Evelyn Vale / devenv-ops-consult:claude-sonnet-4-6@claude-code)

Signed-by: Evelyn Vale
Team&Model: devenv-ops-consult:claude-sonnet-4-6@claude-code
Role: consultant

## Refs

Refs #639
Refs #640