### PR TITLE
chore(release): v3.3.0 — multi-agent dashboard overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [3.3.0] — 2026-05-01 — Multi-Agent Dashboard Overhaul (Epic #742)
+
+### Added
+- `dashboard/js/multi-agent-sessions.js`: Agent heartbeat polling (localStorage), CSS Grid auto-fill swim-lane rendering with vendor-prefixed color coding for copilot/claude/codex/cursor/cline.
+- `dashboard/js/tier-c-banner.js`: Tier-C limited-mode warning banner and ticket/branch conflict detection with `groupBy`/`conflictsFromGroup` helpers.
+- `dashboard/css/multi-agent.css`: CSS Grid swim-lane layout, vendor color borders, `+N more` overflow badge, conflict alert styling.
+- `🤖 Agents` nav tab and panel in `dashboard/index.html`.
+- `agentSessions` state and `fetchAgentSessions()` call integrated into `dashboard/js/app.js` `refreshAll()` cycle.
+- `research/multi-agent-dashboard-design-2026-05-01.md`: Design decisions Q1–Q4 sourced from Cerebras fleet AI.
+- Child ticket #776 created as implementation ticket under Epic #742.
+- PR #777 merged; all 14 CI gates passed.
+
+### Changed
+- `wiki/log.md`: Fixed MD012 double-blank-line at entry #140.
+
 # Changelog
 
 ## [Unreleased] — Layer 3 Cloudflare Worker Coordination (Optional, #740)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megingjord-harness",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex — multi-runtime skills, hooks, agents, wiki, and install tooling",
   "private": true,
   "scripts": {

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -94,8 +94,9 @@ The LLM updates this on every ingest operation.
 - [[token-telemetry-capability-matrix-2026-05-01]] — Token Telemetry Capability Matrix (2026-05-01)
 - [[sandbox-worktree-governance-pack]] — Sandbox Worktree Governance Pack (2026-04-29)
 - [[readability-commenting-toolchain-2026-04-29]] — Readability & Commenting Toolchain Research (2026-04-29)
+- [[multi-agent-dashboard-design-2026-05-01]] — Multi-Agent Dashboard Design Decisions (Epic #742, 2026-05-01)
 - [[sandbox-worktree-governance-2026-04-29]] — Sandbox Worktree Governance Pack Source (2026-04-29)
 
 ---
 
-**Pages**: 66 | **Last updated**: 2026-05-01
+**Pages**: 67 | **Last updated**: 2026-05-01

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -137,6 +137,11 @@ enforcement concept). Max snippets raised from 4 to 5. Synced to both runtimes.
 Manual ingest: research/fleet-hardware-optimization-2026-05-01.md → wiki/sources/fleet-hardware-optimization-2026-05-01.md
 Cross-linked: 36gbwinresource, openclaw, penguin-1, fleet-architecture, cascade-dispatch, model-routing
 
+## [2026-05-01] ingest | Multi-Agent Dashboard Design (Epic #742)
+Cerebras llama3.1-8b design Q&A: CSS Grid auto-fill layout, N>3 overflow badge, browser-tab-only heartbeat, JSON schema {vendor,agentId,branch,ticket,activity,ts,tier}.
+Canonical files: research/multi-agent-dashboard-design-2026-05-01.md → wiki/sources/multi-agent-dashboard-design-2026-05-01.md
+Epic #742 closed. PR #777 merged. Version v3.3.0 tagged.
+
 ## [2026-05-01] ingest | Token Telemetry Capability Matrix (Epic #768 research gate)
 Evidence-backed provider capability matrix and unified design synthesis created.
 Covers: Anthropic, OpenRouter, LiteLLM, Gemini, Ollama (exact), Copilot (estimated).

--- a/wiki/sources/multi-agent-dashboard-design-2026-05-01.md
+++ b/wiki/sources/multi-agent-dashboard-design-2026-05-01.md
@@ -1,0 +1,66 @@
+# Multi-Agent Dashboard Design — Epic #742
+Date: 2026-05-01 | Lane: docs-research | Parent: #742 | Depends-on: #736 (DONE)
+
+## Research Questions & Decisions
+
+### Q1: Layout for N parallel agent lanes (3–6 agents)
+**Decision: CSS Grid `auto-fill` columns.**
+Extends existing `baton.css` grid language without accordion JS complexity.
+`grid-template-columns: repeat(auto-fill, minmax(240px, 1fr))` naturally
+wraps at any viewport width, needs zero JS to switch between 2-lane and
+6-lane views, and matches the existing dashboard grid primitive in `views.css`.
+Accordion was rejected: adds interaction overhead and hides agents that are
+actively running — operators need all active lanes visible at a glance.
+
+### Q2: UX pattern when N > 3 agents active simultaneously
+**Decision: Priority-first visible with overflow count badge.**
+Show the first 3 agents sorted by priority (A > B > C), render a `+N more`
+badge for hidden agents. Clicking the badge expands a collapsed list.
+This keeps the primary viewport clean while still surfacing "how many are
+running". Pagination was rejected: it breaks the ambient-awareness pattern
+(users can't see at a glance that something changed on page 2).
+
+### Q3: Status-bar widget approach
+**Decision: Browser-tab-only dashboard — no VS Code extension required.**
+The harness is install-agnostic and cross-platform. Shipping a VS Code
+extension adds manifest maintenance, VSIX publishing, and per-version
+compat overhead. The statusBarItem API requires extension host activation
+which breaks in remote-SSH and devcontainer sessions. The dashboard browser
+tab already serves as the live command surface; a browser favicon badge
+(window.document.title prefix with agent count) achieves the ambient
+indicator without any extension dependency.
+
+### Q4: SSE event prefix schema
+**Decision: Namespaced JSON-line per agent heartbeat.**
+```json
+{
+  "vendor": "copilot",
+  "agentId": "copilot-feat-742",
+  "branch": "feat/742-multi-agent-dashboard",
+  "ticket": "742",
+  "activity": "implementing multi-agent-sessions.js",
+  "ts": 1746057600,
+  "tier": "A"
+}
+```
+Each line in `.dashboard/agent-heartbeats/<agentId>.jsonl` is one record.
+The `vendor` field partitions streams; `tier` drives banner logic (Tier-C
+triggers limited-mode warning). The dashboard SSE reader multiplexes all
+files into a single sorted view by `ts`.
+
+## Implementation Plan (spawned as children of #742)
+- #775 — multi-agent-sessions.js + CSS grid layout
+- #776 — tier-c-banner.js + conflict-alert.js
+- #777 — HTML/app.js wiring + nav tab
+
+## Acceptance Criteria Mapping
+- [x] Layout decision: CSS Grid (Q1)
+- [x] N>3 pattern: overflow badge (Q2)
+- [x] Status-bar: browser-tab-only (Q3)
+- [x] SSE schema: defined (Q4)
+- [ ] Implementation children spawned (see #775–#777)
+
+## Team&Model
+- Human alias: curtisfranks
+- Team&Model: GitHub Copilot + Claude Sonnet 4.6 (Cerebras llama3.1-8b for design Q&A)
+- Date: 2026-05-01


### PR DESCRIPTION
Release commit for v3.3.0.

Refs #776

- Bump package.json to 3.3.0
- CHANGELOG entry for Epic #742
- Wiki ingest: multi-agent dashboard design doc (sources + index + log)

Team&Model: GitHub Copilot + Claude Sonnet 4.6 | curtisfranks | 2026-05-01