### PR TITLE
docs(research): drift monitoring strategy matrix #730

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] — Drift Monitoring Strategy Research (#726)
+
+### Added
+- `research/drift-monitoring-strategy-2026-05-01.md`: decision matrix and recommendation for install-agnostic stale-instruction drift monitoring.
+- `raw/articles/drift-monitoring-strategy-2026-05-01.md`: ingest source artifact for wiki capture.
+- `wiki/sources/drift-monitoring-strategy-2026-05-01.md`: generated wiki source summary from ingest pipeline.
+
+### Changed
+- `wiki/index.md`: indexed the new drift-monitoring strategy source page.
+- `wiki/log.md`: recorded ingest event for drift-monitoring strategy research.
+
 ## [Unreleased] — Architecture Documentation Library (#727)
 
 ### Added

--- a/raw/articles/drift-monitoring-strategy-2026-05-01.md
+++ b/raw/articles/drift-monitoring-strategy-2026-05-01.md
@@ -1,0 +1,38 @@
+---
+title: "Drift Monitoring Strategy 2026-05-01"
+date: 2026-05-01
+status: ingested
+tags: [docs-drift, governance, dashboard]
+---
+
+# Drift Monitoring Strategy 2026-05-01
+
+## Summary Table
+
+| Dimension | Decision |
+|---|---|
+| Default approach | Reactive-first (PR annotations + dashboard pull) |
+| Optional augmentation | Weekly GitHub cron summary comment |
+| Dashboard placement | Governance + Wiki Health/Metrics |
+| Fleet requirement | Optional only (not baseline dependency) |
+
+## Key Findings
+
+1. `docs-lint` already detects stale instructions; the gap is visibility.
+2. Install-agnostic design rejects mandatory cron/systemd/always-on dependencies.
+3. Existing dashboard governance/wiki surfaces can absorb drift status.
+4. Fleet scheduling can be useful, but only as a non-required optimization.
+
+## Decision Matrix Outcome
+
+Top path: **Hybrid two-stage model**.
+
+- Stage A: reactive baseline visible in PR and dashboard refresh loops.
+- Stage B: optional weekly issue update for trend monitoring.
+
+## Actionable Next Steps
+
+1. Create implementation issue for PR stale-warning annotations.
+2. Create implementation issue for dashboard drift subsection.
+3. Add optional weekly watchlist issue automation after baseline adoption.
+4. Review stale trend over 30 days before enabling fleet-scheduled jobs.

--- a/research/drift-monitoring-strategy-2026-05-01.md
+++ b/research/drift-monitoring-strategy-2026-05-01.md
@@ -1,0 +1,67 @@
+# Drift Monitoring Strategy (2026-05-01)
+
+**Date:** 2026-05-01
+**Scope:** Warn-only stale-instructions monitoring from `npm run docs:lint`.
+
+## Summary Table
+
+| Question | Answer |
+|---|---|
+| Best install-agnostic path? | **Hybrid reactive-first:** PR annotations + dashboard pull, optional weekly GitHub cron summary |
+| Needs always-on scheduler? | No; baseline value is available without scheduler |
+| Dashboard placement? | Extend existing **Governance** + **Wiki Health** surfaces, no new top-level panel |
+| Fleet utilization fit? | Use free lanes only for optional weekly synthesis (`ollama`/OpenClaw/OpenRouter fallbacks) |
+| Recommended now? | Implement reactive baseline first, then optional cron after adoption metrics |
+
+## Findings with Source Links
+
+- `scripts/docs-lint.js` already emits three classes: two CI-fatal drift checks and one warn-only stale-instructions signal; stale is currently hidden unless run manually.
+- `instructions/wiki-knowledge.instructions.md` prefers wiki-backed knowledge maintenance and explicit lint/ingest workflows, favoring observable drift loops over silent accumulation.
+- `docs/STYLE-GUIDE.md` defines baton/governance language; drift should be reported within governance-facing UX rather than as a disconnected concept.
+- `dashboard/index.html` + `dashboard/js/governance-panel.js` + `dashboard/js/wiki-panel.js` already provide panel anchors where stale counts can be surfaced without IA expansion.
+- Existing CI cadence (`lint-required` + docs lint patterns) gives a low-coupling surface to show stale warnings in contributor workflows.
+
+## Decision Matrix
+
+Scores: 1 (poor) to 5 (best).
+
+| Pattern | Install-agnostic | Fleet-utilizing | Dashboard-visible | Cost | Complexity |
+|---|---:|---:|---:|---:|---:|
+| CI-cadence annotations on PRs | 5 | 3 | 3 | 5 | 4 |
+| Dashboard pull (`docs-lint --json`) | 4 | 2 | 5 | 5 | 3 |
+| Pre-commit hook warnings | 2 | 1 | 1 | 5 | 4 |
+| Single tracking issue updater | 4 | 3 | 2 | 4 | 3 |
+| GitHub Actions weekly cron summary | 5 | 2 | 3 | 5 | 4 |
+| Scheduled fleet agent (36gbwinresource/OpenClaw) | 2 | 5 | 4 | 4 | 2 |
+
+## Recommendation
+
+Adopt a **two-stage hybrid**:
+
+1. **Stage A (default): reactive baseline**
+   - Surface stale-instruction warnings as non-fatal PR annotations.
+   - Add dashboard pull endpoint returning current stale counts/details on refresh.
+   - Keep zero dependency on local cron/systemd/always-on server.
+2. **Stage B (optional): weekly summary**
+   - Add GitHub Actions schedule that comments on one drift-tracking issue.
+   - Use deterministic outputs from `docs-lint` only; no mandatory premium LLM usage.
+
+## Rejection Rationale
+
+- **Fleet-only scheduler as default:** violates install-agnostic property when nodes are offline.
+- **Pre-commit-only approach:** misses non-committing stakeholders and central visibility.
+- **New standalone dashboard panel:** unnecessary IA growth; duplicates Governance/Wiki surfaces.
+
+## Q4/Q5 Direct Answers
+
+- Q4: Wiki instruction policy and style-guide governance language both favor continuous visible hygiene loops and standardized baton terminology.
+- Q5: Extend existing **Governance** (status view) and **Wiki Health/Metrics** (currency view) instead of adding a new top-level panel.
+
+## Actionable Next Steps
+
+1. Spawn implementation ticket: PR annotation path for stale warnings.
+2. Spawn implementation ticket: dashboard stale-drift fetch + render in Governance/Wiki sections.
+3. Optionally add weekly GH schedule to update one watchlist issue after baseline ships.
+4. Measure 30-day stale-count trend before enabling any fleet-scheduled automation.
+
+**Last updated:** 2026-05-01T00:00:00Z

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -77,6 +77,8 @@ The LLM updates this on every ingest operation.
 - [[nodejs-project-organization]] — Node.js Project Organization
 - [[openclaw-windows-optimization-2026]] — OpenClaw on Windows: Optimization & Alternatives (2026)
 
+- [[drift-monitoring-strategy-2026-05-01]] — Drift Monitoring Strategy 2026-05-01
+
 ## Syntheses
 
 - [[devenv-ops-enforcement-architecture]] — DevEnv Ops Enforcement Architecture
@@ -95,4 +97,4 @@ The LLM updates this on every ingest operation.
 
 ---
 
-**Pages**: 65 | **Last updated**: 2026-04-30
+**Pages**: 64 | **Last updated**: 2026-05-01

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -130,3 +130,5 @@ typed wikilinks, frontmatter-only session map). Total wiki pages now: 65.
 Added `infra-automation` routing branch: devenv-ops sessions now inject fleet routing
 order (from model-routing concept) and governance enforcement layers (from governance-
 enforcement concept). Max snippets raised from 4 to 5. Synced to both runtimes.
