### PR TITLE
feat(hamr): R9.2 cwd-vs-branch hook automation #934

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased] — HAMR Wave 5 child 3: R9.2 cwd-vs-branch hook automation (#934, EPIC #860)
+
+### Added
+- `scripts/hooks/pre-push-branch-check.sh` (≤100 lines): v3.2.2 §R9.2.1 enforcement. Reads stdin from git's pre-push hook; exits non-zero with diagnostic when local branch ≠ HEAD; appends every push attempt to `~/.megingjord/branch-ops-audit.log`.
+- `scripts/hooks/branch-ops-audit.sh` (≤100 lines): v3.2.2 §R9.2.3 audit log. Multi-purpose handler for `post-checkout` (only branch checkouts, skips file-only) and `post-commit`. Each event appends a JSON-line record with `{ts, op, cwd, head, head_sha, prev, new}`.
+- `scripts/global/install-hooks.sh` (≤100 lines): idempotent installer. Symlinks `pre-push` to the branch-check; writes wrapper scripts for `post-checkout` and `post-commit` that invoke `branch-ops-audit.sh`. Detects + chains existing pre-push hooks (e.g., readability gate) without overwriting.
+- `tests/r92-hooks.spec.js`: 6 tests covering executability, branch-match pass, branch-mismatch fail, audit-log JSON-line emission for post-checkout (branch op), audit-log skip for post-checkout (file op), audit-log emission for post-commit.
+- `package.json` script: `hooks:install`.
+
+### Notes
+- Lane: code-change.
+- Closes the empirically-recurring cwd-vs-branch hazard (4 occurrences across HAMR Waves 1-4).
+- Hooks are opt-in via `npm run hooks:install`; existing pre-push readability gate is preserved via chain-append.
+
 ## [Unreleased] — HAMR Wave 5 child 2: Worker /cache-stats KV writer + push client (#933, EPIC #860)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ npm run deploy:both:apply
 | `hamr:teardown` | `bash scripts/global/hamr-teardown.sh` |
 | `health` | `node scripts/health-check.js` |
 | `help:topic` | `node scripts/help-topic.js` |
+| `hooks:install` | `bash scripts/global/install-hooks.sh` |
 | `issue:transition` | `node scripts/global/issue-transition.js` |
 | `lint` | `node scripts/lint.js` |
 | `lint:all` | `npm run lint:js && npm run lint:py && npm run lint:sh && npm run lint:md` |

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "hamr:compress": "node scripts/global/constitution-compressor.js",
     "hamr:deploy": "bash scripts/global/hamr-deploy.sh",
     "hamr:doctor": "node scripts/global/hamr-doctor.js",
+    "hooks:install": "bash scripts/global/install-hooks.sh",
     "hamr:health": "node scripts/global/substrate-health.js",
     "hamr:rule-gate": "node scripts/global/rule-coverage-gate.js",
     "hamr:spillover": "node scripts/global/header-spillover.js",

--- a/scripts/global/install-hooks.sh
+++ b/scripts/global/install-hooks.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# install-hooks.sh — HAMR Wave 5 child 3 (#934).
+# Idempotent installer for the v3.2.2 §R9.2 git hook bundle.
+# Symlinks scripts/hooks/* into .git/hooks/* so the repo's R9.2 enforcement is active.
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+hooks_src="$repo_root/scripts/hooks"
+hooks_dst="$repo_root/.git/hooks"
+mkdir -p "$hooks_dst"
+
+install_hook() {
+  local name=$1
+  local target=$2
+  local src="$hooks_src/$target"
+  local dst="$hooks_dst/$name"
+  if [ ! -f "$src" ]; then
+    echo "❌ missing source hook: $src"
+    return 1
+  fi
+  chmod +x "$src"
+  # If dst exists and is the existing readability hook, chain by appending invocation.
+  if [ -f "$dst" ] && [ ! -L "$dst" ]; then
+    if grep -q "$target" "$dst" 2>/dev/null; then
+      echo "✅ $name already chains $target"
+      return 0
+    fi
+    echo "" >> "$dst"
+    echo "# Appended by install-hooks.sh (#934) — R9.2 enforcement" >> "$dst"
+    echo "\"$src\" \"\$@\"" >> "$dst"
+    echo "✅ $name extended with $target"
+    return 0
+  fi
+  ln -sf "$src" "$dst"
+  echo "✅ symlinked $name → $target"
+}
+
+install_hook pre-push pre-push-branch-check.sh
+# branch-ops-audit.sh is multi-purpose; chain it under both event names.
+install_hook_audit() {
+  local name=$1
+  local dst="$hooks_dst/$name"
+  if [ -f "$dst" ] && grep -q branch-ops-audit "$dst" 2>/dev/null; then
+    echo "✅ $name already chains branch-ops-audit.sh"
+    return 0
+  fi
+  cat > "$dst" <<EOF
+#!/usr/bin/env bash
+"$hooks_src/branch-ops-audit.sh" $name "\$@"
+EOF
+  chmod +x "$dst"
+  echo "✅ wrote $name wrapper"
+}
+install_hook_audit post-checkout
+install_hook_audit post-commit
+
+echo "R9.2 hooks installed at $hooks_dst — audit log at ~/.megingjord/branch-ops-audit.log"

--- a/scripts/hooks/branch-ops-audit.sh
+++ b/scripts/hooks/branch-ops-audit.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# branch-ops-audit.sh — HAMR Wave 5 child 3 (#934).
+# v3.2.2 §R9.2.3 audit log: appends every checkout/commit op to ~/.megingjord/branch-ops-audit.log.
+# Called from .git/hooks/post-checkout and .git/hooks/post-commit (installed by install-hooks.sh).
+set -euo pipefail
+
+op=${1:-unknown}        # post-checkout | post-commit
+arg1=${2:-}             # post-checkout: prev-HEAD; post-commit: empty
+arg2=${3:-}             # post-checkout: new-HEAD; post-commit: empty
+arg3=${4:-}             # post-checkout: 1=branch / 0=file; post-commit: empty
+
+audit_log="${HOME}/.megingjord/branch-ops-audit.log"
+mkdir -p "$(dirname "$audit_log")"
+
+current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "DETACHED")
+head_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
+
+# post-checkout: only audit branch checkouts, not file checkouts
+if [ "$op" = "post-checkout" ] && [ "$arg3" != "1" ]; then
+  exit 0
+fi
+
+printf '{"ts":%s,"op":"%s","cwd":"%s","head":"%s","head_sha":"%s","prev":"%s","new":"%s"}\n' \
+  "$(date +%s%3N)" "$op" "$(pwd)" "$current_branch" "$head_sha" "$arg1" "$arg2" >> "$audit_log"
+exit 0

