### PR TITLE
chore(governance): add no-sync HTTP guard #723

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -34,6 +34,8 @@ jobs:
         run: npm run format:check
       - name: 100-line lint
         run: npm run lint
+      - name: HTTP handler sync-call guard
+        run: npm run governance:no-sync-http
       - name: Readability gate
         run: npm run lint:readability:ci
       - name: Router smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased] — HTTP Handler Sync-Call Guard (#723)
+
+### Added
+- `scripts/global/no-sync-http-handlers.js`: fails when `execSync` or `spawnSync` appears in dashboard HTTP handler files.
+- `package.json`: added `governance:no-sync-http` script.
+
+### Changed
+- `.github/workflows/quality-gates.yml`: now runs `npm run governance:no-sync-http` as a required quality gate.
+
 ## [Unreleased] — Docs Drift Detector and CI Gate (#722)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "governance:drift": "node scripts/global/governance-drift-classifier.js --json",
     "governance:epics": "node scripts/global/epic-close-validator.js",
     "governance:epic": "node scripts/global/epic-evidence.js",
+    "governance:no-sync-http": "node scripts/global/no-sync-http-handlers.js",
     "governance:reconcile": "node scripts/global/ticket-reconcile.js --json",
     "governance:verify": "node scripts/global/governance-verify.js --json",
     "governance:worktrees": "node scripts/global/worktree-governance-audit.js --json",

--- a/scripts/global/no-sync-http-handlers.js
+++ b/scripts/global/no-sync-http-handlers.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Guard: disallow sync child_process calls in dashboard HTTP handlers
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const TARGET_FILES = [
+  'scripts/dashboard-server.js',
+  'scripts/dashboard-api-handlers.js',
+  'scripts/global/dashboard-api.js',
+  'scripts/global/dashboard-serve.js',
+];
+const PROHIBITED_PATTERN = /\b(execSync|spawnSync)\s*\(/g;
+
+function resolveTargetPath(relativePath) {
+  return path.join(ROOT, relativePath);
+}
+
+function findViolations(relativePath) {
+  const absolutePath = resolveTargetPath(relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    return [{ relativePath, lineNumber: 0, matchText: 'missing file' }];
+  }
+  const fileText = fs.readFileSync(absolutePath, 'utf8');
+  const fileLines = fileText.split('\n');
+  const violations = [];
+  for (let lineIndex = 0; lineIndex < fileLines.length; lineIndex += 1) {
+    const currentLine = fileLines[lineIndex];
+    const regex = new RegExp(PROHIBITED_PATTERN.source, 'g');
+    const match = regex.exec(currentLine);
+    if (!match) continue;
+    violations.push({
+      relativePath,
+      lineNumber: lineIndex + 1,
+      matchText: match[1],
+    });
+  }
+  return violations;
+}
+
+function main() {
+  const allViolations = TARGET_FILES.flatMap(findViolations)
+    .filter(item => item.matchText !== 'missing file');
+  if (allViolations.length === 0) {
+    console.log('no-sync-http-handlers: PASS');
+    process.exit(0);
+  }
+  console.error('no-sync-http-handlers: FAIL');
+  allViolations.forEach(item => {
+    console.error(`- ${item.relativePath}:${item.lineNumber} uses ${item.matchText}()`);
+  });
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `scripts/global/no-sync-http-handlers.js` guard for dashboard HTTP handler files
- add `governance:no-sync-http` npm script
- run guard in quality gates workflow
- update changelog entry for #723

## Validation
- npm run governance:no-sync-http
- npm run lint
- npm run governance:verify

## Fleet/provider utilization
- 36gbwinresource (`qwen2.5-coder:7b`) used for design validation
- OpenClaw preflight and health checks attempted (unreachable in this run)
- OpenRouter, Groq, Google AI Studio, Cerebras probes executed

Refs #723
Closes #723