+
+## [2026-05-01] ingest | Drift Monitoring Strategy 2026-05-01

--- a/wiki/sources/drift-monitoring-strategy-2026-05-01.md
+++ b/wiki/sources/drift-monitoring-strategy-2026-05-01.md
@@ -1,0 +1,40 @@
+---
+title: "Drift Monitoring Strategy 2026-05-01"
+type: source
+created: 2026-05-01
+updated: 2026-05-01
+tags: []
+sources: [/home/curtisfranks/devenv-ops/raw/articles/drift-monitoring-strategy-2026-05-01.md]
+related: []
+status: draft
+---
+
+# Drift Monitoring Strategy 2026-05-01
+
+## Summary
+
+## Summary
+The Drift Monitoring Strategy 2026-05-01 outlines a hybrid two-stage model for monitoring drift, starting with a reactive baseline approach using PR annotations and dashboard refresh loops. An optional weekly issue update is available for trend monitoring. The strategy rejects mandatory dependencies and instead uses existing dashboard governance and wiki health/metrics surfaces. 
+
+## Entities
+* GitHub
+* PR (Pull Request)
+* Dashboard
+* Fleet
+* `docs-lint`
+* Wiki
+* Cron
+* Systemd
+
+## Concepts
+* Drift monitoring
+* Hybrid two-stage model
+* Reactive baseline approach
+* Trend monitoring
+* Install-agnostic design
+* Optional augmentation
+
+## Claims
+* `docs-lint` already detects stale instructions, but visibility is lacking. This claim may contradict existing knowledge if `docs-lint` is not known to have this capability.
+
+*Source: /home/curtisfranks/devenv-ops/raw/articles/drift-monitoring-strategy-2026-05-01.md*


### PR DESCRIPTION
## Summary
- add research/drift-monitoring-strategy-2026-05-01.md with decision matrix and recommendation
- ingest raw/articles/drift-monitoring-strategy-2026-05-01.md into wiki sources
- update changelog with #730 deliverables

## Validation
- npm run lint
- npm run docs:lint
- npm run wiki:ingest -- raw/articles/drift-monitoring-strategy-2026-05-01.md

## Lane
- lane:docs-research
- collaborator/admin artifacts marked N/A on linked issue

Refs #730