### PR TITLE
feat(hamr): substrate-health push + KV writer #943

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased] — HAMR Wave 6 child 3: substrate-health push + Worker /substrate-health KV writer (#943, EPIC #860)
+
+### Added
+- `cloudflare/hamr/routes/substrate-health.ts` (≤100 lines): NEW Worker endpoint mirroring `/cache-stats` (#933). Ed25519 DPoP auth + freshness validation + writes `substrate-health:latest` to KV (consumed by `/mcp doctor:probe` #935).
+- `scripts/global/substrate-health-push.js` (≤100 lines): local push client. Reads `~/.megingjord/substrate-health.json` (#911); signs canonical JSON; POSTs to HAMR `/substrate-health`.
+- `cloudflare/hamr/worker.ts`: `POST /substrate-health` route.
+- `tests/substrate-health-push.spec.js`: 5 tests (2 unit + 3 live route smoke).
+- `package.json` script: `hamr:health-push`.
+
+### Notes
+- Lane: code-change.
+- Worker redeployed (`91e2b5ea-54d1-49c8-adf6-04667b4bf8e2`).
+- Closes producer/consumer chain: `hamr:health` (#911) → `hamr:health-push` (this) → KV → `/mcp doctor:probe` (#935).
+
 ## [Unreleased] — HAMR Wave 6 child 2: /mcp mailbox:read envelope-content fetch (#942, EPIC #860)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ npm run deploy:both:apply
 | `hamr:deploy` | `bash scripts/global/hamr-deploy.sh` |
 | `hamr:doctor` | `node scripts/global/hamr-doctor.js` |
 | `hamr:health` | `node scripts/global/substrate-health.js` |
+| `hamr:health-push` | `node scripts/global/substrate-health-push.js` |
 | `hamr:log-rotate` | `node scripts/global/log-rotate.js` |
 | `hamr:rule-gate` | `node scripts/global/rule-coverage-gate.js` |
 | `hamr:spillover` | `node scripts/global/header-spillover.js` |

--- a/cloudflare/hamr/routes/substrate-health.ts
+++ b/cloudflare/hamr/routes/substrate-health.ts
@@ -1,0 +1,60 @@
+// HAMR /substrate-health — Worker KV writer for substrate-health:latest (#943).
+// Mirrors /cache-stats pattern from #933. Closes the producer gap on /mcp doctor:probe.
+import type { Env } from '../worker';
+
+const HEALTH_KEY = 'substrate-health:latest';
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+function unauthorized(reason: string): Response {
+  return new Response(JSON.stringify({ error: 'unauthorized', reason }), {
+    status: 401, headers: { 'content-type': 'application/json' },
+  });
+}
+
+function badRequest(reason: string): Response {
+  return new Response(JSON.stringify({ error: 'bad_request', reason }), {
+    status: 400, headers: { 'content-type': 'application/json' },
+  });
+}
+
+function decodeKeyring(env: Env): Record<string, string> | null {
+  if (!env.PUBLISHER_KEYRING) return null;
+  try { return JSON.parse(env.PUBLISHER_KEYRING) as Record<string, string>; } catch { return null; }
+}
+
+async function verifyEd25519(spkiB64: string, canonical: string, sigB64: string): Promise<boolean> {
+  try {
+    const spki = Uint8Array.from(atob(spkiB64), (c) => c.charCodeAt(0));
+    const data = new TextEncoder().encode(canonical);
+    const sig = Uint8Array.from(atob(sigB64), (c) => c.charCodeAt(0));
+    const key = await crypto.subtle.importKey('spki', spki, { name: 'Ed25519' }, false, ['verify']);
+    return await crypto.subtle.verify('Ed25519', key, sig, data);
+  } catch { return false; }
+}
+
+export async function substrateHealth(request: Request, env: Env): Promise<Response> {
+  const auth = request.headers.get('authorization') ?? '';
+  if (!auth.startsWith('DPoP ')) return unauthorized('missing_dpop');
+  const sigHeader = request.headers.get('x-hamr-signature') ?? '';
+  const keyId = request.headers.get('x-hamr-key-id') ?? '';
+  const canonical = request.headers.get('x-hamr-canonical') ?? '';
+  if (!sigHeader || !keyId || !canonical) return unauthorized('missing_signature_headers');
+
+  const keyring = decodeKeyring(env);
+  if (!keyring) return unauthorized('no_publisher_keyring_configured');
+  const spkiB64 = keyring[keyId];
+  if (!spkiB64) return unauthorized('unknown_key_id');
+  if (!await verifyEd25519(spkiB64, canonical, sigHeader)) return unauthorized('bad_signature');
+
+  let payload: { ts?: number; providers?: Record<string, unknown>; tier?: unknown };
+  try { payload = await request.json(); } catch { return badRequest('invalid_json'); }
+  if (!payload.providers || typeof payload.providers !== 'object') return badRequest('providers_required');
+  const age = Date.now() - (payload.ts ?? 0);
+  if (payload.ts && age > MAX_AGE_MS) return badRequest('payload_too_old');
+
+  const record = JSON.stringify({ ...payload, ts: payload.ts ?? Date.now(), key_id: keyId });
+  await env.HAMR_KV.put(HEALTH_KEY, record);
+  return new Response(JSON.stringify({ ok: true, written: HEALTH_KEY }), {
+    status: 200, headers: { 'content-type': 'application/json' },
+  });
+}

--- a/cloudflare/hamr/worker.ts
+++ b/cloudflare/hamr/worker.ts
@@ -7,6 +7,7 @@ import { mcp } from './routes/mcp';
 import { mailboxRead, mailboxWrite } from './routes/mailbox';
 import { quota } from './routes/quota';
 import { cacheStats } from './routes/cache-stats';
+import { substrateHealth } from './routes/substrate-health';
 import { scheduled as scheduledHandler } from './scheduled';
 
 export interface Env {
@@ -48,6 +49,7 @@ export default {
       else if (url.pathname === '/mailbox/write' && m === 'POST') res = await mailboxWrite(request, env);
       else if (url.pathname === '/quota' && m === 'GET') res = await quota(env);
       else if (url.pathname === '/cache-stats' && m === 'POST') res = await cacheStats(request, env);
+      else if (url.pathname === '/substrate-health' && m === 'POST') res = await substrateHealth(request, env);
       else res = notFound();
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'internal_error';

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "hamr:doctor": "node scripts/global/hamr-doctor.js",
     "hooks:install": "bash scripts/global/install-hooks.sh",
     "hamr:health": "node scripts/global/substrate-health.js",
+    "hamr:health-push": "node scripts/global/substrate-health-push.js",
     "hamr:log-rotate": "node scripts/global/log-rotate.js",
     "hamr:rule-gate": "node scripts/global/rule-coverage-gate.js",
     "hamr:spillover": "node scripts/global/header-spillover.js",

--- a/scripts/global/substrate-health-push.js
+++ b/scripts/global/substrate-health-push.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// substrate-health-push.js — HAMR Wave 6 child 3 (#943).
+// Runs substrate-health.js (#911) locally; signs canonical JSON; POSTs to HAMR /substrate-health.
+'use strict';
+require('dotenv').config({ quiet: true });
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const HEALTH_FILE = path.join(os.homedir(), '.megingjord', 'substrate-health.json');
+const DEFAULT_HAMR_URL = process.env.HAMR_URL || 'https://hamr.chf3198.workers.dev';
+const KEY_ID = process.env.OPERATOR_KEY_ID || 'operator-default';
+const KEY_FILE = path.join(os.homedir(), '.megingjord', 'keys', 'operator-ed25519.pem');
+
+function loadEd25519Key() {
+  const seedB64 = process.env.OPERATOR_KEY_SEED_B64;
+  if (seedB64) {
+    const seed = Buffer.from(seedB64, 'base64');
+    if (seed.length !== 32) throw new Error('OPERATOR_KEY_SEED_B64 must decode to 32 bytes');
+    const der = Buffer.concat([Buffer.from('302e020100300506032b657004220420', 'hex'), seed]);
+    return crypto.createPrivateKey({ key: der, format: 'der', type: 'pkcs8' });
+  }
+  if (fs.existsSync(KEY_FILE)) return crypto.createPrivateKey(fs.readFileSync(KEY_FILE));
+  throw new Error('no operator Ed25519 key available');
+}
+
+function canonicalize(payload) {
+  return JSON.stringify(payload, Object.keys(payload).sort());
+}
+
+function readHealthSnapshot() {
+  if (!fs.existsSync(HEALTH_FILE)) return null;
+  try { return JSON.parse(fs.readFileSync(HEALTH_FILE, 'utf8')); } catch { return null; }
+}
+
+async function pushHealth(opts = {}) {
+  const url = opts.url || DEFAULT_HAMR_URL;
+  const snapshot = opts.snapshot || readHealthSnapshot();
+  if (!snapshot || !snapshot.providers) return { ok: false, reason: 'no_substrate_health_snapshot' };
+  const payload = { ts: Date.now(), providers: snapshot.providers, tier: snapshot.tier ?? null };
+  const canonical = canonicalize(payload);
+  const key = loadEd25519Key();
+  const sig = crypto.sign(null, Buffer.from(canonical), key).toString('base64');
+  const resp = await fetch(`${url}/substrate-health`, {
+    method: 'POST',
+    headers: {
+      'authorization': 'DPoP substrate-health-push', 'content-type': 'application/json',
+      'x-hamr-key-id': KEY_ID, 'x-hamr-signature': sig, 'x-hamr-canonical': canonical,
+    },
+    body: canonical,
+  });
+  const data = await resp.json().catch(() => ({}));
+  return { ok: resp.ok, status: resp.status, payload, response: data };
+}
+
+if (require.main === module) {
+  pushHealth().then((result) => {
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(result.ok ? 0 : 1);
+  }).catch((err) => { console.error(err.message); process.exit(1); });
+}
+
+module.exports = { pushHealth, canonicalize, loadEd25519Key };

--- a/tests/substrate-health-push.spec.js
+++ b/tests/substrate-health-push.spec.js
@@ -1,0 +1,55 @@
+// substrate-health-push tests (#943).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const PUSH = require(path.resolve(__dirname, '..', 'scripts', 'global', 'substrate-health-push.js'));
+
+test('canonicalize sorts keys deterministically', () => {
+  const a = PUSH.canonicalize({ ts: 1000, providers: { groq: { available: true } }, tier: 'fleet' });
+  const b = PUSH.canonicalize({ tier: 'fleet', providers: { groq: { available: true } }, ts: 1000 });
+  expect(a).toBe(b);
+});
+
+test('loadEd25519Key reads OPERATOR_KEY_SEED_B64', () => {
+  const seed = Buffer.alloc(32, 11).toString('base64');
+  const orig = process.env.OPERATOR_KEY_SEED_B64;
+  process.env.OPERATOR_KEY_SEED_B64 = seed;
+  try {
+    const key = PUSH.loadEd25519Key();
+    expect(key.asymmetricKeyType).toBe('ed25519');
+  } finally {
+    if (orig === undefined) delete process.env.OPERATOR_KEY_SEED_B64;
+    else process.env.OPERATOR_KEY_SEED_B64 = orig;
+  }
+});
+
+test.describe('live /substrate-health route (post-#943 deploy)', () => {
+  const BASE = 'https://hamr.chf3198.workers.dev';
+
+  test('/substrate-health returns 401 missing_dpop without auth', async ({ request }) => {
+    const r = await request.post(`${BASE}/substrate-health`, { data: { providers: {} } });
+    expect(r.status()).toBe(401);
+  });
+
+  test('/substrate-health returns 401 missing_signature_headers with DPoP-only', async ({ request }) => {
+    const r = await request.post(`${BASE}/substrate-health`, {
+      data: { providers: {} }, headers: { authorization: 'DPoP test' },
+    });
+    expect(r.status()).toBe(401);
+    const body = await r.json();
+    expect(body.reason).toBe('missing_signature_headers');
+  });
+
+  test('/substrate-health returns 401 unknown_key_id with bogus key', async ({ request }) => {
+    const r = await request.post(`${BASE}/substrate-health`, {
+      data: { providers: {} },
+      headers: {
+        authorization: 'DPoP test',
+        'x-hamr-signature': 'sig', 'x-hamr-key-id': 'bogus', 'x-hamr-canonical': 'c',
+      },
+    });
+    expect(r.status()).toBe(401);
+    const body = await r.json();
+    expect(['unknown_key_id', 'no_publisher_keyring_configured']).toContain(body.reason);
+  });
+});


### PR DESCRIPTION
## Summary

Wave 6 child 3 — closes producer gap on `/mcp doctor:probe` (Wave 5 #935).

- `cloudflare/hamr/routes/substrate-health.ts` (NEW, ≤100 lines) — Ed25519 DPoP + KV write at `substrate-health:latest`.
- `scripts/global/substrate-health-push.js` (NEW, ≤100 lines) — local push client.
- `cloudflare/hamr/worker.ts` — `POST /substrate-health` route.

## Validation evidence

5/5 tests pass (2 unit + 3 live route smoke); Worker redeployed (`91e2b5ea`).

## Hand-offs

COLLABORATOR_HANDOFF on #943 at #issuecomment-4382573463 (>60s before this PR).

Refs #943
Refs Epic #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)