### PR TITLE
feat(telemetry): add provider token adapters (#771)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.3.2] — 2026-05-01 — Provider Token Adapters (#771)
+
+### Added
+- `scripts/global/token-provider-adapters.js`: adapter layer for Anthropic, OpenRouter, LiteLLM, Gemini, and Ollama usage payloads into canonical token-ledger records.
+- `tests/token-provider-adapters.spec.js`: adapter unit tests covering each provider plus partial payload handling.
+- `research/provider-adapters-implementation-2026-05-01.md`: implementation note with mapping summary and downstream handoff.
+
 ## [3.3.1] — 2026-05-01 — Canonical Token Ledger Schema (#770)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megingjord-harness",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex — multi-runtime skills, hooks, agents, wiki, and install tooling",
   "private": true,
   "scripts": {

--- a/research/provider-adapters-implementation-2026-05-01.md
+++ b/research/provider-adapters-implementation-2026-05-01.md
@@ -1,0 +1,40 @@
+# Provider Adapter Layer Implementation (2026-05-01)
+
+**Date:** 2026-05-01
+**Ticket:** #771
+**Status:** Implemented
+
+## Summary
+
+| Adapter | Source fields | Confidence | Source kind |
+|---|---|---|---|
+| Anthropic Messages | `usage.input_tokens`, `usage.output_tokens`, cache fields | `exact_request` | `anthropic_messages` |
+| OpenRouter | `usage.prompt_tokens`, `usage.completion_tokens`, `usage.reasoning_tokens`, `usage.total_tokens`, `cost` | `exact_request` | `openrouter` |
+| LiteLLM spend log | `prompt_tokens`, `completion_tokens`, `total_tokens`, `spend/cost` | `derived` (`estimated` when pricing not fresh) | `litellm_spend_log` |
+| Gemini | `usageMetadata` / `usage_metadata` token fields | `exact_request` | `gemini_generate_content` |
+| Ollama | `prompt_eval_count`, `eval_count` | `exact_request` | `ollama_generate` |
+
+## Implementation
+
+- Added `scripts/global/token-provider-adapters.js`.
+- All adapters emit canonical records through `normalizeTokenRecord()`.
+- Missing fields normalize to numeric `0`/`null` via canonical schema defaults.
+
+## Test Coverage
+
+- Added `tests/token-provider-adapters.spec.js`.
+- Coverage includes all five adapters and partial payload handling.
+- Non-free lane input in tests emits non-`unknown` confidence values.
+
+## Compatibility Notes
+
+- No existing telemetry readers were changed.
+- Adapter layer is additive and ready for #773 reporting and #774 reconciliation.
+
+## Actionable Next Steps
+
+1. Wire adapters into ingestion paths used by provider-specific logs.
+2. Surface confidence split in dashboard/reporting (#773).
+3. Add reconciliation drift checks against aggregate APIs (#774).
+
+**Last updated:** 2026-05-01T00:00:00Z

--- a/scripts/global/token-provider-adapters.js
+++ b/scripts/global/token-provider-adapters.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+'use strict';
+
+const { normalizeTokenRecord } = require('./token-ledger-schema');
+
+function n(v) { return Number.isFinite(Number(v)) ? Number(v) : 0; }
+
+function mk(base, patch = {}) {
+  return normalizeTokenRecord({ ...base, ...patch });
+}
+
+function anthropic(payload = {}, base = {}) {
+  const usage = payload.usage || {};
+  return mk(base, {
+    provider: 'anthropic', model: payload.model || base.model,
+    input_tokens: n(usage.input_tokens), output_tokens: n(usage.output_tokens),
+    cache_read_tokens: n(usage.cache_read_input_tokens),
+    cache_write_tokens: n(usage.cache_creation_input_tokens),
+    confidence_level: 'exact_request', request_id: payload.id || base.request_id,
+    source_kind: 'anthropic_messages'
+  });
+}
+
+function openrouter(payload = {}, base = {}) {
+  const usage = payload.usage || {};
+  return mk(base, {
+    provider: 'openrouter', model: payload.model || base.model,
+    input_tokens: n(usage.prompt_tokens), output_tokens: n(usage.completion_tokens),
+    cache_read_tokens: n(usage.cached_tokens || (usage.prompt_tokens_details || {}).cached_tokens),
+    reasoning_tokens: n(usage.reasoning_tokens), total_tokens: n(usage.total_tokens),
+    cost_usd: payload.cost ?? usage.cost ?? base.cost_usd, confidence_level: 'exact_request',
+    request_id: payload.id || payload.generation_id || base.request_id, source_kind: 'openrouter'
+  });
+}
+
+function litellm(payload = {}, base = {}) {
+  return mk(base, {
+    provider: 'litellm', model: payload.model || base.model,
+    input_tokens: n(payload.prompt_tokens), output_tokens: n(payload.completion_tokens),
+    total_tokens: n(payload.total_tokens), cost_usd: payload.spend ?? payload.cost,
+    confidence_level: payload.pricing_fresh === false ? 'estimated' : 'derived',
+    request_id: payload.request_id || payload.id || base.request_id, source_kind: 'litellm_spend_log'
+  });
+}
+
+function gemini(payload = {}, base = {}) {
+  const usage = payload.usageMetadata || payload.usage_metadata || {};
+  return mk(base, {
+    provider: 'gemini', model: payload.modelVersion || payload.model || base.model,
+    input_tokens: n(usage.promptTokenCount), output_tokens: n(usage.candidatesTokenCount),
+    cache_read_tokens: n(usage.cachedContentTokenCount), reasoning_tokens: n(usage.thoughtsTokenCount),
+    total_tokens: n(usage.totalTokenCount), confidence_level: 'exact_request',
+    request_id: payload.responseId || payload.id || base.request_id, source_kind: 'gemini_generate_content'
+  });
+}
+
+function ollama(payload = {}, base = {}) {
+  return mk(base, {
+    provider: 'ollama', model: payload.model || base.model,
+    input_tokens: n(payload.prompt_eval_count), output_tokens: n(payload.eval_count),
+    confidence_level: 'exact_request', request_id: payload.id || base.request_id, source_kind: 'ollama_generate'
+  });
+}
+
+module.exports = { anthropic, openrouter, litellm, gemini, ollama };

--- a/tests/token-provider-adapters.spec.js
+++ b/tests/token-provider-adapters.spec.js
@@ -1,0 +1,50 @@
+const { test, expect } = require('@playwright/test');
+const adapters = require('../scripts/global/token-provider-adapters');
+
+test('anthropic adapter maps usage with exact confidence', () => {
+  const r = adapters.anthropic({
+    id: 'msg_1', model: 'claude-sonnet-4-6',
+    usage: { input_tokens: 12, output_tokens: 9, cache_read_input_tokens: 2, cache_creation_input_tokens: 3 }
+  }, { lane: 'premium' });
+  expect(r.provider).toBe('anthropic');
+  expect(r.total_tokens).toBe(26);
+  expect(r.confidence_level).toBe('exact_request');
+});
+
+test('openrouter adapter maps usage and cost', () => {
+  const r = adapters.openrouter({
+    id: 'gen_1', model: 'qwen/qwen3-coder:free', cost: 0.004,
+    usage: { prompt_tokens: 30, completion_tokens: 11, reasoning_tokens: 4, cached_tokens: 5, total_tokens: 50 }
+  }, { lane: 'fleet' });
+  expect(r.provider).toBe('openrouter');
+  expect(r.cache_read_tokens).toBe(5);
+  expect(r.cost_usd).toBe(0.004);
+  expect(r.confidence_level).toBe('exact_request');
+});
+
+test('litellm adapter handles partial payloads', () => {
+  const r = adapters.litellm({ request_id: 'spend_1', prompt_tokens: 8 }, { lane: 'haiku' });
+  expect(r.provider).toBe('litellm');
+  expect(r.input_tokens).toBe(8);
+  expect(r.output_tokens).toBe(0);
+  expect(r.confidence_level).toBe('derived');
+});
+
+test('gemini adapter maps usageMetadata fields', () => {
+  const r = adapters.gemini({
+    responseId: 'resp_1', modelVersion: 'gemini-2.5-pro',
+    usageMetadata: { promptTokenCount: 14, candidatesTokenCount: 7, cachedContentTokenCount: 2, thoughtsTokenCount: 1, totalTokenCount: 24 }
+  }, { lane: 'premium' });
+  expect(r.provider).toBe('gemini');
+  expect(r.reasoning_tokens).toBe(1);
+  expect(r.total_tokens).toBe(24);
+  expect(r.confidence_level).toBe('exact_request');
+});
+
+test('ollama adapter maps eval counters', () => {
+  const r = adapters.ollama({ id: 'run_1', model: 'qwen2.5-coder:7b', prompt_eval_count: 20, eval_count: 6 }, { lane: 'fleet' });
+  expect(r.provider).toBe('ollama');
+  expect(r.input_tokens).toBe(20);
+  expect(r.output_tokens).toBe(6);
+  expect(r.confidence_level).toBe('exact_request');
+});


### PR DESCRIPTION
## Summary
- add provider adapter layer mapping Anthropic/OpenRouter/LiteLLM/Gemini/Ollama payloads to canonical token records
- add adapter unit tests for all providers plus partial payload handling
- add implementation note and bump release metadata to v3.3.2

## Validation
- npm run lint
- npx playwright test tests/token-provider-adapters.spec.js tests/telemetry-schema.spec.js

## Governance
- Refs #771
- COLLABORATOR_HANDOFF posted on issue before PR creation (>=60s)

## Team&Model
- Human alias: curtisfranks
- Team&Model: GitHub Copilot + GPT-5.3-Codex
- Date: 2026-05-01
