### PR TITLE
docs(accuracy): Phase 0 fleet entities + wiki ingest pipeline

### DIFF
--- a/WIKI.md
+++ b/WIKI.md
@@ -50,43 +50,35 @@ status: stub | draft | mature
 
 ## Operations
 
-### Toolchain (run from Megingjord repo root)
-
 | Operation | Command | Script |
 |---|---|---|
-| Ingest one raw source | `npm run wiki:ingest -- raw/articles/<file>.md` | `scripts/wiki/ingest.js` |
-| Lint structure | `npm run wiki:lint` | `scripts/wiki/lint.js` |
-| Anneal (rewrite for consistency) | `npm run wiki:anneal` | `scripts/wiki/anneal.js` |
-| Search wiki | `npm run wiki:search -- "query"` | `scripts/wiki/search.js` |
+| Ingest | `npm run wiki:ingest -- raw/articles/<file>.md` | `scripts/wiki/ingest.js` |
+| Lint | `npm run wiki:lint` | `scripts/wiki/lint.js` |
+| Anneal | `npm run wiki:anneal` | `scripts/wiki/anneal.js` |
+| Search | `npm run wiki:search -- "query"` | `scripts/wiki/search.js` |
 
-`wiki:search` is also exposed globally as `node ~/.copilot/scripts/wiki-search.js` after deploy, so non-Megingjord repos can read the compiled wiki.
+`wiki:search` is exposed globally as `node ~/.copilot/scripts/wiki-search.js` after deploy.
 
-### Ingest pipeline (raw/articles → wiki/sources → wiki/{entities,concepts})
+### Ingest pipeline (raw/articles → wiki/sources → entities/concepts)
 
-The `wiki:ingest` script implements steps 3–6 below; steps 1–2 and 7 are the
-human-or-LLM judgment calls around it.
+`wiki:ingest` implements steps 3–6; 1–2 and 7 are judgment calls.
 
-1. Human places source in `raw/articles/<slug>.md` with frontmatter (set `status: pending`)
+1. Human places source in `raw/articles/<slug>.md` with `status: pending`
 2. LLM reads source, discusses key takeaways
-3. LLM writes `wiki/sources/<slug>.md` summary (one source page per raw file)
-4. LLM updates entity/concept pages (create or revise)
-5. LLM updates `wiki/index.md` with new/changed pages
+3. LLM writes `wiki/sources/<slug>.md` summary
+4. LLM updates entity/concept pages
+5. LLM updates `wiki/index.md`
 6. LLM appends entry to `wiki/log.md`
-7. Mark raw source frontmatter `status: ingested` and commit
+7. Mark raw source `status: ingested` and commit
 
-### Query
-1. LLM reads `wiki/index.md` to find relevant pages
-2. LLM reads those pages, synthesizes answer with `[[citations]]`
-3. Valuable answers get filed as `wiki/syntheses/<slug>.md`
+Walkthrough: `docs/howto/contribute-to-wiki.md`.
 
-### Lint
-1. Check for broken `[[wikilinks]]` (target page must exist)
-2. Check for orphan pages (no inbound links)
-3. Check frontmatter completeness (all required fields present)
-4. Check `wiki/index.md` is in sync with actual wiki/ contents
-5. Flag contradictions between pages
-6. Flag stale claims superseded by newer sources
-7. Output: health report with actionable items
+### Query and lint
+
+Query: LLM reads `wiki/index.md`, then drills into pages, synthesizes
+with `[[citations]]`; valuable answers get filed as syntheses. Lint
+checks broken wikilinks, orphans, frontmatter completeness, index
+drift, contradictions, and stale claims.
 
 ## Cross-Reference Rules
 
@@ -95,17 +87,14 @@ human-or-LLM judgment calls around it.
 - Syntheses must cite ≥2 source/concept pages
 - Bidirectional: if A links to B, B should link back to A
 
-## Fleet Routing (for inference operations)
+## Fleet Routing (inference operations)
 
 | Operation | Primary | Failover |
 |---|---|---|
-| Ingest (summarize + cross-ref) | OpenClaw (7B) | Groq, Cerebras |
-| Query (synthesis) | OpenClaw (7B) | Copilot Pro |
-| Lint (structural checks) | Local scripts | Groq (fast) |
+| Ingest | OpenClaw (deepseek-coder-v2:lite) | Groq, Cerebras |
+| Query | OpenClaw | Copilot Pro |
+| Lint | Local scripts | Groq |
 
 ## Constraints
 
-- All wiki files ≤100 lines (split if needed)
-- Markdown only — no HTML, no binary files in wiki/
-- Git tracks everything — wiki/ is version-controlled
-- Raw sources are the source of truth; wiki is derived
+- Wiki files ≤100 lines; markdown only; git-tracked; raw sources are the source of truth, wiki is derived.

--- a/WIKI.md
+++ b/WIKI.md
@@ -50,14 +50,29 @@ status: stub | draft | mature
 
 ## Operations
 
-### Ingest
-1. Human places source in `raw/` with frontmatter
+### Toolchain (run from Megingjord repo root)
+
+| Operation | Command | Script |
+|---|---|---|
+| Ingest one raw source | `npm run wiki:ingest -- raw/articles/<file>.md` | `scripts/wiki/ingest.js` |
+| Lint structure | `npm run wiki:lint` | `scripts/wiki/lint.js` |
+| Anneal (rewrite for consistency) | `npm run wiki:anneal` | `scripts/wiki/anneal.js` |
+| Search wiki | `npm run wiki:search -- "query"` | `scripts/wiki/search.js` |
+
+`wiki:search` is also exposed globally as `node ~/.copilot/scripts/wiki-search.js` after deploy, so non-Megingjord repos can read the compiled wiki.
+
+### Ingest pipeline (raw/articles → wiki/sources → wiki/{entities,concepts})
+
+The `wiki:ingest` script implements steps 3–6 below; steps 1–2 and 7 are the
+human-or-LLM judgment calls around it.
+
+1. Human places source in `raw/articles/<slug>.md` with frontmatter (set `status: pending`)
 2. LLM reads source, discusses key takeaways
-3. LLM writes `wiki/sources/<slug>.md` summary
+3. LLM writes `wiki/sources/<slug>.md` summary (one source page per raw file)
 4. LLM updates entity/concept pages (create or revise)
 5. LLM updates `wiki/index.md` with new/changed pages
 6. LLM appends entry to `wiki/log.md`
-7. Mark raw source frontmatter `status: ingested`
+7. Mark raw source frontmatter `status: ingested` and commit
 
 ### Query
 1. LLM reads `wiki/index.md` to find relevant pages

--- a/dashboard/js/help-user.js
+++ b/dashboard/js/help-user.js
@@ -41,4 +41,6 @@ const HELP_USER_SECTIONS = [
     body: 'Research wiki statistics: total pages, coverage %, average staleness, most/least accessed. Helps identify gaps and stale content in the research archive.' },
   { id: 'use-wiki-reader', title: '📚 Wiki Reader',
     body: 'Browse and search research/ markdown pages inline. Click a page title to expand its rendered content. Search filters by title and body text.' },
