### PR TITLE
docs(agents): narrow Bearer token heuristic #466

### DIFF
--- a/.claude/agents/security-scanner.md
+++ b/.claude/agents/security-scanner.md
@@ -16,7 +16,7 @@ codebase, git history, packaged artifacts, and CI workflows.
 
 ### 1. Live File Scan
 Search for files containing potential secrets:
-- API keys: patterns like `sk-`, `ghp_`, `gho_`, `Bearer`, `token`, `secret`, `password`
+- API keys: patterns like `sk-`, `ghp_`, `gho_`, `Bearer `, `token`, `secret`, `password`
 - `.env` files with real values (not placeholders)
 - Private keys: `-----BEGIN`, `.pem`, `.key`, `id_rsa`, `id_ed25519`
 - Hard-coded credentials in source files

--- a/.claude/agents/security-scanner.md
+++ b/.claude/agents/security-scanner.md
@@ -16,7 +16,7 @@ codebase, git history, packaged artifacts, and CI workflows.
 
 ### 1. Live File Scan
 Search for files containing potential secrets:
-- API keys: patterns like `sk-`, `ghp_`, `gho_`, `Bearer `, `token`, `secret`, `password`
+- API keys: patterns like `sk-`, `ghp_`, `gho_`, `Bearer` (with trailing space), `token`, `secret`, `password`
 - `.env` files with real values (not placeholders)
 - Private keys: `-----BEGIN`, `.pem`, `.key`, `id_rsa`, `id_ed25519`
 - Hard-coded credentials in source files


### PR DESCRIPTION
## Summary

- Tightens `Bearer` → `Bearer ` (trailing space) in the security-scanner agent's live-file-scan heuristic
- HTTP `Authorization: Bearer <token>` always includes a space; the bare `Bearer` pattern incorrectly matched identifiers like `BearerToken` and env-var suffixes already caught by the `token` keyword

## Lane

`lane:docs-research` — agent instruction file only; no executable code changed.

## Baton artifacts

- MANAGER_HANDOFF: posted on issue #466
- COLLABORATOR_HANDOFF: N/A — docs/research lane
- ADMIN_HANDOFF: N/A — docs/research lane
- CONSULTANT_CLOSEOUT: posted on issue #466

Refs #466

## Test plan

- [x] `npm run lint` — ✅ 336 files, all within 100-line limit
- [x] `npm run lint:readability:ci --max-warnings=389` — ✅ exactly 389 warnings (no regression)
- [x] Manual grep: `Bearer ` (with space) still matches all real `Authorization: Bearer <token>` strings