### PR TITLE
docs(skills): Consultant + Self-Anneal SKILL.md updates #682

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — Consultant SKILL.md Updates (#682)
+
+### Changed
+- `skills/role-consultant-critique/SKILL.md`: Added Comprehensive Check Registry section, Manager Feedback Protocol step, and extended output contract with `checks_run`, `checks_failed`, `remediation_issues` fields.
+- `skills/workflow-self-anneal/SKILL.md`: Added Consultant Integration section and two new trigger conditions for governance/cost-budget FAIL patterns.
+
 ## [Unreleased] — Consultant Feedback Bridge (#681)
 
 ### Added

--- a/skills/role-consultant-critique/SKILL.md
+++ b/skills/role-consultant-critique/SKILL.md
@@ -8,6 +8,12 @@ disable-model-invocation: false
 
 # Role: Consultant Critique
 
+## Comprehensive Check Registry
+
+Run `node scripts/global/consultant-checks.js --issue <N> --json > /tmp/checks.json` before CLOSEOUT.
+Checks span 3 domains: `governance` (baton artifacts, labels, events), `tools` (wiki growth, skill refs), `fleet` (device routing, cost budget).
+Include `checks_run: <N>/<total>` and `checks_failed: <N>` in CLOSEOUT output.
+
 ## Responsibilities
 
 - Perform independent quality/risk review of ALL prior roles.
@@ -42,17 +48,11 @@ disable-model-invocation: false
 4. Add 🎉 emoji reaction to the issue to celebrate closure.
 5. **Emit event**: `emit-event.js --type baton:consultant --issue N --role consultant --agent "Quinn Critic"`.
 6. Close issue: `gh issue close N --comment "Released in vX.Y.Z — summary"`.
+7. **Manager Feedback Protocol**: after confidence scoring, run `node scripts/global/consultant-feedback.js --issue <N> --results /tmp/checks.json`. Require `remediation_issues: [...]` in CLOSEOUT if any FAIL (or `remediation_issues: none`).
 
 ## Reject criteria (governance failures only)
 
-Consultant MAY reject (revert to Collaborator) **only** when:
-- A required handoff artifact (MANAGER_HANDOFF / COLLABORATOR_HANDOFF / ADMIN_HANDOFF) is absent.
-- ACs were not checked ✅ with evidence before handoff.
-- Admin merged before CI was green (verifiable via PR checks).
-
-**Consultant must NOT reject** for: solution quality disagreements, style preferences, or scope additions not in original ACs. Those become `recommended_follow_ups` items.
-
-**Before rejecting**: Post a comment enumerating exactly which governance rule was violated and which artifact/evidence is missing.
+Reject (revert to Collaborator) only when a required artifact is absent, ACs lack evidence, or Admin merged before CI was green. Disagreements on quality/style become `recommended_follow_ups`. Post exact violation before rejecting.
 
 ## Entry criteria
 
@@ -92,4 +92,7 @@ confidence: <low|medium|high>
 wiki_health: <pages_before>→<pages_after>
 fleet_utilization: <devices_used>/<devices_available>
 recommended_follow_ups:
+checks_run: <N>/<total>
+checks_failed: <N>
+remediation_issues: <list or none>
 ```

--- a/skills/workflow-self-anneal/SKILL.md
+++ b/skills/workflow-self-anneal/SKILL.md
@@ -31,6 +31,13 @@ This skill optimizes _process reliability_, not model internals.
 - Repeated carryover/blocked items across iterations.
 - PR/merge latency breaches targets or reopened issues trend up.
 - **Commits exist without linked GitHub issues** (process drift).
+- **Consultant check registry returns ≥1 FAIL on domain:governance**.
+- **Fleet check `fleet-002` (cost-budget) FAIL for ≥2 consecutive cycles**.
+
+## Consultant Integration
+
+Self-anneal may be invoked automatically from `consultant-feedback.js` when `gov-002` (baton-artifact-presence) or `gov-003` (event-emission) FAIL — these are workflow process failures, not implementation bugs.
+Check IDs are managed in `scripts/global/consultant-checks.js` (3 domains: governance/tools/fleet).
 
 ## Input collection
 


### PR DESCRIPTION
## Summary

Updates `role-consultant-critique/SKILL.md` and `workflow-self-anneal/SKILL.md` to incorporate the check registry and feedback automation from Epic #610.

Refs #682 — Epic #610 child #615.

## Changes
- `role-consultant-critique/SKILL.md`: Check Registry section, Manager Feedback Protocol, extended output contract
- `workflow-self-anneal/SKILL.md`: Consultant Integration section, 2 new trigger conditions
- `CHANGELOG.md` entry

## Gates
- `npm run lint`: ✅ PASS
- `npm run governance:verify`: ✅ PASS (0 failures)

## Baton Artifacts
See issue #682 for MANAGER_HANDOFF and COLLABORATOR_HANDOFF.