### PR TITLE
feat(docs): opt-in markdown exec block-lint

### DIFF
--- a/.github/workflows/docs-exec.yml
+++ b/.github/workflows/docs-exec.yml
@@ -1,0 +1,35 @@
+name: Docs Exec
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - 'scripts/global/docs-exec.js'
+      - '.github/workflows/docs-exec.yml'
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - 'scripts/global/docs-exec.js'
+
+concurrency:
+  group: docs-exec-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  exec:
+    name: docs-exec
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+      - name: Run opt-in markdown exec blocks
+        run: node scripts/global/docs-exec.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased] — Phase 6 Markdown Exec Block-Lint (#801)
+
+### Added
+- `scripts/global/docs-exec.js`: opt-in fenced-block runner for docs. Scans markdown for `<!-- exec: [timeout=Ns] -->` markers immediately preceded by ```sh/```bash blocks and executes them. Default behavior is **safe** — blocks without the marker are not executed (inverted from the original skip-tag design for safety).
+- `tests/docs-exec.spec.js`: 6 Playwright tests (no markers, marked-success, marked-failure, no-marker-no-run, per-block timeout, multi-file).
+- `.github/workflows/docs-exec.yml`: CI gate; runs in clean Ubuntu container.
+- `package.json`: `docs:exec` script.
+
+### Notes
+- Token-free, deterministic, exit-code-driven.
+- Default 30s timeout per block; override with `<!-- exec: timeout=Ns -->`.
+
 ## [Unreleased] — Phase 7 Diátaxis + Zensical Research (#802)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ npm run deploy:both:apply
 | `deploy:codex:apply` | `bash scripts/deploy.sh --apply --target codex` |
 | `docs:anchors` | `node scripts/global/docs-anchors.js` |
 | `docs:compile` | `node scripts/docs-compile.js` |
+| `docs:exec` | `node scripts/global/docs-exec.js` |
 | `docs:lint` | `node scripts/docs-lint.js` |
 | `format` | `prettier --write .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js` |
 | `format:check` | `prettier --check .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js` |

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "validate:compat": "node scripts/validate-plugin-compat.js",
     "docs:compile": "node scripts/docs-compile.js",
     "docs:anchors": "node scripts/global/docs-anchors.js",
+    "docs:exec": "node scripts/global/docs-exec.js",
     "adr:new": "log4brains adr new",
     "adr:preview": "log4brains preview",
     "adr:build": "log4brains build",

--- a/scripts/global/docs-exec.js
+++ b/scripts/global/docs-exec.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// scripts/global/docs-exec.js — opt-in fenced-block runner for docs (#801)
+// Scans markdown for ```sh / ```bash blocks IMMEDIATELY preceded by an
+// `<!-- exec: [timeout=Ns] -->` marker and executes the block. Blocks
+// without the marker are ignored — safer default than skip-tags.
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const SKIP_DIRS = new Set(['node_modules', '.git', 'test-results', 'playwright-report', '.dashboard', '.log4brains']);
+const DEFAULT_TIMEOUT_MS = 30000;
+const STDERR_TAIL_CHARS = 400;
+const EXEC_RE = /<!--\s*exec:?\s*(?:timeout=(\d+)s)?\s*-->\s*\n```(?:sh|bash)\n([\s\S]*?)```/g;
+
+function listMarkdown(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listMarkdown(full));
+    else if (entry.name.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+function execBlock(script, timeoutSec) {
+  const timeout = timeoutSec ? parseInt(timeoutSec, 10) * 1000 : DEFAULT_TIMEOUT_MS;
+  try {
+    execSync(script, { timeout, stdio: 'pipe', shell: '/bin/bash' });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, status: err.status, stderr: (err.stderr || '').toString().slice(-STDERR_TAIL_CHARS) };
+  }
+}
+
+function checkFile(mdPath) {
+  const text = fs.readFileSync(mdPath, 'utf-8');
+  const failures = [];
+  let count = 0;
+  for (const match of text.matchAll(EXEC_RE)) {
+    count += 1;
+    const [, timeoutSec, script] = match;
+    const result = execBlock(script, timeoutSec);
+    if (!result.ok) {
+      failures.push(`${mdPath}: exec block #${count} failed (exit ${result.status}): ${result.stderr.trim()}`);
+    }
+  }
+  return { ran: count, failures };
+}
+
+function main() {
+  const root = process.cwd();
+  let totalRan = 0;
+  const allFailures = [];
+  for (const md of listMarkdown(root)) {
+    const { ran, failures } = checkFile(md);
+    totalRan += ran;
+    allFailures.push(...failures);
+  }
+  if (allFailures.length) {
+    process.stderr.write(allFailures.join('\n') + '\n');
+    process.stderr.write(`\n❌ ${allFailures.length} of ${totalRan} exec block(s) failed.\n`);
+    process.exit(1);
+  }
+  process.stdout.write(`✅ All ${totalRan} opt-in exec block(s) passed.\n`);
+}
+
+if (require.main === module) main();
+module.exports = { EXEC_RE, checkFile, execBlock };

--- a/tests/docs-exec.spec.js
+++ b/tests/docs-exec.spec.js
@@ -1,0 +1,71 @@
+// Tests for #801 markdown opt-in exec runner
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+
+const SCRIPT = path.resolve(__dirname, '..', 'scripts', 'global', 'docs-exec.js');
+
+let tmpDir;
+
+test.beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exec-test-'));
+});
+
+test.afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+function run() {
+  try {
+    return { ok: true, stdout: execSync(`node ${SCRIPT}`, { cwd: tmpDir, encoding: 'utf-8' }) };
+  } catch (err) {
+    return { ok: false, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+function write(name, content) {
+  fs.writeFileSync(path.join(tmpDir, name), content);
+}
+
+test('passes when no markers are present', () => {
+  write('doc.md', '# Doc\n\n```bash\necho not-run\n```\n');
+  const r = run();
+  expect(r.ok).toBe(true);
+  expect(r.stdout).toContain('0 opt-in');
+});
+
+test('runs marked block successfully', () => {
+  write('doc.md', '<!-- exec: -->\n```bash\necho hello\n```\n');
+  const r = run();
+  expect(r.ok).toBe(true);
+  expect(r.stdout).toContain('1 opt-in');
+});
+
+test('fails when marked block exits non-zero', () => {
+  write('doc.md', '<!-- exec: -->\n```bash\nfalse\n```\n');
+  const r = run();
+  expect(r.ok).toBe(false);
+  expect(r.stderr + r.stdout).toMatch(/exec block #1 failed/);
+});
+
+test('ignores blocks without the marker', () => {
+  write('doc.md', '```bash\nfalse\n```\n');
+  const r = run();
+  expect(r.ok).toBe(true);
+  expect(r.stdout).toContain('0 opt-in');
+});
+
+test('respects per-block timeout', () => {
+  write('doc.md', '<!-- exec: timeout=1s -->\n```bash\nsleep 5\n```\n');
+  const r = run();
+  expect(r.ok).toBe(false);
+  expect(r.stderr + r.stdout).toMatch(/exec block #1 failed/);
+});
+
+test('runs multiple blocks across multiple files', () => {
+  write('a.md', '<!-- exec: -->\n```bash\necho A\n```\n');
+  write('b.md', '<!-- exec: -->\n```bash\necho B\n```\n');
+  const r = run();
+  expect(r.ok).toBe(true);
+  expect(r.stdout).toContain('2 opt-in');
+});


### PR DESCRIPTION
## Summary

Phase 6 of Epic #795 — token-free, deterministic CI gate for executable markdown blocks.

- `scripts/global/docs-exec.js`: scans markdown for `<!-- exec: [timeout=Ns] -->` markers immediately preceded by ```sh/```bash blocks and executes them. **Opt-in**, not opt-out — safer because most existing docs contain illustrative shell (e.g., `git push`) that shouldn't actually run.
- 6 Playwright tests covering all marker semantics + timeout + multi-file.
- New `docs-exec` CI workflow gates exec-block freshness on every PR.

## Baton artifacts

- MANAGER_HANDOFF: posted on #801
- COLLABORATOR_HANDOFF: posted on #801
- ADMIN_HANDOFF: pending merge ops
- CONSULTANT_CLOSEOUT: pending review

## Test plan

- [x] `npx playwright test tests/docs-exec.spec.js` — 6 passed
- [x] `npm run lint` clean (100-line limit)
- [x] `npm run lint:readability:ci` clean (≤400)
- [x] `node scripts/global/docs-exec.js` against repo: 0 blocks (clean baseline; opt-in adoption is per-doc)
- [ ] CI green

Refs #801, #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)