+  { id: 'use-wiki-ingest', title: '📥 Wiki Ingest',
+    body: 'Drop a source in raw/articles/&lt;slug&gt;.md (frontmatter status: pending), then run <code>npm run wiki:ingest -- raw/articles/&lt;slug&gt;.md</code>. The fleet LLM writes wiki/sources/&lt;slug&gt;.md, updates wiki/index.md and wiki/log.md, and flips the raw source to status: ingested. Walkthrough: <em>docs/howto/contribute-to-wiki.md</em>.' },
 ];

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,7 +28,23 @@ Codex                          policy.json          OR Cloud (Claude /        + 
 - `scripts/global/cascade-dispatch.js` — fleet-first cascade (Free → Fleet → Haiku → Premium)
 - `scripts/global/model-routing-policy.json` — capability matrix, lane order
 - `scripts/global/task-router-dispatch.js` — direct dispatch to a tier
+- `scripts/global/free-router.js` — free-model orchestrator MVP (#786): classifier + signal stack picks a tier, calls a free LLM (Groq) when available, falls back to deterministic cascade-dispatch
 - `agents/router.agent.md` — Routing role definition
+
+### Capability detection (ADR-013)
+
+- `scripts/global/capability-probe.js` — probes providers, fleet hosts, and toolchain; writes manifest
+- `scripts/global/capability-show.js` — reads `.dashboard/capabilities.json`
+- `.dashboard/capabilities.json` — capability manifest consumed by routing, RAG, state-offload, and other optional features
+- Optional cost-reduction features gate on this manifest, so a missing provider or offline fleet host degrades gracefully
+
+### RAG / repo-context search (#784)
+
+- `scripts/global/rag-search.js` — repo-context search MVP; uses MCP server when available, falls back to ripgrep
+
+### State offload (#792)
+
+- `scripts/global/state-offload-client.js` — per-turn state offload client; pushes long state to a Worker so the active context stays small
 
 ### Governance
 
@@ -54,9 +70,13 @@ Codex                          policy.json          OR Cloud (Claude /        + 
 
 ### Fleet
 
-- `inventory/devices.json` — Tailscale IPs, Ollama models, GPU/CPU class
+- `inventory/devices.json` — Tailscale IPs, Ollama models, GPU/CPU class (reconciliation tracked in #765)
 - `scripts/health-check.js` — fleet connectivity probe
-- Runtime targets: `36gbwinresource` (GPU 32 TPS), `OpenClaw` (CPU 7 TPS), `penguin-1` (micro)
+- `wiki/entities/{36gbwinresource,openclaw,penguin-1}.md` — per-device authoritative state
+- Runtime targets (post-2026-05-01 IT pass, SYSTEM-service Ollama):
+  - `36gbwinresource` — Win11 Pro, Quadro T2000 4 GB VRAM; starcoder2:3b at 95 TPS (full GPU), qwen2.5-coder:32b at 1.6 TPS (max-quality)
+  - `openclaw` — CPU-only Win10, 16 GB RAM; deepseek-coder-v2:lite at 8.4 TPS (16B MoE primary)
+  - `penguin-1` — ChromeOS LXC, ~880 MB free RAM; SLM utility role (qwen3:0.6b, gemma3:270m, nomic-embed-text, snowflake-arctic-embed:m)
 
 ## Data flows
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,20 +31,12 @@ Codex                          policy.json          OR Cloud (Claude /        + 
 - `scripts/global/free-router.js` — free-model orchestrator MVP (#786): classifier + signal stack picks a tier, calls a free LLM (Groq) when available, falls back to deterministic cascade-dispatch
 - `agents/router.agent.md` — Routing role definition
 
-### Capability detection (ADR-013)
+### Capability detection / cost-reduction (ADR-013)
 
-- `scripts/global/capability-probe.js` — probes providers, fleet hosts, and toolchain; writes manifest
-- `scripts/global/capability-show.js` — reads `.dashboard/capabilities.json`
-- `.dashboard/capabilities.json` — capability manifest consumed by routing, RAG, state-offload, and other optional features
-- Optional cost-reduction features gate on this manifest, so a missing provider or offline fleet host degrades gracefully
-
-### RAG / repo-context search (#784)
-
-- `scripts/global/rag-search.js` — repo-context search MVP; uses MCP server when available, falls back to ripgrep
-
-### State offload (#792)
-
-- `scripts/global/state-offload-client.js` — per-turn state offload client; pushes long state to a Worker so the active context stays small
+- `scripts/global/capability-probe.js` + `capability-show.js` — probe providers, fleet hosts, toolchain; write/read `.dashboard/capabilities.json`
+- `scripts/global/rag-search.js` (#784) — repo-context search; MCP-first with ripgrep fallback
+- `scripts/global/state-offload-client.js` (#792) — per-turn state offload to a Worker
+- Optional features gate on the capability manifest, so a missing provider or offline fleet host degrades gracefully
 
 ### Governance
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -35,6 +35,8 @@ admin-tracked.
 | 009 | GitHub Feature Adoption | [`009-github-feature-adoption.md`](../research/adr/009-github-feature-adoption.md) |
 | 010 | Ticket Status–Role Ownership Binding Model | [`010-ticket-status-role-model.md`](../research/adr/010-ticket-status-role-model.md) |
 | 011 | Fleet Auto-Discovery Architecture | [`011-fleet-auto-discovery.md`](../research/adr/011-fleet-auto-discovery.md) |
+| 012 | Multi-Agent Worktree Path Governance | [`012-multi-agent-worktree-governance.md`](../research/adr/012-multi-agent-worktree-governance.md) |
+| 013 | Capability Detection Substrate for Optional Cost-Reduction Features | [`013-capability-detection-substrate.md`](../research/adr/013-capability-detection-substrate.md) |
 
 ## Known issues
 

--- a/docs/howto/contribute-to-wiki.md
+++ b/docs/howto/contribute-to-wiki.md
@@ -1,0 +1,143 @@
+# How to contribute to the Megingjord wiki
+
+The wiki is the LLM's long-term memory: cross-referenced fleet,
+governance, architecture, and research notes. It compiles into
+`~/.copilot/wiki/` and is read by every runtime (Copilot, Claude Code,
+Codex). This guide walks through adding a new source.
+
+See `WIKI.md` for the schema reference and ADR-007 for the adoption
+decision.
+
+## Three layers (recap)
+
+| Layer | Path | Edit by |
+|---|---|---|
+| Raw sources | `raw/articles/` | Human (curator) |
+| Wiki | `wiki/` | LLM (auto via `wiki:ingest`) |
+| Schema | `WIKI.md` | Co-owned, by agreement |
+
+You always start in `raw/articles/`. The wiki itself is a derived
+artifact — never hand-author `wiki/sources/`.
+
+## Step-by-step ingest
+
+### 1. Drop the raw source
+
+Place the markdown in `raw/articles/<slug>.md` with frontmatter:
+
+```yaml
+---
+title: "Source title"
+type: research | audit | benchmark | article
+created: 2026-05-02
+status: pending
+---
+```
+
+Filename slug is `kebab-case` and is the join key — both
+`wiki/sources/<slug>.md` and the index entry derive from it.
+
+### 2. Run the ingest script
+
+From the Megingjord repo root:
+
+```bash
+npm run wiki:ingest -- raw/articles/<slug>.md
+```
+
+The `scripts/wiki/ingest.js` script:
+
+1. Calls the configured fleet LLM (OpenClaw primary, Groq/Cerebras failover) to produce a structured summary
+2. Writes `wiki/sources/<slug>.md`
+3. Updates `wiki/index.md`
+4. Appends an entry to `wiki/log.md`
+5. Flips the raw source frontmatter to `status: ingested`
+
+If the LLM is unreachable, the ingest aborts cleanly and leaves the raw
+source untouched.
+
+### 3. Cross-link entities and concepts
+
+The script writes the **source page** but does not auto-create entity
+or concept pages — that's the LLM's judgment call after reading the
+source. After ingest:
+
+1. Identify entities/concepts mentioned (devices, services, patterns, decisions)
+2. Create or update the relevant `wiki/entities/<name>.md` or `wiki/concepts/<name>.md`
+3. Add `[[source-slug]]` to the entity/concept's `sources:` frontmatter
+4. Add reciprocal `[[entity-name]]` links from the source page's `related:` field
+
+### 4. Lint and commit
+
+```bash
+npm run wiki:lint
+```
+
+Lint catches:
+
+- Broken `[[wikilinks]]`
+- Orphan pages (no inbound links)
+- Missing required frontmatter fields
+- Index drift
+- Cross-page contradictions and stale claims
+
+Fix any flagged issues, then commit:
+
+```bash
+git add raw/articles/<slug>.md wiki/sources/<slug>.md wiki/entities/<...>.md wiki/concepts/<...>.md wiki/index.md wiki/log.md
+git commit -m "wiki: ingest <slug>"
+```
+
+### 5. Anneal (optional)
+
+When several related pages have grown organically, run:
+
+```bash
+npm run wiki:anneal
+```
+
+`scripts/wiki/anneal.js` rewrites pages for cross-page consistency
+without changing meaning. Diff before committing.
+
+## Naming and structure rules
+
+- Filenames: `kebab-case.md`, never `Capitalized.md` or `snake_case.md`
+- One concept per page; split when content exceeds 80 lines
+- Wikilinks: `[[page-name]]`, no path prefix, no extension
+- Every entity/concept page must link to ≥1 related page
+- Source summaries must link to the entities/concepts they reference
+- Syntheses must cite ≥2 source/concept pages
+
+## When to use the wiki
+
+- Before research: search for prior work first
+- When answering fleet/governance/architecture questions
+- After significant work: suggest wiki updates as part of the closeout
+
+Search from any repo:
+
+```bash
+node ~/.copilot/scripts/wiki-search.js "your query"
+```
+
+Search from inside Megingjord (with full source context):
+
+```bash
+npm run wiki:search -- "your query"
+```
+
+## Read-only from non-Megingjord repos
+
+The compiled wiki at `~/.copilot/wiki/` is **read-only** from other
+repos. All edits flow through Megingjord and propagate via
+`scripts/sync.sh` / `scripts/deploy.sh`.
+
+If you spot stale wiki content from another repo, open a Megingjord
+issue rather than editing the compiled copy.
+
+## Related
+
+- `WIKI.md` — schema reference
+- `instructions/wiki-knowledge.instructions.md` — global instruction
+- `research/adr/007-llm-wiki-adoption.md` — adoption decision
+- `research/adr/013-capability-detection-substrate.md` — capability gating used by ingest's LLM call

--- a/instructions/wiki-knowledge.instructions.md
+++ b/instructions/wiki-knowledge.instructions.md
@@ -12,11 +12,16 @@ Compiled wiki at `~/.copilot/wiki/` — cross-referenced fleet, skills, governan
 
 | Operation | Where | Command |
 |---|---|---|
-| **Search** | Any repo | `node ~/.copilot/scripts/wiki-search.js "query"` |
+| **Search (compiled)** | Any repo | `node ~/.copilot/scripts/wiki-search.js "query"` |
 | **Read** | Any repo | Read `~/.copilot/wiki/index.md` then drill into pages |
+| **Search (source)** | Megingjord only | `npm run wiki:search -- "query"` |
 | **Ingest** | Megingjord only | `npm run wiki:ingest -- raw/articles/<file>.md` |
 | **Lint** | Megingjord only | `npm run wiki:lint` |
 | **Anneal** | Megingjord only | `npm run wiki:anneal` |
+
+End-to-end ingest pipeline (raw/articles → wiki/sources → entity/concept
+pages → index.md → log.md) is documented in `WIKI.md`; the
+contributor walkthrough is `docs/howto/contribute-to-wiki.md`.
 
 ## When to Use the Wiki
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "megingjord-harness",
   "description": "Megingjord: Governance-first AI agent harness — skills, agents, hooks for structured development workflows",
-  "version": "3.2.0",
+  "version": "3.3.3",
   "author": "chf3198",
   "skills": [
     "skills/docs-drift-maintenance",

--- a/raw/articles/fleet-resource-audit-2026-05-01.md
+++ b/raw/articles/fleet-resource-audit-2026-05-01.md
@@ -1,0 +1,82 @@
+# Fleet Resource Audit — 2026-05-01
+
+## Tailscale mesh
+
+Four nodes, all `active` and direct-routed (no relay):
+
+| Node | Tailscale IP | OS | RTT | Notes |
+|---|---|---|---|---|
+| penguin (this dev) | 100.87.216.75 | Linux | self | Primary dev |
+| 36gbwinresource | 100.91.113.16 | Windows 10 Pro | 11 ms | GPU Quadro T2000 4GB VRAM |
+| desktop-909a7km / OpenClaw | 100.78.22.13 | Windows | 9 ms | CPU only, 16 GB RAM |
+| penguin-1 | 100.86.248.35 | Linux LXC | 326 ms | Off-network mobile, sub-2B models |
+
+## Ollama endpoint health
+
+All three Ollama nodes responded HTTP 200 on `/api/tags`. Cold-load + 2-token warm benchmarks:
+
+| Node | Cold-load | Warm TPS | Available models (live) |
+|---|---|---|---|
+| 36gbwinresource | 2.92 s | 22.0 tok/s (qwen2.5-coder:7b) | qwen2.5-coder:7b only |
+| OpenClaw | 8.34 s | 3.7 tok/s (qwen2.5:7b-instruct) | qwen2.5:7b-instruct, qwen2.5-coder:7b |
+| penguin-1 | n/a | n/a | qwen3.5:0.8b, gemma3:270m |
+
+Drift vs `inventory/devices.json`: 9 models listed are NOT installed (phi3:mini, mistral-nemo, llama3.1:8b, phi3:medium, mistral, tinyllama, lfm2.5-thinking:1.2b, plus 36gbwinresource missing 2 of 3). Routing to any uninstalled model fails at dispatch.
+
+Performance regressions vs inventory baseline:
+- 36gbwinresource: inventory says 32.3 tok/s warm, measured 22.0 (32% slower)
+- OpenClaw: inventory says 7.3 tok/s warm, measured 3.7 (49% slower)
+
+Likely cause: `OLLAMA_KEEP_ALIVE` not set; default 1-min idle eviction forces re-load on every burst.
+
+## Cloud provider state
+
+| Provider | Auth | Smoke | Issue |
+|---|---|---|---|
+| Anthropic | ✅ | ✅ ok | None |
+| OpenAI | valid key | ❌ insufficient_quota | Account credits exhausted; key itself fine |
+| Groq | ✅ | ✅ ok | None |
+| Cerebras | ✅ | ⚠️ queue_exceeded on qwen-3-235b | Smaller models work; large under load fails |
+| Google AI Studio | ✅ | ❌ on `gemini-2.0-flash`, ✅ on `gemini-2.5-flash` | Our code uses deprecated model ID |
+| OpenRouter | ✅ | ❌ Key limit exceeded (paid), ✅ `:free` models | Per-key cap set to $0; account has $5.26 in credits remaining |
+
+## .env parser hazard
+
+`WINRESOURCE_36GB_SSH_PASSWORD=77777TGBmi&&&&&` contains unquoted `&` chars; bash `source .env` aborts at line 40 with a syntax error and silently leaves all later vars unset (including OPENAI_API_KEY). Node's dotenv parses the same file correctly. Any bash script that does `source .env` for cloud-provider keys will appear to have empty cloud creds. Quote the value (`'77777TGBmi&&&&&'`) or move it before any line shells need to read.
+
+## Recommendations summary
+
+1. Populate / fix OpenAI billing OR remove dispatch routes that target it (already failing silently).
+2. Raise per-key cap on OpenRouter API key in dashboard (account credits remain).
+3. Update Gemini model IDs in dispatcher: `gemini-2.0-flash` → `gemini-2.5-flash` or `gemini-2.5-flash-lite-001`.
+4. Set `OLLAMA_KEEP_ALIVE=24h` system env var on Windows hosts to fix cold-load regressions.
+5. Quote `.env` values containing shell metacharacters.
+6. Reconcile `inventory/devices.json` to live `/api/tags` output OR install the missing models.
+
+## Per-device upgrade ideas (for Manager review)
+
+### 36gbwinresource (4 GB VRAM)
+
+Current: qwen2.5-coder:7b at Q4_K_M. Better fits within 4 GB:
+- qwen2.5-coder:7b at IQ3/Q3 with `num_ctx=2048` keeps KV under ~1 GB → headroom for re-quant or 14B-IQ3 attempts
+- Watch: Qwen3-coder 4B (April 2026) being benchmarked as best-in-tier for sub-4 GB
+- Starcoder2-3b is the only credible non-Qwen alternative at this VRAM
+
+### OpenClaw (16 GB RAM, CPU only)
+
+Switching from Ollama to llama.cpp (or llamafile single-binary) on identical 7B model gives ~50% speedup on CPU per Justine Tunney's matmul work. Going 13–14B drops to 1–2 tok/s — worse than current. Right move: same model, faster engine.
+
+### penguin-1 (≤880 MB free RAM)
+
+Underutilized. Permanently-on, low-RAM patterns that reduce upstream tokens:
+- MiniLM-L6-v2 embedder (~80 MB FP32, ~43 MB FP16) for local doc embedding
+- FlashRank lite reranker (<100 MB) for top-k pre-filtering
+- Hybrid BM25 + vector index via sqlite FTS5 + sentence-transformers
+- "Tool runner" sandbox exposing curated commands (grep, jq, sqlite, ripgrep, git log) over Tailscale as MCP tools — larger models call instead of paying tokens to stream files
+- Doc pre-processor: chunk + summarize-extract via gemma3:270m on-device, push to wiki
+
+## Related context
+
+- Karpathy LLM Wiki v2 (April 2026) — typed relationships, decay-based trust, find-contradictions audits
+- Initializer-executor split agent harness pattern (Anthropic) — cleanest no-daemon model
+- GitHub Actions schedule (with off-peak minutes + self-healing catch-up) is dominant zero-install scheduling option

--- a/research/fleet-hardware-optimization-2026-05-01.md
+++ b/research/fleet-hardware-optimization-2026-05-01.md
@@ -1,0 +1,140 @@
+# Fleet Hardware Optimization — Research & Design (2026-05-01)
+
+**Epic:** #734 (P2)
+**Implementation companion:** #765
+**Maintenance companion:** #766
+**Lane:** docs-research
+
+## Vision
+
+Maximize coding-task quality and throughput on each fleet host while keeping
+the harness install-environment-agnostic — every recommendation must work on
+any host of equivalent hardware tier, not just the specific machines owned
+by this operator.
+
+## Three workstreams
+
+### Workstream 1 — 36gbwinresource (4 GB VRAM, NVIDIA Quadro T2000)
+
+Current: `qwen2.5-coder:7b` Q4_K_M, ~22 tok/s warm (regressed from 32.3
+baseline due to idle eviction).
+
+**Candidate matrix** (Groq llama-3.3-70b-versatile, 2026-05-01):
+
+| Model | Quant | VRAM | Quality vs baseline | Install | Replicability /10 |
+|---|---|---|---|---|---|
+| **Qwen3-coder 4B** (Apr 2026) | FP16 | ~2.5 GB | +15% | medium | 8 |
+| qwen2.5-coder:7b IQ3/Q3 | INT8 | ~1.8 GB | +5% | low | 9 |
+| qwen2.5-coder:3b | FP16 | ~1.2 GB | -10% | low | 9 |
+| starcoder2:3b | FP16 | ~1.5 GB | -5% | medium | 7 |
+| granite-code:3b | INT8 | ~1.8 GB | -15% | medium | 8 |
+| deepseek-coder 1.3B | FP16 | ~2.2 GB | +10% | high | 6 |
+| deepseek-coder 6.7B IQ3 | INT8 | ~3.5 GB | +20% | high | 5 |
+
+**Recommendation**: primary = **Qwen3-coder 4B** (best quality-to-VRAM ratio
+in 2026-Q2); fallback = **qwen2.5-coder:7b at IQ3/Q3** with `num_ctx=2048`
+for KV headroom. Both pinned in the install script so any 4 GB-VRAM card
+can replicate.
+
+### Workstream 2 — OpenClaw (16 GB CPU only Windows)
+
+Current: Ollama with `qwen2.5-coder:7b` Q4, ~3.7 tok/s warm (regressed from
+7.3 baseline due to idle eviction). LiteLLM gateway port 4000 currently DOWN.
+
+**Engine matrix** (Groq llama-3.3-70b-versatile, 2026-05-01):
+
+| Path | Expected warm tok/s | Install | Routing impact | Replicability /10 |
+|---|---|---|---|---|
+| Ollama + `OLLAMA_KEEP_ALIVE=24h` | 7.3 | low | none | 8 |
+| **llamafile single-binary** | 11.0 (+50%) | medium | OpenAI-compat endpoint update | 9 |
+| Raw llama.cpp server | 10.5 | high | custom routing | 6 |
+| llamafile + Ollama side-by-side | 11.0 | medium | Ollama orchestrates | 9 |
+
+**Recommendation**: switch to **llamafile single-binary** running
+qwen2.5-coder:7b Q4_K_M with `--mlock` and `-t <physical-cores>`. Same
+model, ~50% CPU speedup per Justine Tunney's matmul work. Keep OpenClaw
+aggregator role as a routing endpoint (the OpenAI-compatible API surface
+stays unchanged from a routing perspective).
+
+LiteLLM port-4000 disposition: deferred to #765 implementation epic — fix
+the gateway OR remove the dispatcher's reference. Current state breaks
+`npm run wiki:ingest`.
+
+### Workstream 3 — penguin-1 (~880 MB free RAM, ChromeOS Linux LXC)
+
+Currently has `qwen3.5:0.8b` and `gemma3:270m` installed but rarely routed.
+Always-on, Tailscale-meshed, idle.
+
+**Utility matrix** (Groq llama-3.3-70b-versatile, 2026-05-01):
+
+| Pattern | Token reduction | RAM | Install | Replicability /10 |
+|---|---|---|---|---|
+| MiniLM-L6-v2 embedder | 30–50% | ~80 MB FP32 / 43 MB FP16 | medium | 8 |
+| FlashRank lite reranker | 10–20% | <100 MB | low | 9 |
+| Hybrid BM25 + MiniLM | 40–60% | ~150 MB | high | 7 |
+| **Tool-runner sandbox** | 5–10% | ~50 MB | medium | 9 |
+| Doc pre-processor (gemma3:270m) | 20–30% | ~200 MB | high | 6 |
+
+**Phased recommendation**:
+1. **Tool-runner sandbox** first — lowest RAM cost, highest replicability,
+   sets the foundation pattern (MCP-server-on-fleet)
+2. **MiniLM-L6-v2 embedder** second — biggest token-reduction lift per MB
+3. **FlashRank reranker** third — multiplies the embedder's value
+
+Hybrid BM25 + MiniLM and the Doc pre-processor are deferred — the install
+complexity does not justify the RAM cost for an always-on tier.
+
+## Independent second opinion (Cerebras llama3.1-8b)
+
+- **Agree** with all three primary recommendations (Qwen3-coder 4B,
+  llamafile, phased tool-runner→embedder→reranker).
+- **Challenge**: 4 GB VRAM may bottleneck on complex computations — flag a
+  per-task complexity guard so the harness escalates to cloud when local
+  inference would be too slow.
+- **Risk**: penguin-1 sequential install could hit resource exhaustion;
+  install-time RAM probe before each phase, fall back gracefully.
+
+## Replicability constraint check
+
+- **36gbwinresource**: recommendations apply to any 4 GB VRAM card (Quadro
+  T2000, RTX 3050 4GB, P620, A2000 4GB) — pure VRAM-tier targeting, not
+  vendor-specific. ✅
+- **OpenClaw**: llamafile is cross-platform (Windows / Linux / macOS via
+  AVX2/AVX512 auto-dispatch). Works on any 16 GB CPU host. ✅
+- **penguin-1**: sub-1 GB Linux applies to Pi 4/5, NUC, Chromebook LXC,
+  any container with the same RAM ceiling. ✅
+
+## Phased adoption order
+
+| Phase | Action | Owner |
+|---|---|---|
+| 1 | Restore baselines: `OLLAMA_KEEP_ALIVE=24h` on both Windows hosts | #765 implementation |
+| 2 | Reconcile `inventory/devices.json` to live `/api/tags` | #765 |
+| 3 | 36gbwinresource: install Qwen3-coder 4B, benchmark, set as primary | #765 |
+| 4 | OpenClaw: install llamafile, switch primary endpoint, benchmark | #765 |
+| 5 | penguin-1: ship tool-runner sandbox MCP server | follow-up child of #765 |
+| 6 | penguin-1: add MiniLM embedder, FlashRank reranker | follow-up child |
+
+## Out of scope
+
+- Hardware purchases.
+- Replacing the existing fleet topology.
+- The ongoing maintenance loop (research in #766).
+
+## Sources
+
+- 2026-05-01 fleet audit: `wiki/sources/fleet-resource-audit-2026-05-01.md`
+- Justine Tunney matmul work — llama.cpp CPU speedup
+- MiniLM-L6-v2 sentence-transformers model card
+- FlashRank lite reranker
+- Karpathy LLM Wiki v2 (typed relationships, decay-based trust)
+- Live Groq dispatch outputs preserved at \`/tmp/ws{1,2,3}.md\` during research
+
+## Fleet utilization for this research
+
+- Workstream 1 (4 GB VRAM matrix): **Groq llama-3.3-70b-versatile** (free)
+- Workstream 2 (CPU engine paths): **Groq llama-3.3-70b-versatile** (free)
+- Workstream 3 (SLM utility patterns): **Groq llama-3.3-70b-versatile** (free)
+- Independent second opinion: **Cerebras llama3.1-8b** (free)
+- OpenClaw on-fleet attempted but slow on CPU; Cerebras provided second opinion instead
+- Synthesis: deterministic local assembly, zero LLM tokens

--- a/research/multi-agent-command-center-2026-05-01.md
+++ b/research/multi-agent-command-center-2026-05-01.md
@@ -1,0 +1,139 @@
+# Multi-Agent Command Center — Research & Design (2026-05-01)
+
+**Epic:** #736
+**Status:** Research phase — pending client review before implementation
+
+## Goal
+
+Make VS Code a multi-agent command center where 3–5 AI agent extensions
+operate concurrently on the same repo on the same machine without
+conflicts.
+
+## VS Code AI agent extension behavior matrix (2026-Q2)
+
+Eleven extensions surveyed. Full citations in epic #736 research dispatch.
+Highlights relevant to coordination design:
+
+| Extension | Multi-window safe? | Direct git writes? | Local port | Session ID |
+|---|---|---|---|---|
+| **GitHub Copilot Chat** (agent mode) | yes | via terminal/agent | none (HTTPS only) | per-window chat IDs |
+| **Claude Code** (CLI + ext) | partial — PID lock file in `~/.claude/ide/`; shared `~/.claude/projects/` causes session-disappear bugs | indirect (Bash tool) | **yes** — random 127.0.0.1:high | session UUID + lock-file PID |
+| **OpenAI Codex** | unknown — no documented multi-instance contract | yes — sandbox-mode aware | unknown | per-run transcripts |
+| **Cursor** (fork) | **best built-in** — Agents Window + v3.2 `/multitask`; isolates branches via worktrees | yes — Background Agents push branches | multiple | `cursor-agent --resume <chatId>` |
+| **Continue.dev** | per-window state; LanceDB race fixed in v1.0.20 | indirect | none | assistant config IDs |
+| **Cline / Roo Code** | **worst** — global state bug #2550, view collision #807, instance task sync #3514 | yes — generates commit messages, runs `git` | optional 9222 (Chrome remote) | task ID, shared globally (bug) |
+| **Aider** (CLI in terminal) | breaks on shared git index | **yes — auto-commits every edit** by default | none | none |
+| **Tabnine Agent** | unknown | unknown | unknown | unknown |
+| **Amazon Q Developer** | unknown | yes — `@git` tool | unknown | per-window chat |
+| **Sourcegraph Cody** | unknown | indirect (Smart Apply) | unknown | conversation IDs |
+| **Native VS Code MCP host** (1.99+) | yes | depends on configured server | per-server (stdio or SSE) | server+tool IDs |
+
+Only **Cursor** is designed for multi-agent concurrent operation.
+**Cline** is the highest-risk coexistence target. **Aider's** default
+auto-commit will fight any other agent on a shared index. **Claude Code**
+already uses PID-keyed lock files — closest to a working model.
+
+## Isolation primitive comparison
+
+| Primitive | Isolation strength | Install cost | 2026 verdict |
+|---|---|---|---|
+| Per-agent VS Code Profile + Window | low (FS still shared) | zero | necessary, not sufficient |
+| Per-agent git worktree | medium (`.git/index.lock` shared) | low | breaks down at >5 worktrees |
+| `jj` (jujutsu) over git | **high** — concurrent workspaces native; no shared `index.lock`; auto-undo via op log | install one binary | **2026 winner per Panozzo + ezyang writeups** |
+| Rootless Podman + Distrobox | very high | one-time setup | use when FS isolation matters |
+| Firecracker / Kata microVM | extreme | heavy | overkill for in-tree work |
+
+## Coordination primitive comparison
+
+| Primitive | Crash-safe | Install-agnostic | Sub-second | Verdict |
+|---|---|---|---|---|
+| `flock` | yes | yes | yes | brittle on NFS/9p/WSL |
+| **SQLite WAL** with TTL leases | yes | yes (single file) | yes | **recommended local primitive** |
+| Custom PID + heartbeat | partial | yes | yes | reinvents SQLite, poorly |
+| **GitHub issue assignee** | yes | yes (cloud) | no (~5000 req/h) | **recommended source-of-truth for ticket ownership** |
+| Tailscale-shared lease | yes | needs Tailscale | yes | overkill single-machine |
+
+**Best blend**: GitHub issue assignee = ticket-ownership truth; SQLite WAL
+= sub-second coordination locally.
+
+## MCP for inter-agent communication
+
+MCP's 2026-Q2 roadmap explicitly adds agent-to-agent as a first-class
+direction. The directly-relevant project:
+
+**`mcp_agent_mail`** (Dicklesworthstone, GitHub) — *"asynchronous
+coordination layer for AI coding agents: identities, inboxes, searchable
+threads, and advisory file leases over FastMCP + Git + SQLite"*. TTL-bounded
+advisory file reservations (default 3600s, renewable). This solves the
+*"both agents tried to edit CHANGELOG.md and one lost"* class of failure
+without hard locks that would head-of-line block.
+
+`lastmile-ai/mcp-agent` is the other major framework — workflow patterns
+(chaining, handoffs) rather than coordination.
+
+## Recommended stack for Megingjord
+
+Five layers, each addressing a specific failure class:
+
+1. **Per-agent VS Code Profile + Window** — disjoint extension sets, settings, tasks per agent. Cleans up extension-state collisions like Cline's global-state bug.
+2. **`jj` over `git`** — concurrent worktrees without `.git/index.lock` contention. Existing git users keep their workflow; `jj` operates on the same `.git/` directory and pushes to GitHub as normal git refs. Solves the recurring branch-switch contamination we saw 5+ times this session.
+3. **`mcp_agent_mail` MCP server on localhost** — single coordination bus all agents subscribe to. Each agent has a Gmail-style identity + inbox; advisory file leases prevent two agents from writing the same file.
+4. **SQLite WAL state file** at `.dashboard/agent-state.sqlite` — sub-second TTL leases for build slots, hook mutexes, worktree-pin claims.
+5. **GitHub issue assignee + role label** — already mostly true; the source of truth for *which agent owns ticket N*. Combined with #730/#732 fleet-state work, this becomes a coherent system.
+
+## Failure-class coverage
+
+| Failure observed in this repo | Layer that fixes it |
+|---|---|
+| Branch silently switches mid-task | Layer 2 (`jj` workspaces don't share an index) |
+| Pre-push hook reverts edits during another agent's push | Layer 3 (file lease) + Layer 4 (hook mutex) |
+| CI race on baton-gates from simultaneous merges | Layer 4 (build-slot lease) |
+| Last-writer-wins on `CHANGELOG.md` / `package.json` | Layer 3 (file lease) |
+| Interleaved/lost lines in `.dashboard/events.jsonl` | Layer 4 (write mutex) or per-agent file prefix |
+| Stash cross-contamination | Layer 1 + Layer 2 (per-Profile per-worktree) |
+| Two agents post handoffs on same issue, race timing gate | Layer 5 (assignee = single owner) |
+
+## Replicability constraint
+
+All five layers must install via existing `npm run setup`:
+- Layer 1: VS Code Profiles import — single CLI command
+- Layer 2: `jj install` — single binary; can be `brew/winget/apt`
+- Layer 3: `mcp_agent_mail` runs as a child of any agent's MCP host
+- Layer 4: SQLite is standard library on any platform
+- Layer 5: already in place
+
+No layer requires cron, systemd, or an always-on daemon.
+
+## Open design questions for client review
+
+- **Q1.** Do we adopt `jj` as the canonical VCS layer? It is the strongest single-decision item. Tradeoff: contributors learn `jj` (15-min ramp; pushes to GitHub as normal git so external collaborators see plain git). Alternative: stay on git, pay the `index.lock` tax with worktrees.
+- **Q2.** Which extensions do we explicitly support vs. block? Recommend a tiered policy:
+  - **Tier-A supported** (multi-agent-safe): Cursor Background Agents, VS Code MCP host, GitHub Copilot Chat, Claude Code, Continue.dev (with v1.0.20+).
+  - **Tier-B requires per-agent worktree + Profile**: Codex, Amazon Q, Cody.
+  - **Tier-C requires opt-in + warnings**: Cline / Roo Code (multi-window bugs), Aider (auto-commit), Tabnine (unknown behavior).
+- **Q3.** Where does the MCP coordination server run? Localhost on the dev workstation is simplest. Tailscale-shared if a fleet device should also coordinate.
+- **Q4.** Does the dashboard grow a "Multi-Agent Sessions" panel? Strong yes — same SSE stream we already have, plus a per-agent identity column.
+- **Q5.** Do we vendor `mcp_agent_mail` in this repo, depend on it as an npm/pip package, or fork? Recommend pin-by-SHA in `inventory/` first; revisit when stable.
+- **Q6.** Hooks vs. trust model. Hooks enforce; we should layer enforcement (Layer 3 advisory) before fail-closed (Layer 4 mutex). Two failed acquisitions = fail to user.
+
+## Recommended next steps (post client review)
+
+If client approves direction: spawn 5 implementation child tickets, one per layer, P1 priority, in dependency order (1 → 2 → 4 → 3 → 5/dashboard). Each child uses standard 4-role baton.
+
+If client wants a smaller starting wedge: spawn only Layer 3 (`mcp_agent_mail` integration) + Layer 4 (SQLite leases) as the "prove it works" MVP, defer `jj` and Profiles until measured benefit.
+
+## Sources
+
+Comprehensive citations in epic #736 dispatch comments. Key URLs:
+
+- [Avoid Losing Work with Jujutsu (jj) for AI Coding Agents](https://www.panozzaj.com/blog/2025/11/22/avoid-losing-work-with-jujutsu-jj-for-ai-coding-agents/)
+- [Parallel Agents ❤️ Sapling (ezyang)](https://blog.ezyang.com/2026/03/parallel-agents-heart-sapling/)
+- [mcp_agent_mail (Dicklesworthstone)](https://github.com/Dicklesworthstone/mcp_agent_mail)
+- [VS Code Profiles official docs](https://code.visualstudio.com/docs/configure/profiles)
+- [VS Code MCP servers docs](https://code.visualstudio.com/docs/copilot/customization/mcp-servers)
+- [Cursor 3.2 Agents Window](https://cursor.com/docs/agent/agents-window)
+- [Claude Code VS Code extension docs](https://code.claude.com/docs/en/vs-code)
+- [Cline issue #2550 — workspace-scoped state](https://github.com/cline/cline/discussions/2550)
+- [Aider git docs](https://aider.chat/docs/git.html)
+- [SQLite File Locking and Concurrency](https://sqlite.org/lockingv3.html)
+- [MCP 2026 Roadmap — agent-to-agent direction](https://mcpplaygroundonline.com/blog/mcp-2026-roadmap-whats-changing-for-developers)

--- a/research/multi-agent-command-center-round-2-2026-05-01.md
+++ b/research/multi-agent-command-center-round-2-2026-05-01.md
@@ -1,0 +1,194 @@
+# Multi-Agent Command Center — Round 2 Research (2026-05-01)
+
+**Epic:** #736
+**Status:** Round 2 research complete; second design discussion pending
+**Client decisions absorbed from Round 1:**
+- Stay on git (no `jj` migration)
+- Tier-A + Tier-B (with Codex prioritized as Tier-B), Tier-C opt-in only
+- Full-stack design-correct end state, single epic
+- Layered enforcement is mandatory
+- Coordination server can use localhost only if resources permit; otherwise out-of-the-box thinking required
+- Multi-agent dashboard overhaul agreed
+- Karpathy LLM Wiki kept in the loop
+
+## Round-2 critical findings
+
+### 1. The "instinctive worktree separation" you observed is REAL — and one-sided
+
+**Confirmed via search of the local git status:** the `.claude/worktrees/` untracked entry that has appeared throughout this session is not an artifact of the harness — it's **Claude Code Desktop's unilateral, non-disable-able session worktree behavior** introduced in the April 2026 Anthropic redesign. CCD creates a fresh `<repo>/.claude/worktrees/<name>/` per session and runs inside it.
+
+- Open Anthropic issue **#50109** requests an opt-out — confirms the behavior is unilateral, not negotiated.
+- Copilot CLI offers worktree mode but **opt-in at session start** (the user must select Worktree vs Workspace).
+- OpenAI Codex and GitHub Copilot Chat have **no documented automatic worktree behavior** for local same-window sessions.
+
+**Implication:** Claude Code already does Layer 2 isolation for its own sessions. The harness should **detect and respect** the existing `.claude/worktrees/` directory rather than fight it; the design should compose with Anthropic's choice rather than override it.
+
+### 2. VS Code 1.109 (Jan 2026) introduced a unified Agent Sessions view
+
+- Hosts Claude / Codex / Copilot side-by-side in **one window**.
+- Each agent uses its provider's SDK + harness independently.
+- **No documented context sharing** between providers and **no documented collision/concurrency rules** — providers operate autonomously.
+- Local agents explicitly run with **"No (direct workspace)" isolation** by default — they all touch the same files.
+- Only **background** agents auto-isolate via worktrees; **cloud** agents isolate via remote VMs.
+
+**Citation:** `code.visualstudio.com/blogs/2026/02/05/multi-agent-development`
+
+### 3. The proposed VS Code API surface for agents
+
+- `vscode.proposed.chatSessionsProvider.d.ts` migrated from provider-based to **controller-based** model (`createChatSessionItemController` replacing `registerChatSessionItemProvider`).
+- A separate proposed API contributes dynamic chat resources (prompt files, custom agents, instructions, skills).
+- `microsoft/vscode#302362` adds **`chat.agent.onPermissionRequest`** for permission resolution and remote approval routing.
+- **No documented "agent identity," "agent presence," or "agent registry" proposed API** as of 2026-Q2.
+
+**Implication:** the harness has to **build its own presence layer** because the platform doesn't provide one yet. We can hook into `chatSessionsProvider` to *contribute* sessions but cannot *enumerate* peer extensions' sessions.
+
+### 4. GitHub Copilot CLI `/fleet` (April 2026)
+
+Copilot CLI shipped its own multi-agent orchestrator: `/fleet` decomposes an objective into independent work items and dispatches to multiple subagents in parallel. Copilot CLI reached GA in February 2026 with Plan mode, Autopilot, and parallel specialised subagents (Explore, Task, Code Review, Plan).
+
+**Implication:** Copilot has its own internal multi-agent story but **no cross-vendor coordination contract**. Our harness is filling the cross-vendor gap.
+
+### 5. OpenAI Codex MultiAgentV2 — the most explicit cross-session contract
+
+- `agents.max_threads` (default 6 concurrent threads)
+- `agents.max_depth` (default 1, prevents deep recursion)
+- Subagents are first-class with root/subagent hints
+- **Sandbox contract is the co-existence story**: `sandbox_mode = "workspace-write"` + `approval_policy = "on-request"` is the documented preset for low-risk local automation
+- Per-profile `cwd` controls + active-profile metadata exposed to clients
+
+**Implication:** Codex's permission profiles + `cwd` give us a **real Tier-B identity surface** to bind to the harness. We can pin a Codex profile to a specific worktree path and the sandbox enforces the boundary.
+
+### 6. Claude Code multi-agent bug surface
+
+Beyond #31787 from Round 1, Round 2 surfaced more:
+- **#28829** — `.claude.json` corruption from non-atomic read-modify-write across N concurrent sessions (toolUsage, clientDataCache, projects all share one global file with no locking; regression in v2.1.59)
+- **#49166** — `/effort` leaks across concurrent sessions instead of being session-scoped
+- **#39808** — globally-enabled plugins load in every instance and conflict on channel ownership
+- **#54393** (April 28 2026) — post-mortem cataloguing 12 multi-agent coordination bugs in a single overnight autonomous cycle
+
+**Implication:** the harness has to **defend against shared-state corruption**, not just file-level conflicts. The `.claude.json` global state means even sessions in separate worktrees can corrupt each other through that one file.
+
+### 7. MCP 2026-Q2 evolution — discovery added, presence not
+
+- **SEP-1649 / PR-2127** added `.well-known/mcp.json` server cards for client-side server discovery. Schema uses protocol version `2025-06-18`. Targeted for the **2026-06 spec release**.
+- This is **server-side discovery only** — there is no MCP mechanism for two MCP-using agents in one workspace to see each other.
+- Multi-agent coordination is **explicitly out of scope for MCP**.
+- The gap is being filled by Google's **A2A protocol** layered on top.
+
+**Implication:** we cannot rely on MCP alone for inter-agent presence. Our coordination server (`mcp_agent_mail` style) is genuinely necessary.
+
+### 8. Industry state of "agent presence in IDE"
+
+- **No formal "agent rendezvous" or "agent presence in IDE" research paper or open standard found** as of 2026-Q2.
+- All documented coordination is one of: (a) separate worktrees + separate windows, (b) shared file system as bus (Anthropic's parallel-Claudes pattern), (c) subagent fan-out within one vendor (Cursor `/multitask`, Copilot CLI `/fleet`).
+- **Bottom line: same window + same checkout + 3 vendors remains an unsolved coordination problem.**
+
+**Implication:** Megingjord is at the cutting edge here. Either we build the primitive ourselves, or we wait 6+ months for the platform.
+
+### 9. Coordination server hosting comparison (under resource constraints)
+
+| Option | Cold latency | Free quota | State location | Works without persistent host? |
+|---|---|---|---|---|
+| **Cloudflare Worker + Durable Object** | 10–50 ms | **100k req/day**, 1 GB KV, SQLite-in-DO | Per-DO SQLite | **Yes — fully edge** |
+| Termux-on-Tailscale (Android phone) | LAN ~20 ms | $0 if old phone | Local phone SQLite | No — phone must stay charging |
+| GCP Cloud Run | ~1–2 s cold | 2M req/mo, 360k vCPU-s | Separate Firestore/GCS | Yes |
+| Fly.io | Always-on | **No free tier in 2026 (CC required)** | Volume | Yes (paid) |
+| GitHub Actions + issue-comment state | Minutes (sched) | Generous Actions minutes | Issue/PR comments | Yes — degenerate "no server" case |
+| PartyKit / Liveblocks | Real-time WS | Free tier metered on MAU | Provider DB | Yes (managed) |
+
+**Recommended: Cloudflare Worker + Durable Object.** Reasons:
+- Consumes zero free-model fleet resources (runs at the edge, not Penguin-1 / OpenClaw / 36gbwinresource)
+- Survives any host's downtime including phone reboots
+- Stateful WebSocket + SQLite per-session in one primitive
+- 100k req/day quota is far above the ~5–10 baton transitions/day a single-operator workflow generates
+- Already the platform Cloudflare uses for its own remote MCP servers (good docs)
+- FastMCP transport — `mcp_agent_mail` works as-is
+
+**Tier-C fallback: GitHub-Actions-as-coordinator.** No infra at all; uses issue comments as KV. Already half of what `manager-ticket-lifecycle` does today.
+
+## Updated 5-layer recommended stack (incorporating Round 2 + client decisions)
+
+| Layer | Tool / Mechanism | Source |
+|---|---|---|
+| **1** | VS Code Profile + Window per agent (where same-window not required) | Round 1 |
+| **2** | Per-agent worktree. **Compose with Claude Code's existing `.claude/worktrees/`** (don't fight it). For Codex/Copilot, harness creates `<repo>/.harness/worktrees/<agent-id>/` and pins via Codex `cwd` profile / Copilot CLI worktree mode. | Round 2 (composition over override) |
+| **3** | **Cloudflare Worker + Durable Object** hosting `mcp_agent_mail`-compatible coordination server. Each agent's MCP host connects via FastMCP. TTL-bounded advisory file leases. | Round 2 (resource-constrained hosting) |
+| **4** | Local SQLite WAL at `.dashboard/agent-state.sqlite` for sub-second leases (build slot, hook mutex). + Defense against `.claude.json` corruption: per-agent `CLAUDE_CONFIG_DIR` env override. | Round 1 + Round 2 (Claude bug defense) |
+| **5** | GitHub issue assignee + role label as ticket-ownership truth (already in place). Fallback Tier-C: GitHub-Actions-as-coordinator if Cloudflare unavailable. | Round 1 |
+
+## Tier policy (with client revisions)
+
+| Tier | Extensions | Stack support |
+|---|---|---|
+| **A — multi-agent-safe** | Cursor Background Agents, native VS Code MCP host, GitHub Copilot Chat (Jan 2026 multi-session view), Claude Code (worktree-isolated by default), Continue.dev ≥1.0.20 | Layer 1+2+3+4+5 |
+| **B — supported with explicit isolation** | **Codex (priority — sandbox-mode + cwd profile binds to worktree)**, Amazon Q Developer, Sourcegraph Cody | Layer 1+2 (forced) + 3+4+5 |
+| **C — opt-in with warnings** | Cline / Roo Code (multi-window bugs), Aider (auto-commit aggressive), Tabnine (unknown behavior) | Requires explicit user consent; harness shows warning banner; no tier-C agent gets coordination-server credentials |
+
+## Same-window multi-chat scenario (the user's primary use case)
+
+Round-2 finding #1 means same-window is now well-defined:
+- **Claude Code session** runs in `.claude/worktrees/<n>/` automatically
+- **Codex session** runs in `.harness/worktrees/codex-<id>/` (harness binds via Codex profile `cwd`)
+- **Copilot Chat session** runs in main checkout (no worktree behavior); harness can detect and warn the user to use Copilot CLI worktree mode for non-trivial work
+- **Coordination server** mediates between all three via MCP for any cross-session activity (lease for shared file, presence broadcast, baton handoff visibility)
+- **Dashboard** shows three lanes — one per active agent — with current branch, current ticket, current file leases held, last activity
+
+## Karpathy LLM Wiki integration
+
+Round-2 findings ingested into wiki via `wiki/sources/multi-agent-command-center-round-2-2026-05-01.md` (see next file). Cross-links: `[[36gbwinresource]]`, `[[openclaw]]`, `[[penguin-1]]`, `[[fleet-architecture]]`, `[[baton-protocol]]`, `[[concurrent-agent-worktrees]]`.
+
+## FINAL ARCHITECTURE LOCK (post round-3 client review)
+
+### Decisions confirmed by client
+
+- **One VS Code window per agent vendor** (Claude / Codex / Copilot / Continue), each rooted at its worktree. Same-window-cross-vendor isolation is impossible per VS Code multi-root semantics + per-vendor pin docs (Codex IDE extension reports `cwd:~/`, Copilot Chat has no documented sub-directory pin, Continue follows IDE workspace root only).
+- **One instance per agent vendor** (≤1 Claude, ≤1 Codex, ≤1 Copilot Chat, ≤1 Continue at a time). All five major Claude multi-session bugs (#28829, #49166, #39808, #54393, #31787) require Claude-on-Claude contention; this rule sidesteps them. `CLAUDE_CONFIG_DIR` per-agent override deferred.
+- **Per-repo per-vendor worktrees**: `<repo>/.claude/worktrees/<n>/` (Claude self-managed by Anthropic) + `<repo>/.harness/worktrees/<vendor>/` (harness-managed for Codex, Copilot, Continue). Both gitignored. Created on first-touch per repo via pre-prompt / pre-tool hooks.
+- **Cloudflare Worker + Durable Object** is optional opt-in coordination host. Default = local SQLite WAL only with "limited mode" banner.
+- **Multi-agent dashboard panel split into a separate epic** (per A8 client decision); this epic ships only the coordination plumbing.
+- **Cross-repo support**: agent windows may navigate between multiple local repos and push to multiple GitHub remotes in one session (per Copilot CLI behavior). Worktree path discipline scales naturally — every repo this vendor visits gets its own `.harness/worktrees/<vendor>/`.
+
+### Final 5-layer stack
+
+| Layer | Mechanism | Default behavior | Scope |
+|---|---|---|---|
+| 1 | VS Code Profile + Window per vendor | required for Tier-A and Tier-B | install-time templates |
+| 2 | Per-repo per-vendor worktree | always on; Claude self-managed; others via pre-prompt hooks | per-repo |
+| 3 | **Optional** Cloudflare Worker + DO MCP coordination | off unless `CLOUDFLARE_WORKER_URL` configured; banner shown when off | per-fleet |
+| 4 | Local SQLite WAL (`<repo>/.dashboard/agent-state.sqlite`) | always on; sub-second leases | per-repo |
+| 5 | GitHub issue assignee + role label = ticket ownership | already in place | per-issue |
+
+### Tier policy (final)
+
+- **A — multi-agent-safe** (Cursor Background Agents, native VS Code MCP host, GitHub Copilot Chat, Claude Code, Continue.dev ≥1.0.20): full stack support
+- **B — Codex priority + supported with forced isolation** (OpenAI Codex via `cwd` profile templating, Amazon Q Developer, Sourcegraph Cody): full stack with Layer 2 mandatory
+- **C — opt-in only with warnings** (Cline / Roo Code, Aider, Tabnine): pre-commit hook detects auto-commit signature on protected branches and blocks; no Layer 3 credentials granted
+
+## Open design decisions for second discussion
+
+1. **Cloudflare Worker hosting**: do we proceed with Cloudflare as primary coordination host, or want a deeper look at Termux-on-Tailscale or hybrid? Cloudflare seems unambiguous given resource constraints.
+2. **Worktree path discipline**: standard prefix `.harness/worktrees/<agent-id>/` for non-Claude agents (since Claude already uses `.claude/worktrees/`). OK to add this prefix?
+3. **Same-window UX**: when user has 3 chats in one VS Code window, should the harness install a status-bar indicator showing each agent's current worktree + ticket? Or rely entirely on the dashboard?
+4. **`.claude.json` corruption defense**: per-agent `CLAUDE_CONFIG_DIR` overrides (recommended). Do we make this automatic via VS Code env injection, or document only?
+5. **Failure mode when Cloudflare Worker is unreachable**: graceful degradation to local SQLite-only? Or hard fail until reconnected? Recommend graceful with banner.
+6. **Codex profile templating**: harness ships a `codex-profile.toml` per agent with cwd + sandbox bound. Agree?
+7. **Cline/Aider Tier-C policy enforcement**: do we add a pre-commit hook that detects Aider's auto-commit signature and blocks it on protected branches?
+8. **Dashboard multi-agent panel**: ship as part of this epic, or split to a child? Recommend part of this epic so the SSE schema evolution is coherent.
+
+## Sources
+
+Full citations across both research dispatches preserved in epic #736 comments.
+
+Key URLs (Round 2):
+- VS Code blog "Your Home for Multi-Agent Development" (Feb 2026): code.visualstudio.com/blogs/2026/02/05/multi-agent-development
+- vscode.proposed.chatSessionsProvider.d.ts: github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+- GitHub Blog "Run multiple agents at once with /fleet": github.blog/ai-and-ml/github-copilot/run-multiple-agents-at-once-with-fleet-in-copilot-cli/
+- Codex Subagents docs: developers.openai.com/codex/subagents
+- Codex Sandbox docs: developers.openai.com/codex/concepts/sandboxing
+- Anthropic claude-code #50109 (worktree opt-out request): github.com/anthropics/claude-code/issues/50109
+- Anthropic claude-code #28829 (.claude.json corruption): github.com/anthropics/claude-code/issues/28829
+- Anthropic claude-code #54393 (12-bug post-mortem): github.com/anthropics/claude-code/issues/54393
+- MCP server-card SEP-1649/PR-2127: github.com/modelcontextprotocol/modelcontextprotocol/pull/2127
+- Cloudflare Workers free tier: developers.cloudflare.com/workers/platform/pricing/
+- Cloudflare Durable Objects pricing: developers.cloudflare.com/durable-objects/platform/pricing/
+- mcp_agent_mail repo: github.com/Dicklesworthstone/mcp_agent_mail

--- a/research/paid-token-floor-reduction-2026-05-01.md
+++ b/research/paid-token-floor-reduction-2026-05-01.md
@@ -1,0 +1,144 @@
+# Paid-Token Floor Reduction — Research & Design (2026-05-01)
+
+**Epic:** #782
+**Status:** Research complete, children created
+**Lane:** docs-research
+
+## Goal
+
+Drive paid Claude Code / Copilot consumption below 50% of current volume by
+moving the orchestration layer, repo-context loading, and per-turn state
+out of the paid context window onto free fleet + free cloud resources.
+
+## Three architectural moves (validated by 2026-Q2 research)
+
+### Move 1 — Free-model orchestrator / decider
+
+**Pattern (2026-Q2 production-converged):** **classifier + signal-extraction stack**, not "small LLM as router". The dominant production pattern uses tiny BERT-class classifiers (~110M params) with regex / keyword / embedding-similarity signals, falling back to a small LLM only on ambiguous edge cases. Reserves the premium model for load-bearing reasoning only.
+
+**Reference projects:**
+
+- **vLLM Semantic Router (Athena v0.2, March 2026)** — open-source Envoy `ext_proc` router with signal-extraction layer. Repo: <https://github.com/vllm-project/semantic-router>, vision paper: <https://developers.redhat.com/articles/2026/03/25/getting-started-vllm-semantic-router-athena-release>
+- **RouteLLM (lm-sys)** — BERT classifier router; 85% cost reduction at 95% GPT-4 quality. Repo: <https://github.com/lm-sys/RouteLLM>, paper: <https://arxiv.org/pdf/2406.18665>
+- **NVIDIA AI Blueprints `llm-router`** — Triton-deployed classifier reference. Repo: <https://github.com/NVIDIA-AI-Blueprints/llm-router>
+- **RouterEval (EMNLP 2025)** — sub-1B classifiers match larger router LLMs at fraction of latency. Paper: <https://aclanthology.org/2025.findings-emnlp.208.pdf>
+
+**Latency budget evidence:**
+- Groq Llama-3.1-8B: ~640 tok/s, ~110-160 ms TTFT — well within one cache-hit boundary
+- ClawRouter sub-1ms in-process routing
+- Opper benchmark: OpenRouter 0.640s vs OpenAI direct 0.712s — routing overhead negligible
+
+**Design for Megingjord:**
+- Port vLLM-SR signal-extraction layer to a Cloudflare Worker (free, edge-fast)
+- Fall back to Groq Llama-3.3-70b for ambiguous cases
+- Cache routing decisions per-task-fingerprint (hash of task description + capability matrix) in Cloudflare KV — repeat decisions return in <10 ms
+
+### Move 2 — Repo-context RAG via penguin-1
+
+**Pattern (2026-Q2 production-converged):** **MCP server exposing `search_repo` tool**, with AST-aware chunking + reranking. Anthropic's "Effective Context Engineering" (Sep 2025) formalized this as **"just-in-time context"** — agents hold lightweight identifiers and load via tool calls at runtime, not eager-stuff CLAUDE.md.
+
+**Reference projects:**
+
+- **`zilliztech/claude-context`** — best fit for our pattern. MCP server exposing `search_code` to Claude Code; pluggable embedders (Ollama, Voyage, Gemini, OpenAI); Milvus/Zilliz vector DB; AST splitter for 14+ languages. Repo: <https://github.com/zilliztech/claude-context>
+- **VS Code 1.114 (April 2026) `#codebase`** is now purely semantic — removed fuzzy fallback. Doc: <https://code.visualstudio.com/docs/copilot/reference/workspace-context>
+- **Continue.dev `@codebase`** — voyage-code-3 (cloud) or nomic-embed-text (local Ollama) + separate reranker. Doc: <https://docs.continue.dev/customize/model-roles/embeddings>
+- **Cursor @codebase** — Turbopuffer + AST chunking + proprietary embedder. Blog: <https://cursor.com/blog/secure-codebase-indexing>
+- **Aider repo-map** — *no embeddings*; NetworkX PageRank over Tree-sitter symbol graph. Alternative path. Doc: <https://aider.chat/docs/repomap.html>
+- **Sourcegraph Cody (2026)** — *retired embeddings*; uses Zoekt + SCIP. Architectural argument: at monorepo scale, structural search wins. Blog: <https://sourcegraph.com/blog/lessons-from-building-ai-coding-assistants-context-retrieval-and-evaluation>
+- **Anthropic guidance** — context-engineering: <https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents>
+
+**Design for Megingjord:**
+- Stand up a `claude-context`-style MCP server on **penguin-1** (already has `nomic-embed-text` + `snowflake-arctic-embed:m` installed)
+- Tree-sitter AST chunking before embedding
+- Vector store: **Cloudflare Vectorize free tier** (30M dims queried + 5M stored, free) — keeps the index off the memory-tight LXC
+- Reranker: FlashRank lite (~100 MB) on penguin-1
+- MCP tool: `search_repo(query, k=5)` returns top-k snippets; agents call instead of `Read`
+
+### Move 3 — Per-turn state offload to free MCP
+
+**Pattern:** state that is RARELY needed but ALWAYS in context (baton state, branch pointer, recent activity, agent identity) lives in a free MCP tool surface; agents fetch on-demand.
+
+**Substrate decision: Cloudflare Workers + Durable Objects + KV** (already greenfield from #740). Free tier:
+- DO: 1M req/mo (on $5/mo Paid plan; or use KV-only on Free)
+- KV: 100k reads + 1k writes/day FREE
+- D1 SQLite: 5M rows read + 100k written/day FREE
+- Vectorize: free tier matches Move 2 needs
+
+**Design for Megingjord:**
+- Re-purpose the Cloudflare Worker stub from #740 (PR #748)
+- Expose MCP tools: `get_baton_state(issue_n)`, `get_branch_pointer(repo)`, `get_recent_activity(since)`, `get_assignee(issue_n)`
+- Coordinate identity with #737's assignee-guard
+- Eviction tradeoff: only offload state ≤500 tokens per fetch with <100 ms latency budget; anything larger or hotter stays in-context
+
+## The lowest-hanging fruit (a fourth move not in the original plan)
+
+### Move 0 (highest ROI, zero risk) — Cloudflare AI Gateway in front of Anthropic
+
+Cache caching in front of any LLM API. Free tier covers our entire current volume with room to spare. **30-60% cache hit rate observed in production agent harnesses** (Cloudflare blog Q4 2025).
+
+- Free
+- 5-20 ms added latency
+- Zero application code change — just point `ANTHROPIC_BASE_URL` at the gateway
+- Independent of Move 1/2/3; **ship this first**
+
+Doc: <https://developers.cloudflare.com/ai-gateway/>
+
+## Free-cloud services matrix (verified 2026-Q2 unless flagged)
+
+| Provider | Service | Free quota | Best fit |
+|---|---|---|---|
+| **Cloudflare** | AI Gateway | unlimited free, just pay upstream | Cache Anthropic — Move 0 |
+| Cloudflare | Workers + DO + KV + D1 | 100k req/day Workers; KV 100k reads/day; D1 5M reads/day | Move 1 router host, Move 3 state |
+| Cloudflare | Workers AI | 10k Neurons/day; Llama 3.1 8B, 3.2 1B/3B, `@cf/baai/bge-base-en-v1.5` (free embeddings) | Move 1 router-LLM fallback, Move 2 embeddings |
+| Cloudflare | Vectorize | 30M dims queried + 5M stored | Move 2 RAG vector store |
+| **Google AI Studio** | Gemini 2.0 Flash | 15 RPM, 1M tokens/day, **no card required** | Move 1 ambiguous-case fallback |
+| Google AI Studio | embedding-004 | 1500 req/day | Move 2 embeddings (alt to Workers AI bge) |
+| **GitHub Models** | inference (incl. Claude 3.5 Sonnet, GPT-4o, Llama 405B) | rate-limited per Copilot tier | Move 1 premium fallback at zero cost |
+| **Modal** | compute | $30/mo recurring free | Move 2 RAG indexing batch jobs |
+| **Supabase** | pgvector | 500 MB Postgres + 5 GB bandwidth | Move 2 RAG store (alt to Vectorize) |
+| **Upstash** | Vector + Redis | 10k vectors free; 10k Redis cmd/day | Move 3 state (alt to KV) |
+| **Turso** | libSQL | 9 GB free | Move 3 state (alt to D1) |
+| Hugging Face | Inference API | ~300 req/hr serverless | Move 2 embeddings fallback |
+| Vercel | Functions + Edge Config | 100GB-hr, 1M edge-fn/mo | Move 1 host alt |
+| AWS | Lambda | 1M req + 400k GB-s/mo always-free | Cron / glue |
+| Google Cloud | Cloud Run | 2M req/mo + 360k vCPU-s | Long-running orchestration alt |
+| Mistral | La Plateforme | rate-limited free tier (verify) | Move 1 fallback |
+
+Skip: **Fly.io** (no free tier), **Replicate / Fireworks / Together / DeepInfra** (one-shot trial credits only), **AWS Bedrock** (12-mo trial only), **RunPod / Lambda Labs** (no free tier).
+
+### Multi-account stacking — explicitly rejected
+
+All major providers' 2026 ToS forbid quota-stacking via multiple accounts. Cloudflare actively detects and rate-floor or suspends. **Recommended pattern: single-account multi-vendor**, where each provider sees one fair-use tenant.
+
+## Combined estimated paid-token reduction
+
+Based on the cost-share breakdown (orchestration 30-50%, premium-only 15-25%, context tax 20-35%, observability 5-10%):
+
+| Move | Est. reduction of CURRENT paid spend | Risk |
+|---|---|---|
+| 0 (AI Gateway cache) | **15-25%** | Trivial — just env var change |
+| 1 (free orchestrator) | **15-25%** | Medium — routing accuracy must be measured |
+| 2 (repo-context RAG) | **15-25%** | Medium — retrieval quality risk |
+| 3 (state offload) | **5-10%** | Low — surface narrow |
+
+**Combined target if all four ship: 50-75% reduction in paid Claude/Copilot tokens** at constant capability. The remaining ~25-50% is irreducible without replacing the harness itself (premium-only multi-hop reasoning + UAT dialog).
+
+## Phased implementation plan (children spawned)
+
+| Phase | Child ticket | Move | Why first |
+|---|---|---|---|
+| 1 | (created below) | Move 0 — AI Gateway | Zero risk, immediate savings, unblocks measurement of moves 1-3 |
+| 2 | (created below) | Move 2 — Repo RAG MCP | Highest ROI per dev-day; reuses penguin-1 already provisioned |
+| 3 | (created below) | Move 3 — State offload MCP | Reuses #740 Cloudflare Worker substrate |
+| 4 | (created below) | Move 1 — Free orchestrator | Highest complexity; needs accuracy benchmarking |
+
+## Constraints honored
+
+- All four moves preserve the install-environment-agnostic property: each is opt-in and falls back to direct Anthropic calls if its substrate is unconfigured
+- Single-account multi-vendor only (no ToS-violating quota stacking)
+- Coordination with #781 (parallel queue) — Move 1 emits queue-aware decisions
+- Coordination with #737 (assignee guard) — Move 3 reuses agent-identity primitive
+
+## Sources (full citation list)
+
+Same URLs as inline citations above. Wiki ingest queued at `wiki/sources/paid-token-floor-reduction-2026-05-01.md`.

--- a/wiki/entities/36gbwinresource.md
+++ b/wiki/entities/36gbwinresource.md
@@ -2,32 +2,70 @@
 title: "36GB Windows Resource"
 type: entity
 created: 2026-04-28
-updated: 2026-04-28
-tags: [fleet, device, inference, gpu]
-sources: ["[[devenv-fleet-topology]]"]
-related: ["[[windows-laptop]]", "[[model-routing]]", "[[openclaw]]"]
-status: draft
+updated: 2026-05-02
+tags: [fleet, device, inference, gpu, system-service-ollama]
+sources: ["[[devenv-fleet-topology]]", "[[fleet-resource-audit-2026-05-01]]", "[[fleet-hardware-optimization-2026-05-01]]"]
+related: ["[[windows-laptop]]", "[[openclaw]]", "[[penguin-1]]", "[[model-routing]]", "[[cascade-dispatch]]"]
+status: current
 ---
 
 # 36GB Windows Resource
 
-Primary fleet inference node for heavy local coding workloads.
+Primary fleet inference node for heavy local coding workloads. Now operates
+under SYSTEM-service Ollama for env-var-honoring KEEP_ALIVE and reboot
+survival.
 
 ## Specs
+
 - CPU: Intel Core i5-9400H
-- RAM: 32GB
-- GPU: NVIDIA Quadro T2000 (4GB VRAM)
-- OS: Windows 10 Pro
+- RAM: 32 GB
+- GPU: NVIDIA Quadro T2000 (4 GB VRAM)
+- OS: Windows 11 Pro
 - Tailscale IP: 100.91.113.16
 
-## Services
-- Ollama on port 11434
-- Models: qwen2.5:7b-instruct, qwen2.5-coder:7b
+## Operating mode (post-2026-05-01 IT pass)
 
-## Routing Role
+- Ollama runs as **SYSTEM-service scheduled task** (`ollserv`, ONSTART, RU SYSTEM, RL HIGHEST)
+- Tray app retired
+- Pagefile increased to 24-32 GB (Win32_PageFileSetting)
+- Defender exclusions for `~\.ollama\` + `ollama.exe` + `ollama app.exe`
+- Machine-scope env vars: `OLLAMA_KEEP_ALIVE=24h`, `NUM_PARALLEL=4`, `MAX_LOADED_MODELS=3`, `FLASH_ATTENTION=1`, `HOST=0.0.0.0:11434`, `MODELS=C:\Users\chf31\.ollama\models`
+
+## Services
+
+- Ollama on port 11434
+
+## Models installed (as of 2026-05-02)
+
+| Model | Size | Tier | Warm TPS | VRAM | CPU offload |
+|---|---|---|---|---|---|
+| qwen2.5-coder:32b | 19.85 GB | max-quality | 1.6 | 3.04 GB | 87% |
+| qwen2.5-coder:7b | 4.68 GB | (legacy, lower priority) | 22 | 3.21 GB | 39% |
+| qwen2.5-coder:7b-instruct-q3_K_S | 3.49 GB | fallback for 7B-class | 29.5 | 3.27 GB | 21% |
+| starcoder2:3b | 1.71 GB | FIM completion | 95 | 1.90 GB | 0% (full GPU) |
+| granite-code:3b | 2.00 GB | instruct fallback | 51 | 2.83 GB | 0% (full GPU) |
+
+**Saturation behavior**: only 1 model fits in VRAM at a time on the 4 GB
+card; each load evicts the previous. The 3B models fully utilize GPU; the
+7B and 32B models split GPU+CPU. `qwen2.5-coder:32b` is the heaviest
+quality option and uses ~22.5 GB total RAM with 87% CPU offload.
+
+## Routing role
+
 - `tier`: performance
 - `inferenceClass`: heavy-coding
 - `priority`: 100
 - Preferred for: implement, refactor, tests, batch, multi-file
+- FIM tasks → starcoder2:3b (fastest, fully GPU-resident)
+- Heavy reasoning → qwen2.5-coder:32b (slowest TPS, highest quality)
 
-See: [[model-routing]], [[devenv-fleet-topology]]
+## Maintenance notes
+
+- KEEP_ALIVE env var was historically unreliable when Ollama ran as a
+  user-scope tray app; the SYSTEM-service migration (2026-05-02) fixed
+  this. Per-request `keep_alive: "24h"` in JSON body remains a
+  deterministic override and is the preferred pattern at the routing layer.
+- See `.dashboard/it-notes/fleet-upgrade-2026-05-01.md` (gitignored, IT-local) for the
+  authoritative operational runbook.
+
+See: [[model-routing]], [[cascade-dispatch]], [[fleet-architecture]]

--- a/wiki/entities/openclaw.md
+++ b/wiki/entities/openclaw.md
@@ -2,49 +2,74 @@
 title: "OpenClaw Gateway"
 type: entity
 created: 2026-04-14
-updated: 2026-05-01
-tags: [fleet, service, inference]
-sources: ["[[openclaw-windows-optimization-2026]]"]
-related: ["[[windows-laptop]]", "[[penguin-1]]", "[[model-routing]]", "[[tiered-agent-architecture]]"]
-status: draft
+updated: 2026-05-02
+tags: [fleet, service, inference, system-service-ollama, deepseek-coder-v2]
+sources: ["[[openclaw-windows-optimization-2026]]", "[[fleet-resource-audit-2026-05-01]]", "[[fleet-hardware-optimization-2026-05-01]]"]
+related: ["[[windows-laptop]]", "[[36gbwinresource]]", "[[penguin-1]]", "[[model-routing]]", "[[tiered-agent-architecture]]", "[[cascade-dispatch]]"]
+status: current
 ---
 
 # OpenClaw Gateway
 
-Self-hosted fleet routing gateway on [[windows-laptop]].
+CPU-only inference host. Now operates under SYSTEM-service Ollama with
+deepseek-coder-v2:lite as primary model — 16B MoE delivering ~140% better
+TPS than the prior dense 7B baseline.
 
 ## Architecture
-- LiteLLM/OpenClaw proxy: single OpenAI-compatible endpoint
-- Ollama backends: local model serving across fleet devices
-- Fleet integration: target for `fleet` lane dispatch in task-router
-- Network scope: exposed to [[tailscale-mesh]] only
 
-## What It Provides to DevEnv Ops
-- Fleet-lane execution endpoint abstraction
-- Centralized model selection and fallback policy
-- Uniform request/response surface for tooling scripts
-- Operational choke-point for reliability telemetry
+- Ollama on port 11434 (SYSTEM-service `ollserv` scheduled task)
+- Fleet integration: target for `fleet-coder` lane dispatch
+- Network scope: Tailscale mesh only
+- New admin account `desktop-909a7km\admin` (replaces prior shared account)
 
-## Models Available (live as of 2026-05-01)
-- qwen2.5:7b-instruct — general instruction following; ~1–2 tok/s CPU
-- qwen2.5-coder:7b — coding-tuned; ~1.3 tok/s CPU cold-start
+## Operating mode (post-2026-05-02 IT pass)
 
-**Removed**: mistral:latest, phi3:mini, llama3.2 (no longer installed)
+- Tray app retired; SYSTEM-service `ollserv` runs `ollama serve` at boot
+- Pagefile increased to 24-32 GB
+- Defender exclusions for `~\.ollama\` + ollama executables
+- Machine-scope env vars: `OLLAMA_KEEP_ALIVE=24h`, `NUM_PARALLEL=4`, `MAX_LOADED_MODELS=3`, `FLASH_ATTENTION=1`, `HOST=0.0.0.0:11434`, `MODELS=C:\Users\Admin\.ollama\models`
 
-## Performance Constraints
-- Host: CPU-only (Intel i3-N305, 8 cores, ~6.3 GiB RAM, no GPU)
-- Inference speed: 1–2 tok/s for 7B quantized models
-- Use GPU nodes (36gbwinresource: 9+ tok/s) for latency-sensitive tasks
-- OpenClaw is preferred for privacy-critical or offline-required workloads
+## Specs
 
-## Current Operational Risk
-- CPU-only inference limits throughput for interactive tasks
-- Gateway health endpoint instability can make fleet lane unavailable
-- See [[openclaw-windows-optimization-2026]] for hardening plan
+- CPU-only (no GPU)
+- 16 GB RAM, 15.8 GB visible
+- Windows 10
+- Tailscale IP: 100.78.22.13
 
-## Failover Chain
-1. OpenClaw (local fleet) — free, low latency
-2. Groq (cloud free tier) — fast, rate limited
-3. Cerebras (cloud free tier) — fast, limited models
+## Models installed (as of 2026-05-02)
 
-See: [[free-tier-inventory]], [[tiered-agent-architecture]]
+| Model | Size | Tier | Warm TPS |
+|---|---|---|---|
+| **deepseek-coder-v2:lite** | 8.91 GB | **primary** (16B MoE, ~2.4B active per token) | **8.4** |
+| granite-code:20b | 11.55 GB | max-quality dense alternative | ~1-2 |
+| qwen2.5-coder:7b | 4.68 GB | legacy fallback | 3.5 |
+| qwen2.5:7b-instruct | 4.68 GB | legacy fallback | 3.5 |
+
+**Saturation behavior**: cannot hold both deepseek (9.9 GB) and granite-20b (12 GB) simultaneously on the 16 GB host; operates as **single-model warm cache** with 24h keep-alive, switching only when an explicit different model is requested.
+
+## Routing role
+
+- `tier`: standard
+- `inferenceClass`: coding
+- `priority`: 60
+- Preferred for: integration, tests, migration, workflow
+- Default model: **deepseek-coder-v2:lite** (best CPU TPS in MoE class)
+- Heavy reasoning: granite-code:20b (slower, higher quality)
+
+## Failover chain (when OpenClaw unavailable)
+
+1. OpenClaw (local fleet) — free, low latency, this entity
+2. 36gbwinresource (GPU fleet) — preferred for FIM/short completions
+3. Groq cloud (llama-3.3-70b-versatile) — fast, rate-limited
+4. Cerebras (qwen-3-235b) — fast, limited capacity
+5. Anthropic Haiku — paid fallback
+
+## Maintenance notes
+
+- KEEP_ALIVE env var was historically unreliable when Ollama ran as a tray
+  app under a now-retired user. SYSTEM-service migration (2026-05-02) fixed
+  the env-var inheritance issue.
+- See `.dashboard/it-notes/fleet-upgrade-2026-05-01.md` (gitignored, IT-local) for the
+  authoritative operational runbook.
+
+See: [[36gbwinresource]], [[penguin-1]], [[fleet-architecture]], [[cascade-dispatch]]

--- a/wiki/entities/penguin-1.md
+++ b/wiki/entities/penguin-1.md
@@ -1,33 +1,83 @@
 ---
-title: "Penguin-1 (SML Chromebook)"
+title: "penguin-1 (SLM Utility Node)"
 type: entity
 created: 2026-04-14
-updated: 2026-04-14
-tags: [fleet, device, chromebook]
-sources: []
-related: ["[[windows-laptop]]", "[[tailscale-mesh]]", "[[openclaw]]"]
-status: draft
+updated: 2026-05-02
+tags: [fleet, device, chromebook, slm, embeddings]
+sources: ["[[fleet-resource-audit-2026-05-01]]", "[[fleet-hardware-optimization-2026-05-01]]"]
+related: ["[[openclaw]]", "[[36gbwinresource]]", "[[tailscale-mesh]]", "[[model-routing]]", "[[cascade-dispatch]]"]
+status: current
 ---
 
-# Penguin-1 (SML Chromebook)
+# penguin-1 (SLM Utility Node)
 
-Primary development machine. Lenovo Chromebook with Linux (Crostini).
+Off-network mobile Chromebook running ChromeOS + Linux LXC. Repurposed
+2026-05-01 from "tiny chat fallback" to **dedicated SLM/embedder utility
+node** that reduces upstream tokens before they hit the paid lanes.
 
 ## Specs
-- CPU: Intel Celeron N4020 (2C/2T)
-- RAM: 2.7 GB usable (shared with ChromeOS)
-- Storage: 64 GB eMMC
-- OS: ChromeOS + Crostini Linux container
 
-## Role in Fleet
-- Runs VS Code + Copilot Pro (primary coding interface)
-- Ollama: tiny models only (tinyllama, phi-2)
-- Connected to [[windows-laptop]] via [[tailscale-mesh]]
-- Uses [[openclaw]] for 7B+ inference offloading
+- ChromeOS + Linux LXC (Crostini-class container)
+- ~880 MB free RAM working budget
+- Tailscale IP: 100.86.248.35
+- 326 ms RTT (mobile / off-network)
+- Disk: tight — pulls fail at "no space left on device" without cleanup
+
+## Operating mode (post-2026-05-01 IT pass)
+
+- Holds 3 models loaded simultaneously under warm cache (~1.37 GB total)
+- Per-request `keep_alive: "24h"` set by routing layer
+- No GPU; all inference is CPU-only
+- Reachable only over the Tailscale mesh; latency rules it out for
+  interactive code completion
+
+## Models installed (as of 2026-05-02)
+
+| Model | Size | Tier | Warm TPS | Use |
+|---|---|---|---|---|
+| qwen3:0.6b | 0.52 GB | tiny chat / FIM | 56.7 | replaces retired qwen3.5:0.8b |
+| gemma3:270m | 0.29 GB | ultra-low-RAM fallback | 37.7 | last-resort SLM |
+| nomic-embed-text | 0.27 GB | text embedder | n/a | upstream RAG vectors |
+| snowflake-arctic-embed:m | 0.22 GB | multilingual embedder | n/a | non-English / mixed text |
+
+`qwen3.5:0.8b` was removed — not on the public Ollama registry, freed
+1 GB of disk.
+
+## Routing role
+
+- `tier`: utility
+- `inferenceClass`: embeddings + sub-2B chat
+- `priority`: 30
+- Preferred for: doc embedding, RAG vector generation, SLM extract/summarize
+  (gemma3:270m), tool-runner sandbox over MCP
+- **Not** for: interactive coding, FIM (RTT too high), reasoning
+- See [[paid-token-floor-reduction-2026-05-01]] for the cost-reduction
+  rationale that drove the role change.
+
+## Failover chain (when penguin-1 unavailable)
+
+1. penguin-1 (this entity) — embeddings + tiny chat
+2. 36gbwinresource — starcoder2:3b for FIM, granite-code:3b for instruct
+3. OpenClaw — deepseek-coder-v2:lite (slower than 36gb's GPU path)
+4. Groq cloud — embeddings via free-tier
+5. Anthropic Haiku — paid fallback
 
 ## Constraints
-- Memory pressure requires [[hardware-evaluation]] vigilance
-- No Docker (Crostini limitation)
-- Browser tabs compete for RAM with dev tools
 
-See: [[hardware-evaluation]], [[tiered-agent-architecture]]
+- Disk capacity is the binding constraint; future SLM additions may
+  require Tailscale-mounted overlay or external storage
+- High RTT (326 ms) makes this node unsuitable for synchronous request
+  paths — use for async batch / pre-processing workloads only
+- Browser tabs share RAM with the LXC; aggressive tab use can starve
+  Ollama out of the working budget
+
+## Maintenance notes
+
+- See `.dashboard/it-notes/fleet-upgrade-2026-05-01.md` (gitignored,
+  IT-local) for the authoritative operational runbook and post-install
+  verification probes.
+- penguin-1 is **not** the primary dev node. The dev workstation
+  registered as `penguin` (Tailscale 100.87.216.75) is a separate
+  device; penguin-1 is the mobile utility node.
+
+See: [[36gbwinresource]], [[openclaw]], [[fleet-architecture]], [[cascade-dispatch]]

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -147,3 +147,14 @@ Evidence-backed provider capability matrix and unified design synthesis created.
 Covers: Anthropic, OpenRouter, LiteLLM, Gemini, Ollama (exact), Copilot (estimated).
 Canonical schema and confidence policy defined. Implementation children #769-#774 created.
 Total wiki pages now: 66.
+
+## 2026-05-01 — Paid Token Floor Reduction #782 ingested
+Manual ingest: research/paid-token-floor-reduction-2026-05-01.md → wiki/sources/paid-token-floor-reduction-2026-05-01.md
+
+## [2026-05-01] ingest | Fleet Resource Audit + Hardware Optimization
+Live fleet audit + hardware optimization findings (post-IT pass 2026-05-01).
+Source files: raw/articles/fleet-resource-audit-2026-05-01.md, research/fleet-hardware-optimization-2026-05-01.md, research/multi-agent-command-center-round-2-2026-05-01.md.
+Wiki pages: wiki/sources/fleet-resource-audit-2026-05-01.md, wiki/sources/fleet-hardware-optimization-2026-05-01.md, wiki/sources/multi-agent-command-center-round-2-2026-05-01.md.
+
+## [2026-05-02] update | Fleet entities refreshed (#803)
+Updated wiki/entities/{36gbwinresource,openclaw,penguin-1}.md to reflect SYSTEM-service Ollama operating mode, current model lineups, and per-request keep_alive: "24h" pattern. Architecture map (docs/ARCHITECTURE.md) and DECISIONS index updated; WIKI.md and wiki-knowledge instruction now document the wiki:ingest pipeline; new docs/howto/contribute-to-wiki.md walks contributors through it.

--- a/wiki/sources/fleet-hardware-optimization-2026-05-01.md
+++ b/wiki/sources/fleet-hardware-optimization-2026-05-01.md
@@ -1,0 +1,55 @@
+---
+title: "Fleet Hardware Optimization 2026-05-01"
+type: source
+created: 2026-05-01
+updated: 2026-05-01
+tags: [fleet, infrastructure, ollama, llamafile, gpu, cpu, slm, qwen3-coder, minilm, flashrank, optimization]
+sources: [/home/curtisfranks/devenv-ops/research/fleet-hardware-optimization-2026-05-01.md]
+related: ["[[36gbwinresource]]", "[[openclaw]]", "[[penguin-1]]", "[[fleet-architecture]]", "[[cascade-dispatch]]", "[[model-routing]]"]
+status: draft
+---
+
+# Fleet Hardware Optimization 2026-05-01
+
+## Summary
+
+Three-workstream research for #734 covering 36gbwinresource (4 GB VRAM GPU),
+OpenClaw (16 GB CPU), and penguin-1 (<1 GB SLM). Each workstream produced a
+candidate matrix and recommendation; an independent Cerebras second opinion
+flagged complexity guards and resource-exhaustion risks. Phased adoption is
+6 steps starting with baseline restoration and ending with SLM utility
+deployment.
+
+## Recommendations (decision-locked)
+
+- **36gbwinresource**: Qwen3-coder 4B as primary; qwen2.5-coder:7b at IQ3/Q3
+  as fallback. Set `num_ctx=2048` for KV headroom.
+- **OpenClaw**: switch from Ollama to **llamafile** single-binary on the
+  same qwen2.5-coder:7b Q4_K_M model — ~50% CPU speedup per Justine Tunney
+  matmul work. Keep OpenClaw aggregator role.
+- **penguin-1**: phased install of (1) tool-runner sandbox MCP server,
+  (2) MiniLM-L6-v2 embedder, (3) FlashRank reranker.
+
+## Replicability
+
+All three recommendations apply to any host of equivalent hardware tier,
+not just the specific machines this operator owns. Workstream 1 covers any
+4 GB VRAM card; workstream 2 any 16 GB CPU host; workstream 3 any sub-1 GB
+always-on Linux device.
+
+## Entities updated by this research
+
+- 36gbwinresource: primary model recommendation moves from qwen2.5-coder:7b
+  to Qwen3-coder 4B
+- OpenClaw: engine moves from Ollama to llamafile (same model)
+- penguin-1: gains MCP tool-runner role plus embedder/reranker utilities
+
+## Cross-links
+
+- See [[fleet-architecture]] for system map
+- See [[cascade-dispatch]] for routing semantics
+- See [[model-routing]] for tier policy
+- See `research/fleet-hardware-optimization-2026-05-01.md` for full matrix
+- Implementation companion: ticket #765
+- Maintenance loop research: ticket #766
+- Source audit: `wiki/sources/fleet-resource-audit-2026-05-01.md`

--- a/wiki/sources/fleet-resource-audit-2026-05-01.md
+++ b/wiki/sources/fleet-resource-audit-2026-05-01.md
@@ -1,0 +1,76 @@
+---
+title: "Fleet Resource Audit 2026-05-01"
+type: source
+created: 2026-05-01
+updated: 2026-05-01
+tags: [fleet, infrastructure, ollama, tailscale, cloud-providers, audit]
+sources: [/home/curtisfranks/devenv-ops/raw/articles/fleet-resource-audit-2026-05-01.md]
+related: ["[[36gbwinresource]]", "[[openclaw]]", "[[penguin-1]]", "[[fleet-architecture]]", "[[tailscale-mesh]]", "[[cascade-dispatch]]"]
+status: draft
+---
+
+# Fleet Resource Audit 2026-05-01
+
+## Summary
+
+Live audit of the Megingjord fleet (Tailscale mesh + Ollama hosts + cloud providers). Tailscale mesh is fully healthy with direct routes to all four nodes. All three Ollama endpoints respond HTTP 200, but installed-model lists show drift vs `inventory/devices.json` (9 listed models not actually installed). Warm-token throughput regressed ~32–49% on both Windows hosts vs inventory baseline benchmarks, likely from default Ollama 1-min idle eviction (no `OLLAMA_KEEP_ALIVE` set).
+
+Cloud providers split: Anthropic and Groq fully working; OpenAI account is `insufficient_quota` (key valid); OpenRouter has per-key cap set to $0 despite $5.26 in remaining account credits; Cerebras 429s on the 235B model under load (smaller models fine); Google AI Studio works on `gemini-2.5-flash` but our dispatcher targets the deprecated `gemini-2.0-flash`.
+
+A `.env` parsing hazard was identified: `WINRESOURCE_36GB_SSH_PASSWORD` contains unquoted `&&&&&` which causes bash `source .env` to abort silently at line 40, leaving all downstream variables unset.
+
+## Entities
+
+- 36gbwinresource (100.91.113.16) — GPU Quadro T2000 4GB VRAM, qwen2.5-coder:7b at 22.0 tok/s warm
+- OpenClaw / desktop-909a7km (100.78.22.13) — CPU 16GB, qwen2.5:7b-instruct + qwen2.5-coder:7b at 3.7 tok/s
+- penguin-1 (100.86.248.35) — Linux LXC ≤880 MB free, qwen3.5:0.8b + gemma3:270m only
+- Anthropic API — fully working
+- Groq API — fully working, llama-3.3-70b-versatile primary
+- Cerebras API — partial; small models OK, qwen-3-235b queue-exceeded under load
+- Google AI Studio — gemini-2.5-flash works; gemini-2.0-flash deprecated
+- OpenAI — key valid but account out of credits
+- OpenRouter — per-key cap = $0; only `:free`-suffix models reachable
+
+## Concepts
+
+- Cold-load eviction risk → set `OLLAMA_KEEP_ALIVE=24h`
+- Per-key spend caps (OpenRouter) distinct from account credits
+- Bash vs dotenv parser divergence on shell metacharacters
+- Inventory-vs-live drift detection (next: `inventory:reconcile` script)
+
+## Performance baselines vs measured
+
+| Host | Inventory tok/s | Measured tok/s | Delta |
+|---|---|---|---|
+| 36gbwinresource | 32.3 (GPU) | 22.0 | -32% |
+| OpenClaw | 7.3 (CPU) | 3.7 | -49% |
+
+## Recommendations
+
+1. Set `OLLAMA_KEEP_ALIVE=24h` system env on Windows hosts (already in maintenanceNote on inventory)
+2. Quote `.env` values containing `&` or other shell metacharacters
+3. Update Gemini dispatch to `gemini-2.5-flash`
+4. Raise OpenRouter per-key spend cap or pin dispatcher to `:free` models
+5. Reconcile `inventory/devices.json` to live `/api/tags` (or install missing models)
+6. Resolve OpenAI billing OR remove dispatch routes targeting it
+
+## Per-device upgrade ideas
+
+- 36gbwinresource: try qwen2.5-coder:7b at IQ3/Q3 for KV headroom; track Qwen3-coder 4B (April 2026)
+- OpenClaw: switch from Ollama to llamafile/llama.cpp on same model for ~50% CPU speedup (no model size change)
+- penguin-1: install MiniLM-L6-v2 embedder (~80 MB) + FlashRank reranker (<100 MB) for upstream-token reduction; expose tool-runner sandbox over Tailscale
+
+## Related research
+
+- Karpathy LLM Wiki v2 — typed relationships, decay-based trust audits
+- Initializer-executor split agent harness pattern (Anthropic) — daemon-free scheduling
+- Justine Tunney matmul work — llama.cpp CPU speedup
+- all-MiniLM-L6-v2 — sentence-transformers model card
+
+## Cross-links
+
+- See [[openclaw]] for current entity entry
+- See [[36gbwinresource]] for current entity entry
+- See [[penguin-1]] for current entity entry
+- See [[fleet-architecture]] for system topology
+- See [[cascade-dispatch]] for routing semantics

--- a/wiki/sources/multi-agent-command-center-round-2-2026-05-01.md
+++ b/wiki/sources/multi-agent-command-center-round-2-2026-05-01.md
@@ -1,0 +1,67 @@
+---
+title: "Multi-Agent Command Center Round 2 2026-05-01"
+type: source
+created: 2026-05-01
+updated: 2026-05-01
+tags: [multi-agent, vs-code, mcp, coordination, worktree, claude-code, codex, copilot, cloudflare, agent-presence]
+sources: [/home/curtisfranks/devenv-ops/research/multi-agent-command-center-round-2-2026-05-01.md]
+related: ["[[36gbwinresource]]", "[[openclaw]]", "[[penguin-1]]", "[[fleet-architecture]]", "[[baton-protocol]]", "[[governance-enforcement]]", "[[cascade-dispatch]]"]
+status: draft
+---
+
+# Multi-Agent Command Center Round 2 2026-05-01
+
+## Summary
+
+Cutting-edge 2026-Q2 research into VS Code as a multi-agent command center. Confirmed: Claude Code Desktop unilaterally creates `<repo>/.claude/worktrees/<n>/` per session (the "instinctive worktree separation" the operator observed); other agents do not. VS Code 1.109 (Jan 2026) shipped a unified Agent Sessions view but no agent-presence API. MCP added server-card discovery (SEP-1649) but explicitly excluded agent-to-agent presence. No formal "agent rendezvous" research artifact exists as of 2026-Q2.
+
+## Key concepts captured
+
+- **Agent presence**: still an open primitive in 2026-Q2; harness must build its own.
+- **Composition over override**: Claude Code already does Layer 2 isolation; harness must compose with `.claude/worktrees/` rather than fight it.
+- **Codex MultiAgentV2** (`agents.max_threads=6`, `agents.max_depth=1`) + sandbox-mode + per-profile `cwd` controls = real Tier-B identity surface.
+- **Cloudflare Worker + Durable Object** is the resource-constrained sweet spot for coordination-server hosting (zero free-fleet impact, 100k req/day free, edge SQLite, FastMCP-compatible).
+- **Defense against `.claude.json` corruption** via per-agent `CLAUDE_CONFIG_DIR` env override (Anthropic issue #28829 + #54393).
+
+## Entities
+
+- Claude Code Desktop — auto-worktree per session (`.claude/worktrees/<n>/`)
+- GitHub Copilot CLI `/fleet` (April 2026) — vendor-internal multi-agent orchestrator
+- OpenAI Codex MultiAgentV2 — `agents.max_threads`, `agents.max_depth`, sandbox profiles
+- VS Code 1.109+ Agent Sessions view — unified host, no cross-vendor coordination
+- `vscode.proposed.chatSessionsProvider.d.ts` — extensibility surface
+- MCP `.well-known/mcp.json` server cards (SEP-1649, 2026-06 spec target)
+- A2A protocol (Google) — agent-to-agent layer building on MCP
+- `mcp_agent_mail` (Dicklesworthstone) — coordination layer with TTL leases
+- Cloudflare Workers + Durable Objects — recommended hosting
+
+## Failure-class catalog (Claude Code multi-session bugs)
+
+- #31787 sessions disappearing
+- #28829 `.claude.json` corruption (non-atomic R-M-W, regression v2.1.59)
+- #49166 `/effort` leaks across sessions
+- #39808 globally-enabled plugins channel collision
+- #54393 post-mortem: 12 multi-agent bugs in one autonomous overnight cycle
+
+## Architecture stack
+
+5 layers, see [[multi-agent-command-center-round-1]] for Round 1 context. Updates from Round 2:
+
+1. VS Code Profile + Window per agent (Round 1 unchanged)
+2. Per-agent worktree — **compose with Claude Code's existing `.claude/worktrees/`**, harness adds `.harness/worktrees/<agent-id>/` for Codex/Copilot
+3. Coordination server hosted on **Cloudflare Worker + Durable Object** (Round 2 — replaces Round 1 localhost-only assumption)
+4. Local SQLite WAL + per-agent `CLAUDE_CONFIG_DIR` defense (Round 2 — adds Claude bug defense)
+5. GitHub issue assignee + Tier-C fallback to GitHub-Actions-as-coordinator (Round 2 — adds fallback)
+
+## Tier policy
+
+- A: multi-agent-safe (Cursor BG Agents, native VS Code MCP host, Copilot Chat, Claude Code, Continue ≥1.0.20)
+- B (priority Codex): supported with forced isolation (Codex via `cwd` profile, Amazon Q, Cody)
+- C: opt-in with warnings (Cline, Aider, Tabnine)
+
+## Cross-links
+
+- See [[fleet-architecture]] for system topology
+- See [[baton-protocol]] for ticket ownership semantics that map to Layer 5
+- See [[governance-enforcement]] for hook layering precedent
+- See `research/concurrent-agent-worktrees-2026-04-24.md` (existing repo runbook)

--- a/wiki/sources/paid-token-floor-reduction-2026-05-01.md
+++ b/wiki/sources/paid-token-floor-reduction-2026-05-01.md
@@ -1,0 +1,41 @@
+---
+title: "Paid Token Floor Reduction Research 2026-05-01"
+type: source
+created: 2026-05-01
+updated: 2026-05-01
+tags: [token-economics, free-orchestrator, rag, cloudflare, ai-gateway, vllm-semantic-router, claude-context, mcp]
+sources: [/home/curtisfranks/devenv-ops/research/paid-token-floor-reduction-2026-05-01.md]
+related: ["[[fleet-architecture]]", "[[cascade-dispatch]]", "[[36gbwinresource]]", "[[openclaw]]", "[[penguin-1]]", "[[model-routing]]"]
+status: draft
+---
+
+# Paid Token Floor Reduction Research 2026-05-01
+
+## Summary
+
+Research for epic #782 — drive paid Claude Code/Copilot consumption below 50% of current volume by offloading orchestration, repo-context loading, and per-turn state to free fleet + free cloud resources.
+
+Key 2026-Q2 findings:
+- vLLM Semantic Router (Athena v0.2) is the production pattern for free-model routing — classifier + signal stack, not LLM-as-router
+- `zilliztech/claude-context` is a working MCP server pattern for repo-RAG via tool calls
+- Anthropic's "Effective Context Engineering" formalizes "just-in-time context" — load via tool calls, not eager-stuff CLAUDE.md
+- Cloudflare AI Gateway in front of Anthropic provides 30-60% cache hit rate at zero infrastructure cost
+- Google AI Studio Gemini 2.0 Flash: 15 RPM / 1M tokens/day FREE, no card required
+- GitHub Models offers free Claude 3.5 Sonnet API access (rate-limited)
+- Multi-account stacking is forbidden by all major 2026 ToS
+
+## Four moves, ranked by ROI
+
+1. Move 0 — Cloudflare AI Gateway in front of Anthropic — 15-25% savings, zero risk
+2. Move 2 — Repo-context RAG via penguin-1 + `claude-context` MCP — 15-25% savings
+3. Move 3 — Per-turn state offload to Cloudflare Worker MCP — 5-10% savings
+4. Move 1 — Free-model orchestrator (vLLM SR / RouteLLM) — 15-25% savings, highest complexity
+
+Combined target: 50-75% reduction in paid token consumption.
+
+## Cross-links
+
+- See `wiki/sources/fleet-resource-audit-2026-05-01.md` for current fleet capacity
+- See `wiki/sources/fleet-hardware-optimization-2026-05-01.md` for #734 model placement
+- See [[cascade-dispatch]] for current routing semantics
+- See [[fleet-architecture]] for system topology


### PR DESCRIPTION
## Summary

Phase 0 of Epic #795 — manual accuracy baseline refresh. Documentation
catches up to current harness state (v3.3.3, post-2026-05-01 IT pass).

- Fleet entities (36gbwinresource, openclaw, penguin-1) reflect SYSTEM-service Ollama operating mode, current model lineups, per-request `keep_alive: "24h"` pattern, and updated TPS/role data.
- ARCHITECTURE.md indexes recent subsystems: capability detection (#788), free-router (#786), RAG search (#784), state offload (#792).
- DECISIONS.md indexes ADR-011/012/013.
- WIKI.md + wiki-knowledge instruction document `npm run wiki:ingest` end-to-end; new `docs/howto/contribute-to-wiki.md` walks contributors through the pipeline.
- HELP panel gains `use-wiki-ingest` section.
- plugin.json synced to 3.3.3.

Lane: `lane:docs-research` — Manager + Consultant only.

## Baton artifacts

- MANAGER_HANDOFF: posted on #803
- COLLABORATOR_HANDOFF: N/A — docs/research lane (posted on #803)
- ADMIN_HANDOFF: N/A — docs/research lane (posted on #803)
- CONSULTANT_CLOSEOUT: pending review

## Test plan

- [x] `npx markdownlint-cli2` clean on all modified markdown
- [x] Pre-push hooks green
- [ ] CI green (baton-gates, label-lint)
- [ ] CONSULTANT_CLOSEOUT review

Refs #803, #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)