### PR TITLE
feat(docs): vale style pack + Drift-equivalent doc-code anchors

### DIFF
--- a/.github/workflows/docs-anchors.yml
+++ b/.github/workflows/docs-anchors.yml
@@ -1,0 +1,34 @@
+name: Docs Anchors
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - 'scripts/global/docs-anchors.js'
+      - '.github/workflows/docs-anchors.yml'
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - 'scripts/global/docs-anchors.js'
+
+concurrency:
+  group: docs-anchors-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  anchors:
+    name: docs-anchors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+      - name: Verify doc anchors in sync with code
+        run: node scripts/global/docs-anchors.js

--- a/.vale/styles/Megingjord/BannedPhrases.yml
+++ b/.vale/styles/Megingjord/BannedPhrases.yml
@@ -1,0 +1,11 @@
+extends: existence
+message: "Banned operator-identity phrase '%s'. The agent owns automation; do not push manual steps onto the user. See instructions/operator-identity-context.instructions.md."
+level: warning
+ignorecase: true
+tokens:
+  - "you will need to manually"
+  - "you'll need to manually"
+  - "the user must manually"
+  - "please manually"
+  - "please run the following manually"
+  - "you will have to do this by hand"

--- a/.vale/styles/Megingjord/Brand.yml
+++ b/.vale/styles/Megingjord/Brand.yml
@@ -1,0 +1,8 @@
+extends: substitution
+message: "Use canonical brand spelling — replace '%s' with '%s' (#797)."
+level: error
+ignorecase: false
+swap:
+  '\bDevEnv Ops\b': 'Megingjord'
+  '\bdevenv-ops\b': 'megingjord-harness'
+  '(?<![\w-])megingjord(?![\w-])': 'Megingjord'

