### PR TITLE
perf(infra): add concurrency and npm cache to scheduled CI workflows #661

### DIFF
--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -14,7 +14,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '22'
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json', 'npm-shrinkwrap.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
       - run: npm ci
       - name: Run drift classifier
         run: node scripts/global/governance-drift-classifier.js --json || true

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -7,6 +7,10 @@ on:
     - cron: '30 8 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: post-merge-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   consultant-activation:
     name: consultant-activation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Megingjord better positions the harness as a **governance-first** AI agent orche
 - **Governance-aligned semantics** (protection, guardrails, policy)
 - **Lower naming-conflict risk** after rejecting "Codex" due OpenAI brand collision and "Aegis" due broad prior use
 
+## [Unreleased] — CI Workflow Efficiency Improvements (#661)
+
+### Changed — Scheduled Workflow Reliability
+- `.github/workflows/post-merge-automation.yml`: added `concurrency` block (`cancel-in-progress: false`) to prevent duplicate triggers for the same PR merge
+- `.github/workflows/drift-detection.yml`: added npm dependency caching (matching pattern in `lint.yml` and `quality-gates.yml`); updated node version 20 → 22 for fleet consistency
+
 ## [Unreleased] — Governance Verifier Hygiene (#652)
 
 ### Fixed — Governance Verifier False Positives


### PR DESCRIPTION
## Summary

- Add missing `concurrency` block to `post-merge-automation.yml` — prevents duplicate triggers for the same PR merge from double-firing
- Add `actions/cache` npm caching to `drift-detection.yml` — same pattern already in `lint.yml` and `quality-gates.yml`
- Update `drift-detection.yml` from node 20 → 22, consistent with all other workflows

Refs #661

[skip-doc-gate] — pure CI efficiency changes (concurrency groups, npm caching), no user-visible behavior change

## Changes

| File | Change |
|---|---|
| `.github/workflows/post-merge-automation.yml` | Add `concurrency: group: post-merge-${{ github.event.pull_request.number \|\| github.run_id }}, cancel-in-progress: false` |
| `.github/workflows/drift-detection.yml` | Add npm cache step; node 20 → 22 |

## Audit Scope

Audited all 12 workflows. Only `post-merge-automation.yml` and `drift-detection.yml` had actionable gaps — all other PR gate workflows already have concurrency + caching, or use `github-script` only (no npm install needed).

## Test plan

- [ ] CI lint-required passes (YAML changes, no JS affected)
- [ ] CI quality-gates passes
- [ ] baton-gates passes (COLLABORATOR_HANDOFF posted on issue #661 at 2026-04-30T18:08:19Z)
- [ ] No behavior change to workflow logic — only CI efficiency improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)