### PR TITLE
feat(governance): GitHub-API drift scan and epic close validator #359

### DIFF
--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -23,6 +23,9 @@ jobs:
             npm-${{ runner.os }}-
       - run: npm ci
       - name: Run drift classifier
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: node scripts/global/governance-drift-classifier.js --json || true
       - name: Summarize drift classes
         run: |
@@ -34,9 +37,15 @@ jobs:
               console.log('Open drift: ' + open);
               console.log('Terminal drift: ' + terminal);
               console.log('Epic drift: ' + epic);
+              console.log('GitHub violations: ' + (r.githubViolations || []).length);
               if (r.totalDrift > 0) process.exit(0);
             "
           fi
+      - name: Summarize epic close-readiness
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/global/epic-close-validator.js || true
       - name: Commit drift report
         run: |
           git config user.name "github-actions[bot]"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] — GitHub-API Drift Scan + Epic Close Validator (#359)
+
+### Added — Live Governance Scanning
+- `scripts/global/governance-github-scanner.js`: paginates all GitHub issues via REST API, checks 5 ADR-010 rules (closed+role, done+role, missing active-status role, epic+ready, multi-status), returns classified violations
+- `scripts/global/epic-close-validator.js`: checks all open `type:epic` issues for close-readiness (status:review, open child count via timeline, CONSULTANT_CLOSEOUT comment)
+- `governance:epics` npm script
+
+### Changed — Governance Drift Pipeline
+- `scripts/global/governance-drift-classifier.js`: now async; calls `governance-github-scanner.js` when `GITHUB_TOKEN` set, merges `githubViolations` into drift report
+- `.github/workflows/drift-detection.yml`: passes `GITHUB_TOKEN`/`GITHUB_REPOSITORY` to drift step; adds epic close-readiness summarize step
+
 ## [Unreleased] — ADR-010 Lifecycle Enforcement + Daily Scan (#358)
 
 ### Added — Label Governance Enforcement

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "routing:report": "node scripts/global/routing-baseline-report.js --days 7",
     "routing:calibrate": "node scripts/global/cascade-calibrate.js",
     "governance:drift": "node scripts/global/governance-drift-classifier.js --json",
+    "governance:epics": "node scripts/global/epic-close-validator.js",
     "governance:epic": "node scripts/global/epic-evidence.js",
     "governance:verify": "node scripts/global/governance-verify.js --json",
     "governance:worktrees": "node scripts/global/worktree-governance-audit.js --json",

--- a/scripts/global/epic-close-validator.js
+++ b/scripts/global/epic-close-validator.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+'use strict';
+
+const GH_HEADERS = token => ({
+  Authorization: `Bearer ${token}`,
+  Accept: 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+});
+
+async function get(url, token) {
+  const res = await fetch(url, { headers: GH_HEADERS(token) });
+  if (!res.ok) throw new Error(`GitHub API ${res.status} on ${url}`);
+  return res.json();
+}
+
+async function getOpenEpics(token, owner, repo) {
+  const epics = [];
+  let page = 1;
+  while (true) {
+    const batch = await get(
+      `https://api.github.com/repos/${owner}/${repo}/issues?labels=type:epic&state=open&per_page=100&page=${page}`,
+      token
+    );
+    if (!batch.length) break;
+    epics.push(...batch);
+    if (batch.length < 100) break;
+    page++;
+  }
+  return epics;
+}
+
+async function getOpenChildCount(token, owner, repo, epicNum) {
+  const timeline = await get(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${epicNum}/timeline?per_page=100`,
+    token
+  );
+  const childNums = [...new Set(
+    timeline
+      .filter(e => e.event === 'cross-referenced' && e.source?.issue?.number)
+      .map(e => e.source.issue.number)
+  )];
+  const openChildren = await Promise.all(
+    childNums.map(n =>
+      get(`https://api.github.com/repos/${owner}/${repo}/issues/${n}`, token)
+        .then(i => (i.state === 'open' ? n : null))
+        .catch(() => null)
+    )
+  );
+  return openChildren.filter(Boolean).length;
+}
+
+async function hasCloseout(token, owner, repo, issueNum) {
+  const comments = await get(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${issueNum}/comments?per_page=100`,
+    token
+  );
+  return comments.some(c => c.body?.includes('CONSULTANT_CLOSEOUT'));
+}
+
+async function validateEpics(token, owner, repo) {
+  const epics = await getOpenEpics(token, owner, repo);
+  const results = [];
+  for (const epic of epics) {
+    const statusLabels = epic.labels.map(l => l.name).filter(l => l.startsWith('status:'));
+    const blockers = [];
+    if (!statusLabels.includes('status:review')) {
+      blockers.push(`not at status:review (current: ${statusLabels.join(', ') || 'none'})`);
+    }
+    const openChildCount = await getOpenChildCount(token, owner, repo, epic.number);
+    if (openChildCount > 0) blockers.push(`${openChildCount} open child issue(s) remain`);
+    const closeout = await hasCloseout(token, owner, repo, epic.number);
+    if (!closeout) blockers.push('missing CONSULTANT_CLOSEOUT comment');
+    results.push({ epicNum: epic.number, title: epic.title, ready: blockers.length === 0, blockers });
+  }
+  return results;
+}
+
+module.exports = { validateEpics };
+
+if (require.main === module) {
+  const token = process.env.GITHUB_TOKEN;
+  const [owner, repo] = (process.env.GITHUB_REPOSITORY || 'chf3198/megingjord-harness').split('/');
+  validateEpics(token, owner, repo)
+    .then(r => console.log(JSON.stringify(r, null, 2)))
+    .catch(e => { console.error(e.message); process.exit(1); });
+}

--- a/scripts/global/epic-close-validator.js
+++ b/scripts/global/epic-close-validator.js
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 'use strict';
 
+const GH_API_VERSION = '2022-11-28';
+
 const GH_HEADERS = token => ({
   Authorization: `Bearer ${token}`,
   Accept: 'application/vnd.github+json',
-  'X-GitHub-Api-Version': '2022-11-28',
+  'X-GitHub-Api-Version': GH_API_VERSION,
 });
 
 async function get(url, token) {

--- a/scripts/global/governance-drift-classifier.js
+++ b/scripts/global/governance-drift-classifier.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
+const { scanGitHubLabels } = require('./governance-github-scanner');
 
 const root = path.resolve(__dirname, '..', '..');
 const logsDir = path.join(root, 'logs');
@@ -57,21 +58,31 @@ function runVerify() {
   }
 }
 
-function buildReport(verifyData) {
+function buildReport(verifyData, gh = { violations: [], counts: { open: 0, terminal: 0, epic: 0 } }) {
   const classes = classify(verifyData.issues || []);
-  const total = verifyData.failedChecks || 0;
+  const total = (verifyData.failedChecks || 0) + gh.violations.length;
   return {
     generatedAt: new Date().toISOString(),
     checkedTickets: verifyData.checkedTickets || 0,
     totalDrift: total,
-    driftByClass: { open: classes.open.length, terminal: classes.terminal.length, epic: classes.epic.length },
+    driftByClass: {
+      open: classes.open.length + gh.counts.open,
+      terminal: classes.terminal.length + gh.counts.terminal,
+      epic: classes.epic.length + gh.counts.epic,
+    },
+    githubViolations: gh.violations,
     details: classes,
     status: total === 0 ? 'no-drift' : 'drift-detected',
   };
 }
 
-function run() {
-  const report = buildReport(JSON.parse(runVerify()));
+async function run() {
+  let ghData = { violations: [], counts: { open: 0, terminal: 0, epic: 0 } };
+  if (process.env.GITHUB_TOKEN) {
+    const [owner, repo] = (process.env.GITHUB_REPOSITORY || '/').split('/');
+    ghData = await scanGitHubLabels(process.env.GITHUB_TOKEN, owner, repo).catch(() => ghData);
+  }
+  const report = buildReport(JSON.parse(runVerify()), ghData);
   fs.mkdirSync(logsDir, { recursive: true });
   fs.writeFileSync(
     path.join(logsDir, 'governance-drift.json'),
@@ -87,4 +98,4 @@ function run() {
 }
 
 module.exports = { classify, classifyIssue };
-if (require.main === module) run();
+if (require.main === module) run().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/global/governance-github-scanner.js
+++ b/scripts/global/governance-github-scanner.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+'use strict';
+
+const VALID_ACTIVE_STATUS_ROLE = {
+  'status:in-progress': 'role:collaborator',
+  'status:testing': 'role:admin',
+  'status:review': 'role:consultant',
+};
+
+async function fetchAllIssues(token, owner, repo) {
+  const issues = [];
+  let page = 1;
+  while (true) {
+    const res = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/issues?state=all&per_page=100&page=${page}`,
+      { headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28' } }
+    );
+    if (!res.ok) throw new Error(`GitHub API ${res.status}`);
+    const batch = await res.json();
+    if (!batch.length) break;
+    issues.push(...batch.filter(i => !i.pull_request));
+    if (batch.length < 100) break;
+    page++;
+  }
+  return issues;
+}
+
+function checkIssue(issue) {
+  const labels = issue.labels.map(l => l.name);
+  const statusLabels = labels.filter(l => l.startsWith('status:'));
+  const roleLabels = labels.filter(l => l.startsWith('role:'));
+  const violations = [];
+
+  if (issue.state === 'closed' && roleLabels.length > 0) {
+    violations.push({ rule: 'closed+role', driftClass: 'terminal', detail: `role labels on closed: ${roleLabels.join(', ')}` });
+  }
+  if (statusLabels.includes('status:done') && roleLabels.length > 0) {
+    violations.push({ rule: 'done+role', driftClass: 'terminal', detail: `status:done retains role: ${roleLabels.join(', ')}` });
+  }
+  for (const [status, required] of Object.entries(VALID_ACTIVE_STATUS_ROLE)) {
+    if (statusLabels.includes(status) && !roleLabels.includes(required)) {
+      violations.push({ rule: `missing-${required}`, driftClass: 'open', detail: `${status} missing ${required}` });
+    }
+  }
+  if (labels.includes('type:epic') && statusLabels.includes('status:ready')) {
+    violations.push({ rule: 'epic+ready', driftClass: 'epic', detail: 'epic at status:ready (child-ticket status only)' });
+  }
+  if (statusLabels.length > 1) {
+    violations.push({ rule: 'multi-status', driftClass: 'open', detail: `multiple status labels: ${statusLabels.join(', ')}` });
+  }
+  return violations;
+}
+
+async function scanGitHubLabels(token, owner, repo) {
+  const issues = await fetchAllIssues(token, owner, repo);
+  const violations = [];
+  const counts = { open: 0, terminal: 0, epic: 0 };
+  for (const issue of issues) {
+    for (const v of checkIssue(issue)) {
+      violations.push({ issueNum: issue.number, title: issue.title, ...v });
+      counts[v.driftClass]++;
+    }
+  }
+  return { violations, counts };
+}
+
+module.exports = { scanGitHubLabels };

