### PR TITLE
feat(dashboard): add token telemetry reporting surfaces (#773)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,15 @@
 - `npm run capability:probe` and `npm run capability:show` scripts.
 - `.env.example`: optional Tier 0/2/3 env-var template.
 
+## [3.3.7] — 2026-05-02 — Token Telemetry Reporting Surfaces (#773)
+
+### Added
+- `routing:telemetry` summary generator writing `logs/token-telemetry-summary.json` for governance-facing token telemetry rollups.
+- Dashboard token telemetry surface for confidence split, lane/model summaries, and non-free coverage visibility.
+
+### Changed
+- Cost view now combines cost and token telemetry reporting using the same routed telemetry feed.
+
 ## [3.3.6] — 2026-05-02 — Copilot Estimated-Lane Telemetry + Caveat Reporting (#772)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ npm run deploy:both:apply
 | `routing:baseline` | `node scripts/global/routing-baseline-report.js` |
 | `routing:calibrate` | `node scripts/global/cascade-calibrate.js` |
 | `routing:report` | `node scripts/global/routing-baseline-report.js --days 7` |
+| `routing:telemetry` | `node scripts/global/token-telemetry-report.js --json` |
 | `setup` | `npm install && echo '✅ megingjord ready — run: npm start'` |
 | `start` | `node scripts/dashboard-server.js` |
 | `state:offload` | `node scripts/global/state-offload-client.js` |

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -21,7 +21,7 @@
     <script src="js/governance-panel.js"></script><script src="js/ticket-log.js"></script>
     <script src="js/tooltips.js"></script><script src="js/app-actions.js"></script>
     <script src="js/credential-store.js"></script><script src="js/provider-presets.js"></script><script src="js/fleet-probe.js"></script><script src="js/settings-panel.js"></script><script src="js/settings-form.js"></script><script src="js/settings-actions.js"></script>
-    <script src="js/event-source.js"></script><script src="js/context-flow-events.js"></script><script src="js/cost-monitor.js"></script><script src="js/multi-agent-sessions.js"></script><script src="js/tier-c-banner.js"></script><script src="js/app.js"></script>
+    <script src="js/event-source.js"></script><script src="js/context-flow-events.js"></script><script src="js/token-telemetry.js"></script><script src="js/cost-monitor.js"></script><script src="js/multi-agent-sessions.js"></script><script src="js/tier-c-banner.js"></script><script src="js/app.js"></script>
 </head>
 <body x-cloak x-data="dashboardApp()" x-init="init()">
     <a href="#main-content" class="skip-link">Skip to content</a>
@@ -91,10 +91,10 @@
             <h2>📊 Metrics <button class="shb" data-tip="wiki-metrics" aria-label="Help: Metrics">?</button></h2><div x-html="renderWikiMetrics(wikiMetrics, wikiHealth)"></div></section></template>
         <template x-if="isView('wiki')"><section id="panel-wiki-reader" class="panel wiki-main">
             <h2>📚 Research Wiki <button class="shb" data-tip="wiki-reader" aria-label="Help: Wiki">?</button></h2><div x-html="renderWikiReader(wikiPages)"></div></section></template>
-        <!-- COST: 1 panel --><template x-if="isView('cost')"><section id="panel-cost" class="panel full-width"><h2>💰 Cost Monitor <button class="shb" data-tip="cost" aria-label="Help: Cost">?</button></h2><div x-html="renderCostMonitor(costData)"></div></section></template>
+        <!-- COST: 1 panel --><template x-if="isView('cost')"><section id="panel-cost" class="panel full-width"><h2>💰 Cost + Token Telemetry <button class="shb" data-tip="cost" aria-label="Help: Cost">?</button></h2><div x-html="renderTokenTelemetryPanel(tokenTelemetry)"></div><div x-html="renderCostMonitor(costData)"></div></section></template>
         <!-- AGENTS --><template x-if="isView('agents')"><section id="panel-agents" class="panel full-width"><h2>🤖 Agent Sessions <button class="shb" data-tip="agents" aria-label="Help: Agents">?</button></h2><div x-html="renderTierCBanner(agentSessions)"></div><div x-html="renderConflictAlerts(agentSessions)"></div><div x-html="renderAgentSessions(agentSessions)"></div></section></template>
         <!-- HELP: 1 panel full-width -->
         <template x-if="isView('help')"><section id="panel-help" class="panel full-width">
             <h2>📘 Help Center</h2><div x-html="renderHelpPanel(helpDevMode)"></div></section></template>
     </main>
-    <footer class="footer"><span>Last refresh: <span x-text="lastRefresh"></span></span><span>megingjord v3.2.0</span></footer><aside id="app-tip" class="app-tip" x-show="activeTip" x-html="activeTip" x-transition.opacity></aside></body></html>
+    <footer class="footer"><span>Last refresh: <span x-text="lastRefresh"></span></span><span>megingjord v3.3.7</span></footer><aside id="app-tip" class="app-tip" x-show="activeTip" x-html="activeTip" x-transition.opacity></aside></body></html>

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -9,7 +9,7 @@ function dashboardApp() {
     batonState: [], ticketLog: [], activityLog: [], governanceState: {},
     wikiHealth: { loaded: false }, wikiMetrics: null, wikiPages: [],
     githubData: null,
-    fleetHealthLog: [], costData: [],
+    fleetHealthLog: [], costData: [], tokenTelemetry: null,
     tooltipsEnabled: false, autoRefreshEnabled: true,
     refreshTimer: null, testTimer: null,
     testRun: { running: false, rounds: 0, ok: 0, fail: 0, last: 'idle' },
@@ -64,7 +64,7 @@ function dashboardApp() {
         this.batonState = evBaton.length ? evBaton : (typeof getBatonState==='function' ? getBatonState() : buildBatonState(getRouterLog()));
         if (typeof fetchFleetHealthLog === 'function') this.fleetHealthLog = await fetchFleetHealthLog();
         if (typeof fetchGovernanceState === 'function') this.governanceState = await fetchGovernanceState();
-        if (typeof fetchCostTelemetry === 'function') this.costData = await fetchCostTelemetry();
+        if (typeof fetchCostTelemetry === 'function') this.costData = await fetchCostTelemetry(); if (typeof fetchTokenTelemetrySummary === 'function') this.tokenTelemetry = await fetchTokenTelemetrySummary();
         if (typeof fetchAgentSessions === 'function') this.agentSessions = await fetchAgentSessions();
         this.lastRefresh = new Date().toLocaleTimeString();
       } finally {

--- a/dashboard/js/cost-monitor.js
+++ b/dashboard/js/cost-monitor.js
@@ -7,13 +7,16 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 async function fetchCostTelemetry() {
   try {
-    const resp = await fetch('/api/logs/cost-telemetry');
-    if (!resp.ok) return [];
-    const text = await resp.text();
-    return text.trim().split('\n').filter(Boolean).map(l => {
+    const [costResp, tokenResp] = await Promise.all([
+      fetch('/api/logs/cost-telemetry'), fetch('/api/logs/token-telemetry-summary')
+    ]);
+    const text = costResp.ok ? await costResp.text() : '';
+    const entries = text.trim().split('\n').filter(Boolean).map(l => {
       try { return JSON.parse(l); } catch { return null; }
     }).filter(Boolean);
-  } catch { return []; }
+    const summary = tokenResp.ok ? await tokenResp.json() : null;
+    return { entries, summary };
+  } catch { return { entries: [], summary: null }; }
 }
 
 function calcMonthlyCost(entries) {
@@ -48,22 +51,31 @@ function renderRecentRows(data) {
 }
 
 function renderCostMonitor(data) {
-  if (!data || !data.length) {
+  const payload = Array.isArray(data) ? { entries: data, summary: null } : (data || { entries: [], summary: null });
+  const entries = payload.entries || [];
+  const summary = payload.summary;
+  if (!entries.length && !summary?.samples) {
     return `<div class="cost-empty">
       <p>No cost telemetry recorded yet.</p>
       <p class="config-note">Entries appear when routing decisions
         are logged via model-routing-telemetry.js.</p>
     </div>`;
   }
-  const monthly = calcMonthlyCost(data);
+  const monthly = calcMonthlyCost(entries);
   const pct = Math.min(100, Math.round((monthly / BUDGET) * 100));
   const alert = monthly > BUDGET * 0.8;
   const barCls = alert ? 'cost-bar warn' : 'cost-bar ok';
   const badge = alert ? `<span class="cost-badge alert">⚠ >80% budget</span>` : '';
-  const distRows = tierDistribution(data).map(row =>
+  const distRows = tierDistribution(entries).map(row =>
     `<tr><td>${row.lane}</td><td>${row.count}</td><td>${row.pct}%</td></tr>`
   ).join('');
+  const conf = summary?.confidence || { exact: 0, estimated: 0, other: 0 };
+  const cov = summary?.nonFreeCoverage || { samples: 0, share: 0 };
+  const providers = (summary?.providers || []).slice(0, 4).map(row =>
+    `<tr><td>${esc(row.provider)}</td><td>${row.samples}</td><td>${row.total_tokens}</td></tr>`).join('');
+  const telemetry = summary?.samples ? `<div class="cost-metric"><span class="cost-label">Token Telemetry</span><span class="cost-value">${summary.totals.total_tokens}</span><span class="cost-budget">tokens / ${summary.samples} samples</span></div><table class="cost-table"><thead><tr><th>Signal</th><th>Value</th><th>Share</th></tr></thead><tbody><tr><td>Exact</td><td>${Math.round(conf.exact * summary.samples)}</td><td>${Math.round(conf.exact * 100)}%</td></tr><tr><td>Estimated</td><td>${Math.round(conf.estimated * summary.samples)}</td><td>${Math.round(conf.estimated * 100)}%</td></tr><tr><td>Non-free lanes</td><td>${cov.samples}</td><td>${Math.round(cov.share * 100)}%</td></tr></tbody></table><table class="cost-table"><thead><tr><th>Provider</th><th>Samples</th><th>Tokens</th></tr></thead><tbody>${providers}</tbody></table></div>` : '';
   return `<div class="cost-summary">
+    ${telemetry}
     <div class="cost-metric">
       <span class="cost-label">Est. Monthly Cost</span>
       <span class="cost-value">$${monthly}</span>
@@ -74,6 +86,8 @@ function renderCostMonitor(data) {
     <table class="cost-table"><thead>
       <tr><th>Lane</th><th>Reqs</th><th>%</th></tr></thead>
       <tbody>${distRows}</tbody></table>
-    <div class="cost-recent"><h4>Last 5 Requests</h4>${renderRecentRows(data)}</div>
+    <div class="cost-recent"><h4>Last 5 Requests</h4>${renderRecentRows(entries)}</div>
   </div>`;
 }
+
+if(typeof module!=="undefined")module.exports={fetchCostTelemetry,calcMonthlyCost,tierDistribution,renderCostMonitor};else Object.assign(window,{fetchCostTelemetry,calcMonthlyCost,tierDistribution,renderCostMonitor});

--- a/dashboard/js/token-telemetry.js
+++ b/dashboard/js/token-telemetry.js
@@ -1,0 +1,19 @@
+async function fetchTokenTelemetrySummary() {
+  try {
+    const resp = await fetch('/api/logs/token-telemetry-summary');
+    if (!resp.ok) return null;
+    return await resp.json();
+  } catch { return null; }
+}
+
+function renderTokenTelemetryPanel(report) {
+  if (!report || !report.samples) return `<div class="cost-empty"><p>No token telemetry summary yet.</p></div>`;
+  const conf = report.confidence || { exact: 0, estimated: 0, other: 0 };
+  const lanes = (report.lanes || []).slice(0, 4).map(row =>
+    `<tr><td>${esc(row.lane)}</td><td>${row.samples}</td><td>${row.total_tokens}</td></tr>`).join('');
+  const models = (report.models || []).slice(0, 4).map(row =>
+    `<tr><td>${esc(row.model)}</td><td>${row.samples}</td><td>${row.total_tokens}</td></tr>`).join('');
+  return `<div class="cost-summary"><div class="cost-metric"><span class="cost-label">Unified Token Ledger</span><span class="cost-value">${report.totals.total_tokens}</span><span class="cost-budget">tokens / ${report.samples} routed samples</span></div><table class="cost-table"><thead><tr><th>Confidence</th><th>Share</th><th>Samples</th></tr></thead><tbody><tr><td>Exact</td><td>${Math.round(conf.exact * 100)}%</td><td>${Math.round(conf.exact * report.samples)}</td></tr><tr><td>Estimated</td><td>${Math.round(conf.estimated * 100)}%</td><td>${Math.round(conf.estimated * report.samples)}</td></tr><tr><td>Non-free lanes</td><td>${Math.round((report.nonFreeCoverage?.share || 0) * 100)}%</td><td>${report.nonFreeCoverage?.samples || 0}</td></tr></tbody></table><table class="cost-table"><thead><tr><th>Lane</th><th>Samples</th><th>Tokens</th></tr></thead><tbody>${lanes}</tbody></table><table class="cost-table"><thead><tr><th>Model</th><th>Samples</th><th>Tokens</th></tr></thead><tbody>${models}</tbody></table></div>`;
+}
+
+if(typeof module!=="undefined")module.exports={fetchTokenTelemetrySummary,renderTokenTelemetryPanel};else Object.assign(window,{fetchTokenTelemetrySummary,renderTokenTelemetryPanel});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megingjord-harness",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex — multi-runtime skills, hooks, agents, wiki, and install tooling",
   "private": true,
   "scripts": {
@@ -41,6 +41,7 @@
     "router:weekly": "node scripts/global/model-routing-weekly-report.js",
     "routing:baseline": "node scripts/global/routing-baseline-report.js",
     "routing:report": "node scripts/global/routing-baseline-report.js --days 7",
+    "routing:telemetry": "node scripts/global/token-telemetry-report.js --json",
     "routing:calibrate": "node scripts/global/cascade-calibrate.js",
     "governance:drift": "node scripts/global/governance-drift-classifier.js --json",
     "governance:epics": "node scripts/global/epic-close-validator.js",

--- a/scripts/dashboard-server.js
+++ b/scripts/dashboard-server.js
@@ -42,12 +42,10 @@ function jsonRes(res, status, body) {
 
 async function handleApi(req, res) {
   const u = req.url;
-  // OpenClaw proxy (must precede fleet regex)
   if (u === '/api/fleet/windows-laptop/openclaw/health') {
     const r = await proxyGet(`${OPENCLAW}/health`);
     return jsonRes(res, r.status, r.body);
   }
-  // Fleet proxy: /api/fleet/<device>/<path>
   const fm = u.match(/^\/api\/fleet\/([^/]+)\/(.+)$/);
   if (fm) {
     const base = FLEET[fm[1]];
@@ -92,6 +90,7 @@ async function handleApi(req, res) {
   if (u === '/api/quota-probes') { const { probeAll } = require('./quota-probes'); return jsonRes(res, 200, await probeAll()); }
   if (u === '/api/copilot-usage') { const { getCopilotQuota } = require('./copilot-tracker'); return jsonRes(res, 200, getCopilotQuota()); }
   if (u === '/api/copilot-usage/sync' && req.method === 'POST') { let b=''; req.on('data',c=>b+=c); req.on('end',()=>{ try { const d=JSON.parse(b); const { setManualUsage } = require('./copilot-tracker'); return jsonRes(res,200,setManualUsage(d.cost,d.requests)); } catch(e){ return jsonRes(res,400,{error:e.message}); } }); return; }
+  if (u === '/api/logs/token-telemetry-summary') { const { writeTokenTelemetryReport } = require('./global/token-telemetry-report'); return jsonRes(res, 200, writeTokenTelemetryReport(30)); }
   if (u === '/api/logs/cost-telemetry') { const lf=path.join(ROOT,'logs','cost-telemetry.jsonl'); const txt=fs.existsSync(lf)?fs.readFileSync(lf,'utf8'):''; res.setHeader('Content-Type','text/plain'); return res.end(txt); }
   jsonRes(res, 404, { error: 'not found' });
 }

--- a/scripts/global/token-telemetry-report.js
+++ b/scripts/global/token-telemetry-report.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { readTelemetry, summarize } = require('./model-routing-telemetry');
+
+const REPORT_FILE = path.join(__dirname, '..', '..', 'logs', 'token-telemetry-summary.json');
+const TOKEN_KEYS = ['input_tokens', 'output_tokens', 'cache_read_tokens', 'cache_write_tokens', 'reasoning_tokens', 'total_tokens'];
+
+function addRow(map, key, entry) {
+  const row = map[key] || { key, samples: 0, total_tokens: 0 };
+  row.samples += 1;
+  row.total_tokens += Number(entry.total_tokens) || 0;
+  map[key] = row;
+}
+
+function sortRows(map, label) {
+  return Object.values(map).sort((a, b) => b.total_tokens - a.total_tokens || b.samples - a.samples)
+    .map(row => ({ [label]: row.key, samples: row.samples, total_tokens: row.total_tokens }));
+}
+
+function buildTokenTelemetryReport(days = 30) {
+  const entries = readTelemetry(days);
+  const stats = summarize(entries);
+  const totals = Object.fromEntries(TOKEN_KEYS.map(key => [key, 0]));
+  const byProvider = {}, byModel = {}, byLane = {}, caveats = {};
+  const nonFreeSamples = entries.filter(entry => ['haiku', 'premium'].includes(entry.lane)).length;
+  entries.forEach(entry => {
+    TOKEN_KEYS.forEach(key => { totals[key] += Number(entry[key]) || 0; });
+    addRow(byProvider, entry.provider || 'unknown', entry);
+    addRow(byModel, entry.model || 'unknown', entry);
+    addRow(byLane, entry.lane || 'unknown', entry);
+    if (entry.caveat_code) caveats[entry.caveat_code] = (caveats[entry.caveat_code] || 0) + 1;
+  });
+  return {
+    generated_at: new Date().toISOString(),
+    period_days: days,
+    samples: entries.length,
+    totals,
+    confidence: stats.confidenceDistribution,
+    lanes: sortRows(byLane, 'lane'),
+    providers: sortRows(byProvider, 'provider'),
+    models: sortRows(byModel, 'model').slice(0, 8),
+    nonFreeCoverage: { samples: nonFreeSamples, share: +(nonFreeSamples / (entries.length || 1)).toFixed(3) },
+    caveats: Object.entries(caveats).map(([code, count]) => ({ code, count }))
+  };
+}
+
+function writeTokenTelemetryReport(days = 30) {
+  fs.mkdirSync(path.dirname(REPORT_FILE), { recursive: true });
+  const report = buildTokenTelemetryReport(days);
+  fs.writeFileSync(REPORT_FILE, JSON.stringify(report, null, 2) + '\n');
+  return report;
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const daysIdx = args.indexOf('--days');
+  const days = Number(daysIdx >= 0 ? (args[daysIdx + 1] || 30) : 30);
+  const json = args.includes('--json');
+  const report = writeTokenTelemetryReport(days);
+  console.log(json ? JSON.stringify(report, null, 2) : `Wrote ${REPORT_FILE}`);
+}
+
+module.exports = { buildTokenTelemetryReport, writeTokenTelemetryReport, REPORT_FILE };

--- a/tests/dashboard.spec.js
+++ b/tests/dashboard.spec.js
@@ -49,4 +49,12 @@ test.describe('Megingjord Dashboard', () => {
     await page.goto('/');
     await expect(page.locator('#btn-test')).toBeVisible();
   });
+
+  test('cost view shows token telemetry content', async ({ page }) => {
+    await page.goto('/');
+    await page.click('button[title="Cost"]');
+    await page.waitForTimeout(300);
+    await expect(page.locator('#panel-cost h2')).toContainText('Cost + Token Telemetry');
+    await expect(page.locator('#panel-cost')).toContainText('Token Telemetry');
+  });
 });

--- a/tests/token-telemetry-report.spec.js
+++ b/tests/token-telemetry-report.spec.js
@@ -1,0 +1,31 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const { recordTelemetry } = require(path.join(__dirname, '../scripts/global/model-routing-telemetry'));
+
+test('token telemetry report summarizes confidence and non-free coverage', () => {
+  const { buildTokenTelemetryReport } = require(path.join(__dirname, '../scripts/global/token-telemetry-report'));
+  recordTelemetry({ lane: 'fleet', provider: 'ollama', model: 'qwen2.5:7b', total_tokens: 900, confidence_level: 'exact_request', outcome: 'ok' });
+  recordTelemetry({ lane: 'premium', provider: 'copilot', model: 'copilot-pro', total_tokens: 600, confidence_level: 'estimated', outcome: 'ok' });
+  const report = buildTokenTelemetryReport(30);
+  expect(report.samples).toBeGreaterThan(1);
+  expect(report.totals.total_tokens).toBeGreaterThan(0);
+  expect(report.confidence.exact).toBeGreaterThan(0);
+  expect(report.nonFreeCoverage.samples).toBeGreaterThan(0);
+  expect(report.providers.some(row => row.provider === 'copilot')).toBeTruthy();
+});
+
+test('token telemetry panel render includes confidence and lanes', () => {
+  global.esc = value => String(value);
+  const { renderTokenTelemetryPanel } = require(path.join(__dirname, '../dashboard/js/token-telemetry.js'));
+  const html = renderTokenTelemetryPanel({
+    samples: 4,
+    totals: { total_tokens: 2200 },
+    confidence: { exact: 0.5, estimated: 0.25, other: 0.25 },
+    nonFreeCoverage: { samples: 2, share: 0.5 },
+    lanes: [{ lane: 'fleet', samples: 2, total_tokens: 1200 }],
+    models: [{ model: 'qwen2.5:7b', samples: 2, total_tokens: 1200 }]
+  });
+  expect(html).toContain('Unified Token Ledger');
+  expect(html).toContain('Exact');
+  expect(html).toContain('fleet');
+});


### PR DESCRIPTION
## Summary
- add a token telemetry summary generator that writes logs/token-telemetry-summary.json
- expose the summary through the dashboard API and render confidence, lane, provider, and non-free coverage data in the dashboard cost view
- add focused dashboard and reporting tests, plus README/changelog/package release metadata updates

## Validation
- runTests: tests/token-telemetry-report.spec.js, tests/dashboard.spec.js, tests/telemetry-schema.spec.js
- npm run routing:telemetry
- npm run lint
- npm run governance:no-sync-http
- node scripts/global/openclaw-preflight.js --json
- OpenClaw health ok and OpenClaw chat ok with model ollama/qwen2.5:7b-instruct
- node -r dotenv/config -e require('./scripts/quota-probes').probeAll()
- node scripts/global/fleet-benchmark-runner.js --timeout-ms 45000

## Conflict check
- kept work on feat/773-token-telemetry-reporting-ws1 only
- left unrelated local changes in research/model-compare/design-analysis/LLM-EVALUATION-MATRIX.md, .claude/settings.json, and .worktrees/ untouched
- avoided Claude/Codex sandbox branches: origin/sandbox/claude-code, origin/sandbox/codex, origin/sandbox/copilot

Refs #773