--- a/.vale/styles/Megingjord/Terms.yml
+++ b/.vale/styles/Megingjord/Terms.yml
@@ -1,0 +1,9 @@
+extends: substitution
+message: "Use canonical term — replace '%s' with '%s' (docs/STYLE-GUIDE.md)."
+level: warning
+ignorecase: true
+swap:
+  '\bbaton handoff\b': 'handoff artifact'
+  '\bsequential roles?\b': 'baton'
+  '\bcopilot agent\b': 'agent'
+  '\blocal LLM\b': 'fleet'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased] — Phase 2 Vale + Drift-equivalent Anchors (#797)
+
+### Added
+- `.vale/styles/Megingjord/Brand.yml`, `BannedPhrases.yml`, `Terms.yml`: opt-in Megingjord style pack covering canonical brand spelling, operator-identity banned phrases, and canonical terminology. Available for activation per-scope in `.vale.ini`.
+- `scripts/global/docs-anchors.js`: Drift-equivalent doc-code anchor checker. Scans `.md` for `<!-- anchor: path/to/file.ext[#L10-L20] [hash:...] -->` markers and verifies the anchored region still hashes to the declared value. `--fix` mode rewrites hashes to the current state.
+- `tests/docs-anchors.spec.js`: 8 Playwright tests (no anchors, missing hash, --fix, in-sync, code drift, missing target, line-range slice, line-range drift).
+- `.github/workflows/docs-anchors.yml`: CI gate that fails when anchored code changes without a doc update.
+- `package.json`: `docs:anchors` script.
+
+### Notes
+- Vale Megingjord pack is provided but not activated in `.vale.ini` by default (would false-positive on instructions/operator-identity-context.instructions.md, which legitimately quotes the banned phrases as part of its own ban list). Future tickets can opt the pack into specific scopes.
+- Verification-round corrections honored: dropped Mozilla pack (unverifiable); kept verified packs (Microsoft, Google, Elastic, Grafana, Canonical) as future activation targets.
+
 ## [Unreleased] — Phase 1 README Compile Pipeline (#796)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ npm run deploy:both:apply
 | `deploy:claude:apply` | `bash scripts/deploy.sh --apply --target claude` |
 | `deploy:codex` | `bash scripts/deploy.sh --target codex` |
 | `deploy:codex:apply` | `bash scripts/deploy.sh --apply --target codex` |
+| `docs:anchors` | `node scripts/global/docs-anchors.js` |
 | `docs:compile` | `node scripts/docs-compile.js` |
 | `docs:lint` | `node scripts/docs-lint.js` |
 | `format` | `prettier --write .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js` |

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "validate:triage": "node scripts/validate-plugin-triage.js",
     "validate:compat": "node scripts/validate-plugin-compat.js",
     "docs:compile": "node scripts/docs-compile.js",
+    "docs:anchors": "node scripts/global/docs-anchors.js",
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
     "test:quality": "npx playwright test tests/google-quality.spec.js",

--- a/scripts/global/docs-anchors.js
+++ b/scripts/global/docs-anchors.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// scripts/global/docs-anchors.js — Drift-equivalent doc-code anchor checker (#797)
+// Scans .md for `<!-- anchor: path/to/file.ext[#L10-L20] [hash:abc1234] -->` markers
+// and verifies the anchored file/range still matches. Fails when the anchored
+// region changed without the doc being updated.
+//
+// Usage:
+//   node scripts/global/docs-anchors.js          # check anchors, exit 1 on drift
+//   node scripts/global/docs-anchors.js --fix    # rewrite hashes to current state
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const FIX = process.argv.includes('--fix');
+const ANCHOR_RE = /<!--\s*anchor:\s*([^\s#]+)(?:#L(\d+)(?:-L(\d+))?)?(?:\s+hash:([0-9a-f]{7,40}))?\s*-->/g;
+const SKIP_DIRS = new Set(['node_modules', '.git', 'test-results', 'playwright-report', '.dashboard']);
+
+function listMarkdown(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listMarkdown(full));
+    else if (entry.name.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+function snippetHash(filePath, startLine, endLine) {
+  const content = fs.readFileSync(filePath, 'utf-8').split('\n');
+  const slice = startLine ? content.slice(startLine - 1, endLine || startLine).join('\n') : content.join('\n');
+  return crypto.createHash('sha1').update(slice).digest('hex').slice(0, 12);
+}
+
+function checkAnchor(match, mdPath) {
+  const [full, target, startStr, endStr, declaredHash] = match;
+  const targetPath = path.resolve(path.dirname(mdPath), target);
+  if (!fs.existsSync(targetPath)) {
+    return { violation: `${mdPath}: anchor target missing — ${target}` };
+  }
+  const startLine = startStr ? parseInt(startStr, 10) : null;
+  const endLine = endStr ? parseInt(endStr, 10) : null;
+  const currentHash = snippetHash(targetPath, startLine, endLine);
+  if (!declaredHash) {
+    if (FIX) return { rewrite: [full, full.replace('-->', `hash:${currentHash} -->`)] };
+    return { violation: `${mdPath}: anchor missing hash for ${target} — run with --fix or paste hash:${currentHash}` };
+  }
+  if (declaredHash !== currentHash) {
+    if (FIX) return { rewrite: [full, full.replace(`hash:${declaredHash}`, `hash:${currentHash}`)] };
+    return { violation: `${mdPath}: anchor drift on ${target} — declared ${declaredHash}, actual ${currentHash}` };
+  }
+  return {};
+}
+
+function checkFile(mdPath) {
+  const text = fs.readFileSync(mdPath, 'utf-8');
+  let updated = text;
+  const violations = [];
+  for (const match of text.matchAll(ANCHOR_RE)) {
+    const result = checkAnchor(match, mdPath);
+    if (result.violation) violations.push(result.violation);
+    if (result.rewrite) updated = updated.replace(result.rewrite[0], result.rewrite[1]);
+  }
+  if (FIX && updated !== text) fs.writeFileSync(mdPath, updated);
+  return violations;
+}
+
+function main() {
+  const root = process.cwd();
+  const allViolations = [];
+  for (const md of listMarkdown(root)) {
+    allViolations.push(...checkFile(md));
+  }
+  if (allViolations.length) {
+    process.stderr.write(allViolations.join('\n') + '\n');
+    process.stderr.write(`\n❌ ${allViolations.length} anchor violation(s).\n`);
+    process.exit(FIX ? 0 : 1);
+  }
+  process.stdout.write('✅ All doc anchors in sync with code.\n');
+}
+
+if (require.main === module) main();
+module.exports = { snippetHash, checkFile, ANCHOR_RE };

--- a/tests/docs-anchors.spec.js
+++ b/tests/docs-anchors.spec.js
@@ -1,0 +1,97 @@
+// Tests for #797 Drift-equivalent doc anchor checker
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+
+const SCRIPT = path.resolve(__dirname, '..', 'scripts', 'global', 'docs-anchors.js');
+
+let tmpDir;
+
+test.beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'anchors-test-'));
+});
+
+test.afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function run(args = '') {
+  try {
+    return { ok: true, stdout: execSync(`node ${SCRIPT} ${args}`, { cwd: tmpDir, encoding: 'utf-8' }) };
+  } catch (err) {
+    return { ok: false, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+function write(name, content) {
+  fs.writeFileSync(path.join(tmpDir, name), content);
+}
+
+test('passes when no anchors are present', () => {
+  write('readme.md', '# No anchors here\n\nJust prose.\n');
+  const r = run();
+  expect(r.ok).toBe(true);
+  expect(r.stdout).toContain('in sync');
+});
+
+test('flags an anchor without a hash', () => {
+  write('lib.js', 'function foo() { return 1; }\n');
+  write('doc.md', '<!-- anchor: lib.js -->\nDescribes foo.\n');
+  const r = run();
+  expect(r.ok).toBe(false);
+  expect(r.stderr + r.stdout).toMatch(/missing hash/);
+});
+
+test('--fix populates missing hashes', () => {
+  write('lib.js', 'function foo() { return 1; }\n');
+  write('doc.md', '<!-- anchor: lib.js -->\nDescribes foo.\n');
+  run('--fix');
+  const updated = fs.readFileSync(path.join(tmpDir, 'doc.md'), 'utf-8');
+  expect(updated).toMatch(/hash:[0-9a-f]{12}/);
+});
+
+test('passes when declared hash matches current content', () => {
+  write('lib.js', 'function foo() { return 1; }\n');
+  write('doc.md', '<!-- anchor: lib.js -->\n');
+  run('--fix');
+  const r = run();
+  expect(r.ok).toBe(true);
+  expect(r.stdout).toContain('in sync');
+});
+
+test('fails when anchored code changes without doc update', () => {
+  write('lib.js', 'function foo() { return 1; }\n');
+  write('doc.md', '<!-- anchor: lib.js -->\n');
+  run('--fix');
+  write('lib.js', 'function foo() { return 99; }\n');
+  const r = run();
+  expect(r.ok).toBe(false);
+  expect(r.stderr + r.stdout).toMatch(/anchor drift/);
+});
+
+test('flags a missing anchor target', () => {
+  write('doc.md', '<!-- anchor: missing.js hash:0123456789ab -->\n');
+  const r = run();
+  expect(r.ok).toBe(false);
+  expect(r.stderr + r.stdout).toMatch(/anchor target missing/);
+});
+
+test('line-range anchors hash the slice not the whole file', () => {
+  write('lib.js', 'line1\nline2\nline3\nline4\n');
+  write('doc.md', '<!-- anchor: lib.js#L2-L3 -->\n');
+  run('--fix');
+  write('lib.js', 'line1\nline2\nline3\nline4-CHANGED\n');
+  expect(run().ok).toBe(true);
+});
+
+test('line-range anchors fail when the slice changes', () => {
+  write('lib.js', 'line1\nline2\nline3\nline4\n');
+  write('doc.md', '<!-- anchor: lib.js#L2-L3 -->\n');
+  run('--fix');
+  write('lib.js', 'line1\nline2-CHANGED\nline3\nline4\n');
+  const r = run();
+  expect(r.ok).toBe(false);
+  expect(r.stderr + r.stdout).toMatch(/anchor drift/);
+});


### PR DESCRIPTION
## Summary

Phase 2 of Epic #795 — token-free, deterministic doc-quality gates.

- **Megingjord Vale style pack** (`Brand`, `BannedPhrases`, `Terms`) — opt-in style rules covering canonical brand, banned operator-identity phrases, and canonical terminology drift.
- **Drift-equivalent anchors** — `scripts/global/docs-anchors.js` with `--fix` mode validates `<!-- anchor: path[#L10-L20] [hash:abc...] -->` markers against current code state. Fails CI when anchored code changes without doc update.
- 8 Playwright tests covering all anchor lifecycle scenarios (missing hash, --fix, in-sync, drift detection, missing target, line-range slice precision).
- New `docs-anchors` CI workflow gates anchor freshness on every PR.

Verification-round corrections honored: dropped Mozilla Vale pack (unverifiable); kept Microsoft/Google/Elastic/Grafana/Canonical as future activation targets. Built custom anchor checker rather than vendoring Drift (avoids Tree-sitter + Rust toolchain dependency).

## Baton artifacts

- MANAGER_HANDOFF: posted on #797
- COLLABORATOR_HANDOFF: posted on #797
- ADMIN_HANDOFF: pending merge ops
- CONSULTANT_CLOSEOUT: pending review

## Test plan

- [x] `node scripts/global/docs-anchors.js` against live repo: ✅ in sync (no false positives)
- [x] `npx playwright test tests/docs-anchors.spec.js` — 8 passed
- [x] `npm run lint` clean (100-line limit)
- [x] `npm run lint:readability:ci` clean (≤400 warnings)
- [x] `npm run docs:lint` clean
- [x] `npx markdownlint-cli2 CHANGELOG.md` 0 errors
- [ ] CI green (baton-gates, docs-anchors, lint-required, quality-required)

Refs #797, #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)