### PR TITLE
feat(judge-quorum): 2-of-N independence-based judge gate #895

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased] — HAMR Wave 1: judge-quorum.js — 2-of-N independence-based judge gate (#895)
+
+### Added
+- `scripts/global/judge-quorum.js` (89 lines, ESM): 2-of-N family-independent judge quorum gate. Hardcoded Wave 1 family registry (qwen, llama, claude, gemini, mistral) with provenance tags (vendor-attested / unverified). Gate types: `routine` (1 judge), `stage2` (2 different families), `closeout` (2 different families, ≥1 vendor-attested). Agreement threshold 0.10; mean score on agreement; `escalate()` selects a 3rd family on disagreement. `dispatcher` parameter is required injection in Wave 1 — throws on missing dispatcher; Wave 4 wires real cascade-dispatch adapter. No new third-party dependencies; uses only `node:crypto` (none needed beyond ESM built-ins).
+- `tests/judge-quorum.spec.js` (89 lines, Playwright-test): 8 deterministic stub-based tests covering: family registry shape, routine/stage2/closeout gate selection, agreement/disagreement detection, escalation family selection, and missing-dispatcher error. Zero live LLM calls.
+- `wiki/concepts/judge-quorum.md` (61 lines): concept page with frontmatter, three-orthogonal-axes table (cost / locality / provenance), gate-type map from v3.2 §3.2, Wave 1 dispatcher-injection limitation, and cross-references to #890 and #881.
+
+### Notes
+- Lane: code-change (new executable scripts + tests).
+- Independence principle from HAMR v3.2 §3.2 (#890): judge gate cares about provenance axis only, not cloud-vs-local locality. A Tailscale-hosted Ollama model with vendor-attested manifest satisfies the gate at zero token cost.
+- Wave 4 (#TBD) will inject the real cascade-dispatch wrapper as the default dispatcher; Wave 1 ships the quorum logic and registry only.
+- Refs #895, Refs #860.
 ## [Unreleased] — HAMR Wave 1: baton-signing.js — Ed25519 sign/verify + 4-tier key probe (#894, EPIC #860)
 
 ### Added

--- a/scripts/global/judge-quorum.js
+++ b/scripts/global/judge-quorum.js
@@ -1,0 +1,90 @@
+// judge-quorum.js — HAMR Wave 1: 2-of-N family-independent judge gate (#895)
+// Independence-based quorum; dispatcher injected for testability (Wave 4 wires real dispatch).
+'use strict';
+
+/** @type {Record<string, Array<{model: string, provenance: string}>>} */
+const FAMILY_REGISTRY = {
+  qwen:    [{ model: 'qwen-3-235b@cerebras', provenance: 'vendor-attested' },
+            { model: 'qwen2.5-coder:32b@36gbwinresource', provenance: 'unverified' }],
+  llama:   [{ model: 'llama-3.3-70b-versatile@groq', provenance: 'vendor-attested' },
+            { model: 'llama3.3:70b@windows-laptop', provenance: 'unverified' }],
+  claude:  [{ model: 'claude-sonnet-4-6@anthropic', provenance: 'vendor-attested' },
+            { model: 'claude-opus-4-7@anthropic', provenance: 'vendor-attested' }],
+  gemini:  [{ model: 'gemini-2.5-flash@google', provenance: 'vendor-attested' }],
+  mistral: [{ model: 'mistral:latest@penguin-1', provenance: 'unverified' }],
+};
+const ATTESTED = new Set(['vendor-attested', 'source-built', 'hardware-rooted']);
+
+/** Return a shallow copy of the family registry.
+ * @returns {Record<string, Array<{model: string, provenance: string}>>} Registry copy.
+ */
+function judgeFamilies() {
+  return Object.fromEntries(Object.entries(FAMILY_REGISTRY).map(([k, v]) => [k, [...v]]));
+}
+
+/** Default dispatcher — throws to surface missing injection errors.
+ * @param {string} _m - Model.
+ * @param {string} _p - Prompt.
+ * @returns {Promise<never>} Throws.
+ */
+async function defaultDispatcher(_m, _p) {
+  throw new Error('no dispatcher configured — inject options.dispatcher');
+}
+
+function preferAttested(entries) {
+  return entries.find(e => ATTESTED.has(e.provenance)) ?? entries[0];
+}
+
+function selectPair(gateType) {
+  const order = ['qwen', 'llama', 'claude', 'gemini', 'mistral'];
+  const cands = order.map(f => ({ family: f, ...preferAttested(FAMILY_REGISTRY[f]) }));
+  if (gateType !== 'closeout') return [cands[0], cands[1]];
+  const first = cands.find(c => ATTESTED.has(c.provenance)) ?? cands[0];
+  const second = cands.find(c => c.family !== first.family) ?? cands[1];
+  return [first, second];
+}
+
+async function callOne(spec, prompt, dispatch) {
+  const { score } = await dispatch(spec.model, prompt);
+  return { family: spec.family, model: spec.model, score, provenance: spec.provenance };
+}
+
+/** Run the judge quorum gate.
+ * @param {string} prompt - Text to evaluate.
+ * @param {{gateType?: 'routine'|'stage2'|'closeout', dispatcher?: Function, models?: string[]}} options - Options.
+ * @returns {Promise<{score: number, agreement: boolean, judges: object[], disagreement_reason?: string}>} Result.
+ */
+async function judge(prompt, options = {}) {
+  const { gateType = 'routine', dispatcher = defaultDispatcher } = options;
+  if (gateType === 'routine') {
+    const entry = preferAttested(FAMILY_REGISTRY.qwen);
+    const judgeResult = await callOne({ family: 'qwen', ...entry }, prompt, dispatcher);
+    return { score: judgeResult.score, agreement: true, judges: [judgeResult] };
+  }
+  const pair = selectPair(gateType);
+  const results = await Promise.all(pair.map(j => callOne(j, prompt, dispatcher)));
+  const diff = Math.abs(results[0].score - results[1].score);
+  const mean = (results[0].score + results[1].score) / 2;
+  if (diff > 0.10) {
+    return { score: mean, agreement: false, judges: results,
+      disagreement_reason: `score_diff_${diff.toFixed(2)}` };
+  }
+  return { score: mean, agreement: true, judges: results };
+}
+
+/** Escalate disagreement to a 3rd judge from a different family.
+ * @param {string} prompt - Text to evaluate.
+ * @param {object[]} prevJudges - The two disagreeing judge records.
+ * @param {Function} [dispatcher] - Injected dispatch function.
+ * @returns {Promise<{score: number|null, judge?: object, reason?: string}>} Escalation result.
+ */
+async function escalate(prompt, prevJudges, dispatcher = defaultDispatcher) {
+  const used = new Set(prevJudges.map(j => j.family));
+  const third = Object.keys(FAMILY_REGISTRY).find(f => !used.has(f));
+  if (!third) return { score: null, reason: 'no_third_family_available' };
+  const entry = preferAttested(FAMILY_REGISTRY[third]);
+  const judgeResult = await callOne({ family: third, ...entry }, prompt, dispatcher);
+  return { score: judgeResult.score, judge: judgeResult };
+}
+
+module.exports = { judge, judgeFamilies, escalate };

--- a/tests/judge-quorum.spec.js
+++ b/tests/judge-quorum.spec.js
@@ -1,0 +1,88 @@
+// judge-quorum.spec.js — HAMR Wave 1 judge-quorum unit tests (#895)
+// All tests use deterministic stubs — no live LLM calls, no API keys.
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const MOD_PATH = path.join(__dirname, '..', 'scripts', 'global', 'judge-quorum.js');
+const jq = require(MOD_PATH);
+const PROMPT = 'Is this governance artifact correctly formatted?';
+
+// Stub factory: returns dispatcher that yields score per model, defaulting to 0.8
+const stubDispatch = (scoresByModel) => async (model) => ({ score: scoresByModel[model] ?? 0.8 });
+
+// 1. judgeFamilies() returns 5 families
+test('judgeFamilies returns all 5 expected families', () => {
+  const families = jq.judgeFamilies();
+  expect(Object.keys(families)).toHaveLength(5);
+  for (const f of ['qwen', 'llama', 'claude', 'gemini', 'mistral']) {
+    expect(families).toHaveProperty(f);
+    expect(Array.isArray(families[f])).toBe(true);
+  }
+});
+
+// 2. routine gate returns single judge result
+test('judge routine gate returns single judge record', async () => {
+  const dispatch = stubDispatch({ 'qwen-3-235b@cerebras': 0.9 });
+  const result = await jq.judge(PROMPT, { gateType: 'routine', dispatcher: dispatch });
+  expect(result.judges).toHaveLength(1);
+  expect(result.score).toBe(0.9);
+  expect(result.agreement).toBe(true);
+  expect(result.judges[0].family).toBe('qwen');
+});
+
+// 3. stage2 gate selects 2 different families
+test('judge stage2 selects 2 judges from different families', async () => {
+  const dispatch = stubDispatch({});
+  const result = await jq.judge(PROMPT, { gateType: 'stage2', dispatcher: dispatch });
+  expect(result.judges).toHaveLength(2);
+  const families = result.judges.map(j => j.family);
+  expect(families[0]).not.toBe(families[1]);
+});
+
+// 4. closeout gate ensures at least one vendor-attested judge
+test('judge closeout gate includes at least one vendor-attested judge', async () => {
+  const dispatch = stubDispatch({});
+  const result = await jq.judge(PROMPT, { gateType: 'closeout', dispatcher: dispatch });
+  expect(result.judges).toHaveLength(2);
+  const provenances = result.judges.map(j => j.provenance);
+  const hasAttested = provenances.some(p =>
+    ['vendor-attested', 'source-built', 'hardware-rooted'].includes(p));
+  expect(hasAttested).toBe(true);
+});
+
+// 5. agreement: scores within 0.10 threshold
+test('judge agreement true when score diff <= 0.10', async () => {
+  const dispatch = stubDispatch({ 'qwen-3-235b@cerebras': 0.95, 'llama-3.3-70b-versatile@groq': 0.92 });
+  const result = await jq.judge(PROMPT, { gateType: 'stage2', dispatcher: dispatch });
+  expect(result.agreement).toBe(true);
+  expect(result.score).toBeCloseTo(0.935, 5);
+  expect(result.disagreement_reason).toBeUndefined();
+});
+
+// 6. disagreement: scores > 0.10 apart
+test('judge disagreement flagged when score diff > 0.10', async () => {
+  const dispatch = stubDispatch({ 'qwen-3-235b@cerebras': 0.95, 'llama-3.3-70b-versatile@groq': 0.50 });
+  const result = await jq.judge(PROMPT, { gateType: 'stage2', dispatcher: dispatch });
+  expect(result.agreement).toBe(false);
+  expect(typeof result.disagreement_reason).toBe('string');
+  expect(result.disagreement_reason).toMatch(/^score_diff_/);
+});
+
+// 7. escalate selects a 3rd judge from a different family
+test('escalate selects 3rd judge from a family not in prevJudges', async () => {
+  const prevJudges = [
+    { family: 'qwen', model: 'qwen-3-235b@cerebras', score: 0.95, provenance: 'vendor-attested' },
+    { family: 'llama', model: 'llama-3.3-70b-versatile@groq', score: 0.50, provenance: 'vendor-attested' },
+  ];
+  const dispatch = stubDispatch({});
+  const result = await jq.escalate(PROMPT, prevJudges, dispatch);
+  expect(result.score).not.toBeNull();
+  expect(result.judge.family).not.toBe('qwen');
+  expect(result.judge.family).not.toBe('llama');
+});
+
+// 8. missing dispatcher raises a clear error
+test('missing dispatcher raises descriptive error', async () => {
+  await expect(jq.judge(PROMPT, { gateType: 'routine' }))
+    .rejects.toThrow('no dispatcher configured');
+});

--- a/wiki/concepts/judge-quorum.md
+++ b/wiki/concepts/judge-quorum.md
@@ -1,0 +1,61 @@
+---
+title: "Judge Quorum"
+type: concept
+created: 2026-05-04
+updated: 2026-05-04
+tags: [hamr, judge, quorum, provenance]
+sources: ["[[hamr-v3-2-2026-05-04]]"]
+related: ["[[baton-protocol]]", "[[governance-enforcement]]", "[[fleet-architecture]]"]
+status: draft
+---
+
+# Judge Quorum
+
+A governance gate that requires agreement from two or more judges drawn from
+**independent model families** before accepting a high-stakes result. The design
+principle is **independence-by-supply-chain**, not cloud-vs-local locality: a judge
+is valid if it cannot share a compromised model image with the work it is judging.
+
+## Three Orthogonal Axes
+
+The v3.1 design conflated these. v3.2 separates them explicitly:
+
+| Axis | Values |
+|---|---|
+| Cost | free / paid |
+| Locality | local-tailnet / remote-cloud |
+| Provenance | unverified / vendor-attested / source-built / hardware-rooted |
+
+A judge gate cares **only** about the provenance axis. A Tailscale-hosted Ollama
+model with a signed manifest is a valid verified-provenance judge at zero token cost.
+
+## Gate-Type Map (v3.2 §3.2)
+
+| Gate type | Required judges |
+|---|---|
+| Routine routing (no governance impact) | Any 1 fleet model |
+| Bundle integrity verification | SLSA verifier + Cosign (deterministic, no LLM) |
+| Rule-coverage Stage-1 (every build) | Deterministic keyword check, no LLM |
+| Rule-coverage Stage-2 (weekly) | Quorum of 2, different families |
+| `CONSULTANT_CLOSEOUT` validation | Quorum of 2, different families, ≥1 verified-provenance |
+
+## Agreement Protocol
+
+1. Two judges from different families score the artifact (0..1).
+2. `|score_A - score_B| ≤ 0.10` → agreement; return mean score.
+3. `|score_A - score_B| > 0.10` → disagreement; caller may invoke `escalate()`.
+4. `escalate()` selects a 3rd family not used by the two disagreeing judges.
+5. If no 3rd family is available, returns `reason: 'no_third_family_available'`.
+
+## Wave 1 Limitation
+
+`scripts/global/judge-quorum.js` (#895) ships the family registry, gate-type
+selection, and agreement logic. The `dispatcher` parameter is **required injection**
+in Wave 1 — the module throws if no dispatcher is provided. Wave 4 will wire the
+real cascade-dispatch adapter as the default dispatcher.
+
+## Cross-References
+
+- Spec: HAMR v3.2 redesign baseline #890 §3.2 (`research/hamr-v3-2-2026-05-04.md`)
+- Threat context: HAMR Spike S6 #881 — A3-E HIGH (poisoned fleet model) eliminated by R1+R2+R3+quorum
+- Execution: Wave 1 child #895 → Wave 4 wires real dispatch


### PR DESCRIPTION
## Summary

- HAMR Wave 1 foundation module (#895, EPIC #860) implementing v3.2 §3.2 R1 judge-gate redesign (#890): provenance-based independence model, NOT cloud-only.
- `scripts/global/judge-quorum.js`: 5-family registry (qwen, llama, claude, gemini, mistral) with provenance tags; `routine` / `stage2` / `closeout` gate types; agreement threshold 0.10; `escalate()` 3rd-family fallback; required `dispatcher` injection (Wave 4 wires real cascade-dispatch).
- A Tailscale-hosted Ollama model with vendor-attested manifest satisfies the gate at zero token cost.

Refs #895
Refs #860

## Files

- `scripts/global/judge-quorum.js` (90 lines, CommonJS)
- `tests/judge-quorum.spec.js` (88 lines, 8 deterministic stub tests, zero live LLM)
- `wiki/concepts/judge-quorum.md` (61 lines)
- `CHANGELOG.md` `[Unreleased]` entry

## Validation evidence

| Gate | Result |
|---|---|
| `npx playwright test tests/judge-quorum.spec.js` | **8/8 passed** in 1.1 s |
| `npm run lint:js` | 0 errors on changed files |
| `node scripts/lint.js` | 0 violations on changed files |
| `node scripts/lint-readability.js --max-warnings=420` | **PASS** (419 ≤ 420) |
| `npx markdownlint-cli2 wiki/concepts/judge-quorum.md` | 0 errors |

## Crash-recovery note

This implementation **survived a VS Code crash mid-batch** while running inside an isolated agent worktree (`.claude/worktrees/agent-a5e5bb6e2d5b965f4`). Recovery: pre-crash files validated cleanly; ESM `export {}` converted to CJS `module.exports` (project default); spec dynamic `import()` switched to `require()` (matches #894 pattern); readability single-letter `r` vars renamed.

> Note: original PR #899 was created from the wrong cwd (main repo on stale `feat/894-baton-signing` branch). This PR is reopened from the worktree on the correct `feat/895-judge-quorum` branch. Validates an additional crash-recovery learning: always verify `gh pr create` cwd matches the intended branch.

## Copilot Team boundary

No overlap with `dashboard/js/token-reconcile.js`, `scripts/global/token-*.js`, `cost-report.js`, `model-routing-engine.js`.

## Baton trail

- **MANAGER_HANDOFF**: posted on issue #895.
- **COLLABORATOR_HANDOFF**: posted on issue #895.
- **ADMIN_HANDOFF**: pending CI green + merge.
- **CONSULTANT_CLOSEOUT**: pending merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)