### PR TITLE
feat(hamr): cross-team instruction integration #951

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,3 +81,7 @@ Install tools via CLI as needed. Don’t ask permission.
 ## Team&Model Signing
 
 AI-authored baton artifacts, PR evidence, and governance docs must include human alias + structured `Team&Model` provenance.
+
+## HAMR Cross-Team Routing
+
+All governed provider calls route through HAMR (`https://hamr.chf3198.workers.dev`). Activate per-checkout: `npm run hamr:activate`. Canonical contract: `instructions/hamr-routing.instructions.md`. The Global Task Router (lane selection) and HAMR (cost/observability mechanics) are complementary — HAMR does not duplicate lane policy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,12 @@ This repo is the **development workbench** for the DevEnv Ops Harness runtimes:
 - Repo-local overrides may tighten the format, but must not remove provenance.
 - See `instructions/team-model-signing.instructions.md`.
 
+## HAMR cross-team routing
+
+- All 3 teams route governed provider calls through HAMR (`https://hamr.chf3198.workers.dev`).
+- Activate per-checkout: `npm run hamr:activate`. Verify: `npm run hamr:sync-verify`.
+- Canonical contract: `instructions/hamr-routing.instructions.md`.
+
 ## Development → Deploy workflow
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased] — HAMR Wave 7 child A: cross-team instruction integration (#951, EPIC #860)
+
+### Added
+- `instructions/hamr-routing.instructions.md` (≤100 lines): canonical HAMR governance contract used by all 3 teams (Claude Code, Copilot, Codex). Documents producer chains, provider-call wrapper contract, /mcp dispatch, cost levers, and boundaries vs Copilot Team active surface.
+
+### Changed
+- `CLAUDE.md`: imports new HAMR routing instructions.
+- `AGENTS.md`: adds "HAMR cross-team routing" section pointing to canonical file.
+- `.github/copilot-instructions.md`: adds "HAMR Cross-Team Routing" section with explicit non-duplication note.
+- `instructions/global-task-router.instructions.md`: adds boundary clarification (lane vs cost-mechanics) and "do not duplicate HAMR mechanics" rule.
+
+### Notes
+- Lane: code-change.
+- Dedup audit performed — no existing instruction had HAMR-adjacent canonical content; only `global-task-router` overlapped (lane policy), resolved via cross-reference.
+- Strict-superset preserved across all 4 governance files.
+
 ## [Unreleased] — HAMR Wave 6 child 4: Anthropic Batch live validator (#944, EPIC #860)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ and AI agent governance. All instructions below are binding for Claude Code sess
 @instructions/visual-qa-governance.instructions.md
 @instructions/playwright-mcp-low-resource.instructions.md
 @instructions/wiki-knowledge.instructions.md
+@instructions/hamr-routing.instructions.md
 
 ## Runtime Context
 

--- a/instructions/global-task-router.instructions.md
+++ b/instructions/global-task-router.instructions.md
@@ -40,3 +40,7 @@ If fleet signals `escalation_needed=true`: use the `suggested_tier` (haiku first
 - Start in lowest adequate lane; never skip haiku to reach premium.
 - Premium escalation requires a short rationale. Record: lane, model, rationale, trigger.
 - If premium share exceeds 20% over 7 days, routing engine forces fleet lane (`npm run routing:report`).
+
+## Cost/observability mechanics within each lane
+
+This file selects the **lane**. Cost levers (caching, spillover, sticky-route, batching) and observability (cache-hit gate, /quota, /mcp doctor:probe) live in HAMR, not here. See `instructions/hamr-routing.instructions.md`. Do not duplicate HAMR mechanics in this file.

--- a/instructions/hamr-routing.instructions.md
+++ b/instructions/hamr-routing.instructions.md
@@ -1,0 +1,69 @@
+---
+name: HAMR Routing
+description: Use the HAMR Worker (cost levers, signed observability, MCP capability dispatch) for every governed provider call across all 3 teams.
+type: instructions
+---
+
+# HAMR Routing (Wave 1-6 production)
+
+HAMR (`https://hamr.chf3198.workers.dev`) is the cross-team cost+observability layer.
+Each team — Claude Code, Copilot, Codex — is expected to route through it.
+Activate with `npm run hamr:activate` once per checkout.
+
+## Producer chain (must run periodically)
+
+| Producer (local)            | Pushes to                     | Consumed by              |
+|-----------------------------|-------------------------------|--------------------------|
+| `npm run hamr:cache-push`   | KV `cache-stats:hit-rate-7d`  | `/quota` `hit_rate_7d`   |
+| `npm run hamr:health-push`  | KV `substrate-health:latest`  | `/mcp doctor:probe`      |
+| `npm run hamr:cache-emit`   | `~/.megingjord/cache-stats.jsonl` | `cache-hit-gate.runGate()` |
+
+A 6h cron is installed by `npm run hamr:install-cron`. Operators MAY skip when
+their machine is offline; the Worker scheduled handler advertises staleness via
+`/quota.stale=true`.
+
+## Provider call contract (all 3 teams)
+
+Every governed provider call SHOULD flow through `scripts/global/hamr-provider-wrapper.js`:
+
+```js
+const { wrapProviderCall } = require('./hamr-provider-wrapper');
+const result = await wrapProviderCall('anthropic', () => sdk.messages.create(req), { tier });
+```
+
+The wrapper auto-applies `cacheHeaders(provider)` (#926), records `appendCacheStat`
+on response (#932), and returns spillover hint via `maybeSpillover` (#927) on rate-limit.
+
+## /mcp capability dispatch
+
+POST to `/mcp` with Ed25519 DPoP auth (use `baton-signing.js` #894) and body
+`{capability, params}`. Capabilities: `bundle:fetch`, `doctor:probe`, `mailbox:read`.
+Bundle SHA may be advertised via `x-hamr-bundle-sha` for SLSA gate verification.
+
+## Cost levers (covered here, do NOT redefine in team docs)
+
+- Cache adapters per provider — see `wiki/concepts/cache-adapters.md` (#926).
+- Header-driven spillover across 6 providers — `wiki/concepts/header-spillover.md` (#927).
+- Sticky-route per tier — `scripts/global/sticky-route.js` (#926).
+- Anthropic Batch routing for time-elastic work (`isBatchEligible`, #927).
+
+## Boundaries
+
+- HAMR scripts live in `scripts/global/` only. Do NOT duplicate logic in team-specific paths.
+- The global task router (`global-task-router.instructions.md`) chooses the **lane** (Free/Fleet/Haiku/Premium); HAMR provides the **cost/observability mechanics** within each lane. No conflict.
+- Copilot Team owns `dashboard/js/token-reconcile.js`, `cost-report.js`, `model-routing-engine.js`. HAMR wrapper does NOT modify those — wrapper produces JSONL + KV signals those files can read.
+
+## Activation gates (before claiming HAMR-active)
+
+Run on each checkout:
+
+```bash
+npm run hamr:activate         # installs git hooks + cron
+npm run hamr:sync-verify      # confirms scripts present in ~/.copilot/, ~/.codex/
+npx playwright test tests/hamr-team-integration.spec.js   # smoke test
+```
+
+## Override
+
+Repos that explicitly opt out (e.g., air-gapped) MUST set `MEGINGJORD_HAMR_DISABLED=1`.
+Non-set defaults to opt-in for governed work.


### PR DESCRIPTION
## Summary

Wave 7 child A — single canonical HAMR governance entry point for all 3 teams (Claude Code, Copilot, Codex).

- `instructions/hamr-routing.instructions.md` (NEW, 69 lines) — canonical contract.
- `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md` — pointers (additive).
- `instructions/global-task-router.instructions.md` — boundary clarification (lane vs cost-mechanics; no duplication).

Dedup audit complete; only adjacent content was lane policy in global-task-router (resolved via cross-ref). All files ≤100 lines.

## Hand-offs

COLLABORATOR_HANDOFF on #951 at #issuecomment-4383437731 (>60s before this PR).

Refs #951
Refs Epic #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)