### PR TITLE
feat(telemetry): Copilot estimated-lane caveat reporting #772

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ flowchart LR
 - Multi-runtime deployment model with dry-run/apply scripts
 - Governance baton model: Manager → Collaborator → Admin → Consultant
 - Fleet-aware routing, telemetry, and policy enforcement
+- Confidence-aware telemetry separates exact vs estimated Copilot usage with report caveats
 - Static dashboard with operations + governance visibility
 - LLM wiki integration for reusable institutional knowledge
 - Accessibility + UX baseline checks aligned to WCAG 2.2 and Core Web Vitals

--- a/scripts/copilot-tracker.js
+++ b/scripts/copilot-tracker.js
@@ -78,6 +78,20 @@ function getCopilotQuota() {
   };
 }
 
+function getCopilotEstimatedRecord() {
+  const data = loadUsage();
+  const reqs = data.manualOverride?.requests ?? data.requests;
+  const cost = data.manualOverride?.cost ?? data.estimatedCost;
+  return {
+    provider: 'copilot', model: 'copilot-pro', input_tokens: 0, output_tokens: 0,
+    total_tokens: 0, cost_usd: Number(cost || 0), confidence_level: 'estimated',
+    caveat_code: 'copilot_estimated_lane',
+    caveat_detail: 'Copilot token counts are estimated/manual; no exact per-request API available.',
+    source_kind: data.manualOverride ? 'copilot_manual_sync' : 'copilot_estimator',
+    request_id: `${data.period}:${reqs}`
+  };
+}
+
 module.exports = {
-  loadUsage, addRequests, setManualUsage, getCopilotQuota
+  loadUsage, addRequests, setManualUsage, getCopilotQuota, getCopilotEstimatedRecord
 };

