### PR TITLE
feat(infra): add cost-baseline measurement tooling #671

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ Megingjord better positions the harness as a **governance-first** AI agent orche
 - **Governance-aligned semantics** (protection, guardrails, policy)
 - **Lower naming-conflict risk** after rejecting "Codex" due OpenAI brand collision and "Aegis" due broad prior use
 
+## [Unreleased] — Verification Baseline + Cost Measurement (#671)
+
+### Added — Cost Baseline Tooling
+- `scripts/global/cost-baseline.js`: before/after comparison tool; reads `logs/cost-telemetry.jsonl`, shows current projected monthly cost vs pre-optimization baseline ($60.38/mo, ~1090 req, 100% premium); outputs savings delta
+- `npm run cost:baseline`: runs cost-baseline.js for 30-day window comparison
+
 ## [Unreleased] — Instruction Token Footprint Reduction (#667)
 
 ### Changed — Instruction Optimization

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js",
     "format:check": "prettier --check .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js",
     "cost-report": "node scripts/global/cost-report.js",
+    "cost:baseline": "node scripts/global/cost-baseline.js",
     "lint:readability": "node scripts/lint-readability.js",
     "lint:readability:ci": "node scripts/lint-readability.js --max-warnings=389",
     "readability:snapshot": "bash scripts/readability-snapshot.sh",

--- a/scripts/global/cost-baseline.js
+++ b/scripts/global/cost-baseline.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+'use strict';
+// Cost baseline report: current vs. pre-optimization baseline.
+// Pre-opt (April baseline): $60.38/mo, ~1090 requests, 100% premium.
+
+const fs = require('fs');
+const path = require('path');
+
+const LOG = path.join(__dirname, '..', '..', 'logs', 'cost-telemetry.jsonl');
+const BUDGET = 10;
+const RATES = { free: 0, fleet: 0, haiku: 0.00264, premium: 0.027 };
+const PRE_OPT = { monthlyUsd: 60.38, requests: 1000 + 90, tier: '100% premium' };
+
+const args = process.argv.slice(2);
+const days = Number(args[args.indexOf('--days') + 1] || 30);
+const json = args.includes('--json');
+
+function readEvents() {
+  if (!fs.existsSync(LOG)) return [];
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  return fs.readFileSync(LOG, 'utf8').split('\n').filter(Boolean)
+    .map(l => { try { return JSON.parse(l); } catch { return null; } })
+    .filter(r => r && new Date(r.ts).getTime() >= cutoff);
+}
+
+function summarize(entries) {
+  const oldest = entries.reduce((mn, e) => Math.min(mn, new Date(e.ts).getTime()), Date.now());
+  const spanDays = Math.max(1, (Date.now() - oldest) / (24 * 60 * 60 * 1000));
+  const total = entries.reduce((s, e) => s + (RATES[e.lane] || 0), 0);
+  const proj = +(total * (30 / spanDays)).toFixed(2);
+  const byLane = {};
+  entries.forEach(e => { byLane[e.lane] = (byLane[e.lane] || 0) + 1; });
+  return { proj, byLane, count: entries.length };
+}
+
+const events = readEvents();
+
+if (json) {
+  const cur = events.length ? summarize(events) : null;
+  console.log(JSON.stringify({ preOpt: PRE_OPT, current: cur, days }));
+  process.exit(0);
+}
+
+console.log(`\n=== Cost Baseline (last ${days}d) ===\n`);
+console.log(`Pre-opt:  $${PRE_OPT.monthlyUsd}/mo | ${PRE_OPT.requests} req | ${PRE_OPT.tier}`);
+
+if (!events.length) {
+  console.log('Current:  no telemetry — run routed queries to populate log.\n');
+  process.exit(0);
+}
+
+const cur = summarize(events);
+const saving = PRE_OPT.monthlyUsd - cur.proj;
+const pct = (saving / PRE_OPT.monthlyUsd * 100).toFixed(1);
+const budgetPct = (cur.proj / BUDGET * 100).toFixed(1);
+
+console.log(`Current:  $${cur.proj}/mo | ${cur.count} req | budget: ${budgetPct}%`);
+Object.entries(cur.byLane).forEach(([lane, n]) =>
+  console.log(`  ${lane.padEnd(8)}: ${n} req`));
+console.log(`\nSavings vs pre-opt: $${saving.toFixed(2)}/mo (${pct}%)\n`);


### PR DESCRIPTION
## Summary

- Adds `scripts/global/cost-baseline.js`: standalone before/after comparison tool with pre-optimization baseline ($60.38/mo, ~1090 req, 100% premium) and current projected monthly cost with savings delta
- Adds `npm run cost:baseline` npm script
- Note: `cost-baseline.js` reads `logs/cost-telemetry.jsonl` directly (standalone, no dependency on sibling modules)

Refs #671

## Baton Artifacts

COLLABORATOR_HANDOFF: See [issue #671 comment](https://github.com/chf3198/megingjord-harness/issues/671#issuecomment-4355507994)

ADMIN_HANDOFF: N/A — pending CI

CONSULTANT_CLOSEOUT: N/A — pending review

## Test plan
- [ ] `node scripts/global/cost-baseline.js` exits 0; shows pre-opt baseline
- [ ] `npm run cost:baseline` works
- [ ] `node scripts/lint.js` → ✅ all files within 100-line limit
- [ ] `npm run lint:readability:ci` → 389 warnings (baseline)
- [ ] CI gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)