### PR TITLE
chore(repo): add .editorconfig with universal rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig — universal indent/whitespace rules
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{py,toml}]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.{sh,bash}]
+indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased] — Codebase Organization: .editorconfig (#821)
+
+### Added
+- `.editorconfig` at repo root with universal indent/whitespace rules. Per-extension overrides for Python/TOML (4-space), Markdown (preserve trailing whitespace for line breaks), and Makefile (tabs).
+
+### Notes
+- `.secrets.baseline` (detect-secrets) deferred to a follow-up: requires Python tooling (`pipx install detect-secrets`) that isn't available in this checkout. Can be added with `detect-secrets scan > .secrets.baseline` in any environment that has it.
+
 ## [Unreleased] — Codebase Organization: Relocate Legacy Artifacts (#820)
 
 ### Changed


### PR DESCRIPTION
## Summary

Implementation child of Epic #818 per #819 research priority B (scope revised).

- `.editorconfig` at repo root with universal indent/whitespace rules + per-extension overrides for Python/TOML, Markdown, Makefile.
- `.secrets.baseline` deferred to a follow-up because `detect-secrets` Python tooling isn't available in this execution environment.

## Baton artifacts

- MANAGER_HANDOFF: posted on #821 (with scope revision)
- COLLABORATOR_HANDOFF: posted on #821
- ADMIN_HANDOFF: pending
- CONSULTANT_CLOSEOUT: pending

## Test plan

- [x] `npm run lint` clean
- [ ] CI green

Refs #821, #818