### PR TITLE
docs(research): Diátaxis IA audit + Zensical migration plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — Phase 7 Diátaxis + Zensical Research (#802)
+
+### Added
+- `research/diataxis-ia-audit-2026-05-02.md`: Diátaxis classification matrix.
+- `research/zensical-migration-plan-2026-05-02.md`: migration plan honoring verified runway facts.
+
 ## [Unreleased] — Phase 5 Issue Forms Cleanup (#800)
 
 ### Added

--- a/research/diataxis-ia-audit-2026-05-02.md
+++ b/research/diataxis-ia-audit-2026-05-02.md
@@ -1,0 +1,92 @@
+# Diátaxis IA Audit — Megingjord Documentation
+
+**Date**: 2026-05-02
+**Ticket**: #802 (Phase 7 of Epic #795)
+
+## Summary
+
+Classify Megingjord's documentation surface against the four Diátaxis quadrants (Tutorial / How-to / Reference / Explanation). Identify gaps, duplications, and placement misfits. Output is a placement matrix; reorganization is a separate child ticket.
+
+## Diátaxis quadrants (recap)
+
+| | Practical | Theoretical |
+|---|---|---|
+| Learning-oriented | **Tutorial** | **Explanation** |
+| Goal-oriented | **How-to** | **Reference** |
+
+- **Tutorial**: lesson, hand-holding, "learning by doing." Reader is new.
+- **How-to**: recipe, problem-solving, "I need to accomplish X." Reader knows the goal.
+- **Reference**: lookup, dry, complete. Reader knows what they're searching for.
+- **Explanation**: discussion, why-this-decision, big-picture. Reader has time and curiosity.
+
+## Classification matrix
+
+### Tutorials (learning by doing)
+
+Currently: **0 surfaces.** This is the largest gap. New contributors arrive at `README.md` (which is closer to a Reference summary) and have no guided "first hour" path.
+
+### How-to (goal-oriented)
+
+| Surface | Quadrant fit | Notes |
+|---|---|---|
+| `docs/howto/baton-workflow.md` | ✅ How-to | Strong: "if you're playing role X, do these steps" |
+| `docs/howto/contribute-to-wiki.md` | ✅ How-to | New (#803); walkthrough of `wiki:ingest` |
+| `docs/howto/fleet-routing.md` | ✅ How-to | Strong |
+| `docs/howto/help-inventory.md` | ⚠️ Mixed | Lists HELP topics; closer to Reference |
+| `docs/howto/doc-update-trigger-matrix.md` | ⚠️ Mixed | Decision matrix; partially Reference |
+
+### Reference (lookup)
+
+| Surface | Quadrant fit | Notes |
+|---|---|---|
+| `docs/STYLE-GUIDE.md` | ✅ Reference | Canonical terminology |
+| `docs/HELP-GUIDELINES.md` | ✅ Reference | UX patterns lookup |
+| `docs/DECISIONS.md` | ✅ Reference (index) | Auto-rendered now (#798) |
+| `research/adr/*.md` | ✅ Reference | Each ADR is Reference for one decision |
+| `instructions/*.instructions.md` | ✅ Reference (governance) | "What rules apply when" |
+| `WIKI.md` | ✅ Reference | Wiki schema |
+| `README.md` | ⚠️ Mixed | Auto-scripts table is Reference; vision blurb is Explanation |
+| `AGENTS.md` | ✅ Reference | Agent inventory |
+| `CLAUDE.md` | ✅ Reference | Claude runtime config |
+| `CHANGELOG.md` | ✅ Reference | Version history |
+
+### Explanation (why)
+
+| Surface | Quadrant fit | Notes |
+|---|---|---|
+| `docs/ARCHITECTURE.md` | ✅ Explanation | System map; explains the why |
+| `research/adr/*.md` (Context + Consequences sections) | ✅ Explanation | The "why" portions of each ADR |
+| `research/*.md` (non-ADR research) | ✅ Explanation | Forward-looking analysis |
+| `wiki/syntheses/*.md` | ✅ Explanation | Cross-cutting analysis |
+| `wiki/concepts/*.md` | ⚠️ Mixed | Some are Explanation, some are Reference |
+
+## Identified gaps
+
+1. **Tutorial gap (severity: high)** — no "first hour with Megingjord" walkthrough. Closest is `README.md` quick-start, which is too dense for a learner.
+2. **Mixed HELP inventory** — `docs/howto/help-inventory.md` lists HELP topics but is essentially Reference; should move to `docs/reference/help-inventory.md` or remain explicitly named as Reference.
+3. **README role overload** — README mixes Reference (scripts table, runtime mapping), How-to (quick-start), and Explanation (vision + "why robust"). Acceptable for a project README but worth tracking.
+4. **Wiki concept/synthesis fuzziness** — boundary between `wiki/concepts/` (Reference) and `wiki/syntheses/` (Explanation) is not always clear. Document the rule in `WIKI.md`.
+
+## Identified duplications
+
+- `docs/DECISIONS.md` is a Reference index of ADRs; `research/adr/README.md` is also a Reference index. Two indices for the same content. Recommendation: keep `docs/DECISIONS.md` as the canonical index (it's auto-rendered via log4brains since #798); convert `research/adr/README.md` to a contributor-style How-to ("how to add an ADR").
+
+## Recommended placements
+
+For implementation in a separate child ticket:
+
+- Create `docs/tutorial/first-hour.md` — guided walk through cloning, `npm run setup`, opening dashboard, running a baton, viewing wiki.
+- Move `docs/howto/help-inventory.md` → `docs/reference/help-inventory.md`.
+- Convert `research/adr/README.md` → "how to add a new ADR" walkthrough (How-to), referencing log4brains.
+- Add a `WIKI.md` clarifier on concepts vs. syntheses boundary.
+
+## Out of scope
+
+- Any actual moves or rewrites — those land in a follow-up implementation ticket post-client-review per Manager scope.
+
+## Sources
+
+- Diátaxis: https://diataxis.fr/
+- Inventory of current docs: `find docs/ instructions/ research/adr -name "*.md"` (2026-05-02)
+
+Refs #802, #795

--- a/research/zensical-migration-plan-2026-05-02.md
+++ b/research/zensical-migration-plan-2026-05-02.md
@@ -1,0 +1,68 @@
+# Zensical Migration Plan — Megingjord Documentation
+
+**Date**: 2026-05-02
+**Ticket**: #802 (Phase 7 of Epic #795)
+**Status**: research + plan only; implementation deferred to a separate child ticket
+
+## Context (verified facts only)
+
+Per the Phase 7 verification round, framing must reflect verified primary sources, not the original ticket's overstatements:
+
+- **Material for MkDocs is in maintenance mode**, not sunsetting on a fixed date. The 2025-11-05 announcement guarantees critical-bug + security fixes for **≥12 months** (i.e. through ~Nov 2026 minimum). No specific deletion date is published.
+- **Zensical performance language is qualitative**: "milliseconds instead of minutes" for incremental builds. The "4-5× faster differential builds" claim circulating in summaries is **unsourced** and must not be repeated.
+- **Zensical lineage**: Rust core, MIT license, MkDocs-compat, written by the same squidfunk team that maintains Material for MkDocs. Treat as the official successor.
+
+## Migration timing
+
+- **Runway**: at minimum through Nov 2026, with explicit security fixes guaranteed.
+- **Recommendation**: no rush. Use the runway. Migrate when:
+  - Zensical reaches a stable 1.0 with the plugin set we depend on, **AND**
+  - Either (a) a meaningful build-time pain point appears, or (b) Material's maintenance cadence visibly slips.
+
+Either trigger justifies the migration; neither is currently true.
+
+## Plugin / config map
+
+Megingjord does not currently use Material for MkDocs at the time of this plan. Documentation lives in plain markdown under `docs/`, `research/`, and `wiki/`, served via GitHub's native rendering. The Diátaxis IA audit (companion document) suggests reorganizing toward a Tutorial/How-to/Reference/Explanation layout, which both Material and Zensical can render cleanly.
+
+If/when we adopt Zensical:
+
+| Today | Migration step |
+|---|---|
+| Plain markdown viewed via GitHub | `mkdocs.yml` (Zensical-compatible) declared |
+| log4brains (#798) static site for ADRs | Stays as separate static; embed link from Zensical sidebar |
+| `npm run docs:compile` (#796) | Stays; produces README scripts table consumed by both |
+| `npm run docs:anchors` (#797) | Stays; orthogonal to renderer |
+
+Zensical's MkDocs-compat means `mkdocs.yml` syntax is the input today; plugin compatibility is the open question.
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Zensical remains pre-1.0 longer than planned | Medium | Material runway covers ≥12 months; reassess at 6 months. |
+| Plugin we depend on doesn't port | Medium | Catalog needed plugins before migration; raise issue upstream early. |
+| Material reaches end-of-security earlier than announced | Low | Monitor squidfunk repo activity; the 12-month commitment is in writing. |
+| Diátaxis reorganization conflicts with renderer choice | Low | Markdown source is renderer-agnostic; any reorg lands first. |
+
+## Decision
+
+Defer Zensical migration. Re-evaluate at one of:
+
+- 2026-08-15 (mid-runway check-in)
+- Zensical 1.0 release announcement
+- First sign of Material maintenance slip
+
+Diátaxis reorganization (separate child ticket) is independent and can land at any time.
+
+## Out of scope
+
+- Actual `mkdocs.yml` config or build-time setup — those land in an implementation ticket post-client-review.
+
+## Sources
+
+- Material for MkDocs maintenance-mode announcement: https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/
+- Zensical setup docs: https://zensical.org/docs/setup/basics/
+- Verification round on Epic #795 (2026-05-02): caught the unsourced "4-5×" multiplier and the missing fixed sunset date
+
+Refs #802, #795


### PR DESCRIPTION
## Summary

Phase 7 of Epic #795 — research + design only, lane:docs-research. Two research deliverables produced; implementation deferred to follow-up children.

- `research/diataxis-ia-audit-2026-05-02.md`: Diátaxis classification of every doc surface; identifies Tutorial gap, README overload, DECISIONS.md/ADR-README index duplication.
- `research/zensical-migration-plan-2026-05-02.md`: migration plan that honors verified runway facts (Material maintenance ≥12mo; Zensical qualitative speed). Decision: defer, re-evaluate 2026-08 or at Zensical 1.0.

Verification-round corrections honored throughout (no false sunset date; no unsourced 4-5× multiplier).

## Baton artifacts

- MANAGER_HANDOFF: posted on #802
- COLLABORATOR_HANDOFF: N/A — docs/research lane (posted on #802)
- ADMIN_HANDOFF: N/A — docs/research lane (posted on #802)
- CONSULTANT_CLOSEOUT: pending

## Test plan

- [x] `npm run lint` clean
- [x] `npx markdownlint-cli2` 0 errors on new files + CHANGELOG
- [x] Verified facts only (no overstated sunset date or unsourced multiplier)
- [ ] CI green

Refs #802, #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)