### PR TITLE
feat(substrate-health): runtime tier-classification probe #911

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [Unreleased] — HAMR Wave 2 child 2: substrate-health probe (#911, EPIC #860)
+
+### Added
+- `scripts/global/substrate-health.js` (≤100 lines, CommonJS): runtime tier sensor per HAMR v3.2 §R7 + v3.2.1 §R9.3. Probes deployed HAMR core Worker (#910) `/healthz`, fleet hosts, providers, and judge families. Writes `~/.megingjord/substrate-health.json` (operator-local, gitignored). Each individual probe ≤3 s with fail-soft via `Promise.race` + timeout pattern.
+- `scripts/global/capability-probe.js`: extended with `--substrate-health` flag invoking the new probe (REFACTOR per S1 #876 audit, NOT a parallel module).
+- `tests/substrate-health.spec.js`: 8 fixture-based Playwright tests covering tier-derivation rules + worker-unreachable handling + OUT_FILE path invariant. Zero live calls during test.
+- `wiki/concepts/substrate-health.md` (≤100 lines): API reference + tier-derivation rules + JSON schema + R9.3 timeout policy + relationship to capability-probe.js.
+- `package.json` script: `hamr:health` (alphabetically sorted).
+- README scripts table regenerated via `docs:compile`.
+
+### Tier-derivation rules
+
+- `hamr_worker.reachable == false` → `tier3-offline (worker-unreachable)`.
+- `hamr_worker.tier == 'tier3-offline'` → `tier3-offline (worker-self-reported)`.
+- `fleetUp == 0 && providersUp == 0` → `tier3-offline (no-fleet-or-providers)`.
+- 4-component score (worker tier1 + ≥1 fleet + ≥2 providers + ≥2 judge families) all true → `tier1-full`.
+- Otherwise → `tier2-degraded`.
+
+### Notes
+- Lane: code-change (Manager + Collaborator + Admin + Consultant).
+- 8/8 tests pass; readability gate 419 ≤ 420; markdownlint 0 errors.
+- Distinct from #896 `hamr:doctor` (which is the operator-facing CLI surfacing capability + remediation): substrate-health is the **machine-readable runtime state** that HAMR's routing engine reads.
+- Disjoint from Copilot Team active surface.
+
 ## [Unreleased] — HAMR Wave 2 child 6: SLSA-L3 + OIDC + Cosign release pipeline (#912, EPIC #860)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ npm run deploy:both:apply
 | `governance:worktrees` | `node scripts/global/worktree-governance-audit.js --json` |
 | `hamr:deploy` | `bash scripts/global/hamr-deploy.sh` |
 | `hamr:doctor` | `node scripts/global/hamr-doctor.js` |
+| `hamr:health` | `node scripts/global/substrate-health.js` |
 | `hamr:teardown` | `bash scripts/global/hamr-teardown.sh` |
 | `health` | `node scripts/health-check.js` |
 | `help:topic` | `node scripts/help-topic.js` |

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "governance:worktrees": "node scripts/global/worktree-governance-audit.js --json",
     "hamr:deploy": "bash scripts/global/hamr-deploy.sh",
     "hamr:doctor": "node scripts/global/hamr-doctor.js",
+    "hamr:health": "node scripts/global/substrate-health.js",
     "hamr:teardown": "bash scripts/global/hamr-teardown.sh",
     "health": "node scripts/health-check.js",
     "help:topic": "node scripts/help-topic.js",

--- a/scripts/global/capability-probe.js
+++ b/scripts/global/capability-probe.js
@@ -90,9 +90,18 @@ async function probe() {
   return manifest;
 }
 
-if (require.main === module) probe().then(m => {
-  if (process.argv.includes('--json')) process.stdout.write(JSON.stringify(m, null, 2) + '\n');
-  else process.stdout.write(`✅ probed ${Object.keys(m.providers).length} providers, ${Object.keys(m.fleet).length} fleet hosts\n`);
-});
+if (require.main === module) {
+  if (process.argv.includes('--substrate-health')) {
+    require('./substrate-health').writeSubstrateHealth().then((r) => {
+      if (process.argv.includes('--json')) process.stdout.write(JSON.stringify(r, null, 2) + '\n');
+      else process.stdout.write(`✅ substrate-health: ${r.tier} (${r.reason})\n`);
+    }).catch((e) => { process.stderr.write(e.message + '\n'); process.exit(1); });
+  } else {
+    probe().then(m => {
+      if (process.argv.includes('--json')) process.stdout.write(JSON.stringify(m, null, 2) + '\n');
+      else process.stdout.write(`✅ probed ${Object.keys(m.providers).length} providers, ${Object.keys(m.fleet).length} fleet hosts\n`);
+    });
+  }
+}
 
 module.exports = { probe, probeProvider, probeFleet, probeTailscale, PROVIDER_PROBES, ...hamr };

--- a/scripts/global/substrate-health.js
+++ b/scripts/global/substrate-health.js
@@ -1,0 +1,91 @@
+// HAMR Wave 2 child 2: substrate-health probe (#911) — runtime tier sensor.
+// Per HAMR v3.2 §R7 + v3.2.1 §R9.3. Writes ~/.megingjord/substrate-health.json.
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const PROBE_TIMEOUT_MS = 3000;
+const HAMR_WORKER_URL = process.env.HAMR_WORKER_URL || 'https://hamr.chf3198.workers.dev';
+const OUT_FILE = path.join(os.homedir(), '.megingjord', 'substrate-health.json');
+
+async function withTimeout(label, fn, ms = PROBE_TIMEOUT_MS) {
+  try {
+    return await Promise.race([
+      fn(),
+      new Promise((_, rj) => setTimeout(() => rj(new Error(`${label}_timeout`)), ms)),
+    ]);
+  } catch (e) {
+    return { __error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+async function probeHamrWorker(workerUrl = HAMR_WORKER_URL) {
+  const result = await withTimeout('hamr_worker', async () => {
+    const t0 = Date.now();
+    const resp = await fetch(`${workerUrl}/healthz`);
+    const elapsed_ms = Date.now() - t0;
+    if (!resp.ok) return { reachable: false, http_status: resp.status, elapsed_ms };
+    const body = await resp.json();
+    return {
+      reachable: true,
+      http_status: resp.status,
+      elapsed_ms,
+      tier: body.tier,
+      reason: body.reason,
+    };
+  });
+  if (result.__error) return { reachable: false, reason: result.__error };
+  return result;
+}
+
+function deriveTier(probe) {
+  if (!probe.hamr_worker.reachable) return { tier: 'tier3-offline', reason: 'hamr-worker-unreachable' };
+  if (probe.hamr_worker.tier === 'tier3-offline') return { tier: 'tier3-offline', reason: 'worker-self-reported-offline' };
+  const fleetUp = Object.values(probe.fleet || {}).filter((f) => f && f.reachable).length;
+  const providersUp = Object.values(probe.providers || {}).filter((p) => p && p.available).length;
+  const judgesUp = Object.values(probe.judges || {}).filter((j) => j && j.available).length;
+  if (fleetUp === 0 && providersUp === 0) return { tier: 'tier3-offline', reason: 'no-fleet-or-providers' };
+  const fullCount = (probe.hamr_worker.tier === 'tier1-full' ? 1 : 0) + (fleetUp >= 1 ? 1 : 0) + (providersUp >= 2 ? 1 : 0) + (judgesUp >= 2 ? 1 : 0);
+  if (fullCount === 4) return { tier: 'tier1-full', reason: 'all-substrates-healthy' };
+  return { tier: 'tier2-degraded', reason: `partial fleet=${fleetUp} providers=${providersUp} judges=${judgesUp} worker=${probe.hamr_worker.tier}` };
+}
+
+function readCapabilities() {
+  const capPath = path.join(process.cwd(), '.dashboard', 'capabilities.json');
+  if (!fs.existsSync(capPath)) return null;
+  try { return JSON.parse(fs.readFileSync(capPath, 'utf8')); } catch { return null; }
+}
+
+async function probeSubstrateHealth(opts = {}) {
+  const caps = opts.capabilities ?? readCapabilities();
+  const probe = {
+    schema_version: 1,
+    ts: Date.now(),
+    hamr_worker: await probeHamrWorker(opts.workerUrl),
+    fleet: caps?.fleet ?? {},
+    providers: caps?.providers ?? {},
+    judges: { qwen: { available: !!caps?.providers?.cerebras?.available, provenance: 'vendor-attested' },
+              llama: { available: !!caps?.providers?.groq?.available, provenance: 'vendor-attested' },
+              claude: { available: !!caps?.providers?.anthropic?.available, provenance: 'vendor-attested' },
+              gemini: { available: !!caps?.providers?.google_ai_studio?.available, provenance: 'vendor-attested' } },
+  };
+  const { tier, reason } = deriveTier(probe);
+  return { ...probe, tier, reason };
+}
+
+async function writeSubstrateHealth(opts = {}) {
+  const result = await probeSubstrateHealth(opts);
+  fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true });
+  fs.writeFileSync(OUT_FILE, JSON.stringify(result, null, 2));
+  return result;
+}
+
+if (require.main === module) {
+  writeSubstrateHealth().then((r) => {
+    if (process.argv.includes('--json')) console.log(JSON.stringify(r, null, 2));
+    else console.log(`✅ substrate-health: ${r.tier} (${r.reason}) → ${OUT_FILE}`);
+  }).catch((e) => { console.error(e.message); process.exit(1); });
+}
+
+module.exports = { probeSubstrateHealth, writeSubstrateHealth, probeHamrWorker, deriveTier, OUT_FILE };

--- a/tests/substrate-health.spec.js
+++ b/tests/substrate-health.spec.js
@@ -1,0 +1,83 @@
+// substrate-health probe tests (#911) — fixture-based, no live calls.
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+
+const SH = require(path.resolve(__dirname, '..', 'scripts', 'global', 'substrate-health.js'));
+
+const TIER1_CAPS = {
+  fleet: { 'windows-laptop': { reachable: true, models: ['x'] }, 'penguin-1': { reachable: true } },
+  providers: { anthropic: { available: true }, cerebras: { available: true }, groq: { available: true }, openai: { available: true } },
+};
+const TIER2_CAPS = {
+  fleet: { 'windows-laptop': { reachable: true } },
+  providers: { anthropic: { available: true } },
+};
+const TIER3_CAPS = { fleet: {}, providers: {} };
+
+test('deriveTier returns tier1-full when all substrates healthy', () => {
+  const probe = {
+    hamr_worker: { reachable: true, tier: 'tier1-full' },
+    fleet: TIER1_CAPS.fleet,
+    providers: TIER1_CAPS.providers,
+    judges: { qwen: { available: true }, llama: { available: true }, claude: { available: true } },
+  };
+  expect(SH.deriveTier(probe).tier).toBe('tier1-full');
+});
+
+test('deriveTier returns tier2-degraded with partial substrates', () => {
+  const probe = {
+    hamr_worker: { reachable: true, tier: 'tier2-degraded' },
+    fleet: TIER2_CAPS.fleet,
+    providers: TIER2_CAPS.providers,
+    judges: { qwen: { available: true } },
+  };
+  const r = SH.deriveTier(probe);
+  expect(r.tier).toBe('tier2-degraded');
+  expect(r.reason).toContain('partial');
+});
+
+test('deriveTier returns tier3-offline when worker unreachable', () => {
+  const probe = {
+    hamr_worker: { reachable: false, reason: 'connection_refused' },
+    fleet: {}, providers: {}, judges: {},
+  };
+  const r = SH.deriveTier(probe);
+  expect(r.tier).toBe('tier3-offline');
+  expect(r.reason).toBe('hamr-worker-unreachable');
+});
+
+test('deriveTier returns tier3-offline when worker self-reports offline', () => {
+  const probe = {
+    hamr_worker: { reachable: true, tier: 'tier3-offline' },
+    fleet: { x: { reachable: true } }, providers: { y: { available: true } }, judges: {},
+  };
+  const r = SH.deriveTier(probe);
+  expect(r.tier).toBe('tier3-offline');
+  expect(r.reason).toBe('worker-self-reported-offline');
+});
+
+test('deriveTier returns tier3-offline with no fleet or providers (worker tier2)', () => {
+  const probe = {
+    hamr_worker: { reachable: true, tier: 'tier2-degraded' },
+    fleet: {}, providers: {}, judges: {},
+  };
+  expect(SH.deriveTier(probe).tier).toBe('tier3-offline');
+});
+
+test('probeSubstrateHealth handles missing capabilities snapshot', async () => {
+  // Pass an empty capabilities object to bypass disk read; stub worker probe via env.
+  const result = await SH.probeSubstrateHealth({ capabilities: { fleet: {}, providers: {} }, workerUrl: 'http://127.0.0.1:1' });
+  expect(result.tier).toBe('tier3-offline');
+  expect(result.hamr_worker.reachable).toBe(false);
+});
+
+test('probeHamrWorker returns reachable:false on bad URL', async () => {
+  const r = await SH.probeHamrWorker('http://127.0.0.1:1');
+  expect(r.reachable).toBe(false);
+});
+
+test('OUT_FILE is under operator home (~/.megingjord/)', () => {
+  expect(SH.OUT_FILE).toMatch(/\.megingjord[\/\\]substrate-health\.json$/);
+  expect(SH.OUT_FILE.startsWith(require('os').homedir())).toBe(true);
+});

--- a/wiki/concepts/substrate-health.md
+++ b/wiki/concepts/substrate-health.md
@@ -1,0 +1,93 @@
+---
+title: HAMR Substrate-Health Probe
+type: concept
+created: 2026-05-05
+updated: 2026-05-05
+tags: [hamr, wave2, substrate-health, tier-classification, probe]
+related: ["[[hamr-v3-2-2026-05-04]]", "[[hamr-v3-2-1-2026-05-05]]", "[[hamr-doctor]]", "[[hamr-core-worker]]", "[[capability-detection]]"]
+status: draft
+---
+
+# HAMR Substrate-Health Probe
+
+## Purpose
+
+Runtime sensor that classifies HAMR's current operational tier
+(tier1-full / tier2-degraded / tier3-offline) per v3.2 §R7 +
+v3.2.1 §R9.3. Distinct from #896 `hamr:doctor` (which is the
+operator-facing CLI surfacing capability + remediation):
+substrate-health is the **machine-readable runtime state** that
+HAMR's routing engine reads to make per-call decisions.
+
+Output: `~/.megingjord/substrate-health.json` (operator-local;
+gitignored).
+
+## API
+
+`scripts/global/substrate-health.js` (CommonJS):
+
+| Function | Purpose |
+|---|---|
+| `probeSubstrateHealth(opts?)` | Build the probe object (no disk write). |
+| `writeSubstrateHealth(opts?)` | Probe + write `~/.megingjord/substrate-health.json`. |
+| `probeHamrWorker(workerUrl?)` | Probe the deployed HAMR core Worker `/healthz`. |
+| `deriveTier(probe)` | Classify tier from probe object. |
+
+CLI (extends #877 capability-probe.js): `npm run hamr:health` →
+`node scripts/global/substrate-health.js [--json]`. Or
+`node scripts/global/capability-probe.js --substrate-health`.
+
+## Tier-derivation rules
+
+```
+hamr_worker.reachable == false               → tier3-offline (worker-unreachable)
+hamr_worker.tier == 'tier3-offline'          → tier3-offline (worker-self-reported)
+fleetUp == 0 && providersUp == 0             → tier3-offline (no-fleet-or-providers)
+fullCount(worker tier1 + fleet ≥1 + providers ≥2 + judges ≥2) == 4
+                                              → tier1-full
+otherwise                                    → tier2-degraded
+```
+
+`fullCount` is a 4-component score: HAMR Worker self-reports
+tier1-full, ≥1 fleet host reachable, ≥2 providers available, ≥2
+judge families available. All four must be true for tier1-full.
+
+## Schema
+
+```json
+{
+  "schema_version": 1,
+  "ts": <unix-ms>,
+  "tier": "tier1-full" | "tier2-degraded" | "tier3-offline",
+  "reason": "<human-readable>",
+  "hamr_worker": { "reachable": bool, "tier"?: string, "elapsed_ms"?: number },
+  "fleet": { "<host>": { "reachable": bool, "models"?: [...] } },
+  "providers": { "<name>": { "available": bool } },
+  "judges": { "qwen": { "available": bool, "provenance": string }, "llama": ..., "claude": ..., "gemini": ... }
+}
+```
+
+## R9.3 timeout policy
+
+Each individual probe times out at 3 s with fail-soft (wraps a
+`Promise.race` against a deadline). Total probe runtime is
+≤10 s under all conditions. Family-fallback is delegated to
+`judge-quorum.js` (#895) for actual judge calls — substrate-
+health only checks reachability based on the capability-probe
+provider availability flags.
+
+## Extends `capability-probe.js`
+
+Per S1 #876 audit, this is a REFACTOR-extending of the existing
+capability-probe.js, NOT a new parallel module. The new
+`--substrate-health` flag invokes `substrate-health.js`'s
+`writeSubstrateHealth()`. The existing capability-probe.js
+behavior is unchanged when invoked without the flag.
+
+## References
+
+- HAMR v3.2 §R7: `research/hamr-v3-2-2026-05-04.md` (#890).
+- v3.2.1 §R9.3: `research/hamr-v3-2-1-2026-05-05.md` (#907).
+- HAMR core Worker `/healthz` (#910): `cloudflare/hamr/routes/healthz.ts`.
+- Capability probe: `scripts/global/capability-probe.js` (#877).
+- Implementation: this PR (#911).


### PR DESCRIPTION
## Summary

HAMR Wave 2 child 2 per v3.2 §R7 + v3.2.1 §R9.3. Machine-readable runtime tier sensor that classifies HAMR substrate as `tier1-full` / `tier2-degraded` / `tier3-offline`.

Refs #911
Refs #860

## What it does

Probes:
1. Deployed HAMR core Worker (#910) `/healthz` endpoint (3 s timeout).
2. Fleet hosts (reuses capability-probe.js #877 fleet snapshot).
3. Providers (reuses capability-probe.js provider snapshot).
4. Judge families (derived from provider availability + provenance tags).

Writes `~/.megingjord/substrate-health.json` (operator-local, gitignored).

## Tier-derivation rules

| Condition | Tier |
|---|---|
| `hamr_worker.reachable == false` | `tier3-offline (worker-unreachable)` |
| `hamr_worker.tier == 'tier3-offline'` | `tier3-offline (worker-self-reported)` |
| `fleetUp == 0 && providersUp == 0` | `tier3-offline (no-fleet-or-providers)` |
| 4-component score (worker tier1 + ≥1 fleet + ≥2 providers + ≥2 judges) all true | `tier1-full` |
| Otherwise | `tier2-degraded` |

## Architecture

- **REFACTOR-extension of `capability-probe.js`** per S1 #876 audit (NOT a parallel module). New `--substrate-health` flag invokes `substrate-health.js`'s `writeSubstrateHealth()`. Existing capability-probe behavior unchanged when invoked without the flag.
- **Distinct from `hamr:doctor` (#896)**: substrate-health is the **machine-readable runtime state** that HAMR's routing engine reads at runtime; hamr:doctor is the operator-facing CLI.
- **R9.3 timeout policy**: each probe ≤3 s with fail-soft via `Promise.race`; total ≤10 s.
- **Family-fallback** delegated to `judge-quorum.js` (#895) for actual judge calls.

## Validation

- `npx playwright test tests/substrate-health.spec.js`: **8/8 passed** in 1.2 s
- `node scripts/lint-readability.js --max-warnings=420`: **PASS** (419 ≤ 420)
- `npx markdownlint-cli2 wiki/concepts/substrate-health.md CHANGELOG.md`: 0 errors
- File sizes: substrate-health.js 91, spec 83, wiki page 93 — all under 100-line policy

## Files

- `scripts/global/substrate-health.js` (91 lines, CommonJS, new)
- `scripts/global/capability-probe.js` (107 lines, REFACTOR-extended; scripts/global exempt via IGNORE_PATHS)
- `tests/substrate-health.spec.js` (83 lines, 8 fixture-based tests)
- `wiki/concepts/substrate-health.md` (93 lines)
- `package.json` script: `hamr:health`
- `README.md` scripts table regenerated
- `CHANGELOG.md` entry

## Baton trail

- **MANAGER_HANDOFF**: posted on issue #911.
- **COLLABORATOR_HANDOFF**: posted on issue #911.
- **ADMIN_HANDOFF**: pending CI green + merge.
- **CONSULTANT_CLOSEOUT**: pending merge.

## Copilot Team boundary

No overlap with `dashboard/js/token-reconcile.js`, `scripts/global/token-*.js`, `cost-report.js`, `model-routing-engine.js`, or `instructions/role-baton-routing.instructions.md` (Copilot's #909 v2.0 redesign already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)