### PR TITLE
feat(hamr): Anthropic Batch live validator (cost-gated) #944

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] — HAMR Wave 6 child 4: Anthropic Batch live validator (#944, EPIC #860)
+
+### Added
+- `scripts/global/batch-validator.js` (≤100 lines): dry-run + opt-in live validator for `submitBatch` (#927). Default mode: builds 1-request 32-token Haiku payload, validates eligibility, exits without submitting (**$0 operator cost**). Live mode: requires both `--live` and `--operator-approved` flags (double-flag cost gate); submits + polls 30s/30min; asserts `status: 'ended'`. Estimated live cost: <$0.0001.
+- `tests/batch-validator.spec.js`: 5 tests (sample-batch shape, dry-run output, CLI dry-run exit 0, CLI live without approval exits 1, eligibility check).
+- `package.json` script: `hamr:batch-validate`.
+
+### Notes
+- Lane: code-change.
+- Cost-gate enforcement verified: `--live` without `--operator-approved` exits 1 with diagnostic.
+
 ## [Unreleased] — HAMR Wave 6 child 3: substrate-health push + Worker /substrate-health KV writer (#943, EPIC #860)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ npm run deploy:both:apply
 | `governance:weekly` | `node scripts/global/governance-weekly-report.js` |
 | `governance:worktrees` | `node scripts/global/worktree-governance-audit.js --json` |
 | `hamr:batch-router` | `node scripts/global/anthropic-batch-router.js` |
+| `hamr:batch-validate` | `node scripts/global/batch-validator.js` |
 | `hamr:cache-emit` | `node scripts/global/cache-stats-emit.js` |
 | `hamr:cache-gate` | `node scripts/global/cache-hit-gate.js` |
 | `hamr:cache-push` | `node scripts/global/cache-stats-push.js` |

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "governance:weekly": "node scripts/global/governance-weekly-report.js",
     "governance:worktrees": "node scripts/global/worktree-governance-audit.js --json",
     "hamr:batch-router": "node scripts/global/anthropic-batch-router.js",
+    "hamr:batch-validate": "node scripts/global/batch-validator.js",
     "hamr:cache-emit": "node scripts/global/cache-stats-emit.js",
     "hamr:cache-gate": "node scripts/global/cache-hit-gate.js",
     "hamr:cache-push": "node scripts/global/cache-stats-push.js",

--- a/scripts/global/batch-validator.js
+++ b/scripts/global/batch-validator.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// batch-validator.js — HAMR Wave 6 child 4 (#944).
+// Dry-run + opt-in live mode for Anthropic Batch API submission.
+// Default: dry-run = $0 operator cost. Live mode requires --live --operator-approved.
+'use strict';
+require('dotenv').config({ quiet: true });
+
+const { submitBatch, pollBatch, isBatchEligible } = require('./anthropic-batch-router');
+
+const HAIKU_MODEL = 'claude-haiku-4-5-20251001';
+const POLL_INTERVAL_MS = 30_000;
+const MAX_WAIT_MS = 30 * 60 * 1000;
+
+function buildSampleBatch() {
+  return [{
+    custom_id: `batch-validator-${Date.now()}`,
+    params: {
+      model: HAIKU_MODEL, max_tokens: 32,
+      messages: [{ role: 'user', content: 'Say "ok" and stop.' }],
+    },
+  }];
+}
+
+function dryRun() {
+  const requests = buildSampleBatch();
+  const eligibility = isBatchEligible({ kind: 'wiki-anneal', deadlineMs: 24 * 60 * 60 * 1000 });
+  return {
+    mode: 'dry-run', operator_cost_usd: 0,
+    requests, eligibility, would_submit_to: 'https://api.anthropic.com/v1/messages/batches',
+    expected_request_count: requests.length, ok: eligibility.eligible,
+  };
+}
+
+async function liveRun() {
+  if (!process.env.ANTHROPIC_API_KEY) return { mode: 'live', ok: false, reason: 'ANTHROPIC_API_KEY not set' };
+  const requests = buildSampleBatch();
+  const submission = await submitBatch(requests);
+  if (!submission.batch_id) return { mode: 'live', ok: false, reason: 'submit_returned_no_batch_id', submission };
+  const polled = await pollBatch(submission.batch_id, { intervalMs: POLL_INTERVAL_MS, maxWaitMs: MAX_WAIT_MS });
+  return {
+    mode: 'live', operator_cost_usd_estimate: '<$0.0001 (1×32-token Haiku)',
+    submission, polled, ok: polled.status === 'ended',
+  };
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+  if (args.has('--live') && !args.has('--operator-approved')) {
+    console.error('--live requires --operator-approved (cost-gate enforced)');
+    process.exit(1);
+  }
+  const result = args.has('--live') ? await liveRun() : dryRun();
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.ok ? 0 : 1);
+}
+
+if (require.main === module) {
+  main().catch((err) => { console.error(err.message); process.exit(1); });
+}
+
+module.exports = { dryRun, liveRun, buildSampleBatch };

--- a/tests/batch-validator.spec.js
+++ b/tests/batch-validator.spec.js
@@ -1,0 +1,41 @@
+// batch-validator tests (#944).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const VAL = require(path.resolve(__dirname, '..', 'scripts', 'global', 'batch-validator.js'));
+const SCRIPT = path.resolve(__dirname, '..', 'scripts', 'global', 'batch-validator.js');
+
+test('buildSampleBatch returns 1-request payload with Haiku model', () => {
+  const requests = VAL.buildSampleBatch();
+  expect(requests).toHaveLength(1);
+  expect(requests[0].params.model).toMatch(/haiku-4-5/);
+  expect(requests[0].params.max_tokens).toBe(32);
+});
+
+test('dryRun returns mode:dry-run and zero operator cost', () => {
+  const r = VAL.dryRun();
+  expect(r.mode).toBe('dry-run');
+  expect(r.operator_cost_usd).toBe(0);
+  expect(r.would_submit_to).toMatch(/api\.anthropic\.com/);
+  expect(r.expected_request_count).toBe(1);
+  expect(r.ok).toBe(true);
+});
+
+test('CLI without flags runs dry-run and exits 0', () => {
+  const result = spawnSync('node', [SCRIPT], { encoding: 'utf8' });
+  expect(result.status).toBe(0);
+  const parsed = JSON.parse(result.stdout);
+  expect(parsed.mode).toBe('dry-run');
+});
+
+test('CLI --live without --operator-approved exits 1', () => {
+  const result = spawnSync('node', [SCRIPT, '--live'], { encoding: 'utf8' });
+  expect(result.status).toBe(1);
+  expect(result.stderr).toMatch(/operator-approved/);
+});
+
+test('eligibility: wiki-anneal at 24h deadline = eligible', () => {
+  const r = VAL.dryRun();
+  expect(r.eligibility.eligible).toBe(true);
+});


### PR DESCRIPTION
## Summary

Wave 6 child 4 (final Wave 6 child) — operator-cost-gated Batch submission test harness.

- `scripts/global/batch-validator.js` (NEW, ≤100 lines) — dry-run default ($0 cost); `--live --operator-approved` double-flag gate enables real submit + 30s/30min poll against Anthropic Batch API.

## Validation evidence

5/5 tests pass; CLI dry-run exits 0; `--live` without `--operator-approved` exits 1 (cost-gate verified).

## Hand-offs

COLLABORATOR_HANDOFF on #944 at #issuecomment-4382588529 (>60s before this PR).

Refs #944
Refs Epic #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)