### PR TITLE
feat(infra): add API smoke tests for critical dashboard endpoints

### DIFF
--- a/tests/api-smoke.spec.js
+++ b/tests/api-smoke.spec.js
@@ -1,0 +1,60 @@
+// API smoke tests — critical endpoint health and concurrency gate (#713 / epic #380)
+const { test, expect } = require('@playwright/test');
+
+const CRITICAL_ENDPOINTS = [
+  '/api/wiki-health',
+  '/api/wiki-pages',
+  '/api/wiki-metrics',
+  '/api/host-info',
+  '/api/router/metrics',
+  '/api/events',
+  '/api/fleet-health',
+  '/api/copilot-usage',
+];
+const CONCURRENT_THRESHOLD_MS = 3000;
+const SEQUENTIAL_THRESHOLD_MS = 3000;
+const RAPID_REQUEST_COUNT = 3;
+
+test.describe('API smoke — critical endpoint health (#713)', () => {
+  test('each critical endpoint returns HTTP 200 with JSON content-type', async ({ request }) => {
+    for (const endpoint of CRITICAL_ENDPOINTS) {
+      const response = await request.get(endpoint);
+      expect(response.status(), `${endpoint} returned non-200`).toBe(200);
+      expect(
+        response.headers()['content-type'],
+        `${endpoint} did not return JSON`
+      ).toContain('application/json');
+    }
+  });
+
+  test('all 8 critical endpoints respond concurrently within 3000ms', async ({ request }) => {
+    const startMs = Date.now();
+    const responses = await Promise.all(
+      CRITICAL_ENDPOINTS.map(endpoint => request.get(endpoint))
+    );
+    const elapsedMs = Date.now() - startMs;
+    responses.forEach((response, index) => {
+      expect(
+        response.status(),
+        `${CRITICAL_ENDPOINTS[index]} failed under concurrent load`
+      ).toBe(200);
+    });
+    expect(
+      elapsedMs,
+      `Concurrent API load took ${elapsedMs}ms — event loop may be blocked`
+    ).toBeLessThan(CONCURRENT_THRESHOLD_MS);
+  });
+
+  test('3 rapid sequential requests to /api/wiki-health return 200 without blocking', async ({ request }) => {
+    const startMs = Date.now();
+    for (let requestNum = 0; requestNum < RAPID_REQUEST_COUNT; requestNum++) {
+      const response = await request.get('/api/wiki-health');
+      expect(response.status(), `wiki-health request ${requestNum + 1} failed`).toBe(200);
+    }
+    const elapsedMs = Date.now() - startMs;
+    expect(
+      elapsedMs,
+      `3 sequential wiki-health requests took ${elapsedMs}ms (>3000ms = blocking)`
+    ).toBeLessThan(SEQUENTIAL_THRESHOLD_MS);
+  });
+});


### PR DESCRIPTION
## Summary
- New `tests/api-smoke.spec.js` (60 lines): 3 test suites smoke-testing 8 critical API endpoints
- Individual endpoint: each returns HTTP 200 + JSON content-type
- Concurrent load: 8 `Promise.all` requests complete within 3000ms (event-loop blocking detector)
- Rapid sequential: 3 wiki-health requests within 3000ms

## Refs #713

## Evidence
- `npm run lint` → ✅ 336 files ≤100 lines
- `lint:readability:ci` → ✅ exit 0 (389/389, no new warnings)
- `tests/api-smoke.spec.js` → ✅ 3/3 passed (1.2s)

## Test plan
- [x] 100-line lint passes
- [x] Readability baseline unchanged
- [x] 3 new API smoke test suites pass

COLLABORATOR_HANDOFF: posted as issue comment #713
ADMIN_HANDOFF: included below
CONSULTANT_CLOSEOUT: posted to issue #713 after merge