### PR TITLE
feat(rag): repo-context search MVP with MCP+ripgrep fallback #784

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased] — Phase 2 RAG Search MVP (#784)
+
+### Added
+- `scripts/global/rag-search.js`: repo-context search with MCP-first when capability manifest reports rag_server reachable, ripgrep-fallback otherwise. Returns top-k snippets with file path + line numbers.
+- `tests/rag-search.spec.js`: 6 Playwright tests covering capability gating, env-override priority, empty-query handling, ripgrep fallback.
+- `package.json`: `rag:search` script.
+- Full embeddings-backed MCP server deployment tracked as follow-up child.
+
 ## [Unreleased] — Phase 0 Capability Probe + Manifest (#788)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "agent:coord:remote": "node scripts/global/agent-coord-remote.js",
     "capability:probe": "node scripts/global/capability-probe.js",
     "capability:show": "node scripts/global/capability-show.js",
+    "rag:search": "node scripts/global/rag-search.js",
     "validate:triage": "node scripts/validate-plugin-triage.js",
     "validate:compat": "node scripts/validate-plugin-compat.js",
     "test": "npx playwright test",

--- a/scripts/global/rag-search.js
+++ b/scripts/global/rag-search.js
@@ -1,0 +1,74 @@
+// Phase 2 / #784 — repo-context RAG search MVP
+// MCP-first when capability allows; ripgrep-fallback otherwise.
+// Returns top-k snippets with file path + line numbers.
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const FETCH_TIMEOUT_MS = 4000;
+const RG_TIMEOUT_MS = 6000;
+const DEFAULT_TOP_K = 5;
+const SNIPPET_CONTEXT_LINES = 3;
+const MANIFEST_PATH = path.join(process.cwd(), '.dashboard', 'capabilities.json');
+
+function _capability() {
+  if (!fs.existsSync(MANIFEST_PATH)) return null;
+  try { return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8')); } catch { return null; }
+}
+
+function _ragUrl() {
+  const cap = _capability();
+  if (!cap?.mcp?.rag_server?.reachable) return null;
+  return process.env.MCP_RAG_URL || cap?.mcp?.rag_server?.url || null;
+}
+
+async function _searchViaMcp(url, query, k) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const resp = await fetch(`${url}/search?q=${encodeURIComponent(query)}&k=${k}`, { signal: controller.signal });
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    return data.results || null;
+  } catch { return null; }
+  finally { clearTimeout(timer); }
+}
+
+function _searchViaRipgrep(query, k) {
+  try {
+    const safeQuery = query.replace(/[^\w\s.-]/g, ' ').trim();
+    if (!safeQuery) return [];
+    const cmd = `rg --json --max-count ${k} -C ${SNIPPET_CONTEXT_LINES} -- ${JSON.stringify(safeQuery)}`;
+    const out = execSync(cmd, { encoding: 'utf8', timeout: RG_TIMEOUT_MS, maxBuffer: 1024 * 1024 });
+    const lines = out.trim().split('\n').filter(Boolean);
+    const matches = lines.map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+    return matches
+      .filter(m => m.type === 'match')
+      .slice(0, k)
+      .map(m => ({
+        path: m.data?.path?.text,
+        line: m.data?.line_number,
+        snippet: m.data?.lines?.text?.trim() || '',
+        source: 'ripgrep',
+      }));
+  } catch { return []; }
+}
+
+async function search(query, k = DEFAULT_TOP_K) {
+  if (!query || typeof query !== 'string') return { results: [], source: 'invalid-query' };
+  const url = _ragUrl();
+  if (url) {
+    const mcpResults = await _searchViaMcp(url, query, k);
+    if (mcpResults) return { results: mcpResults, source: 'mcp' };
+  }
+  const rgResults = _searchViaRipgrep(query, k);
+  return { results: rgResults, source: 'ripgrep-fallback' };
+}
+
+module.exports = { search, _capability, _ragUrl, _searchViaRipgrep, DEFAULT_TOP_K };
+
+if (require.main === module) {
+  const query = process.argv.slice(2).join(' ');
+  if (!query) { process.stderr.write('Usage: rag-search.js <query>\n'); process.exit(1); }
+  search(query).then(r => process.stdout.write(JSON.stringify(r, null, 2) + '\n'));
+}

--- a/tests/rag-search.spec.js
+++ b/tests/rag-search.spec.js
@@ -1,0 +1,68 @@
+// Tests for #784 RAG search MVP
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const RAG = '../scripts/global/rag-search';
+
+let originalCwd;
+let tmpDir;
+
+test.beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rag-test-'));
+  fs.mkdirSync(path.join(tmpDir, '.dashboard'), { recursive: true });
+  process.chdir(tmpDir);
+  delete require.cache[require.resolve(RAG)];
+  delete process.env.MCP_RAG_URL;
+});
+
+test.afterEach(() => {
+  process.chdir(originalCwd);
+});
+
+test('_ragUrl returns null without manifest', () => {
+  const r = require(RAG);
+  expect(r._ragUrl()).toBeNull();
+});
+
+test('_ragUrl returns null when mcp.rag_server unreachable', () => {
+  fs.writeFileSync(path.join(tmpDir, '.dashboard', 'capabilities.json'), JSON.stringify({
+    mcp: { rag_server: { reachable: false } },
+  }));
+  const r = require(RAG);
+  expect(r._ragUrl()).toBeNull();
+});
+
+test('_ragUrl returns URL from manifest when reachable', () => {
+  fs.writeFileSync(path.join(tmpDir, '.dashboard', 'capabilities.json'), JSON.stringify({
+    mcp: { rag_server: { reachable: true, url: 'http://example.com:11435' } },
+  }));
+  const r = require(RAG);
+  expect(r._ragUrl()).toBe('http://example.com:11435');
+});
+
+test('_ragUrl env var overrides manifest URL', () => {
+  fs.writeFileSync(path.join(tmpDir, '.dashboard', 'capabilities.json'), JSON.stringify({
+    mcp: { rag_server: { reachable: true, url: 'http://manifest:11435' } },
+  }));
+  process.env.MCP_RAG_URL = 'http://env-override:11435';
+  const r = require(RAG);
+  expect(r._ragUrl()).toBe('http://env-override:11435');
+});
+
+test('search returns invalid-query for empty input', async () => {
+  const { search } = require(RAG);
+  const r = await search('');
+  expect(r.source).toBe('invalid-query');
+  expect(r.results).toEqual([]);
+});
+
+test('search falls back to ripgrep when no manifest', async () => {
+  fs.writeFileSync(path.join(tmpDir, 'sample.js'), 'function foo() { return 42; }\n');
+  const { search } = require(RAG);
+  const r = await search('foo');
+  expect(r.source).toBe('ripgrep-fallback');
+  expect(Array.isArray(r.results)).toBe(true);
+});


### PR DESCRIPTION
## Summary

Phase 2 of #782, MVP slice. Repo-context search; MCP-first when capability gate passes, ripgrep-fallback otherwise.

- `scripts/global/rag-search.js` (65 lines)
- `tests/rag-search.spec.js` (71 lines, 6 passing)
- `npm run rag:search`

Full embeddings-backed MCP server deployment is a follow-up child since standing up Milvus/Vectorize is multi-day infra; client surface ready for it.

## Compose

- ✅ Governance: search-only; never bypasses any gate
- ✅ Wiki: zero changes
- ✅ Fleet-config: capability-gated via #788 manifest

Refs #784