### PR TITLE
feat(coord): add Layer 4 local SQLite WAL coordination primitive #739

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ raw/**/*.epub
 Thumbs.db
 logs/
 logs/copilot-usage.json
+
+# Multi-agent coordination (#739) and worktree governance (#738)
+.dashboard/agent-state.sqlite*
+.harness/worktrees/
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased] — Layer 4 Local SQLite WAL Coordination (#739)
+
+### Added
+- `scripts/global/agent-coord-local.js`: always-on default coordination primitive at `<repo>/.dashboard/agent-state.sqlite`. TTL-bounded leases (acquireLease / releaseLease) and per-agent heartbeats (heartbeat / listActiveAgents) using `better-sqlite3` in WAL mode. API surface mirrors what Layer 3 (#740 Cloudflare Worker) will implement.
+- `tests/agent-coord-local.spec.js`: 5 Playwright tests covering lease acquisition blocking, TTL expiry, release, heartbeat tracking, and stale-agent exclusion.
+- `package.json`: `better-sqlite3` dependency; `agent:coord:status` script.
+- `.gitignore`: `.dashboard/agent-state.sqlite*`, `.harness/worktrees/`, `.claude/worktrees/`.
+
 ## [Unreleased] — Drift Monitoring Strategy Research (#726)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "wiki:search": "node scripts/wiki/search.js",
     "help:topic": "node scripts/help-topic.js",
     "docs:lint": "node scripts/docs-lint.js",
+    "agent:coord:status": "node scripts/global/agent-coord-local.js status",
     "validate:triage": "node scripts/validate-plugin-triage.js",
     "validate:compat": "node scripts/validate-plugin-compat.js",
     "test": "npx playwright test",
@@ -88,6 +89,7 @@
     "prettier": "^3.6.2"
   },
   "dependencies": {
+    "better-sqlite3": "^12.9.0",
     "dotenv": "^17.4.1"
   }
 }

--- a/scripts/global/agent-coord-local.js
+++ b/scripts/global/agent-coord-local.js
@@ -1,0 +1,86 @@
+// Layer 4: Local SQLite WAL coordination primitive (#739)
+// API surface mirrors what Layer 3 (Cloudflare DO, #740) will implement.
+const path = require('path');
+const fs = require('fs');
+let Database;
+try { Database = require('better-sqlite3'); }
+catch { Database = null; }
+
+const DB_DIR = path.join(process.cwd(), '.dashboard');
+const DB_PATH = path.join(DB_DIR, 'agent-state.sqlite');
+const MS_PER_SEC = 1000;
+const STATUS_LOOKBACK_SEC = 300;
+
+let _db = null;
+
+function _open() {
+  if (_db) return _db;
+  if (!Database) {
+    throw new Error('better-sqlite3 not installed; agent coord disabled');
+  }
+  fs.mkdirSync(DB_DIR, { recursive: true });
+  _db = new Database(DB_PATH);
+  _db.pragma('journal_mode = WAL');
+  _db.exec(`CREATE TABLE IF NOT EXISTS leases (
+    key TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    expires_at INTEGER NOT NULL
+  )`);
+  _db.exec(`CREATE TABLE IF NOT EXISTS heartbeats (
+    agent_id TEXT PRIMARY KEY,
+    last_seen INTEGER NOT NULL
+  )`);
+  return _db;
+}
+
+function acquireLease(key, ttlSec, agentId) {
+  const db = _open();
+  const now = Date.now();
+  const existing = db.prepare('SELECT expires_at FROM leases WHERE key = ?').get(key);
+  if (existing && existing.expires_at > now) return null;
+  const expiresAt = now + ttlSec * MS_PER_SEC;
+  db.prepare('INSERT OR REPLACE INTO leases (key, agent_id, expires_at) VALUES (?, ?, ?)')
+    .run(key, agentId, expiresAt);
+  return { key, agentId, expiresAt };
+}
+
+function releaseLease(handle) {
+  if (!handle) return false;
+  const db = _open();
+  const result = db.prepare('DELETE FROM leases WHERE key = ? AND agent_id = ?')
+    .run(handle.key, handle.agentId);
+  return result.changes > 0;
+}
+
+function heartbeat(agentId) {
+  const db = _open();
+  db.prepare('INSERT OR REPLACE INTO heartbeats (agent_id, last_seen) VALUES (?, ?)')
+    .run(agentId, Date.now());
+}
+
+function listActiveAgents(maxAgeSec) {
+  const db = _open();
+  const cutoff = Date.now() - maxAgeSec * MS_PER_SEC;
+  return db.prepare('SELECT agent_id, last_seen FROM heartbeats WHERE last_seen >= ?')
+    .all(cutoff);
+}
+
+function _close() {
+  if (_db) { _db.close(); _db = null; }
+}
+
+module.exports = {
+  acquireLease, releaseLease, heartbeat, listActiveAgents, _close,
+  DB_PATH,
+};
+
+if (require.main === module) {
+  const [, , cmd, ...args] = process.argv;
+  if (cmd === 'status') {
+    const agents = listActiveAgents(STATUS_LOOKBACK_SEC);
+    process.stdout.write(`Active agents (last 5 min): ${agents.length}\n`);
+    agents.forEach(a => process.stdout.write(`  ${a.agent_id} (${new Date(a.last_seen).toISOString()})\n`));
+  } else {
+    process.stderr.write('Usage: node agent-coord-local.js status\n');
+  }
+}

