### PR TITLE
feat(governance): ADR-010 lifecycle enforcement rules + daily scan #358

### DIFF
--- a/.github/workflows/label-lint.yml
+++ b/.github/workflows/label-lint.yml
@@ -50,6 +50,23 @@ jobs:
             } else if (areaLabels.length > 1) {
               violations.push(`**Rule 6**: Multiple \`area:\` labels found: ${areaLabels.join(', ')}. Only one is allowed.`);
             }
+            if (issue.state === 'closed' && roleLabels.length > 0) {
+              violations.push(`**Rule 7**: Closed issue must not retain \`role:\` labels. Remove: ${roleLabels.join(', ')}.`);
+            }
+            const STATUS_ROLE_REQUIRED = {
+              'status:in-progress': 'role:collaborator',
+              'status:testing':     'role:admin',
+              'status:review':      'role:consultant',
+            };
+            for (const [status, required] of Object.entries(STATUS_ROLE_REQUIRED)) {
+              if (statusLabels.includes(status) && !roleLabels.includes(required)) {
+                violations.push(`**Rule 8**: \`${status}\` requires \`${required}\`. Add it.`);
+              }
+            }
+            const isEpic = labels.includes('type:epic');
+            if (isEpic && statusLabels.includes('status:ready')) {
+              violations.push('**Rule 9**: Epics cannot be at `status:ready` — that status is for child tickets only.');
+            }
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number: issueNum, per_page: 100,
             });

--- a/.github/workflows/label-scan.yml
+++ b/.github/workflows/label-scan.yml
@@ -1,0 +1,89 @@
+name: Label Scan (ADR-010 Daily Audit)
+# Scans ALL issues (open + closed) daily for ADR-010 label violations.
+# label-lint.yml only fires on issue events — this catches historical drift.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  label-scan:
+    name: adr-010-label-scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan issues for ADR-010 violations
+        uses: actions/github-script@f28e40c7f34bde8b3046d788e986cb6290c5673b # v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const marker = '<!-- adr-010-label-scan -->';
+            const STATUS_ROLE_REQUIRED = {
+              'status:in-progress': 'role:collaborator',
+              'status:testing':     'role:admin',
+              'status:review':      'role:consultant',
+            };
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'all', per_page: 100,
+            });
+
+            let violations = 0;
+            for (const issue of issues) {
+              const labels = issue.labels.map(l => l.name);
+              const statusLabels = labels.filter(l => l.startsWith('status:'));
+              const roleLabels   = labels.filter(l => l.startsWith('role:'));
+              const v = [];
+
+              if (issue.state === 'closed' && roleLabels.length > 0) {
+                v.push(`Closed issue retains role labels: ${roleLabels.join(', ')}`);
+              }
+              if (statusLabels.includes('status:done') && roleLabels.length > 0) {
+                v.push(`status:done retains role labels: ${roleLabels.join(', ')}`);
+              }
+              for (const [status, required] of Object.entries(STATUS_ROLE_REQUIRED)) {
+                if (statusLabels.includes(status) && !roleLabels.includes(required)) {
+                  v.push(`${status} missing required ${required}`);
+                }
+              }
+              if (labels.includes('type:epic') && statusLabels.includes('status:ready')) {
+                v.push('epic at status:ready (invalid — child tickets only)');
+              }
+              if (statusLabels.length > 1) {
+                v.push(`multiple status labels: ${statusLabels.join(', ')}`);
+              }
+
+              if (v.length === 0) continue;
+              violations++;
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: issue.number, per_page: 100,
+              });
+              const existing = comments.find(c => c.body?.includes(marker));
+              const body = [
+                marker,
+                '',
+                '## ⚠️ ADR-010 Label Scan Violation',
+                '',
+                `Issue #${issue.number} has invalid label state:`,
+                '',
+                v.map(x => `- ${x}`).join('\n'),
+                '',
+                '**Current labels**: ' + labels.map(l => `\`${l}\``).join(', '),
+                '',
+                '_This comment was posted by the daily label-scan workflow. It will not re-post if unchanged._',
+              ].join('\n');
+
+              if (!existing) {
+                await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body });
+              } else if (existing.body !== body) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              }
+            }
+            console.log(`Scan complete. ${issues.length} issues checked, ${violations} with violations.`);
+            if (violations > 0) core.setFailed(`${violations} ADR-010 violations found.`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — ADR-010 Lifecycle Enforcement + Daily Scan (#358)
+
+### Added — Label Governance Enforcement
+- `.github/workflows/label-lint.yml`: Rule 7 (closed+role), Rule 8 (positive role per active status), Rule 9 (epic+status:ready guard)
+- `.github/workflows/label-scan.yml`: new scheduled daily ADR-010 scan of all issues with idempotent violation comments
+
 ## [Unreleased] — End-to-End Anneal Verification Reliability (#683)
 
 ### Changed


### PR DESCRIPTION
## Summary

- `.github/workflows/label-lint.yml`: adds Rule 7 (closed+role), Rule 8 (positive role enforcement for in-progress/testing/review), Rule 9 (epic+status:ready guard) — closes Gap 1, 2, and 4 from governance audit
- `.github/workflows/label-scan.yml`: new scheduled daily workflow that paginates ALL issues (open+closed) and posts idempotent ADR-010 violation comments — closes Gap 5

## Test plan

- [ ] label-lint.yml fires on `issues` events and now enforces Rules 7-9
- [ ] label-scan.yml can be triggered via `workflow_dispatch` manually
- [ ] ESLint passes with 0 errors
- [ ] Readability CI gate at 389 warnings (baseline unchanged)
- [ ] Prettier format check passes

Refs #358

COLLABORATOR_HANDOFF: see issue #358 comments
ADMIN_HANDOFF: see issue #358 comments

🤖 Generated with [Claude Code](https://claude.ai/claude-code)