### PR TITLE
feat(governance): continuous drift classification and reporting #360

### DIFF
--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -1,0 +1,40 @@
+name: Drift Detection
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  drift-detection:
+    name: governance-drift-detection
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - name: Run drift classifier
+        run: node scripts/global/governance-drift-classifier.js --json || true
+      - name: Summarize drift classes
+        run: |
+          if [ -f logs/governance-drift.json ]; then
+            node -e "
+              const r = require('./logs/governance-drift.json');
+              const { open, terminal, epic } = r.driftByClass;
+              console.log('Drift status: ' + r.status);
+              console.log('Open drift: ' + open);
+              console.log('Terminal drift: ' + terminal);
+              console.log('Epic drift: ' + epic);
+              if (r.totalDrift > 0) process.exit(0);
+            "
+          fi
+      - name: Commit drift report
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add logs/governance-drift.json
+          git diff --cached --quiet || git commit -m "chore(governance): update drift detection report"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ Megingjord better positions the harness as a **governance-first** AI agent orche
 - **Governance-aligned semantics** (protection, guardrails, policy)
 - **Lower naming-conflict risk** after rejecting "Codex" due OpenAI brand collision and "Aegis" due broad prior use
 
+## [Unreleased] — Continuous Governance Drift Detection (#360)
+
+### Added — Governance Drift Classification
+- `scripts/global/governance-drift-classifier.js`: classifies governance issues into `open`, `terminal`, and `epic` drift classes; exits 1 on drift detected
+- `tests/governance-drift.spec.js`: 11 targeted unit tests for all drift classification paths
+- `.github/workflows/drift-detection.yml`: daily + manual CI workflow writing `logs/governance-drift.json`
+- npm script `governance:drift` for manual drift runs
+- Extended `scripts/global/governance-weekly-report.js` with `driftByClass` metrics and robust verifier error handling
+
 ## [Unreleased] — Sandbox Launcher Sync (#647)
 
 ### Added — Worktree Governance Automation

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "routing:baseline": "node scripts/global/routing-baseline-report.js",
     "routing:report": "node scripts/global/routing-baseline-report.js --days 7",
     "routing:calibrate": "node scripts/global/cascade-calibrate.js",
+    "governance:drift": "node scripts/global/governance-drift-classifier.js --json",
     "governance:epic": "node scripts/global/epic-evidence.js",
     "governance:verify": "node scripts/global/governance-verify.js --json",
     "governance:worktrees": "node scripts/global/worktree-governance-audit.js --json",

--- a/scripts/global/governance-drift-classifier.js
+++ b/scripts/global/governance-drift-classifier.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const root = path.resolve(__dirname, '..', '..');
+const logsDir = path.join(root, 'logs');
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+
+// Issue strings matching closed/done tickets missing terminal artifacts.
+const TERMINAL_PATTERNS = [
+  /missing CONSULTANT_CLOSEOUT/,
+  /missing GitHub Evidence Block/,
+  /closed status contains role label/,
+];
+
+// Issue strings that indicate epic-level integrity failures.
+const EPIC_PATTERNS = [
+  /epic closed with open children/,
+];
+
+/**
+ * Classify a single governance issue string into one of:
+ *   'epic' | 'terminal' | 'open'
+ * @param {string} issue
+ * @returns {'epic'|'terminal'|'open'}
+ */
+function classifyIssue(issue) {
+  if (EPIC_PATTERNS.some(rx => rx.test(issue))) return 'epic';
+  if (TERMINAL_PATTERNS.some(rx => rx.test(issue))) return 'terminal';
+  return 'open';
+}
+
+/**
+ * Classify a list of governance issue strings into drift classes.
+ * @param {string[]} issues
+ * @returns {{ open: object[], terminal: object[], epic: object[] }}
+ */
+function classify(issues) {
+  const classes = { open: [], terminal: [], epic: [] };
+  for (const message of issues) {
+    const driftClass = classifyIssue(message);
+    classes[driftClass].push({ message, driftClass });
+  }
+  return classes;
+}
+
+function runVerify() {
+  try {
+    return execSync('node scripts/global/governance-verify.js --json', {
+      cwd: root, encoding: 'utf8',
+    });
+  } catch (err) {
+    return err.stdout || '{}';
+  }
+}
+
+function buildReport(verifyData) {
+  const classes = classify(verifyData.issues || []);
+  const total = verifyData.failedChecks || 0;
+  return {
+    generatedAt: new Date().toISOString(),
+    checkedTickets: verifyData.checkedTickets || 0,
+    totalDrift: total,
+    driftByClass: { open: classes.open.length, terminal: classes.terminal.length, epic: classes.epic.length },
+    details: classes,
+    status: total === 0 ? 'no-drift' : 'drift-detected',
+  };
+}
+
+function run() {
+  const report = buildReport(JSON.parse(runVerify()));
+  fs.mkdirSync(logsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(logsDir, 'governance-drift.json'),
+    JSON.stringify(report, null, 2)
+  );
+  if (asJson) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    const { open, terminal, epic } = report.driftByClass;
+    console.log(`Drift: ${report.status} | open=${open} terminal=${terminal} epic=${epic}`);
+  }
+  process.exit(report.totalDrift ? 1 : 0);
+}
+
+module.exports = { classify, classifyIssue };
+if (require.main === module) run();

--- a/scripts/global/governance-weekly-report.js
+++ b/scripts/global/governance-weekly-report.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
+const { classify } = require('./governance-drift-classifier');
 
 const root = path.resolve(__dirname, '..', '..');
 const dir = path.join(root, 'tickets');
