### PR TITLE
docs: add ARCHITECTURE, HELP-GUIDELINES, and DECISIONS index #727

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] — Architecture Documentation Library (#727)
+
+### Added
+- `docs/ARCHITECTURE.md`: system data-flow map and subsystem index (routing, governance, wiki, dashboard, fleet) with file pointers to canonical sources.
+- `docs/HELP-GUIDELINES.md`: HELP panel UX patterns — section-id taxonomy (`start-*`, `use-*`, `trouble-*`, `dev-*`), body HTML conventions, file-size discipline, wikilink rules.
+- `docs/DECISIONS.md`: index for the 11 ADRs in `research/adr/` (canonical store) with how-to-add-a-new-ADR guidance.
+
 ## [Unreleased] — HTTP Handler Sync-Call Guard (#723)
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,85 @@
+# Megingjord — Architecture
+
+Governance-first multi-runtime AI agent harness. This document is a navigation
+map; each subsystem links to the canonical source files where details live.
+
+## High-level data flow
+
+```
+Editor / Agent runtime         Routing               Execution                Governance
+───────────────────────        ───────────           ─────────────            ──────────────
+VS Code Copilot          ─→    cascade-dispatch ─→  Fleet (Ollama via         GitHub issues +
+Claude Code                    + model-routing-     Tailscale)                workflows + skills
+Codex                          policy.json          OR Cloud (Claude /        + scripts/global/
+                                                    OpenAI / Groq /
+                                                    Cerebras / Google AI)
+                                                       │
+                                                       ▼
+                                          .dashboard/events.jsonl
+                                                       │
+                                                       ▼
+                                                Dashboard (SSE)
+```
+
+## Subsystems
+
+### Routing
+
+- `scripts/global/cascade-dispatch.js` — fleet-first cascade (Free → Fleet → Haiku → Premium)
+- `scripts/global/model-routing-policy.json` — capability matrix, lane order
+- `scripts/global/task-router-dispatch.js` — direct dispatch to a tier
+- `agents/router.agent.md` — Routing role definition
+
+### Governance
+
+- `.github/workflows/` — baton-gates, evidence-completeness, doc-update-gate, label-lint, etc.
+- `scripts/global/governance-drift-classifier.js` — drift detection
+- `scripts/global/ticket-reconcile.js` — local↔GitHub ticket consistency
+- `scripts/global/epic-close-validator.js` — epic close-readiness
+
+### Wiki (LLM Knowledge System)
+
+- `~/.copilot/wiki/` — compiled wiki (read-only from non-Megingjord repos)
+- `wiki/` (this repo) — source markdown that compiles into the above
+- `~/.copilot/scripts/wiki-search.js` — search CLI used by `npm run help:topic`
+- `scripts/wiki/ingest.js`, `lint.js`, `anneal.js` — pipeline
+
+### Dashboard
+
+- `dashboard/index.html` — Alpine.js shell, all panels declared as `<template>`
+- `dashboard/js/app.js` — `dashboardApp()` Alpine root component, refresh cycle
+- `dashboard/js/render-panels.js` — pure functions returning HTML for each panel
+- `dashboard/js/event-source.js` + `event-bus.js` — SSE client + JSONL polling
+- `scripts/dashboard-server.js` — Node HTTP server :8090, SSE handler
+
+### Fleet
+
+- `inventory/devices.json` — Tailscale IPs, Ollama models, GPU/CPU class
+- `scripts/health-check.js` — fleet connectivity probe
+- Runtime targets: `36gbwinresource` (GPU 32 TPS), `OpenClaw` (CPU 7 TPS), `penguin-1` (micro)
+
+## Data flows
+
+- **Events** — agents/tools append JSONL to `.dashboard/events.jsonl`; dashboard server tails the file and broadcasts via SSE; clients render in Live Activity / Baton panels.
+- **Baton** — every issue is a baton; roles transition Manager → Collaborator → Admin → Consultant; each posts a named handoff comment; CI gates verify the trail.
+- **State** — short-term state in `.dashboard/state/` (gitignored); long-term truth in GitHub issues/PRs.
+
+## Deployment targets
+
+- `~/.copilot/` — Copilot runtime install root (skills, hooks, scripts, wiki)
+- `~/.claude/` — Claude Code install root (commands, agents, hooks)
+- `~/.codex/` — Codex runtime install root
+- Megingjord repo — source of truth; nothing is edited in deployed roots directly
+
+## Cross-runtime sync
+
+- `scripts/sync.sh` — copy from repo to runtime root (copilot/claude/codex/all)
+- `scripts/deploy.sh` — sync + post-deploy hooks (`npm run deploy:apply`)
+- Per-runtime targets via `--target` flag
+
+## Related documents
+
+- `docs/HELP-GUIDELINES.md` — HELP panel UX patterns
+- `docs/DECISIONS.md` — index of architecture decision records
+- `docs/STYLE-GUIDE.md` — terminology
+- `research/adr/` — full ADR set

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,52 @@
+# Architecture Decision Records — Index
+
+ADRs document significant architecture and process decisions for Megingjord.
+The canonical store is [`research/adr/`](../research/adr/) — this file is an
+index, not a duplicate. To prevent split source-of-truth, **never** add
+decision records under `docs/DECISIONS/`; always add them to `research/adr/`.
+
+## How to add a new ADR
+
+1. Pick the next sequential number (current highest: 011).
+2. Copy `research/adr/README.md` template structure into `research/adr/NNN-slug.md`.
+3. Fill in: Status (Proposed / Accepted / Deprecated / Superseded), Date,
+   Context, Decision, Consequences, Alternatives Considered.
+4. Reference any superseded ADR with a "Supersedes ADR-XXX" line.
+5. Update this index in the same PR.
+6. Link the ADR from related skills, instructions, or design docs.
+
+The `manager-ticket-lifecycle` baton workflow applies: ADRs that change
+governance must go through Manager → Consultant; technical-only ADRs may be
+admin-tracked.
+
+## Existing ADRs
+
+| # | Title | File |
+|---|-------|------|
+| 001 | Skills as Versioned Code | [`001-skills-as-code.md`](../research/adr/001-skills-as-code.md) |
+| 002 | Dashboard Stack — Alpine.js + Static | [`002-dashboard-stack.md`](../research/adr/002-dashboard-stack.md) |
+| 003 | Free-Tier Failover Routing | [`003-failover-routing.md`](../research/adr/003-failover-routing.md) |
+| 004 | Global Task Router | [`004-global-task-router.md`](../research/adr/004-global-task-router.md) |
+| 004 | Model Routing via Custom Agents | [`004-model-routing-agents.md`](../research/adr/004-model-routing-agents.md) |
+| 005 | Ticket-Driven Work Management | [`005-ticket-driven-work.md`](../research/adr/005-ticket-driven-work.md) |
+| 006 | Visual QA Gate for Web Releases | [`006-visual-qa-gate.md`](../research/adr/006-visual-qa-gate.md) |
+| 007 | LLM Wiki Knowledge System Adoption | [`007-llm-wiki-adoption.md`](../research/adr/007-llm-wiki-adoption.md) |
+| 008 | Canonical Ticket Lifecycle and Status-Role Binding | [`008-canonical-ticket-lifecycle.md`](../research/adr/008-canonical-ticket-lifecycle.md) |
+| 009 | GitHub Feature Adoption | [`009-github-feature-adoption.md`](../research/adr/009-github-feature-adoption.md) |
+| 010 | Ticket Status–Role Ownership Binding Model | [`010-ticket-status-role-model.md`](../research/adr/010-ticket-status-role-model.md) |
+| 011 | Fleet Auto-Discovery Architecture | [`011-fleet-auto-discovery.md`](../research/adr/011-fleet-auto-discovery.md) |
+
+## Known issues
+
+- ADR-004 has a duplicate number (Global Task Router and Model Routing via
+  Custom Agents). One should be renumbered when a related change next touches
+  the routing subsystem; both are referenced from active instructions today,
+  so renumbering blindly would create dangling links.
+- README.md under `research/adr/` is the long-form contributor guide; this
+  file is the navigation index for the broader documentation set.
+
+## Related
+
+- [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) — system map (subsystems linked to ADRs)
+- [`docs/HELP-GUIDELINES.md`](HELP-GUIDELINES.md) — HELP panel UX patterns
+- [`docs/STYLE-GUIDE.md`](STYLE-GUIDE.md) — canonical terminology

--- a/docs/HELP-GUIDELINES.md
+++ b/docs/HELP-GUIDELINES.md
@@ -1,0 +1,78 @@
+# HELP Panel UX Guidelines
+
+The Megingjord dashboard HELP panels are composed of two JavaScript files in
+`dashboard/js/`: `help-user.js` (task-oriented operator help) and `help-dev.js`
+(developer/architecture help). Each file exports an array of section objects
+with shape `{ id, title, body }` consumed by `renderHelpPanel()` in
+`help-content.js`.
+
+## Section ID prefix taxonomy
+
+Every section's `id` must use one of these prefixes so the renderer can group
+sections into the correct help category:
+
+- `start-*` — orientation and dashboard tour (e.g. `start-what`, `start-tour`)
+- `use-*` — operator workflow per panel (e.g. `use-baton`, `use-governance`)
+- `trouble-*` — troubleshooting recipes (e.g. `trouble-offline`, `trouble-stale`)
+- `dev-*` — developer / architecture / skill-development (`help-dev.js` only)
+
+## Body-string conventions
+
+Body strings are HTML fragments rendered via `x-html` after passing through
+`renderWikiLinks()`. Use these patterns consistently:
+
+- `<strong>` — nouns and UI labels (panel names, button names, status terms)
+- `<em>` — inline emphasis and the wikilink suffix
+- `<code>` — file paths, shell commands, and `npm run` invocations
+- `<br>` — line breaks **within** a body string (avoid block elements)
+- `<em>Learn more: [[wiki-page]]</em>` — canonical wikilink-suffix pattern
+
+The `[[wiki-page]]` token is transformed to a clickable Alpine-wired anchor
+that switches the dashboard to Wiki view.
+
+## When to add to which file
+
+- `help-user.js` — anything an operator does to monitor or operate the fleet.
+  Reading panels, running stress tests, troubleshooting offline devices.
+- `help-dev.js` — anything that requires editing this repo: architecture,
+  contribution flow, skill development, file structure, API endpoints.
+
+If a section is useful to both audiences, prefer `help-user.js` and link from
+`help-dev.js` via wikilink rather than duplicating the body.
+
+## File-size discipline
+
+The repo lint rule (`scripts/lint.js`) enforces ≤100 lines per file. When a
+help file approaches 90 lines, split by topic into a new file (e.g.
+`help-troubleshooting.js`) and add the corresponding `<script>` tag to
+`dashboard/index.html` and the new `HELP_*_SECTIONS` constant import in
+`help-content.js`.
+
+## Wikilink discipline
+
+Only reference wiki pages that exist in `~/.copilot/wiki/concepts/` or
+`~/.copilot/wiki/entities/`. The `docs-lint` CI gate (#722) fails on any
+broken wikilink. Run `npm run docs:lint` locally before committing.
+
+To check available pages: `npm run help:topic -- <term>`.
+
+## Section ordering
+
+Within each file, group sections by their id-prefix family in the order
+declared above (start, use, trouble, dev). The renderer concatenates files in
+order so consistent grouping yields predictable category collapse.
+
+## Avoid
+
+- Block elements (`<div>`, `<ul>`, `<ol>`) in `body` — they break category-summary collapse
+- Inline `<a href>` to external URLs — use wikilinks; if external is unavoidable, render via `renderHelpPanel`'s feedback footer
+- Markdown syntax — bodies are HTML fragments, not markdown
+- Hard-coded fleet IPs or credentials — those belong in `inventory/`, not help text
+
+## Testing changes
+
+```
+npm run lint        # ≤100-line check
+npm run docs:lint   # HELP↔script and HELP↔wiki drift
+npm start           # Open dashboard, click "📘 Help" view, verify rendering
+```


### PR DESCRIPTION
## Summary

Phase 4 of epic #601 — adds the architecture documentation library.

- `docs/ARCHITECTURE.md` (85 lines) — system map: routing, governance, wiki, dashboard, fleet subsystems with file pointers
- `docs/HELP-GUIDELINES.md` (78 lines) — HELP panel UX patterns derived from current help-user.js / help-dev.js
- `docs/DECISIONS.md` (52 lines) — index for the 11 ADRs in `research/adr/` (canonical store unchanged; no new directory created)

## Lane

`lane:docs-research` — Manager + Consultant only.
- COLLABORATOR_HANDOFF: N/A (posted on issue #727)
- ADMIN_HANDOFF: N/A (posted on issue #727)

## Fleet utilization

- Groq `llama-3.3-70b-versatile` drafted HELP-GUIDELINES.md and ARCHITECTURE.md outline
- DECISIONS.md generated from a deterministic shell loop over `research/adr/` — zero LLM tokens
- 36gbwinresource and Cerebras attempted but rate-limited / unreachable

## Conflict avoidance

- ✅ No `wiki/` files touched (PR #602 active)
- ✅ No `.github/workflows/` touched (dependabot active)
- ✅ No README/CONTRIBUTING touched
- ✅ No existing `research/adr/*.md` modified
- ✅ NEW files only

Refs #727

## Test plan

- [x] `npm run lint` — ✅ 342 files all ≤100 lines
- [x] `npm run docs:lint` — ✅ clean (0 warnings)
- [x] All 3 docs files ≤100 lines (85, 78, 52)
- [x] No source-of-truth split: `docs/DECISIONS.md` is index only; ADRs stay in `research/adr/`