### PR TITLE
feat(infra): add cost-telemetry.js and per-dispatch cost accounting #667

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Megingjord better positions the harness as a **governance-first** AI agent orche
 - **Governance-aligned semantics** (protection, guardrails, policy)
 - **Lower naming-conflict risk** after rejecting "Codex" due OpenAI brand collision and "Aegis" due broad prior use
 
+## [Unreleased] — Cost Telemetry + Routing Discipline (#667)
+
+### Added — Cost Accounting per Dispatch
+- `scripts/global/cost-telemetry.js`: per-dispatch cost logger writing `logs/cost-telemetry.jsonl`; computes `cost_usd` per tier at 2026 blended pricing; budget alert at 80% of $10/mo
+- `scripts/global/task-router-dispatch.js`: now calls `recordCostEvent()` on every fleet dispatch
+- `npm run cost:baseline`: runs cost-telemetry summarizer for 30-day window
+- `scripts/lint.js`: added `.claude` to IGNORE list (excludes agent worktrees from 100-line scan)
+
 ## [Unreleased] — CI Workflow Efficiency Improvements (#661)
 
 ### Changed — Scheduled Workflow Reliability

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js",
     "format:check": "prettier --check .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js",
     "cost-report": "node scripts/global/cost-report.js",
+    "cost:baseline": "node scripts/global/cost-telemetry.js",
     "lint:readability": "node scripts/lint-readability.js",
     "lint:readability:ci": "node scripts/lint-readability.js --max-warnings=389",
     "readability:snapshot": "bash scripts/readability-snapshot.sh",

--- a/scripts/global/cost-telemetry.js
+++ b/scripts/global/cost-telemetry.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+'use strict';
+// Cost telemetry — per-dispatch cost accounting, separate from routing telemetry.
+const fs = require('fs');
+const path = require('path');
+
+const FILE = path.join(__dirname, '..', '..', 'logs', 'cost-telemetry.jsonl');
+const MAX_ENTRIES = 500;
+
+// Blended $/request at ~3K tokens avg (2026 Anthropic/OpenRouter pricing)
+const COST_PER_REQ = {
+  free: 0,
+  fleet: 0,
+  haiku: 0.00264,  // 3K * $0.00088/1K
+  premium: 0.027,  // 3K * $0.009/1K
+};
+
+const MONTHLY_BUDGET_USD = 10;
+
+function ensureDir() { fs.mkdirSync(path.dirname(FILE), { recursive: true }); }
+
+function recordCostEvent(lane, model, opts = {}) {
+  ensureDir();
+  const cost = COST_PER_REQ[lane] ?? COST_PER_REQ.premium;
+  const row = {
+    ts: new Date().toISOString(),
+    lane: lane || 'free',
+    model: model || 'unknown',
+    cost_usd: cost,
+    outcome: opts.outcome || 'ok',
+    escalation_reason: opts.escalation_reason || null,
+    rate_limit: opts.rate_limit || false,
+  };
+  const existing = fs.existsSync(FILE)
+    ? fs.readFileSync(FILE, 'utf8').split('\n').filter(Boolean) : [];
+  const lines = [...existing.slice(-(MAX_ENTRIES - 1)), JSON.stringify(row)];
+  fs.writeFileSync(FILE, lines.join('\n') + '\n');
+  return row;
+}
+
+function readCostEvents(days = 30) {
+  if (!fs.existsSync(FILE)) return [];
+  const cutoff = Date.now() - days * 86400000;
+  return fs.readFileSync(FILE, 'utf8').split('\n').filter(Boolean)
+    .map(l => { try { return JSON.parse(l); } catch { return null; } })
+    .filter(r => r && new Date(r.ts).getTime() >= cutoff);
+}
+
+function summarizeCost(entries) {
+  const n = entries.length || 1;
+  const byLane = {};
+  let totalCost = 0;
+  entries.forEach(e => {
+    byLane[e.lane] = (byLane[e.lane] || 0) + 1;
+    totalCost += e.cost_usd || 0;
+  });
+  const daysInWindow = 30;
+  const projectedMonthly = entries.length
+    ? (totalCost / daysInWindow) * 30 : 0;
+  const budgetPct = (projectedMonthly / MONTHLY_BUDGET_USD * 100).toFixed(1);
+  return {
+    samples: entries.length,
+    totalCostUsd: +totalCost.toFixed(4),
+    projectedMonthlyUsd: +projectedMonthly.toFixed(2),
+    budgetPct: +budgetPct,
+    budgetAlert: projectedMonthly > MONTHLY_BUDGET_USD * 0.8,
+    byLane: Object.fromEntries(
+      Object.entries(byLane).map(([k, v]) => [k, { count: v, pct: +((v / n) * 100).toFixed(1) }])
+    ),
+  };
+}
+
+if (require.main === module) {
+  const events = readCostEvents(30);
+  const s = summarizeCost(events);
+  console.log(`Cost baseline (last 30d): $${s.totalCostUsd} actual`);
+  console.log(`Projected monthly: $${s.projectedMonthlyUsd} / $${MONTHLY_BUDGET_USD} budget`);
+  console.log(`Budget used: ${s.budgetPct}%${s.budgetAlert ? ' ⚠ ALERT' : ''}`);
+  Object.entries(s.byLane).forEach(([k, v]) =>
+    console.log(`  ${k.padEnd(8)} ${v.count} req (${v.pct}%)`));
+}
+
+module.exports = { recordCostEvent, readCostEvents, summarizeCost, MONTHLY_BUDGET_USD };