--- a/scripts/global/governance-github-scanner.js
+++ b/scripts/global/governance-github-scanner.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
+const GH_API_VERSION = '2022-11-28';
+
 const VALID_ACTIVE_STATUS_ROLE = {
   'status:in-progress': 'role:collaborator',
   'status:testing': 'role:admin',
@@ -13,7 +15,7 @@ async function fetchAllIssues(token, owner, repo) {
   while (true) {
     const res = await fetch(
       `https://api.github.com/repos/${owner}/${repo}/issues?state=all&per_page=100&page=${page}`,
-      { headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28' } }
+      { headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': GH_API_VERSION } }
     );
     if (!res.ok) throw new Error(`GitHub API ${res.status}`);
     const batch = await res.json();
@@ -56,9 +58,9 @@ async function scanGitHubLabels(token, owner, repo) {
   const violations = [];
   const counts = { open: 0, terminal: 0, epic: 0 };
   for (const issue of issues) {
-    for (const v of checkIssue(issue)) {
-      violations.push({ issueNum: issue.number, title: issue.title, ...v });
-      counts[v.driftClass]++;
+    for (const violation of checkIssue(issue)) {
+      violations.push({ issueNum: issue.number, title: issue.title, ...violation });
+      counts[violation.driftClass]++;
     }
   }
   return { violations, counts };


### PR DESCRIPTION
## Summary

- `scripts/global/governance-github-scanner.js` (new, 68 lines): live ADR-010 label scan via GitHub REST API with pagination — closes Gap 3
- `scripts/global/epic-close-validator.js` (new, 87 lines): epic close-readiness check (status:review, open children via timeline, CONSULTANT_CLOSEOUT)
- `scripts/global/governance-drift-classifier.js`: now async, integrates GitHub scanner when `GITHUB_TOKEN` set, adds `githubViolations` to drift report
- `.github/workflows/drift-detection.yml`: passes `GITHUB_TOKEN`/`GITHUB_REPOSITORY`, adds epic readiness step
- `package.json`: adds `governance:epics` npm script

## Test plan

- [ ] `node scripts/global/governance-drift-classifier.js --json` runs locally (no GITHUB_TOKEN = no GitHub scan, passes clean)
- [ ] `node scripts/global/epic-close-validator.js` runs when GITHUB_TOKEN set
- [ ] ESLint 0 errors
- [ ] Readability baseline 389 (unchanged)
- [ ] Prettier passes

Refs #359

COLLABORATOR_HANDOFF: see issue #359 comments
ADMIN_HANDOFF: see issue #359 comments

🤖 Generated with [Claude Code](https://claude.ai/claude-code)