### PR TITLE
feat(governance): add docs-lint drift detector and CI gate #722

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,42 @@
+name: Docs Lint
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'dashboard/js/help-*.js'
+      - 'instructions/**'
+      - 'scripts/**'
+      - 'package.json'
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [main]
+    paths:
+      - 'dashboard/js/help-*.js'
+      - 'instructions/**'
+      - 'scripts/**'
+      - 'package.json'
+
+concurrency:
+  group: docs-lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docs_lint:
+    name: docs-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+      - name: Sync wiki cache
+        run: |
+          mkdir -p "$HOME/.copilot/wiki/concepts" "$HOME/.copilot/wiki/entities"
+          if [ -d wiki/concepts ]; then cp -r wiki/concepts/* "$HOME/.copilot/wiki/concepts/" 2>/dev/null || true; fi
+          if [ -d wiki/entities ]; then cp -r wiki/entities/* "$HOME/.copilot/wiki/entities/" 2>/dev/null || true; fi
+      - name: Run docs:lint
+        run: node scripts/docs-lint.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] — Docs Drift Detector and CI Gate (#722)
+
+### Added
+- `scripts/docs-lint.js`: deterministic docs-drift checker. Validates that every `npm run X` token in `dashboard/js/help-*.js` resolves to a real `package.json` script, every `[[wikilink]]` resolves to a real wiki page in `~/.copilot/wiki/concepts/` or `~/.copilot/wiki/entities/`, and warns on `instructions/*.md` files older than 90 days.
+- `.github/workflows/docs-lint.yml`: NEW workflow that runs `npm run docs:lint` on PRs touching HELP, instructions, scripts, or package.json. Syncs `wiki/` to `~/.copilot/wiki/` before the check.
+- `package.json`: added `docs:lint` script.
+
 ## [Unreleased] — HELP Wikilinks and help:topic CLI (#718)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "wiki:anneal": "node scripts/wiki/anneal.js",
     "wiki:search": "node scripts/wiki/search.js",
     "help:topic": "node scripts/help-topic.js",
+    "docs:lint": "node scripts/docs-lint.js",
     "validate:triage": "node scripts/validate-plugin-triage.js",
     "validate:compat": "node scripts/validate-plugin-compat.js",
     "test": "npx playwright test",

--- a/scripts/docs-lint.js
+++ b/scripts/docs-lint.js
@@ -1,0 +1,59 @@
+// Docs drift detector — checks HELP↔script, HELP↔wiki, stale instructions (#722)
+const fs = require('fs');
+const path = require('path');
+
+const STALE_THRESHOLD_DAYS = 90;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const HELP_DIR = 'dashboard/js';
+const INSTRUCTIONS_DIR = 'instructions';
+const WIKI_BASE = path.join(process.env.HOME, '.copilot/wiki');
+
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const scripts = packageJson.scripts || {};
+let failCount = 0;
+let warnCount = 0;
+
+const helpFiles = fs.readdirSync(HELP_DIR)
+  .filter(name => name.startsWith('help-') && name.endsWith('.js'));
+
+helpFiles.forEach(name => {
+  const filePath = path.join(HELP_DIR, name);
+  const content = fs.readFileSync(filePath, 'utf8');
+
+  const scriptRegex = /npm run ([\w:-]+)/g;
+  let match;
+  while ((match = scriptRegex.exec(content)) !== null) {
+    if (!scripts[match[1]]) {
+      console.log(`❌ Missing script: ${match[1]} in ${name}`);
+      failCount += 1;
+    }
+  }
+
+  const wikiRegex = /\[\[([\w-]+)\]\]/g;
+  while ((match = wikiRegex.exec(content)) !== null) {
+    const conceptPath = path.join(WIKI_BASE, 'concepts', `${match[1]}.md`);
+    const entityPath = path.join(WIKI_BASE, 'entities', `${match[1]}.md`);
+    if (!fs.existsSync(conceptPath) && !fs.existsSync(entityPath)) {
+      console.log(`❌ Missing wiki: ${match[1]} in ${name}`);
+      failCount += 1;
+    }
+  }
+});
+
+const now = Date.now();
+const staleThresholdMs = STALE_THRESHOLD_DAYS * MS_PER_DAY;
+
+fs.readdirSync(INSTRUCTIONS_DIR)
+  .filter(name => name.endsWith('.md'))
+  .forEach(name => {
+    const stats = fs.statSync(path.join(INSTRUCTIONS_DIR, name));
+    if ((now - stats.mtimeMs) > staleThresholdMs) {
+      console.log(`⚠️  Stale (>${STALE_THRESHOLD_DAYS}d): ${name}`);
+      warnCount += 1;
+    }
+  });
+
+console.log(failCount === 0
+  ? `✅ docs-lint clean (${warnCount} warnings)`
+  : `❌ docs-lint: ${failCount} issues, ${warnCount} warnings`);
+process.exit(failCount > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- Adds `scripts/docs-lint.js` (59 lines) — three deterministic docs-drift checks:
  - **HELP → script**: every `npm run X` token in `dashboard/js/help-*.js` resolves to a real script in `package.json`
  - **HELP → wiki**: every `[[wikilink]]` resolves to a real page in `~/.copilot/wiki/concepts/` or `~/.copilot/wiki/entities/`
  - **Stale instructions** (warn-only): flags `instructions/*.md` files older than 90 days
- Adds **NEW** `.github/workflows/docs-lint.yml` (42 lines)
- Adds `npm run docs:lint` script
- Phase 3 of epic #601 documentation modernization

## Fleet utilization

- Groq `llama-3.3-70b-versatile` generated the core docs-lint.js logic
- 36gbwinresource and Cerebras attempted (rate-limited / endpoint unreachable)

## Conflict avoidance

- NEW workflow file only — no edits to existing `.github/workflows/`
- No `wiki/` files touched (PR #602 active)
- No README/CONTRIBUTING touched

## Baton artifacts

- MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT on issue #722

Refs #722

## Test plan

- [x] `npm run lint` — ✅ 339 files all ≤100 lines
- [x] `npm run lint:readability:ci --max-warnings=389` — ✅ exactly 389
- [x] `npm run docs:lint` on clean main — ✅ clean
- [x] Drift detection verified
- [ ] CI gates green (pending)