--- a/tests/agent-coord-local.spec.js
+++ b/tests/agent-coord-local.spec.js
@@ -1,0 +1,61 @@
+// Tests for Layer 4 local SQLite WAL coordination primitive (#739)
+const { test, expect } = require('@playwright/test');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+let coord;
+let originalCwd;
+
+test.beforeEach(() => {
+  originalCwd = process.cwd();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coord-test-'));
+  process.chdir(tmpDir);
+  delete require.cache[require.resolve('../scripts/global/agent-coord-local')];
+  coord = require('../scripts/global/agent-coord-local');
+});
+
+test.afterEach(() => {
+  if (coord && coord._close) coord._close();
+  process.chdir(originalCwd);
+});
+
+test('acquire lease blocks second caller while held', () => {
+  const first = coord.acquireLease('build-slot', 60, 'agent-a');
+  expect(first).not.toBeNull();
+  expect(first.key).toBe('build-slot');
+  const second = coord.acquireLease('build-slot', 60, 'agent-b');
+  expect(second).toBeNull();
+});
+
+test('lease auto-expires after TTL', async () => {
+  const first = coord.acquireLease('build-slot', 1, 'agent-a');
+  expect(first).not.toBeNull();
+  await new Promise(r => setTimeout(r, 1100));
+  const second = coord.acquireLease('build-slot', 60, 'agent-b');
+  expect(second).not.toBeNull();
+  expect(second.agentId).toBe('agent-b');
+});
+
+test('release lease allows re-acquisition', () => {
+  const first = coord.acquireLease('build-slot', 60, 'agent-a');
+  expect(coord.releaseLease(first)).toBe(true);
+  const second = coord.acquireLease('build-slot', 60, 'agent-b');
+  expect(second).not.toBeNull();
+});
+
+test('heartbeat then listActiveAgents returns the agent', () => {
+  coord.heartbeat('agent-a');
+  const active = coord.listActiveAgents(300);
+  expect(active.some(a => a.agent_id === 'agent-a')).toBe(true);
+});
+
+test('listActiveAgents excludes stale heartbeats', async () => {
+  coord.heartbeat('agent-old');
+  await new Promise(r => setTimeout(r, 1100));
+  coord.heartbeat('agent-new');
+  const recent = coord.listActiveAgents(1);
+  const ids = recent.map(a => a.agent_id);
+  expect(ids).toContain('agent-new');
+  expect(ids).not.toContain('agent-old');
+});


### PR DESCRIPTION
## Summary

Layer 4 of #736 multi-agent command center: always-on default coordination primitive at `<repo>/.dashboard/agent-state.sqlite` using `better-sqlite3` in WAL mode.

- TTL-bounded leases (`acquireLease`/`releaseLease`)
- Per-agent heartbeats (`heartbeat`/`listActiveAgents`)
- API surface mirrors future Layer 3 Cloudflare DO (#740) — swappable
- 5 Playwright tests, all passing
- gitignore for `.dashboard/agent-state.sqlite*`, `.harness/worktrees/`, `.claude/worktrees/`

## Lane

`lane:code-change`

## Baton artifacts on issue #739

MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT (after CI green)

Refs #739

## Test plan

- [x] `npx playwright test tests/agent-coord-local.spec.js` — 5 passed in 3.6s
- [x] `npm run lint` — 348 files all ≤100 lines
- [x] `npm run lint:readability:ci --max-warnings=389` — exactly 389
- [x] `npm run docs:lint` — clean
- [ ] CI gates (pending)