### PR TITLE
feat(dashboard): add event-animation CSS classes to Context Flow

### DIFF
--- a/dashboard/css/context.css
+++ b/dashboard/css/context.css
@@ -93,3 +93,8 @@
   background: var(--bg); border: 1px solid var(--border);
   border-radius: 3px; padding: 0 0.2rem;
 }
+
+/* Context Flow event-driven animation classes (#706) */
+@keyframes cf-pulse { 0% { opacity:1; filter:drop-shadow(0 0 4px #60a5fa); } 100% { opacity:.5; filter:none; } }
+.cf-active { animation: cf-pulse 3s ease-out forwards; }
+.cf-idle   { opacity: 0.35; }


### PR DESCRIPTION
## Summary
- Adds `@keyframes cf-pulse`, `.cf-active`, and `.cf-idle` to `dashboard/css/context.css`
- Prerequisite CSS layer for event-wiring module (#707) that toggles these classes on SSE fleet events
- File stays at exactly 100 lines

## Refs #706

## Evidence
- `npm run lint` → ✅ all 333 files ≤100 lines
- `lint:readability:ci` → ✅ exit 0 (389/389 warnings, at baseline)
- `tests/layout-regression.spec.js` → ✅ 4/4 passed

## Test plan
- [x] 100-line lint passes
- [x] Readability baseline unchanged
- [x] Layout regression tests pass (4/4)
- [x] No existing selectors modified; additive CSS only

COLLABORATOR_HANDOFF: posted as issue comment #706
ADMIN_HANDOFF: included below
CONSULTANT_CLOSEOUT: included in issue #706 after merge