### PR TITLE
feat(ci): post-merge sandbox launcher sync to main

### DIFF
--- a/.github/workflows/post-merge-sandbox-sync.yml
+++ b/.github/workflows/post-merge-sandbox-sync.yml
@@ -1,0 +1,47 @@
+name: Sandbox Launcher Sync
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sandbox-launcher-sync
+  cancel-in-progress: true
+
+jobs:
+  sync-sandbox-launchers:
+    name: sync-sandbox-launchers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const sha = context.sha;
+            const branches = [
+              'sandbox/copilot',
+              'sandbox/codex',
+              'sandbox/claude-code',
+            ];
+            const results = [];
+            for (const branch of branches) {
+              try {
+                await github.rest.git.updateRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `heads/${branch}`,
+                  sha,
+                  force: true,
+                });
+                results.push(`✓ ${branch} → ${sha.slice(0, 7)}`);
+              } catch (err) {
+                if (err.status === 422 || err.status === 404) {
+                  results.push(`– ${branch}: not found on origin, skipped`);
+                } else {
+                  throw err;
+                }
+              }
+            }
+            core.info(results.join('\n'));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Megingjord better positions the harness as a **governance-first** AI agent orche
 - **Governance-aligned semantics** (protection, guardrails, policy)
 - **Lower naming-conflict risk** after rejecting "Codex" due OpenAI brand collision and "Aegis" due broad prior use
 
+## [Unreleased] — Sandbox Launcher Sync (#647)
+
+### Added — Worktree Governance Automation
+- `.github/workflows/post-merge-sandbox-sync.yml`: fires on push to `main`; force-resets `sandbox/copilot`, `sandbox/codex`, `sandbox/claude-code` to the new main SHA via the GitHub REST API — closes the gap where `worktree-governance-required` enforced currency but no automation maintained it
+
 ## [Unreleased] — HELP Docs and Doc Governance (Epic #335)
 
 ### Added — HELP Documentation Infrastructure (#522 #639 #640 #641 #644)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/post-merge-sandbox-sync.yml` (47 lines)
- Triggers on `push` to `main`; force-updates `sandbox/copilot`, `sandbox/codex`, `sandbox/claude-code` to the pushed SHA via the GitHub REST API (`git.updateRef`)
- Missing branches skipped gracefully (404/422 → info log, not failure)
- `permissions: contents: write` only; `actions/github-script` pinned to full SHA
- `concurrency: cancel-in-progress: true` prevents redundant parallel runs

## Motivation

`worktree-governance-required` enforces `max: 0` commits behind `origin/main` on all sandbox launcher branches, but nothing advanced those branches when `main` moved. Every PR merge broke all subsequent open PRs, requiring manual resets before CI could pass. This closes that hole permanently without weakening the invariant.

## AC checklist

- [x] Workflow present at `.github/workflows/post-merge-sandbox-sync.yml`
- [x] Trigger: `push` to `main` only
- [x] Force-updates all three sandbox/* branches to pushed SHA
- [x] Missing branches skipped gracefully
- [x] `permissions: contents: write` only
- [x] `actions/github-script` pinned to full commit SHA
- [x] 47 lines — passes `npm run lint`
- [x] No checkout step — pure REST API

## Test plan

- [ ] Merge a PR to main; confirm all three sandbox/* branches appear at the new SHA in the branch list
- [ ] `worktree-governance-required` passes on the next PR after merge

Refs #647

## Baton evidence

- `MANAGER_HANDOFF` — https://github.com/chf3198/megingjord-harness/issues/647#issuecomment-4350688450
- `COLLABORATOR_HANDOFF` — https://github.com/chf3198/megingjord-harness/issues/647#issuecomment-4350693575

🤖 Generated with [Claude Code](https://claude.ai/claude-code)