### PR TITLE
docs(adr): ADR-017 package-lock.json commit vs gitignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased] — ADR-017: package-lock.json Commit vs. Gitignore (#822)
+
+### Added
+- `research/adr/017-package-lock-decision.md`: ADR (Proposed) documenting the decision to commit `package-lock.json` (currently gitignored) and defer the actual flip to an isolated follow-up PR with CI verification. Surfaces evidence that Dependabot npm ecosystem is silently broken because PRs cannot be opened without a committed lockfile.
+- `docs/DECISIONS.md`: ADR-017 row added.
+
+### Notes
+- This ticket lands the ADR only. The actual lockfile flip is deferred to a follow-up child that includes:
+  - Removing `package-lock.json` from `.gitignore`
+  - Committing the current Node-22-produced lockfile
+  - Adding CI step `npm install --frozen-lockfile` (or equivalent)
+  - Confirming Dependabot npm PRs start opening
+
 ## [Unreleased] — Codebase Organization: .editorconfig (#821)
 
 ### Added

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -39,6 +39,7 @@ ADRs that change governance must follow Manager → Consultant baton.
 | 014 | Fleet Model Placement on Windows Hosts | [`014-fleet-model-placement-on-windows-hosts.md`](../research/adr/014-fleet-model-placement-on-windows-hosts.md) |
 | 015 | Model Routing via Custom Agents (renumbered from ADR-004) | [`015-model-routing-agents.md`](../research/adr/015-model-routing-agents.md) |
 | 016 | log4brains as the ADR Pipeline | [`016-log4brains-adr-pipeline.md`](../research/adr/016-log4brains-adr-pipeline.md) |
+| 017 | package-lock.json — Commit vs. Gitignore Decision (Proposed) | [`017-package-lock-decision.md`](../research/adr/017-package-lock-decision.md) |
 
 ## Resolved issues
 

--- a/research/adr/017-package-lock-decision.md
+++ b/research/adr/017-package-lock-decision.md
@@ -1,0 +1,78 @@
+# ADR-017: package-lock.json — Commit vs. Gitignore Decision
+
+**Status**: Proposed
+**Date**: 2026-05-02
+**Ticket**: #822 (implementation child of Epic #818, scoped from #819 research)
+
+## Context
+
+`package-lock.json` has been gitignored at the repo root since the initial seed commit (`514e364`, 2026-04-11). This is **non-standard** for a Node.js project: npm's official guidance and ecosystem convention is to commit the lockfile for reproducible installs and Dependabot integration.
+
+Recent observation: branch refs like `dependabot/npm_and_yarn/eslint-10.2.1`, `dependabot/npm_and_yarn/markdownlint-cli2-0.22.1`, and `dependabot/npm_and_yarn/eslint-plugin-jsdoc-62.9.0` exist (force-updated repeatedly) but **no corresponding open PRs**. Dependabot's npm ecosystem cannot complete a PR without a committed lockfile to update — strong evidence that the gitignore is **silently breaking** automated dependency PRs for the npm ecosystem (GitHub Actions ecosystem PRs, which don't need a lockfile, are working).
+
+## Options Considered
+
+### Option A — Keep gitignored
+
+- Preserves current install flow (each user runs `npm install`).
+- Multi-runtime sync (claude/codex/copilot) doesn't need to coordinate lockfile updates.
+- Each operator's Node version produces a lock matching their environment.
+
+**Cost**: Dependabot npm ecosystem silently broken; no reproducible CI installs; drift between dev environments is unobserved.
+
+### Option B — Commit `package-lock.json`
+
+- Restores Dependabot npm ecosystem (PRs get opened with lockfile updates).
+- Reproducible CI / fresh-clone installs.
+- Standard ecosystem convention; lower onboarding friction for contributors.
+
+**Cost**: Every future PR that touches dependencies must regenerate and commit the lockfile. Slight increase in PR surface area. CI must enforce that `npm install` produces no diff in the lockfile.
+
+### Option C — Use `npm shrinkwrap`
+
+- Equivalent to committing `package-lock.json` semantically; rarely used in 2026 for non-published apps.
+
+Rejected: same trade-offs as Option B without the broader ecosystem alignment.
+
+## Decision
+
+**Recommend Option B (commit the lockfile)**, but **defer the actual flip to a separate, isolated PR** that includes:
+
+1. Removing `package-lock.json` from `.gitignore`.
+2. Committing the current `package-lock.json` produced by Node 22 (the pinned `.nvmrc` + `package.json#engines`).
+3. Adding a CI step that runs `npm install --frozen-lockfile` (or equivalent) to verify the lockfile stays in sync.
+4. Confirming Dependabot npm PRs start opening after the flip.
+
+This ADR documents the decision and the deferred action. This ticket (#822) lands the ADR only; the flip lives in a follow-up child created when an admin can verify the fresh-clone install path in CI.
+
+## Consequences
+
+### Positive (when the flip lands)
+
+- Dependabot npm ecosystem starts working.
+- Reproducible installs across dev + CI.
+- Standard ecosystem convention; one less surprise for new contributors.
+
+### Negative
+
+- PRs that change dependencies must regenerate the lockfile (small overhead).
+- Initial flip may surface previously-unnoticed dependency drift; baseline that drift in the flip PR.
+
+## Out of scope
+
+- The actual flip — separate follow-up child ticket per the deferred-action note above.
+- Migration to pnpm / yarn — not on the table.
+
+## Sources
+
+- npm v11 docs on lockfile: <https://docs.npmjs.com/cli/v11/configuring-npm/package-lock-json>
+- Dependabot npm ecosystem requirements: <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference>
+- Megingjord branch evidence: `dependabot/npm_and_yarn/*` refs without paired PRs (observed 2026-05-02 via `git fetch origin`).
+
+## Related
+
+- Epic #818 (codebase organization)
+- #819 (research that flagged the lockfile decision)
+- ADR-013 (capability detection substrate — independent but related to install ergonomics)
+
+Refs #822, #818


### PR DESCRIPTION
## Summary

Implementation child of Epic #818 per #819 research priority C. Scope revised: lands the ADR only; deferring the actual lockfile flip to a separate isolated follow-up with CI verification.

ADR-017 (Proposed) surfaces evidence that the current gitignored state silently breaks Dependabot npm ecosystem.

## Baton artifacts

- MANAGER_HANDOFF: posted on #822 (with scope revision)
- COLLABORATOR_HANDOFF: posted on #822
- ADMIN_HANDOFF: pending
- CONSULTANT_CLOSEOUT: pending

## Test plan

- [x] `npm run lint` clean
- [x] `npx markdownlint-cli2` clean
- [ ] CI green

Refs #822, #818