### PR TITLE
chore(refs): post-#820 broken-ref cleanup

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,6 +1,6 @@
 wiki/sources/
 wiki/syntheses/
-model-compare/
+research/model-compare/
 raw/
 CHANGELOG-archive.md
 .dashboard/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased] — Codebase Organization: post-#820 broken-ref cleanup (#818)
+
+### Changed
+- `.markdownlintignore`: `model-compare/` → `research/model-compare/` (path moved in #820).
+- `docs/howto/doc-update-trigger-matrix.md`: `model-compare/**` → `research/model-compare/**` (same).
+
+### Notes
+- Final-validation pass for Epic #818 caught two configuration files still referencing the old `model-compare/` path. Historical references in `CHANGELOG-archive.md` and earlier research/triage docs are intentionally preserved for historical accuracy.
+
 ## [Unreleased] — ADR-017: package-lock.json Commit vs. Gitignore (#822)
 
 ### Added

--- a/docs/howto/doc-update-trigger-matrix.md
+++ b/docs/howto/doc-update-trigger-matrix.md
@@ -26,7 +26,7 @@ Generated: 2026-04-30 | Refs #522 #335
 | `logs/**` | Generated/ephemeral data |
 | `research/**` | Research is self-documenting |
 | `wiki/**` | Wiki content is its own doc surface |
-| `model-compare/**` | Benchmark data; not user-facing |
+| `research/model-compare/**` | Benchmark data; not user-facing |
 | `.github/ISSUE_TEMPLATE/**` | Templates are docs themselves |
 | `lint-configs/**` | Config only; behavior unchanged unless `npm run lint` output changes |
 


### PR DESCRIPTION
## Summary

Final-validation pass on Epic #818 caught 2 configuration references still pointing at the old `model-compare/` path. Trivial 2-line update.

## Baton artifacts

- ADMIN_HANDOFF: posted on #827
- COLLABORATOR_HANDOFF: N/A — config-only lane (posted)
- CONSULTANT_CLOSEOUT: pending

## Test plan

- [x] `npm run lint` clean
- [ ] CI green

Refs #827, #818