--- a/scripts/hooks/pre-push-branch-check.sh
+++ b/scripts/hooks/pre-push-branch-check.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# pre-push-branch-check.sh — HAMR Wave 5 child 3 (#934).
+# v3.2.2 §R9.2.1 hook contract: blocks push when HEAD branch ≠ refspec being pushed.
+# Reads stdin lines from git: "<local_ref> <local_sha> <remote_ref> <remote_sha>".
+set -euo pipefail
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+audit_log="${HOME}/.megingjord/branch-ops-audit.log"
+mkdir -p "$(dirname "$audit_log")"
+
+violations=0
+while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  [ -z "${local_ref:-}" ] && continue
+  local_branch=${local_ref#refs/heads/}
+  remote_branch=${remote_ref#refs/heads/}
+  if [ "$local_branch" != "$current_branch" ]; then
+    echo "❌ R9.2.1 violation: pushing $local_branch but HEAD is $current_branch"
+    echo "    cwd: $(pwd)"
+    echo "    refspec: $local_ref → $remote_ref"
+    violations=$((violations + 1))
+  fi
+  printf '{"ts":%s,"op":"pre-push","cwd":"%s","head":"%s","local_ref":"%s","remote_ref":"%s","local_sha":"%s","violation":%s}\n' \
+    "$(date +%s%3N)" "$(pwd)" "$current_branch" "$local_ref" "$remote_ref" "$local_sha" \
+    "$([ "$local_branch" != "$current_branch" ] && echo true || echo false)" >> "$audit_log"
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo "Refusing push: $violations cwd-vs-branch mismatch(es). See ~/.megingjord/branch-ops-audit.log."
+  exit 1
+fi
+exit 0

--- a/tests/r92-hooks.spec.js
+++ b/tests/r92-hooks.spec.js
@@ -1,0 +1,60 @@
+// R9.2 hook automation tests (#934).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const { execSync, spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const PRE_PUSH = path.join(REPO_ROOT, 'scripts', 'hooks', 'pre-push-branch-check.sh');
+const AUDIT = path.join(REPO_ROOT, 'scripts', 'hooks', 'branch-ops-audit.sh');
+const INSTALLER = path.join(REPO_ROOT, 'scripts', 'global', 'install-hooks.sh');
+
+test('all three hook scripts exist and are executable', () => {
+  for (const f of [PRE_PUSH, AUDIT, INSTALLER]) {
+    expect(fs.existsSync(f)).toBe(true);
+    expect(fs.statSync(f).mode & 0o100).toBeTruthy();
+  }
+});
+
+test('pre-push hook exits 0 when local branch matches HEAD', () => {
+  const currentBranch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: REPO_ROOT }).toString().trim();
+  const stdin = `refs/heads/${currentBranch} abc123 refs/heads/${currentBranch} def456\n`;
+  const result = spawnSync(PRE_PUSH, [], { input: stdin, cwd: REPO_ROOT });
+  expect(result.status).toBe(0);
+});
+
+test('pre-push hook exits 1 when local branch ≠ HEAD', () => {
+  const stdin = 'refs/heads/some-other-branch abc123 refs/heads/some-other-branch def456\n';
+  const result = spawnSync(PRE_PUSH, [], { input: stdin, cwd: REPO_ROOT });
+  expect(result.status).toBe(1);
+  expect(result.stdout.toString()).toContain('R9.2.1 violation');
+});
+
+test('audit script writes JSON-line on post-checkout branch op', () => {
+  const auditLog = path.join(process.env.HOME, '.megingjord', 'branch-ops-audit.log');
+  const beforeLines = fs.existsSync(auditLog) ? fs.readFileSync(auditLog, 'utf8').split('\n').length : 0;
+  spawnSync(AUDIT, ['post-checkout', 'aaa', 'bbb', '1'], { cwd: REPO_ROOT });
+  const afterLines = fs.readFileSync(auditLog, 'utf8').split('\n').length;
+  expect(afterLines).toBeGreaterThan(beforeLines);
+  const lastLine = fs.readFileSync(auditLog, 'utf8').trim().split('\n').pop();
+  const parsed = JSON.parse(lastLine);
+  expect(parsed.op).toBe('post-checkout');
+  expect(parsed.prev).toBe('aaa');
+  expect(parsed.new).toBe('bbb');
+});
+
+test('audit script skips file-only checkouts (arg3=0)', () => {
+  const auditLog = path.join(process.env.HOME, '.megingjord', 'branch-ops-audit.log');
+  const before = fs.existsSync(auditLog) ? fs.readFileSync(auditLog, 'utf8') : '';
+  spawnSync(AUDIT, ['post-checkout', 'aaa', 'bbb', '0'], { cwd: REPO_ROOT });
+  const after = fs.readFileSync(auditLog, 'utf8');
+  expect(after).toBe(before);
+});
+
+test('audit script writes post-commit record', () => {
+  const auditLog = path.join(process.env.HOME, '.megingjord', 'branch-ops-audit.log');
+  const beforeLines = fs.existsSync(auditLog) ? fs.readFileSync(auditLog, 'utf8').split('\n').length : 0;
+  spawnSync(AUDIT, ['post-commit'], { cwd: REPO_ROOT });
+  const afterLines = fs.readFileSync(auditLog, 'utf8').split('\n').length;
+  expect(afterLines).toBeGreaterThan(beforeLines);
+});


### PR DESCRIPTION
## Summary

Wave 5 child 3 of HAMR Epic #860 — closes the empirically-recurring cwd-vs-branch hazard (4 occurrences across HAMR Waves 1-4) per v3.2.2 §R9.2 patch.

- `scripts/hooks/pre-push-branch-check.sh` (NEW, ≤100 lines) — R9.2.1 enforcement; blocks push when local branch ≠ HEAD.
- `scripts/hooks/branch-ops-audit.sh` (NEW, ≤100 lines) — R9.2.3 audit log; emits JSON-line per post-checkout/post-commit op.
- `scripts/global/install-hooks.sh` (NEW, ≤100 lines) — idempotent installer; chain-appends to existing pre-push.

## Validation evidence

6/6 tests pass (`tests/r92-hooks.spec.js`).

## Hand-offs

- COLLABORATOR_HANDOFF on #934 at #issuecomment-4382193692 (>60s before this PR).
- ADMIN_HANDOFF + CONSULTANT_CLOSEOUT also posted on #934.

Refs #934
Refs Epic #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)