--- a/scripts/global/cost-report.js
+++ b/scripts/global/cost-report.js
@@ -38,6 +38,14 @@ function report() {
   console.log(`Premium share: ${(stats.premiumShare * 100).toFixed(1)}%`);
   console.log(`Avg multiplier: ${stats.avgMultiplier}`);
   console.log(`Success rate: ${(stats.successRate * 100).toFixed(1)}%`);
+  const conf = stats.confidenceDistribution || { exact: 0, estimated: 0, other: 0 };
+  console.log('\nConfidence split (exact vs estimated):');
+  console.log(`  exact: ${(conf.exact * 100).toFixed(1)}%`);
+  console.log(`  estimated: ${(conf.estimated * 100).toFixed(1)}%`);
+  console.log(`  other: ${(conf.other * 100).toFixed(1)}%`);
+  if (conf.estimated > 0) {
+    console.log('  caveat: estimated entries are non-exact and may include manual Copilot sync data.');
+  }
 
   if (stats.premiumShare > 0.2) {
     console.log(`\n⚠  Premium share ${(stats.premiumShare * 100).toFixed(0)}% exceeds 20% target.`);

--- a/scripts/global/model-routing-telemetry.js
+++ b/scripts/global/model-routing-telemetry.js
@@ -5,10 +5,17 @@ const path = require('path');
 const { normalizeTokenRecord } = require('./token-ledger-schema');
 
 const FILE = path.join(__dirname, '..', '..', 'logs', 'model-routing-telemetry.jsonl');
+const DAY_MS = 86400000;
 
 function ensureDir() { fs.mkdirSync(path.dirname(FILE), { recursive: true }); }
 
 const MAX_ENTRIES = 100;
+
+function pctMap(counts, sampleCount) {
+  return Object.fromEntries(
+    Object.entries(counts).map(([key, value]) => [key, +(value / sampleCount).toFixed(3)])
+  );
+}
 
 function recordTelemetry(entry) {
   ensureDir();
@@ -42,24 +49,26 @@ function recordTelemetry(entry) {
 
 function readTelemetry(days = 30) {
   if (!fs.existsSync(FILE)) return [];
-  const cutoff = Date.now() - days * 86400000;
+  const cutoff = Date.now() - days * DAY_MS;
   return fs.readFileSync(FILE, 'utf8').split('\n').filter(Boolean)
     .map(l => { try { return JSON.parse(l); } catch { return null; } })
     .filter(r => r && new Date(r.ts).getTime() >= cutoff);
 }
 
 function summarize(entries) {
-  const n = entries.length || 1;
+  const sampleCount = entries.length || 1;
   const byLane = { free: 0, fleet: 0, haiku: 0, premium: 0 };
   const byConfidence = { exact: 0, estimated: 0, other: 0 };
   const escalations = { haiku: 0, premium: 0 };
-  entries.forEach(e => {
-    byLane[e.lane] = (byLane[e.lane] || 0) + 1;
-    const c = e.confidence_level;
-    if (c && String(c).startsWith('exact')) byConfidence.exact += 1;
-    else if (c === 'estimated') byConfidence.estimated += 1;
+  entries.forEach(entry => {
+    byLane[entry.lane] = (byLane[entry.lane] || 0) + 1;
+    const confidenceLevel = entry.confidence_level;
+    if (confidenceLevel && String(confidenceLevel).startsWith('exact')) byConfidence.exact += 1;
+    else if (confidenceLevel === 'estimated') byConfidence.estimated += 1;
     else byConfidence.other += 1;
-    if (e.escalation) escalations[e.escalation] = (escalations[e.escalation] || 0) + 1;
+    if (entry.escalation) {
+      escalations[entry.escalation] = (escalations[entry.escalation] || 0) + 1;
+    }
   });
   const premium = entries.filter(e => e.lane === 'premium').length;
   const ok = entries.filter(e => e.outcome === 'ok').length;
@@ -67,18 +76,14 @@ function summarize(entries) {
   const mult = entries.reduce((s, e) => s + (Number(e.multiplier) || 0), 0);
   return {
     samples: entries.length,
-    laneDistribution: Object.fromEntries(
-      Object.entries(byLane).map(([k, v]) => [k, +(v / n).toFixed(3)])
-    ),
-    confidenceDistribution: Object.fromEntries(
-      Object.entries(byConfidence).map(([k, v]) => [k, +(v / n).toFixed(3)])
-    ),
+    laneDistribution: pctMap(byLane, sampleCount),
+    confidenceDistribution: pctMap(byConfidence, sampleCount),
     escalationCounts: escalations,
-    premiumShare: +(premium / n).toFixed(3),
-    successRate: +(ok / n).toFixed(3),
-    failRate: +((n - ok) / n).toFixed(3),
-    rollbackRate: +(rollback / n).toFixed(3),
-    avgMultiplier: +(mult / n).toFixed(3),
+    premiumShare: +(premium / sampleCount).toFixed(3),
+    successRate: +(ok / sampleCount).toFixed(3),
+    failRate: +((sampleCount - ok) / sampleCount).toFixed(3),
+    rollbackRate: +(rollback / sampleCount).toFixed(3),
+    avgMultiplier: +(mult / sampleCount).toFixed(3),
   };
 }
 

--- a/scripts/global/model-routing-telemetry.js
+++ b/scripts/global/model-routing-telemetry.js
@@ -51,9 +51,14 @@ function readTelemetry(days = 30) {
 function summarize(entries) {
   const n = entries.length || 1;
   const byLane = { free: 0, fleet: 0, haiku: 0, premium: 0 };
+  const byConfidence = { exact: 0, estimated: 0, other: 0 };
   const escalations = { haiku: 0, premium: 0 };
   entries.forEach(e => {
     byLane[e.lane] = (byLane[e.lane] || 0) + 1;
+    const c = e.confidence_level;
+    if (c && String(c).startsWith('exact')) byConfidence.exact += 1;
+    else if (c === 'estimated') byConfidence.estimated += 1;
+    else byConfidence.other += 1;
     if (e.escalation) escalations[e.escalation] = (escalations[e.escalation] || 0) + 1;
   });
   const premium = entries.filter(e => e.lane === 'premium').length;
@@ -64,6 +69,9 @@ function summarize(entries) {
     samples: entries.length,
     laneDistribution: Object.fromEntries(
       Object.entries(byLane).map(([k, v]) => [k, +(v / n).toFixed(3)])
+    ),
+    confidenceDistribution: Object.fromEntries(
+      Object.entries(byConfidence).map(([k, v]) => [k, +(v / n).toFixed(3)])
     ),
     escalationCounts: escalations,
     premiumShare: +(premium / n).toFixed(3),

--- a/scripts/global/model-routing-weekly-report.js
+++ b/scripts/global/model-routing-weekly-report.js
@@ -4,10 +4,11 @@ const fs = require('fs');
 const path = require('path');
 const { readTelemetry, summarize } = require('./model-routing-telemetry');
 const { loadUsage } = require('../copilot-tracker');
+const DAY_MS = 86400000;
 
 function report() {
   const week = readTelemetry(7);
-  const prev = readTelemetry(14).filter(e => new Date(e.ts).getTime() < Date.now() - 7 * 86400000);
+  const prev = readTelemetry(14).filter(e => new Date(e.ts).getTime() < Date.now() - 7 * DAY_MS);
   const now = summarize(week);
   const old = summarize(prev);
   const usage = loadUsage();

--- a/scripts/global/model-routing-weekly-report.js
+++ b/scripts/global/model-routing-weekly-report.js
@@ -15,6 +15,12 @@ function report() {
     generatedAt: new Date().toISOString(),
     period: usage.period,
     premiumShare: { current: now.premiumShare, previous: old.premiumShare, delta: now.premiumShare - old.premiumShare },
+    confidenceSplit: {
+      current: now.confidenceDistribution,
+      previous: old.confidenceDistribution,
+      estimatedDelta:
+        (now.confidenceDistribution?.estimated || 0) - (old.confidenceDistribution?.estimated || 0)
+    },
     quality: { successRate: now.successRate, failRate: now.failRate, rollbackRate: now.rollbackRate },
     efficiency: { avgMultiplier: now.avgMultiplier, requests: usage.manualOverride?.requests ?? usage.requests }
   };

--- a/scripts/global/token-ledger-schema.js
+++ b/scripts/global/token-ledger-schema.js
@@ -34,6 +34,8 @@ function normalizeTokenRecord(entry = {}) {
     total_tokens: total,
     cost_usd: entry.cost_usd == null ? null : n(entry.cost_usd),
     confidence_level: level,
+    caveat_code: entry.caveat_code || null,
+    caveat_detail: entry.caveat_detail || null,
     request_id: entry.request_id || null,
     source_kind: entry.source_kind || 'routing_telemetry',
   };

--- a/scripts/global/token-provider-adapters.js
+++ b/scripts/global/token-provider-adapters.js
@@ -62,4 +62,17 @@ function ollama(payload = {}, base = {}) {
   });
 }
 
-module.exports = { anthropic, openrouter, litellm, gemini, ollama };
+function copilot(payload = {}, base = {}) {
+  return mk(base, {
+    provider: 'copilot', model: payload.model || base.model || 'copilot-pro',
+    input_tokens: n(payload.input_tokens), output_tokens: n(payload.output_tokens),
+    total_tokens: payload.total_tokens ?? (n(payload.input_tokens) + n(payload.output_tokens)),
+    cost_usd: payload.cost_usd ?? payload.estimated_cost_usd,
+    confidence_level: 'estimated', request_id: payload.request_id || base.request_id,
+    source_kind: 'copilot_estimator', caveat_code: 'copilot_estimated_lane',
+    caveat_detail: payload.caveat_detail ||
+      'No exact Copilot per-request token API; values are estimated or manually synced.'
+  });
+}
+
+module.exports = { anthropic, openrouter, litellm, gemini, ollama, copilot };

--- a/tests/telemetry-schema.spec.js
+++ b/tests/telemetry-schema.spec.js
@@ -15,6 +15,7 @@ test('recordTelemetry writes entry with required schema fields', () => {
   expect(entry.taskClass).toBe('coding');
   expect(entry.complexityScore).toBe(0.35);
   expect(['local', 'cheap', 'fleet', 'free', 'haiku', 'premium']).toContain(entry.lane);
+  expect(['exact_request', 'exact_aggregate', 'derived', 'estimated', 'unknown']).toContain(entry.confidence_level);
 });
 
 // AC5: lane is one of known tiers
@@ -40,6 +41,16 @@ test('telemetry rolling window trims to max 100 entries', () => {
   }
   const entries = readTelemetry(30);
   expect(entries.length).toBeLessThanOrEqual(100);
+});
+
+test('telemetry summarize includes confidence split', () => {
+  const { summarize } = require(path.join(__dirname, '../scripts/global/model-routing-telemetry'));
+  const out = summarize([
+    { lane: 'fleet', confidence_level: 'exact_request', outcome: 'ok' },
+    { lane: 'premium', confidence_level: 'estimated', outcome: 'ok' }
+  ]);
+  expect(out.confidenceDistribution.exact).toBe(0.5);
+  expect(out.confidenceDistribution.estimated).toBe(0.5);
 });
 
 // AC4: npm run cost-report resolves to cost-report.js

--- a/tests/token-provider-adapters.spec.js
+++ b/tests/token-provider-adapters.spec.js
@@ -48,3 +48,11 @@ test('ollama adapter maps eval counters', () => {
   expect(r.output_tokens).toBe(6);
   expect(r.confidence_level).toBe('exact_request');
 });
+
+test('copilot adapter is estimated and includes caveat', () => {
+  const r = adapters.copilot({ estimated_cost_usd: 0.52, request_id: '2026-05:13' }, { lane: 'premium' });
+  expect(r.provider).toBe('copilot');
+  expect(r.confidence_level).toBe('estimated');
+  expect(r.caveat_code).toBe('copilot_estimated_lane');
+  expect(r.caveat_detail).toContain('No exact Copilot');
+});

--- a/tests/unit-modules.spec.js
+++ b/tests/unit-modules.spec.js
@@ -76,4 +76,12 @@ test.describe('Judge gate wiring — #512', () => {
     expect(src).toContain('judgeModel: jcfg.model');
     expect(src).toContain('judge_latency_ms: j.latency_ms');
   });
+
+  test('copilot-tracker exports estimated record with caveat', () => {
+    const { getCopilotEstimatedRecord } = require('../scripts/copilot-tracker.js');
+    const rec = getCopilotEstimatedRecord();
+    expect(rec.provider).toBe('copilot');
+    expect(rec.confidence_level).toBe('estimated');
+    expect(rec.caveat_code).toBe('copilot_estimated_lane');
+  });
 });


### PR DESCRIPTION
## Summary
Implements #772 by normalizing Copilot telemetry into the unified ledger as estimated confidence and surfacing caveats to prevent exactness claims.

## What changed
- Added canonical caveat fields to token records (`caveat_code`, `caveat_detail`).
- Added `copilot` adapter in provider adapters with explicit estimated-lane caveat metadata.
- Added confidence split reporting (`exact`, `estimated`, `other`) in telemetry summaries and weekly report.
- Updated cost report to print exact-vs-estimated split and caveat note.
- Added `getCopilotEstimatedRecord()` export in copilot tracker.
- Added implementation evidence doc and release metadata update (`3.3.6`).
- Follow-up commit trims readability warnings to keep CI under the repository cap.

## Validation
- Targeted tests: token adapters, telemetry schema, unit modules ✅
- `npm run lint` ✅
- `npm run governance:no-sync-http` ✅
- Fleet/cloud evidence:
  - OpenClaw preflight + health/chat
  - Fleet benchmark with strong 36gbwinresource result (`test-results/fleet-benchmark-772.json`)
  - Capability probe confirming OpenRouter, Google AI Studio, Groq, Cerebras availability

## Notes
- The doc-update workflow currently omits `CHANGELOG.md` and `package.json` from its changed-file list for this PR even though they are in the branch diff, so the documented bypass token is included below.

Closes #772

Refs #772

[skip-doc-gate]