--- a/scripts/global/cost-telemetry.js
+++ b/scripts/global/cost-telemetry.js
@@ -40,14 +40,14 @@ function recordCostEvent(lane, model, opts = {}) {
 
 function readCostEvents(days = 30) {
   if (!fs.existsSync(FILE)) return [];
-  const cutoff = Date.now() - days * 86400000;
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
   return fs.readFileSync(FILE, 'utf8').split('\n').filter(Boolean)
     .map(l => { try { return JSON.parse(l); } catch { return null; } })
     .filter(r => r && new Date(r.ts).getTime() >= cutoff);
 }
 
 function summarizeCost(entries) {
-  const n = entries.length || 1;
+  const total = entries.length || 1;
   const byLane = {};
   let totalCost = 0;
   entries.forEach(e => {
@@ -65,18 +65,18 @@ function summarizeCost(entries) {
     budgetPct: +budgetPct,
     budgetAlert: projectedMonthly > MONTHLY_BUDGET_USD * 0.8,
     byLane: Object.fromEntries(
-      Object.entries(byLane).map(([k, v]) => [k, { count: v, pct: +((v / n) * 100).toFixed(1) }])
+      Object.entries(byLane).map(([k, v]) => [k, { count: v, pct: +((v / total) * 100).toFixed(1) }])
     ),
   };
 }
 
 if (require.main === module) {
   const events = readCostEvents(30);
-  const s = summarizeCost(events);
-  console.log(`Cost baseline (last 30d): $${s.totalCostUsd} actual`);
-  console.log(`Projected monthly: $${s.projectedMonthlyUsd} / $${MONTHLY_BUDGET_USD} budget`);
-  console.log(`Budget used: ${s.budgetPct}%${s.budgetAlert ? ' ⚠ ALERT' : ''}`);
-  Object.entries(s.byLane).forEach(([k, v]) =>
+  const summary = summarizeCost(events);
+  console.log(`Cost baseline (last 30d): $${summary.totalCostUsd} actual`);
+  console.log(`Projected monthly: $${summary.projectedMonthlyUsd} / $${MONTHLY_BUDGET_USD} budget`);
+  console.log(`Budget used: ${summary.budgetPct}%${summary.budgetAlert ? ' ⚠ ALERT' : ''}`);
+  Object.entries(summary.byLane).forEach(([k, v]) =>
     console.log(`  ${k.padEnd(8)} ${v.count} req (${v.pct}%)`));
 }
 

--- a/scripts/global/task-router-dispatch.js
+++ b/scripts/global/task-router-dispatch.js
@@ -6,6 +6,7 @@ const { chatComplete: ollamaChat } = require('./ollama-direct');
 const { getProfile } = require('./fleet-config');
 const { resolveRouting } = require('./model-routing-engine');
 const { recordTelemetry } = require('./model-routing-telemetry');
+const { recordCostEvent } = require('./cost-telemetry');
 const policy = require('./model-routing-policy.json');
 
 const args = process.argv.slice(2);
@@ -63,6 +64,7 @@ async function main() {
   recordTelemetry({ lane: resolved.lane, model: resolved.modelId, multiplier: resolved.multiplier,
     taskClass: resolved.taskClass, complexityScore: route.complexity ?? null,
     rollbackApplied: resolved.rollbackApplied, outcome, execute: true });
+  recordCostEvent(resolved.lane, resolved.modelId, { outcome });
   const result = { route: effectiveRoute, routing: resolved, decision };
   if (json) {
     console.log(JSON.stringify(result, null, 2));

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -11,7 +11,7 @@ const LIMIT = 100;
 const IGNORE = [
   'node_modules', '.git', 'playwright-report',
   'test-results', 'package-lock.json', '.dashboard',
-  'logs',
+  'logs', '.claude',
   // Global resources have their own governance
   'skills', 'hooks'
 ];


### PR DESCRIPTION
## Summary

- Adds `scripts/global/cost-telemetry.js`: per-dispatch cost logger with 30-day summary, projected monthly cost, and 80% budget alert
- Wires `recordCostEvent()` into `task-router-dispatch.js` after every fleet dispatch
- Adds `npm run cost:baseline` script
- Excludes `.claude` agent worktrees from 100-line lint scan

Refs #668

## Baton Artifacts

COLLABORATOR_HANDOFF: See issue #668 comment

ADMIN_HANDOFF: N/A — pending CI

CONSULTANT_CLOSEOUT: N/A — pending review

## Test plan
- [ ] `npm run cost:baseline` runs without error
- [ ] `node scripts/lint.js` → ✅ all files within 100-line limit
- [ ] `npm run lint:readability:ci` → 389 warnings (baseline)
- [ ] CI gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)