### PR TITLE
feat(infra): enable Actions create+approve PRs; ADR-018 Accepted

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,7 @@ name: Release Please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased] — Enable Actions to create+approve PRs; unblock release-please (#840, ADR-018 Accepted)
+
+### Added
+- `research/adr/018-actions-pr-permission.md` (Accepted): documents enabling `can_approve_pull_request_reviews=true` while retaining `default_workflow_permissions=read`. Fleet-drafted risk register (Groq llama-3.3-70b).
+- `docs/DECISIONS.md`: ADR-018 row.
+
+### Changed
+- Repo-level Actions permission flipped via `gh api PUT /repos/.../actions/permissions/workflow` to `can_approve_pull_request_reviews=true`. `default_workflow_permissions` retained at `read`.
+- `.github/workflows/release-please.yml`: added `workflow_dispatch:` trigger for manual verification.
+
+### Notes
+- Unblocks the auto-tag flow silently failing since release-please was introduced. Latest tags stuck at v3.3.7 with the [Unreleased] block accumulating.
+
 ## [Unreleased] — Fleet matrix refresh automation + freshness gate (#833)
 
 ### Added

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -40,6 +40,7 @@ ADRs that change governance must follow Manager → Consultant baton.
 | 015 | Model Routing via Custom Agents (renumbered from ADR-004) | [`015-model-routing-agents.md`](../research/adr/015-model-routing-agents.md) |
 | 016 | log4brains as the ADR Pipeline | [`016-log4brains-adr-pipeline.md`](../research/adr/016-log4brains-adr-pipeline.md) |
 | 017 | package-lock.json — Commit vs. Gitignore Decision | [`017-package-lock-decision.md`](../research/adr/017-package-lock-decision.md) |
+| 018 | Enable GitHub Actions to create and approve pull requests | [`018-actions-pr-permission.md`](../research/adr/018-actions-pr-permission.md) |
 
 ## Resolved issues
 

--- a/research/adr/018-actions-pr-permission.md
+++ b/research/adr/018-actions-pr-permission.md
@@ -1,0 +1,69 @@
+# ADR-018: Enable GitHub Actions to create and approve pull requests
+
+**Status**: Accepted
+**Date**: 2026-05-03
+**Ticket**: #840 (implementing)
+
+## Context
+
+`release-please` (googleapis/release-please-action) opens a release PR on every main push. This requires `pull-requests: write` (declared in the workflow) **and** the repo-level setting *Allow GitHub Actions to create and approve pull requests* (`can_approve_pull_request_reviews=true`). The workflow declaration alone is insufficient — the repo-level toggle overrides it.
+
+Prior state on this repo: `default_workflow_permissions=read`, `can_approve_pull_request_reviews=false`. Symptom: every release-please run since #783 silently failed with `GitHub Actions is not permitted to create or approve pull requests`. Latest auto-tag was v3.3.7; the [Unreleased] CHANGELOG block (covering #774, #830, #818-cluster, #833) could not be auto-tagged.
+
+## Decision
+
+Set the repo-level Actions permission as follows:
+
+```sh
+gh api -X PUT /repos/chf3198/megingjord-harness/actions/permissions/workflow \
+  -F default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=true
+```
+
+- `default_workflow_permissions=read` — keeps the least-privilege baseline. Workflows that need write must declare it per-job (existing convention; e.g., release-please.yml already does).
+- `can_approve_pull_request_reviews=true` — unblocks release-please and any future workflow that legitimately needs to open or approve PRs.
+
+## Consequences
+
+### Positive
+
+- release-please ships unblocked; auto-tag flow restored.
+- No reduction of `default_workflow_permissions` baseline; per-job permissions remain the contract.
+- Future workflows (e.g., dependabot, repo-meta-sync from #800) that need PR-creation work without further repo-setting changes.
+
+### Negative / risks
+
+(Risk register fleet-drafted via Groq llama-3.3-70b, refined for context.)
+
+- **Unauthorized PR approvals**: any workflow can now approve PRs via `GITHUB_TOKEN`. Mitigation: branch-protection requires CODEOWNER review for protected paths; required-status-checks include `consultant-gate` which blocks merge on missing CONSULTANT_CLOSEOUT.
+- **Malicious workflow creates a release PR**: third-party action could try to open a release-style PR. Mitigation: `permissions: read-all` baseline + per-job elevation; pinned-SHA policy (per-job audit catches drift); `googleapis/release-please-action` already pinned by SHA in this repo.
+- **Compromised dependency injects a PR**: if a devDependency action is compromised, it could open a PR. Mitigation: dependabot + package-lock.json (now committed via #830) + npm audit baseline; required reviews still gate merge.
+- **Approval ring-fencing bypass**: `can_approve_pull_request_reviews=true` lets `GITHUB_TOKEN`-issuing workflows approve their own PRs in theory. Mitigation: GitHub does not count `GITHUB_TOKEN`-issued approvals toward branch-protection required reviews — required reviewers must still be human (or signed by a CODEOWNER user, not the bot). This is the documented behavior.
+- **Repo metadata exposure**: writes to repo via `GITHUB_TOKEN` are bounded to `pull-requests: write`-declared workflows; not a permission expansion of arbitrary write paths.
+- **Audit signal**: every PR open/approve event is logged to repo audit log. Operators can query `gh api repos/.../audit-log` (when on Enterprise) or fall back to PR-history grep for off-pattern actor (`github-actions[bot]`).
+
+### Verification
+
+After the API call, confirm:
+
+1. `gh api /repos/chf3198/megingjord-harness/actions/permissions/workflow` returns `can_approve_pull_request_reviews: true`.
+2. Manually dispatch the `release-please` workflow; confirm a release-please PR is created (currently expected to bump v3.3.7 → v3.4.0 against the [Unreleased] block).
+
+## Alternatives considered
+
+- **Use a Personal Access Token with `repo`+`workflow` scopes** in the release-please workflow. Rejected: PATs require rotation and tie the workflow to a user identity. Repo-setting flip is more durable.
+- **Drop release-please** in favor of manual `gh release create`. Rejected: release-please's CHANGELOG-driven version bump is a load-bearing convention here.
+- **Self-host a separate "release bot" GitHub App**. Rejected: heavyweight for a single-workflow need.
+
+## Out of scope
+
+- Branch-protection ruleset reshape (separate decision; ADR-009 + ADR-010 cover today's posture).
+- Adding `permissions:` blocks to workflows that don't have them (separate sweep).
+
+## Sources
+
+- [GitHub docs — managing GitHub Actions settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests)
+- [release-please-action README](https://github.com/googleapis/release-please-action)
+- ADR-009 (GitHub Feature Adoption) — broader posture this fits within
+
+Refs #840, #830


### PR DESCRIPTION
## Summary

Closes #840. Unblocks `release-please` (silently failing every main push since intro). Repo-level permission flipped via `gh api`; ADR-018 documents the trade-off; `workflow_dispatch:` added to release-please for manual verification.

- `default_workflow_permissions=read` retained (no widening)
- `can_approve_pull_request_reviews=true` (was false)

## Baton artifacts

- MANAGER_HANDOFF: posted on #840
- COLLABORATOR_HANDOFF: posted on #840
- ADMIN_HANDOFF: pending
- CONSULTANT_CLOSEOUT: pending

## Test plan

- [x] `gh api` confirms `can_approve_pull_request_reviews=true`
- [x] Lint, docs-lint, readability, markdownlint all clean
- [ ] CI green
- [ ] Post-merge: release-please opens its first PR

Refs #840, #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)