### PR TITLE
docs(tickets): backfill BLOCKER_NOTE on 6 legacy ready #465

### DIFF
--- a/tickets/126-settings-layout.md
+++ b/tickets/126-settings-layout.md
@@ -28,3 +28,9 @@ Implementation Targets:
 
 - Status transition: `triage -> ready`
 - Ready for collaborator implementation.
+
+## BLOCKER_NOTE
+
+- owner: collaborator (dashboard-UX specialized)
+- unblock_condition: dashboard CSS baseline stable; narrow-viewport regression tests pass
+- eta_or_review_time: manager review by 2026-05-07 governance queue

--- a/tickets/130-harness-openclaw-reliability-hardening.md
+++ b/tickets/130-harness-openclaw-reliability-hardening.md
@@ -27,3 +27,9 @@ Constraints:
 - Status transition: `triage -> ready`
 - Ready for collaborator implementation under branch:
   - `feat/130-openclaw-harness-reliability-hardening`
+
+## BLOCKER_NOTE
+
+- owner: collaborator (OpenClaw integration)
+- unblock_condition: #128 epic (OpenClaw infrastructure) reaches `status:ready` with preflight/dispatch stable
+- eta_or_review_time: manager review by 2026-05-07 governance queue

--- a/tickets/131-openclaw-research-and-wiki-evolution.md
+++ b/tickets/131-openclaw-research-and-wiki-evolution.md
@@ -25,3 +25,9 @@ Acceptance Criteria:
 
 - Status transition: `triage -> ready`
 - Ready for collaborator research + documentation updates.
+
+## BLOCKER_NOTE
+
+- owner: collaborator (LLM reliability research)
+- unblock_condition: #128 epic infrastructure settled; OpenClaw gateway patterns documented; local-inference alternatives matured
+- eta_or_review_time: manager review by 2026-05-07 governance queue

--- a/tickets/133-research-fleet-live-indicator-options.md
+++ b/tickets/133-research-fleet-live-indicator-options.md
@@ -25,3 +25,9 @@ Deliverable:
 
 - Status transition: `triage -> ready`
 - Ready for collaborator research synthesis and wiki updates.
+
+## BLOCKER_NOTE
+
+- owner: collaborator (fleet operations research)
+- unblock_condition: #132 epic architecture choices finalized; resource trade-off data available from current fleet runs
+- eta_or_review_time: manager review by 2026-05-07 governance queue

--- a/tickets/137-advanced-wiki-automation-wave-2.md
+++ b/tickets/137-advanced-wiki-automation-wave-2.md
@@ -25,3 +25,9 @@ Constraints:
 
 - Status transition: `triage -> ready`
 - Ready for collaborator implementation.
+
+## BLOCKER_NOTE
+
+- owner: collaborator (wiki infra + AI synthesis)
+- unblock_condition: #120 epic (wiki health) closed; contradiction/staleness baseline established; synthesis prompt design approved
+- eta_or_review_time: manager review by 2026-05-07 governance queue

--- a/tickets/146-weekly-cost-quality-self-anneal-scorecard.md
+++ b/tickets/146-weekly-cost-quality-self-anneal-scorecard.md
@@ -26,3 +26,9 @@ Constraints:
 
 - Status transition: `triage -> ready`
 - Ready for collaborator implementation.
+
+## BLOCKER_NOTE
+
+- owner: collaborator (dashboard + scoring)
+- unblock_condition: #139 epic (self-anneal governance) and #143 (cost/quality scoring framework) reach implementation readiness; threshold rules defined
+- eta_or_review_time: manager review by 2026-05-07 governance queue


### PR DESCRIPTION
## Summary
Backfill BLOCKER_NOTE evidence on 6 legacy P1 ready tickets per issue #465.

## Changes
- Add BLOCKER_NOTE to tickets #126, #130, #131, #133, #137, #146
- Each includes owner, unblock_condition, and manager review ETA (2026-05-07)
- Blockers reference parent epics/infrastructure milestones

## Validation
- Governance verify: 1 failure (pre-existing #599 missing Priority)
- `npm run lint`: ✅ (pre-existing logs/ exclusion)
- `npx playwright test`: 11 passed ✅

Refs #465
[skip-doc-gate]