@@ -22,7 +23,12 @@ function tickets() {
 }
 
 function verify() {
-  const raw = execSync('node scripts/global/governance-verify.js --json', { cwd: root, encoding: 'utf8' });
+  let raw;
+  try {
+    raw = execSync('node scripts/global/governance-verify.js --json', { cwd: root, encoding: 'utf8' });
+  } catch (err) {
+    raw = err.stdout || '{}';
+  }
   return JSON.parse(raw);
 }
 
@@ -40,6 +46,8 @@ function run() {
   const terminal = s => /^done\s*\(`closed`\)/i.test(s) || /^cancelled/i.test(s);
   const staleReady = list.filter(t => /^ready\b/i.test(t.status) && /^P[01]$/.test(t.priority)
     && now - t.mtimeMs > cutoff && !t.blocker).length;
+  const dc = classify(v.issues || []);
+  const driftByClass = { open: dc.open.length, terminal: dc.terminal.length, epic: dc.epic.length };
   const out = {
     generatedAt: new Date().toISOString(),
     metrics: {
@@ -48,7 +56,7 @@ function run() {
       failedChecks: v.failedChecks,
       epicIntegrityFailures: v.issues.filter(i => i.includes('epic closed with open children')).length,
       evidenceFailures: v.issues.filter(i => i.includes('missing GitHub Evidence Block')).length,
-      staleReadyP0P1: staleReady
+      staleReadyP0P1: staleReady, driftByClass
     },
     recommendations: recommendations({ failedChecks: v.failedChecks, staleReadyP0P1: staleReady,
       evidenceFailures: v.issues.filter(i => i.includes('missing GitHub Evidence Block')).length })

--- a/tests/governance-drift.spec.js
+++ b/tests/governance-drift.spec.js
@@ -1,0 +1,79 @@
+// tests/governance-drift.spec.js — targeted unit tests for drift classifier (#360)
+const { test, expect } = require('@playwright/test');
+const { classify, classifyIssue } = require('../scripts/global/governance-drift-classifier');
+
+test.describe('governance-drift-classifier — drift class detection', () => {
+  test('empty issues produce empty classified lists', () => {
+    const result = classify([]);
+    expect(result.open).toHaveLength(0);
+    expect(result.terminal).toHaveLength(0);
+    expect(result.epic).toHaveLength(0);
+  });
+
+  test('open drift — baton missing Signed-by on in-progress ticket', () => {
+    const issue = '122-fix.md: baton sections missing Signed-by: COLLABORATOR_HANDOFF';
+    expect(classifyIssue(issue)).toBe('open');
+    const result = classify([issue]);
+    expect(result.open).toHaveLength(1);
+    expect(result.open[0].driftClass).toBe('open');
+  });
+
+  test('open drift — ready SLA violation', () => {
+    const issue = '130-task.md: ready >24h without BLOCKER_NOTE fields';
+    expect(classifyIssue(issue)).toBe('open');
+  });
+
+  test('open drift — missing workflow merge_group trigger', () => {
+    const issue = '.github/workflows/lint.yml: missing merge_group trigger';
+    expect(classifyIssue(issue)).toBe('open');
+  });
+
+  test('terminal drift — missing CONSULTANT_CLOSEOUT on closed ticket', () => {
+    const issue = '120-epic.md: missing CONSULTANT_CLOSEOUT';
+    expect(classifyIssue(issue)).toBe('terminal');
+    const result = classify([issue]);
+    expect(result.terminal).toHaveLength(1);
+    expect(result.terminal[0].driftClass).toBe('terminal');
+  });
+
+  test('terminal drift — missing GitHub Evidence Block', () => {
+    const issue = '130-task.md: missing GitHub Evidence Block';
+    expect(classifyIssue(issue)).toBe('terminal');
+  });
+
+  test('terminal drift — closed status contains role label', () => {
+    const issue = '125-task.md: closed status contains role label';
+    expect(classifyIssue(issue)).toBe('terminal');
+  });
+
+  test('epic drift — epic closed with open children', () => {
+    const issue = '120-epic.md: epic closed with open children 127';
+    expect(classifyIssue(issue)).toBe('epic');
+    const result = classify([issue]);
+    expect(result.epic).toHaveLength(1);
+    expect(result.epic[0].driftClass).toBe('epic');
+  });
+
+  test('epic drift has highest priority over terminal patterns', () => {
+    const issue = '120-epic.md: epic closed with open children 127, missing CONSULTANT_CLOSEOUT';
+    expect(classifyIssue(issue)).toBe('epic');
+  });
+
+  test('classify preserves message text in result objects', () => {
+    const issue = '140-task.md: missing CONSULTANT_CLOSEOUT';
+    const result = classify([issue]);
+    expect(result.terminal[0].message).toBe(issue);
+  });
+
+  test('mixed issues classify correctly into all three classes', () => {
+    const issues = [
+      '120-epic.md: epic closed with open children 127',
+      '125-task.md: missing CONSULTANT_CLOSEOUT',
+      '130-task.md: baton sections missing Signed-by: MANAGER_HANDOFF',
+    ];
+    const result = classify(issues);
+    expect(result.epic).toHaveLength(1);
+    expect(result.terminal).toHaveLength(1);
+    expect(result.open).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
Implements continuous governance drift detection and reporting for ticket lifecycle integrity.

## Changes
- add `scripts/global/governance-drift-classifier.js` to classify drift into `open`, `terminal`, and `epic`
- extend `scripts/global/governance-weekly-report.js` with robust verifier parsing + `driftByClass` metrics
- add workflow `.github/workflows/drift-detection.yml` (scheduled + manual)
- add targeted unit tests `tests/governance-drift.spec.js` (11 tests)
- add npm script `governance:drift`

## Validation
- `npm run lint`
- `npx playwright test tests/governance-drift.spec.js --reporter=line`
- `node scripts/global/governance-weekly-report.js` (verified `metrics.driftByClass` output)

Refs #360
