### PR TITLE
feat(hamr): /cache-stats KV writer + push client #933

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased] — HAMR Wave 5 child 2: Worker /cache-stats KV writer + push client (#933, EPIC #860)
+
+### Added
+- `cloudflare/hamr/routes/cache-stats.ts` (≤100 lines): NEW Worker endpoint. POST with Ed25519 DPoP auth (re-uses #927 verification pattern); validates `hit_rate ∈ [0,1]` and timestamp freshness (≤24h); writes `cache-stats:hit-rate-7d` to KV (consumed by `/quota` #927).
+- `cloudflare/hamr/worker.ts`: routes `POST /cache-stats` to new handler.
+- `scripts/global/cache-stats-push.js` (≤100 lines): local push client. Reads operator Ed25519 key from `OPERATOR_KEY_SEED_B64` env or `~/.megingjord/keys/operator-ed25519.pem` PEM file (re-uses #894 4-tier key store). Computes hit-rate from `cache-hit-gate.runGate()`, signs canonical JSON, POSTs to HAMR `/cache-stats`.
+- `tests/cache-stats-push.spec.js`: 5 tests (3 unit + 2 live route smoke).
+- `package.json` script: `hamr:cache-push`.
+
+### Notes
+- Lane: code-change.
+- Worker redeployed (version `d694c47f-343e-4cc8-812f-c7de22d16de9`).
+- Live-verified `/cache-stats` returns 401 `missing_dpop` and 401 `missing_signature_headers` correctly.
+- Closes the producer gap on `/quota.hit_rate_7d`; consumer flow already shipped in Wave 4 #927.
+
 ## [Unreleased] — HAMR Wave 5 child 1: cache-stats.jsonl emit-site wiring (#932, EPIC #860)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ npm run deploy:both:apply
 | `hamr:batch-router` | `node scripts/global/anthropic-batch-router.js` |
 | `hamr:cache-emit` | `node scripts/global/cache-stats-emit.js` |
 | `hamr:cache-gate` | `node scripts/global/cache-hit-gate.js` |
+| `hamr:cache-push` | `node scripts/global/cache-stats-push.js` |
 | `hamr:compress` | `node scripts/global/constitution-compressor.js` |
 | `hamr:deploy` | `bash scripts/global/hamr-deploy.sh` |
 | `hamr:doctor` | `node scripts/global/hamr-doctor.js` |

--- a/cloudflare/hamr/routes/cache-stats.ts
+++ b/cloudflare/hamr/routes/cache-stats.ts
@@ -1,0 +1,67 @@
+// HAMR /cache-stats — Worker-side KV writer for cache-stats:hit-rate-7d (#933).
+// Closes the producer gap on /quota's hit_rate_7d signal.
+// Operator pushes signed payload from `cache-stats-push.js`; we Ed25519-verify, then KV-write.
+import type { Env } from '../worker';
+
+const HIT_RATE_KEY = 'cache-stats:hit-rate-7d';
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+function unauthorized(reason: string): Response {
+  return new Response(JSON.stringify({ error: 'unauthorized', reason }), {
+    status: 401, headers: { 'content-type': 'application/json' },
+  });
+}
+
+function badRequest(reason: string): Response {
+  return new Response(JSON.stringify({ error: 'bad_request', reason }), {
+    status: 400, headers: { 'content-type': 'application/json' },
+  });
+}
+
+function decodeKeyring(env: Env): Record<string, string> | null {
+  if (!env.PUBLISHER_KEYRING) return null;
+  try { return JSON.parse(env.PUBLISHER_KEYRING) as Record<string, string>; } catch { return null; }
+}
+
+async function verifyEd25519(spkiB64: string, canonical: string, sigB64: string): Promise<boolean> {
+  try {
+    const spki = Uint8Array.from(atob(spkiB64), (c) => c.charCodeAt(0));
+    const data = new TextEncoder().encode(canonical);
+    const sig = Uint8Array.from(atob(sigB64), (c) => c.charCodeAt(0));
+    const key = await crypto.subtle.importKey('spki', spki, { name: 'Ed25519' }, false, ['verify']);
+    return await crypto.subtle.verify('Ed25519', key, sig, data);
+  } catch { return false; }
+}
+
+export async function cacheStats(request: Request, env: Env): Promise<Response> {
+  const auth = request.headers.get('authorization') ?? '';
+  if (!auth.startsWith('DPoP ')) return unauthorized('missing_dpop');
+  const sigHeader = request.headers.get('x-hamr-signature') ?? '';
+  const keyId = request.headers.get('x-hamr-key-id') ?? '';
+  const canonical = request.headers.get('x-hamr-canonical') ?? '';
+  if (!sigHeader || !keyId || !canonical) return unauthorized('missing_signature_headers');
+
+  const keyring = decodeKeyring(env);
+  if (!keyring) return unauthorized('no_publisher_keyring_configured');
+  const spkiB64 = keyring[keyId];
+  if (!spkiB64) return unauthorized('unknown_key_id');
+  if (!await verifyEd25519(spkiB64, canonical, sigHeader)) return unauthorized('bad_signature');
+
+  let payload: { hit_rate?: number; sample_count?: number; ts?: number };
+  try { payload = await request.json(); } catch { return badRequest('invalid_json'); }
+  if (typeof payload.hit_rate !== 'number' || payload.hit_rate < 0 || payload.hit_rate > 1) {
+    return badRequest('hit_rate_out_of_range');
+  }
+  const age = Date.now() - (payload.ts ?? 0);
+  if (payload.ts && age > MAX_AGE_MS) return badRequest('payload_too_old');
+
+  const record = JSON.stringify({
+    hit_rate: payload.hit_rate, sample_count: payload.sample_count ?? 0,
+    ts: payload.ts ?? Date.now(), key_id: keyId,
+  });
+  await env.HAMR_KV.put(HIT_RATE_KEY, String(payload.hit_rate));
+  await env.HAMR_KV.put(`${HIT_RATE_KEY}:meta`, record);
+  return new Response(JSON.stringify({ ok: true, written: HIT_RATE_KEY, hit_rate: payload.hit_rate }), {
+    status: 200, headers: { 'content-type': 'application/json' },
+  });
+}

--- a/cloudflare/hamr/worker.ts
+++ b/cloudflare/hamr/worker.ts
@@ -6,6 +6,7 @@ import { bundle } from './routes/bundle';
 import { mcp } from './routes/mcp';
 import { mailboxRead, mailboxWrite } from './routes/mailbox';
 import { quota } from './routes/quota';
+import { cacheStats } from './routes/cache-stats';
 
 export interface Env {
   HAMR_KV: KVNamespace;
@@ -45,6 +46,7 @@ export default {
       else if (url.pathname === '/mailbox/read' && m === 'GET') res = await mailboxRead(request, env);
       else if (url.pathname === '/mailbox/write' && m === 'POST') res = await mailboxWrite(request, env);
       else if (url.pathname === '/quota' && m === 'GET') res = await quota(env);
+      else if (url.pathname === '/cache-stats' && m === 'POST') res = await cacheStats(request, env);
       else res = notFound();
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'internal_error';

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "hamr:batch-router": "node scripts/global/anthropic-batch-router.js",
     "hamr:cache-emit": "node scripts/global/cache-stats-emit.js",
     "hamr:cache-gate": "node scripts/global/cache-hit-gate.js",
+    "hamr:cache-push": "node scripts/global/cache-stats-push.js",
     "hamr:compress": "node scripts/global/constitution-compressor.js",
     "hamr:deploy": "bash scripts/global/hamr-deploy.sh",
     "hamr:doctor": "node scripts/global/hamr-doctor.js",

--- a/scripts/global/cache-stats-push.js
+++ b/scripts/global/cache-stats-push.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// cache-stats-push.js — HAMR Wave 5 child 2 (#933).
+// Computes rolling 7d hit-rate locally and POSTs Ed25519-signed payload to HAMR /cache-stats.
+'use strict';
+require('dotenv').config({ quiet: true });
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const { runGate } = require('./cache-hit-gate');
+
+const DEFAULT_HAMR_URL = process.env.HAMR_URL || 'https://hamr.chf3198.workers.dev';
+const KEY_ID = process.env.OPERATOR_KEY_ID || 'operator-default';
+const KEY_FILE = path.join(os.homedir(), '.megingjord', 'keys', 'operator-ed25519.pem');
+
+function loadEd25519Key() {
+  const seedB64 = process.env.OPERATOR_KEY_SEED_B64;
+  if (seedB64) {
+    const seed = Buffer.from(seedB64, 'base64');
+    if (seed.length !== 32) throw new Error('OPERATOR_KEY_SEED_B64 must decode to 32 bytes');
+    const der = Buffer.concat([Buffer.from('302e020100300506032b657004220420', 'hex'), seed]);
+    return crypto.createPrivateKey({ key: der, format: 'der', type: 'pkcs8' });
+  }
+  if (fs.existsSync(KEY_FILE)) return crypto.createPrivateKey(fs.readFileSync(KEY_FILE));
+  throw new Error('no operator Ed25519 key available (set OPERATOR_KEY_SEED_B64 or place key at ~/.megingjord/keys/operator-ed25519.pem)');
+}
+
+function canonicalize(payload) {
+  return JSON.stringify(payload, Object.keys(payload).sort());
+}
+
+async function pushHitRate(opts = {}) {
+  const url = opts.url || DEFAULT_HAMR_URL;
+  const gate = runGate({ floor: 0 });
+  if (gate.hit_rate === null) return { ok: false, reason: 'no_samples_in_window' };
+  const payload = { hit_rate: gate.hit_rate, sample_count: gate.sample_count, ts: Date.now() };
+  const canonical = canonicalize(payload);
+  const key = loadEd25519Key();
+  const sig = crypto.sign(null, Buffer.from(canonical), key).toString('base64');
+  const resp = await fetch(`${url}/cache-stats`, {
+    method: 'POST',
+    headers: {
+      'authorization': 'DPoP cache-stats-push', 'content-type': 'application/json',
+      'x-hamr-key-id': KEY_ID, 'x-hamr-signature': sig, 'x-hamr-canonical': canonical,
+    },
+    body: canonical,
+  });
+  const data = await resp.json().catch(() => ({}));
+  return { ok: resp.ok, status: resp.status, payload, response: data };
+}
+
+if (require.main === module) {
+  pushHitRate().then((result) => {
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(result.ok ? 0 : 1);
+  }).catch((err) => { console.error(err.message); process.exit(1); });
+}
+
+module.exports = { pushHitRate, canonicalize, loadEd25519Key };

--- a/tests/cache-stats-push.spec.js
+++ b/tests/cache-stats-push.spec.js
@@ -1,0 +1,55 @@
+// cache-stats-push tests (#933).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const PUSH = require(path.resolve(__dirname, '..', 'scripts', 'global', 'cache-stats-push.js'));
+
+test('canonicalize sorts keys deterministically', () => {
+  const a = PUSH.canonicalize({ hit_rate: 0.85, sample_count: 10, ts: 1000 });
+  const b = PUSH.canonicalize({ ts: 1000, hit_rate: 0.85, sample_count: 10 });
+  expect(a).toBe(b);
+  expect(a).toBe('{"hit_rate":0.85,"sample_count":10,"ts":1000}');
+});
+
+test('loadEd25519Key reads OPERATOR_KEY_SEED_B64 when set', () => {
+  const seed = Buffer.alloc(32, 7).toString('base64');
+  const orig = process.env.OPERATOR_KEY_SEED_B64;
+  process.env.OPERATOR_KEY_SEED_B64 = seed;
+  try {
+    const key = PUSH.loadEd25519Key();
+    expect(key.asymmetricKeyType).toBe('ed25519');
+  } finally {
+    if (orig === undefined) delete process.env.OPERATOR_KEY_SEED_B64;
+    else process.env.OPERATOR_KEY_SEED_B64 = orig;
+  }
+});
+
+test('loadEd25519Key throws on bad seed length', () => {
+  const orig = process.env.OPERATOR_KEY_SEED_B64;
+  process.env.OPERATOR_KEY_SEED_B64 = Buffer.alloc(16).toString('base64');
+  try {
+    expect(() => PUSH.loadEd25519Key()).toThrow(/32 bytes/);
+  } finally {
+    if (orig === undefined) delete process.env.OPERATOR_KEY_SEED_B64;
+    else process.env.OPERATOR_KEY_SEED_B64 = orig;
+  }
+});
+
+test.describe('live /cache-stats route (post-#933 deploy)', () => {
+  const BASE = 'https://hamr.chf3198.workers.dev';
+
+  test('/cache-stats returns 401 missing_dpop without auth', async ({ request }) => {
+    const r = await request.post(`${BASE}/cache-stats`, { data: {} });
+    expect(r.status()).toBe(401);
+  });
+
+  test('/cache-stats returns 401 missing_signature_headers when only DPoP present', async ({ request }) => {
+    const r = await request.post(`${BASE}/cache-stats`, {
+      data: { hit_rate: 0.9, ts: Date.now() },
+      headers: { authorization: 'DPoP test' },
+    });
+    expect(r.status()).toBe(401);
+    const body = await r.json();
+    expect(body.reason).toBe('missing_signature_headers');
+  });
+});


### PR DESCRIPTION
## Summary

Wave 5 child 2 of HAMR Epic #860 — closes the producer gap on `/quota.hit_rate_7d`.

- `cloudflare/hamr/routes/cache-stats.ts` (NEW, ≤100 lines) — Worker endpoint with Ed25519 DPoP auth + freshness check + KV write.
- `cloudflare/hamr/worker.ts` — `POST /cache-stats` route.
- `scripts/global/cache-stats-push.js` (NEW, ≤100 lines) — local push client; signs canonical JSON; reads operator key from env or PEM file.

## Validation evidence

5/5 tests pass (3 unit + 2 live route smoke). Worker redeployed (`d694c47f-343e-4cc8-812f-c7de22d16de9`); live-verified 401 paths.

## Hand-offs

- COLLABORATOR_HANDOFF on #933 at https://github.com/chf3198/megingjord-harness/issues/933#issuecomment-4382159425 (>60s before this PR per evidence-completeness rule).
- ADMIN_HANDOFF + CONSULTANT_CLOSEOUT also posted on #933.

Refs #933
Refs Epic #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)