### PR TITLE
feat(hamr): log rotation + scheduled freshness signal #941

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased] — HAMR Wave 6 child 1: log rotation + scheduled freshness signal (#941, EPIC #860)
+
+### Added
+- `scripts/global/log-rotate.js` (≤100 lines): generic JSONL rotator. Caps at N lines (default 10k); on overflow, gzip-archives `<file>.<iso-ts>.gz` then truncates. CLI: `npm run hamr:log-rotate -- <file> [--max-lines=<N>]`.
+- `cloudflare/hamr/scheduled.ts` (≤100 lines): Cloudflare scheduled handler. Reads `cache-stats:hit-rate-7d:meta`; if `ts > 24h ago` (or missing), sets `cache-stats:hit-rate-7d:stale=true`.
+- `cloudflare/hamr/wrangler.toml`: `crons = ["0 */6 * * *"]` cron trigger every 6h.
+- `tests/log-rotate.spec.js`: 4 tests (countLines, missing-file, no-rotate, rotate-archives-truncates with gzip roundtrip).
+- `package.json`: `hamr:log-rotate` script.
+
+### Changed
+- `cloudflare/hamr/worker.ts`: exports `scheduled(event, env)` invoking `scheduledHandler`.
+- `cloudflare/hamr/routes/quota.ts`: response now includes additive `stale: boolean` field; reads `cache-stats:hit-rate-7d:stale` KV key.
+
+### Notes
+- Lane: code-change.
+- Worker redeployed (`d5f69c67-1430-4485-9a90-bbacf85b726d`); cron schedule live (every 6h).
+- Live-verified `/quota` returns `stale: false` correctly; additive — existing consumers unaffected.
+
 ## [Unreleased] — HAMR Wave 5 child 4: real /mcp serving (capability dispatch) (#935, EPIC #860)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ npm run deploy:both:apply
 | `hamr:deploy` | `bash scripts/global/hamr-deploy.sh` |
 | `hamr:doctor` | `node scripts/global/hamr-doctor.js` |
 | `hamr:health` | `node scripts/global/substrate-health.js` |
+| `hamr:log-rotate` | `node scripts/global/log-rotate.js` |
 | `hamr:rule-gate` | `node scripts/global/rule-coverage-gate.js` |
 | `hamr:spillover` | `node scripts/global/header-spillover.js` |
 | `hamr:sticky-route` | `node scripts/global/sticky-route.js` |

--- a/cloudflare/hamr/routes/quota.ts
+++ b/cloudflare/hamr/routes/quota.ts
@@ -3,6 +3,7 @@
 import type { Env } from '../worker';
 
 const HIT_RATE_KEY = 'cache-stats:hit-rate-7d';
+const STALE_KEY = 'cache-stats:hit-rate-7d:stale';
 const PROVIDER_PREFIX = 'provider-spillover:';
 
 interface ProviderState {
@@ -32,13 +33,21 @@ async function readProviderStates(env: Env): Promise<Record<string, ProviderStat
   return out;
 }
 
+async function readStale(env: Env): Promise<boolean> {
+  const raw = await env.HAMR_KV.get(STALE_KEY);
+  return raw === 'true';
+}
+
 export async function quota(env: Env): Promise<Response> {
-  const [hit_rate_7d, providers] = await Promise.all([readHitRate(env), readProviderStates(env)]);
+  const [hit_rate_7d, providers, stale] = await Promise.all([
+    readHitRate(env), readProviderStates(env), readStale(env),
+  ]);
   return new Response(JSON.stringify({
     schema_version: 2,
     ts: Date.now(),
     hit_rate_7d,
     providers,
+    stale,
     placeholder: false,
   }), {
     status: 200,

--- a/cloudflare/hamr/scheduled.ts
+++ b/cloudflare/hamr/scheduled.ts
@@ -1,0 +1,25 @@
+// HAMR scheduled handler — Wave 6 child 1 (#941).
+// Cron-fired freshness check: if cache-stats meta is older than 24h, sets
+// `cache-stats:hit-rate-7d:stale=true` so /quota can advertise staleness.
+import type { Env } from './worker';
+
+const META_KEY = 'cache-stats:hit-rate-7d:meta';
+const STALE_KEY = 'cache-stats:hit-rate-7d:stale';
+const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+export async function scheduled(env: Env, now: number = Date.now()): Promise<{ stale: boolean; age_ms: number | null }> {
+  const raw = await env.HAMR_KV.get(META_KEY);
+  if (!raw) {
+    await env.HAMR_KV.put(STALE_KEY, 'true');
+    return { stale: true, age_ms: null };
+  }
+  let parsed: { ts?: number };
+  try { parsed = JSON.parse(raw); } catch {
+    await env.HAMR_KV.put(STALE_KEY, 'true');
+    return { stale: true, age_ms: null };
+  }
+  const age = typeof parsed.ts === 'number' ? now - parsed.ts : null;
+  const stale = age === null || age > STALE_THRESHOLD_MS;
+  await env.HAMR_KV.put(STALE_KEY, stale ? 'true' : 'false');
+  return { stale, age_ms: age };
+}

--- a/cloudflare/hamr/worker.ts
+++ b/cloudflare/hamr/worker.ts
@@ -7,6 +7,7 @@ import { mcp } from './routes/mcp';
 import { mailboxRead, mailboxWrite } from './routes/mailbox';
 import { quota } from './routes/quota';
 import { cacheStats } from './routes/cache-stats';
+import { scheduled as scheduledHandler } from './scheduled';
 
 export interface Env {
   HAMR_KV: KVNamespace;
@@ -57,5 +58,8 @@ export default {
     const out = withSecurity(res);
     out.headers.set('x-hamr-elapsed-ms', String(Date.now() - t0));
     return out;
+  },
+  async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
+    await scheduledHandler(env);
   },
 } satisfies ExportedHandler<Env>;

--- a/cloudflare/hamr/wrangler.toml
+++ b/cloudflare/hamr/wrangler.toml
@@ -20,3 +20,6 @@ id = "a01abe088f454a59973e72736978b5e5"
 
 # PUBLISHER_KEYRING is set via `wrangler secret put PUBLISHER_KEYRING`
 # (NOT committed to wrangler.toml; format is JSON {key_id: base64-spki-public-key})
+
+[triggers]
+crons = ["0 */6 * * *"]  # cache-stats freshness check every 6h (#941)

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "hamr:doctor": "node scripts/global/hamr-doctor.js",
     "hooks:install": "bash scripts/global/install-hooks.sh",
     "hamr:health": "node scripts/global/substrate-health.js",
+    "hamr:log-rotate": "node scripts/global/log-rotate.js",
     "hamr:rule-gate": "node scripts/global/rule-coverage-gate.js",
     "hamr:spillover": "node scripts/global/header-spillover.js",
     "hamr:sticky-route": "node scripts/global/sticky-route.js",

--- a/scripts/global/log-rotate.js
+++ b/scripts/global/log-rotate.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// log-rotate.js — HAMR Wave 6 child 1 (#941).
+// Generic JSONL rotator: caps at N lines; on overflow, gzip-archives + truncates.
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const zlib = require('node:zlib');
+
+const DEFAULT_MAX_LINES = 10000;
+
+function countLines(file) {
+  if (!fs.existsSync(file)) return 0;
+  const data = fs.readFileSync(file, 'utf8');
+  if (!data) return 0;
+  return data.endsWith('\n') ? data.split('\n').length - 1 : data.split('\n').length;
+}
+
+function archive(file) {
+  const data = fs.readFileSync(file);
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const archivePath = `${file}.${ts}.gz`;
+  fs.writeFileSync(archivePath, zlib.gzipSync(data));
+  return archivePath;
+}
+
+/** Rotate a JSONL file when its line count exceeds maxLines.
+ * Writes gzipped archive at <file>.<iso-ts>.gz then truncates.
+ * @param {string} file - Path to JSONL file.
+ * @param {object} [opts] - { maxLines }.
+ * @returns {{rotated: boolean, lines: number, max: number, archive?: string}} Outcome.
+ */
+function rotate(file, opts = {}) {
+  const max = opts.maxLines ?? DEFAULT_MAX_LINES;
+  if (!fs.existsSync(file)) return { rotated: false, lines: 0, max };
+  const lines = countLines(file);
+  if (lines <= max) return { rotated: false, lines, max };
+  const archivePath = archive(file);
+  fs.writeFileSync(file, '');
+  return { rotated: true, lines, max, archive: archivePath };
+}
+
+if (require.main === module) {
+  const target = process.argv[2];
+  if (!target) {
+    console.error('usage: log-rotate.js <file> [--max-lines=<N>]');
+    process.exit(1);
+  }
+  const flag = process.argv.find((a) => a.startsWith('--max-lines='));
+  const maxLines = flag ? parseInt(flag.split('=')[1], 10) : undefined;
+  const file = path.resolve(target);
+  const result = rotate(file, { maxLines });
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(0);
+}
+
+module.exports = { rotate, countLines, DEFAULT_MAX_LINES };

--- a/tests/log-rotate.spec.js
+++ b/tests/log-rotate.spec.js
@@ -1,0 +1,50 @@
+// log-rotate tests (#941).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const zlib = require('zlib');
+
+const ROT = require(path.resolve(__dirname, '..', 'scripts', 'global', 'log-rotate.js'));
+
+function tmpFile() { return path.join(os.tmpdir(), `log-rotate-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`); }
+
+test('countLines counts JSONL lines correctly', () => {
+  const f = tmpFile();
+  fs.writeFileSync(f, '{"a":1}\n{"a":2}\n{"a":3}\n');
+  expect(ROT.countLines(f)).toBe(3);
+  fs.unlinkSync(f);
+});
+
+test('countLines returns 0 on missing or empty file', () => {
+  expect(ROT.countLines('/nonexistent/path/log.jsonl')).toBe(0);
+  const f = tmpFile();
+  fs.writeFileSync(f, '');
+  expect(ROT.countLines(f)).toBe(0);
+  fs.unlinkSync(f);
+});
+
+test('rotate skips when under maxLines', () => {
+  const f = tmpFile();
+  fs.writeFileSync(f, '{"a":1}\n{"a":2}\n');
+  const r = ROT.rotate(f, { maxLines: 100 });
+  expect(r.rotated).toBe(false);
+  expect(r.lines).toBe(2);
+  fs.unlinkSync(f);
+});
+
+test('rotate archives + truncates when over maxLines', () => {
+  const f = tmpFile();
+  let content = '';
+  for (let i = 0; i < 50; i += 1) content += JSON.stringify({ i }) + '\n';
+  fs.writeFileSync(f, content);
+  const r = ROT.rotate(f, { maxLines: 10 });
+  expect(r.rotated).toBe(true);
+  expect(r.lines).toBe(50);
+  expect(fs.existsSync(r.archive)).toBe(true);
+  expect(fs.readFileSync(f, 'utf8')).toBe('');
+  const restored = zlib.gunzipSync(fs.readFileSync(r.archive)).toString();
+  expect(restored.split('\n').filter(Boolean)).toHaveLength(50);
+  fs.unlinkSync(f);
+  fs.unlinkSync(r.archive);
+});


### PR DESCRIPTION
## Summary

Wave 6 child 1 of HAMR Epic #860 — operational hygiene.

- `scripts/global/log-rotate.js` (NEW, ≤100 lines) — generic JSONL rotator (gzip archive on overflow).
- `cloudflare/hamr/scheduled.ts` (NEW, ≤100 lines) — cron-fired freshness check.
- `cloudflare/hamr/wrangler.toml` — `crons = ["0 */6 * * *"]`.
- `cloudflare/hamr/routes/quota.ts` — additive `stale: boolean` field.
- `cloudflare/hamr/worker.ts` — `scheduled` export.

## Validation evidence

4/4 log-rotate tests pass; Worker redeployed (`d5f69c67`); cron schedule live; `/quota` live-verified `stale: false`.

## Hand-offs

COLLABORATOR_HANDOFF on #941 at #issuecomment-4382542851 (>60s before this PR).

Refs #941
Refs Epic #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)