### PR TITLE
feat(adr): adopt log4brains pipeline + resolve ADR-004 duplicate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ logs/copilot-usage.json
 .dashboard/agent-state.sqlite*
 .harness/worktrees/
 .claude/worktrees/
+
+# log4brains build output (#798)
+.log4brains/

--- a/.log4brains.yml
+++ b/.log4brains.yml
@@ -1,0 +1,4 @@
+project:
+  name: Megingjord ADRs
+  tz: America/New_York
+  adrFolder: ./research/adr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased] — Phase 3 log4brains ADR Pipeline (#798)
+
+### Added
+- `log4brains@1.1.0` devDependency: ADR pipeline with MADR templates, hot-reload preview, static-publish.
+- `.log4brains.yml`: project config pointing at `research/adr/`.
+- `package.json`: `adr:new`, `adr:preview`, `adr:build` scripts.
+- `research/adr/016-log4brains-adr-pipeline.md`: ADR documenting log4brains adoption and the slow-cadence trade-off.
+
+### Changed
+- `research/adr/004-model-routing-agents.md` → `research/adr/015-model-routing-agents.md` (renumbered via `git mv` to resolve the long-standing ADR-004 duplicate; first line updated to `ADR-015`).
+- `docs/DECISIONS.md`: rewritten as a quick-nav pointer to the auto-rendered log4brains site; lists all 16 ADRs.
+- `research/adr/README.md`: index row for the renumbered ADR-015.
+- `research/tiered-agent-architecture.md` and `raw/articles/tiered-agent-architecture.md`: TODO references updated from ADR-004 to ADR-015.
+- `.gitignore`: ignore `.log4brains/` build output.
+
+### Notes
+- Verification-round correction honored: ADR-016 documents the slow-cadence risk (log4brains v1.1.0 released 2024-12-17). Mitigation: vendor or fork upstream package if it goes dark.
+- GitHub Pages publish workflow deferred to a follow-up ticket; `npm run adr:build` produces the static site locally today.
+
 ## [Unreleased] — Phase 2 Vale + Drift-equivalent Anchors (#797)
 
 ### Added
@@ -48,6 +67,19 @@
 - `research/adr/013-capability-detection-substrate.md`: ADR documenting the substrate model.
 - `npm run capability:probe` and `npm run capability:show` scripts.
 - `.env.example`: optional Tier 0/2/3 env-var template.
+
+## [3.3.5] — 2026-05-02 — Copilot Estimated-Lane Telemetry + Caveats (#772)
+
+### Added
+- `scripts/global/token-provider-adapters.js`: added `copilot()` adapter that preserves estimator/manual paths while emitting canonical `estimated` confidence ledger records.
+- `research/token-copilot-estimated-lane-implementation-2026-05-02.md`: implementation evidence with fleet/cloud probe outputs and governance-oriented next steps.
+- `tests/token-provider-adapters.spec.js`, `tests/telemetry-schema.spec.js`, `tests/unit-modules.spec.js`: added coverage for Copilot estimated-lane caveats and confidence split reporting.
+
+### Changed
+- `scripts/global/token-ledger-schema.js`: canonical records now carry `confidence_note`; Copilot records default to `estimated` confidence even when routed through premium lane labels.
+- `scripts/copilot-tracker.js`: added `getCopilotLedgerRecord()` so existing Copilot usage tracking can be exported as canonical estimated-lane telemetry.
+- `scripts/global/model-routing-telemetry.js`: summary output now includes confidence distribution and caveat rate.
+- `scripts/global/cost-report.js` and `scripts/global/model-routing-weekly-report.js`: reporting now separates exact vs estimated confidence shares and includes Copilot caveat-aware record output.
 
 ## [3.3.4] — 2026-05-01 — Fleet Model Upgrades (#765)
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ npm run deploy:both:apply
 <!-- docs packageScripts -->
 | Script | Command |
 |---|---|
+| `adr:build` | `log4brains build` |
+| `adr:new` | `log4brains adr new` |
+| `adr:preview` | `log4brains preview` |
 | `agent:coord:remote` | `node scripts/global/agent-coord-remote.js` |
 | `agent:tier-c` | `node scripts/global/tier-c-guard.js` |
 | `capability:probe` | `node scripts/global/capability-probe.js` |

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,23 +1,23 @@
 # Architecture Decision Records — Index
 
 ADRs document significant architecture and process decisions for Megingjord.
-The canonical store is [`research/adr/`](../research/adr/) — this file is an
-index, not a duplicate. To prevent split source-of-truth, **never** add
-decision records under `docs/DECISIONS/`; always add them to `research/adr/`.
+Canonical store: [`research/adr/`](../research/adr/).
+
+This index is **auto-renderable** — run `npm run adr:preview` for the
+hot-reload web UI or `npm run adr:build` for a static site.
+The hand-edited table below remains as a quick navigation reference.
 
 ## How to add a new ADR
 
-1. Pick the next sequential number (current highest: 011).
-2. Copy `research/adr/README.md` template structure into `research/adr/NNN-slug.md`.
-3. Fill in: Status (Proposed / Accepted / Deprecated / Superseded), Date,
-   Context, Decision, Consequences, Alternatives Considered.
-4. Reference any superseded ADR with a "Supersedes ADR-XXX" line.
-5. Update this index in the same PR.
-6. Link the ADR from related skills, instructions, or design docs.
+```bash
+npm run adr:new -- "decision title"
+```
 
-The `manager-ticket-lifecycle` baton workflow applies: ADRs that change
-governance must go through Manager → Consultant; technical-only ADRs may be
-admin-tracked.
+This scaffolds a MADR-templated file under `research/adr/`. Fill in
+Status, Context, Decision, Consequences, Alternatives. The
+log4brains pipeline auto-numbers and indexes the new ADR.
+
+ADRs that change governance must follow Manager → Consultant baton.
 
 ## Existing ADRs
 
@@ -27,7 +27,6 @@ admin-tracked.
 | 002 | Dashboard Stack — Alpine.js + Static | [`002-dashboard-stack.md`](../research/adr/002-dashboard-stack.md) |
 | 003 | Free-Tier Failover Routing | [`003-failover-routing.md`](../research/adr/003-failover-routing.md) |
 | 004 | Global Task Router | [`004-global-task-router.md`](../research/adr/004-global-task-router.md) |
-| 004 | Model Routing via Custom Agents | [`004-model-routing-agents.md`](../research/adr/004-model-routing-agents.md) |
 | 005 | Ticket-Driven Work Management | [`005-ticket-driven-work.md`](../research/adr/005-ticket-driven-work.md) |
 | 006 | Visual QA Gate for Web Releases | [`006-visual-qa-gate.md`](../research/adr/006-visual-qa-gate.md) |
 | 007 | LLM Wiki Knowledge System Adoption | [`007-llm-wiki-adoption.md`](../research/adr/007-llm-wiki-adoption.md) |
@@ -36,16 +35,14 @@ admin-tracked.
 | 010 | Ticket Status–Role Ownership Binding Model | [`010-ticket-status-role-model.md`](../research/adr/010-ticket-status-role-model.md) |
 | 011 | Fleet Auto-Discovery Architecture | [`011-fleet-auto-discovery.md`](../research/adr/011-fleet-auto-discovery.md) |
 | 012 | Multi-Agent Worktree Path Governance | [`012-multi-agent-worktree-governance.md`](../research/adr/012-multi-agent-worktree-governance.md) |
-| 013 | Capability Detection Substrate for Optional Cost-Reduction Features | [`013-capability-detection-substrate.md`](../research/adr/013-capability-detection-substrate.md) |
+| 013 | Capability Detection Substrate | [`013-capability-detection-substrate.md`](../research/adr/013-capability-detection-substrate.md) |
+| 014 | Fleet Model Placement on Windows Hosts | [`014-fleet-model-placement-on-windows-hosts.md`](../research/adr/014-fleet-model-placement-on-windows-hosts.md) |
+| 015 | Model Routing via Custom Agents (renumbered from ADR-004) | [`015-model-routing-agents.md`](../research/adr/015-model-routing-agents.md) |
+| 016 | log4brains as the ADR Pipeline | [`016-log4brains-adr-pipeline.md`](../research/adr/016-log4brains-adr-pipeline.md) |
 
-## Known issues
+## Resolved issues
 
-- ADR-004 has a duplicate number (Global Task Router and Model Routing via
-  Custom Agents). One should be renumbered when a related change next touches
-  the routing subsystem; both are referenced from active instructions today,
-  so renumbering blindly would create dangling links.
-- README.md under `research/adr/` is the long-form contributor guide; this
-  file is the navigation index for the broader documentation set.
+- The historical ADR-004 duplicate (Global Task Router vs. Model Routing via Custom Agents) was resolved in Phase 3 of #795: the routing-agents file was renumbered to ADR-015 via `git mv`. See ADR-016 for the log4brains adoption that prevents future drift.
 
 ## Related
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
     "validate:compat": "node scripts/validate-plugin-compat.js",
     "docs:compile": "node scripts/docs-compile.js",
     "docs:anchors": "node scripts/global/docs-anchors.js",
+    "adr:new": "log4brains adr new",
+    "adr:preview": "log4brains preview",
+    "adr:build": "log4brains build",
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
     "test:quality": "npx playwright test tests/google-quality.spec.js",
@@ -93,6 +96,7 @@
     "eslint": "^9.39.4",
     "eslint-plugin-jsdoc": "^50.8.0",
     "globals": "^17.5.0",
+    "log4brains": "^1.1.0",
     "markdown-magic": "^4.8.0",
     "markdownlint-cli2": "^0.17.2",
     "prettier": "^3.6.2"

--- a/research/adr/015-model-routing-agents.md
+++ b/research/adr/015-model-routing-agents.md
@@ -1,7 +1,8 @@
-# ADR-004: Model Routing via Custom Agents
+# ADR-015: Model Routing via Custom Agents
 
 **Status**: Accepted
 **Date**: 2025-07-13
+**Renumbered**: 2026-05-02 — was ADR-004 (duplicate of `004-global-task-router.md`); renumbered to 015 in Phase 3 of #795 to resolve the duplicate while preserving git history via `git mv`.
 
 ## Context
 

--- a/research/adr/016-log4brains-adr-pipeline.md
+++ b/research/adr/016-log4brains-adr-pipeline.md
@@ -1,0 +1,61 @@
+# ADR-016: log4brains as the ADR Pipeline
+
+**Status**: Accepted
+**Date**: 2026-05-02
+**Supersedes**: hand-maintained `docs/DECISIONS.md` index (kept as a static navigation pointer)
+
+## Context
+
+ADRs were tracked in `research/adr/` with a hand-edited
+`docs/DECISIONS.md` index. The index drifted from the actual files at
+multiple points (most recently in Phase 0 of Epic #795, where
+ADR-011/012/013 had been added without index updates), and the
+ADR-004 number collision (Global Task Router vs. Model Routing via
+Custom Agents) accumulated for ~9 months. We needed a tool that:
+
+- Auto-generates the index from the file collection.
+- Provides a templated, MADR-compatible authoring path.
+- Supports static publishing for offline/portable browsing.
+
+## Decision
+
+Adopt **log4brains v1.1.0** as the ADR pipeline:
+
+- Config: `.log4brains.yml` points at `research/adr/`.
+- Authoring: `npm run adr:new -- "title"` creates a new MADR file with proper numbering.
+- Preview: `npm run adr:preview` opens a local web UI.
+- Build: `npm run adr:build` produces a static site (`.log4brains/out/`).
+
+Existing 13 ADRs (001–013) are preserved as-is. ADR-014 was already
+in place (Fleet Model Placement on Windows Hosts). The duplicate
+ADR-004 was renumbered: `004-model-routing-agents.md` → `015-model-routing-agents.md`
+via `git mv` to preserve history.
+
+`docs/DECISIONS.md` is retained as a one-line pointer to the canonical
+log4brains-rendered index, plus a brief contributor guide for adding
+new ADRs.
+
+## Consequences
+
+### Positive
+
+- Auto-generated index removes the drift class entirely.
+- MADR templates standardize new ADR shape.
+- Static site can be published to GitHub Pages in a follow-up if/when desired.
+- Preview server enables hot-reload editing during ADR drafting.
+
+### Negative / risks
+
+- **Slow upstream cadence** (verified during Phase 2 verification round): log4brains v1.1.0 was released 2024-12-17. The package still works and remains the most feature-complete ADR pipeline (MADR-default, IDE-integrated, static-publish), but adoption accepts the risk that fixes may lag. Mitigation: vendor or fork the npm package if upstream goes dark.
+- One additional devDependency to track in routine `npm audit` triage.
+- GitHub Pages publish workflow deferred to a follow-up ticket.
+
+## Alternatives Considered
+
+- **Keep `docs/DECISIONS.md` hand-maintained** — what we had. Drift cost was real but bounded; the manual maintenance load is one update per ADR (~15 ADRs total). Rejected because the drift kept happening despite policy.
+- **`adr-tools` (npryce)** — entirely stagnant; last release 2018. Rejected outright.
+- **Custom in-repo script** — would duplicate features that log4brains already provides; rejected on YAGNI grounds.
+
+## Phase 3 of Epic #795
+
+Refs #798, #795

--- a/research/adr/README.md
+++ b/research/adr/README.md
@@ -7,6 +7,6 @@
 | [001](001-skills-as-code.md) | Skills as versioned code | Accepted | 2026-04-11 |
 | [002](002-dashboard-stack.md) | Dashboard stack: Alpine.js + static | Accepted | 2026-04-11 |
 | [003](003-failover-routing.md) | Free-tier failover routing | Proposed | 2026-04-11 |
-| [004](004-model-routing-agents.md) | Model routing via custom agents | Accepted | 2025-07-13 |
+| [015](015-model-routing-agents.md) | Model routing via custom agents (renumbered from ADR-004) | Accepted | 2025-07-13 |
 | [006](006-visual-qa-gate.md) | Visual QA gate for web releases | Accepted | 2025-07-16 |
 | [007](007-llm-wiki-adoption.md) | LLM Wiki knowledge system adoption | Accepted | 2026-04-13 |

--- a/research/tiered-agent-architecture.md
+++ b/research/tiered-agent-architecture.md
@@ -90,4 +90,4 @@ Sub-1B models cannot code reliably. They serve as:
 - [ ] Test OpenClaw BYOK integration in VS Code
 - [ ] Benchmark Tailscale→OpenClaw tool-call latency
 - [ ] Prototype SML classifier with lfm2.5-thinking
-- [ ] Create ADR-004 for this architecture decision
+- [x] ADR-015 documents this architecture decision (originally ADR-004; renumbered 2026-05-02 in Phase 3 of #795)

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -11,7 +11,7 @@ const LIMIT = 100;
 const IGNORE = [
   'node_modules', '.git', 'playwright-report',
   'test-results', 'package-lock.json', '.dashboard',
-  'logs', '.claude',
+  'logs', '.claude', '.log4brains',
   // Global resources have their own governance
   'skills', 'hooks'
 ];


### PR DESCRIPTION
## Summary

Phase 3 of Epic #795 — adopt log4brains as the ADR pipeline and resolve the long-standing ADR-004 numbering conflict.

- `log4brains@1.1.0` devDependency with `.log4brains.yml` pointing at `research/adr/`.
- New npm scripts: `adr:new`, `adr:preview`, `adr:build`.
- ADR-016 documents the adoption + slow-cadence trade-off (verification-round honored).
- `004-model-routing-agents.md` → `015-model-routing-agents.md` via `git mv` (preserves history); first-line title updated; in-repo references updated.
- `docs/DECISIONS.md` rewritten as a quick-nav pointer + 16-row index.

GitHub Pages publish workflow deferred to a follow-up — `npm run adr:build` produces the static site locally today.

## Baton artifacts

- MANAGER_HANDOFF: posted on #798
- COLLABORATOR_HANDOFF: posted on #798
- ADMIN_HANDOFF: pending merge ops
- CONSULTANT_CLOSEOUT: pending review

## Test plan

- [x] `npx log4brains adr list` lists all 16 ADRs with no duplicate
- [x] `npm run adr:build` succeeds — 16 ADRs in `.log4brains/out`
- [x] `npm run lint` clean (100-line limit)
- [x] `npm run lint:readability:ci` clean (≤400 warnings)
- [x] `npx markdownlint-cli2 CHANGELOG.md docs/DECISIONS.md` 0 errors
- [ ] CI green (baton-gates, docs-anchors, docs-compile, lint-required, quality-required)

Refs #798, #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)