### PR TITLE
feat(telemetry): canonical token-ledger schema + confidence model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [3.3.1] — 2026-05-01 — Canonical Token Ledger Schema (#770)
+
+### Added
+- `scripts/global/token-ledger-schema.js`: canonical token-ledger normalizer with confidence enum (`exact_request`, `exact_aggregate`, `derived`, `estimated`, `unknown`) and lane-aware defaults.
+- `research/token-ledger-schema-implementation-2026-05-01.md`: implementation note documenting canonical fields, confidence policy, and compatibility guarantees.
+
+### Changed
+- `scripts/global/model-routing-telemetry.js`: now appends canonical token-ledger fields on every write while preserving historical telemetry keys (`ts`, `lane`, `model`, etc.) for existing consumers.
+
 ## [3.3.0] — 2026-05-01 — Multi-Agent Dashboard Overhaul (Epic #742)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megingjord-harness",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex — multi-runtime skills, hooks, agents, wiki, and install tooling",
   "private": true,
   "scripts": {

--- a/research/token-ledger-schema-implementation-2026-05-01.md
+++ b/research/token-ledger-schema-implementation-2026-05-01.md
@@ -1,0 +1,52 @@
+# Token Ledger Schema Implementation (2026-05-01)
+
+**Date:** 2026-05-01
+**Ticket:** #770
+**Status:** Implemented
+
+## Summary
+
+| Item | Decision |
+|---|---|
+| Canonical shape | Added in `scripts/global/token-ledger-schema.js` |
+| Confidence enum | `exact_request`, `exact_aggregate`, `derived`, `estimated`, `unknown` |
+| Write-time enforcement | Invalid/missing confidence is normalized by lane |
+| Compatibility | Existing telemetry fields (`ts`, `lane`, `model`, etc.) preserved |
+
+## Canonical Fields
+
+Required normalized fields now emitted per routing telemetry write:
+
+- `provider`
+- `model`
+- `timestamp`
+- `input_tokens`
+- `output_tokens`
+- `cache_read_tokens`
+- `cache_write_tokens`
+- `reasoning_tokens`
+- `total_tokens`
+- `cost_usd`
+- `confidence_level`
+- `request_id`
+- `source_kind`
+
+## Confidence Policy Applied at Write-Time
+
+- `haiku` / `premium` lanes default to `derived` when confidence is absent.
+- Other lanes default to `estimated` when confidence is absent.
+- Explicit confidence values are accepted only when they are in the canonical enum.
+
+## Backward Compatibility
+
+`scripts/global/model-routing-telemetry.js` still writes historical fields used by
+current readers (`readTelemetry()`, `summarize()`). Canonical fields are appended
+without removing legacy fields.
+
+## Actionable Next Steps
+
+1. Wire provider adapters (#771) to pass exact confidence where available.
+2. Add dashboard/reporting surfaces (#773) to show confidence split.
+3. Add reconciliation + drift alerting (#774) using canonical totals.
+
+**Last updated:** 2026-05-01T23:55:00Z

--- a/scripts/global/model-routing-telemetry.js
+++ b/scripts/global/model-routing-telemetry.js
@@ -2,6 +2,7 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const { normalizeTokenRecord } = require('./token-ledger-schema');
 
 const FILE = path.join(__dirname, '..', '..', 'logs', 'model-routing-telemetry.jsonl');
 
@@ -11,7 +12,7 @@ const MAX_ENTRIES = 100;
 
 function recordTelemetry(entry) {
   ensureDir();
-  const row = {
+  const legacy = {
     ts: new Date().toISOString(),
     lane: entry.lane || 'free',
     model: entry.model || 'unknown',
@@ -23,6 +24,15 @@ function recordTelemetry(entry) {
     rollbackApplied: entry.rollbackApplied || false,
     execute: entry.execute || false,
   };
+  const canonical = normalizeTokenRecord({
+    ...entry,
+    lane: legacy.lane,
+    model: legacy.model,
+    timestamp: legacy.ts,
+    provider: entry.provider || legacy.lane,
+    source_kind: entry.source_kind || 'routing_telemetry',
+  });
+  const row = { ...legacy, ...canonical };
   const existing = fs.existsSync(FILE)
     ? fs.readFileSync(FILE, 'utf8').split('\n').filter(Boolean) : [];
   const lines = [...existing.slice(-(MAX_ENTRIES - 1)), JSON.stringify(row)];

--- a/scripts/global/token-ledger-schema.js
+++ b/scripts/global/token-ledger-schema.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+'use strict';
+
+const CONFIDENCE = ['exact_request', 'exact_aggregate', 'derived', 'estimated', 'unknown'];
+
+function n(v) { return Number.isFinite(Number(v)) ? Number(v) : 0; }
+
+function laneConfidence(lane) {
+  if (lane === 'haiku' || lane === 'premium') return 'derived';
+  return 'estimated';
+}
+
+function normalizeTokenRecord(entry = {}) {
+  const input = n(entry.input_tokens);
+  const output = n(entry.output_tokens);
+  const cacheRead = n(entry.cache_read_tokens);
+  const cacheWrite = n(entry.cache_write_tokens);
+  const reasoning = n(entry.reasoning_tokens);
+  const total = entry.total_tokens == null
+    ? input + output + cacheRead + cacheWrite + reasoning
+    : n(entry.total_tokens);
+  const level = CONFIDENCE.includes(entry.confidence_level)
+    ? entry.confidence_level
+    : laneConfidence(entry.lane);
+  return {
+    provider: entry.provider || entry.lane || 'unknown',
+    model: entry.model || 'unknown',
+    timestamp: entry.timestamp || new Date().toISOString(),
+    input_tokens: input,
+    output_tokens: output,
+    cache_read_tokens: cacheRead,
+    cache_write_tokens: cacheWrite,
+    reasoning_tokens: reasoning,
+    total_tokens: total,
+    cost_usd: entry.cost_usd == null ? null : n(entry.cost_usd),
+    confidence_level: level,
+    request_id: entry.request_id || null,
+    source_kind: entry.source_kind || 'routing_telemetry',
+  };
+}
+
+module.exports = { CONFIDENCE, normalizeTokenRecord };


### PR DESCRIPTION
Implements ticket #770 (parent #768) with canonical token-ledger normalization and confidence enforcement at write-time.

Refs #770

## What changed
- Added canonical schema normalizer in scripts/global/token-ledger-schema.js.
- Updated scripts/global/model-routing-telemetry.js to append canonical fields while keeping legacy fields for compatibility.
- Added implementation doc: research/token-ledger-schema-implementation-2026-05-01.md.
- Release metadata updated: package.json to 3.3.1, CHANGELOG.md entry for #770.

## Validation
- npm run lint
- Playwright targeted tests: tests/no-network-errors.spec.js, tests/api-smoke.spec.js

Team&Model: GitHub Copilot + GPT-5.3-Codex | curtisfranks | 2026-05-01
