### PR TITLE
feat(hamr): provider-wrapper opt-in shim #952

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased] — HAMR Wave 7 child B: hamr-provider-wrapper opt-in shim (#952, EPIC #860)
+
+### Added
+- `scripts/global/hamr-provider-wrapper.js` (≤100 lines): `wrapProviderCall(provider, callFn, opts)` — opt-in shim that injects HAMR cost levers (`cacheHeaders` #926, `appendCacheStat` #932, `maybeSpillover` #927, `pickStickyProvider` #926) around any provider call. Pure library; zero modification to existing call sites. Honors `MEGINGJORD_HAMR_DISABLED=1` for opt-out.
+- `tests/hamr-provider-wrapper.spec.js`: 7 tests (cacheHeaders pass-through, spillover on 429, no-spillover on 200, sticky decision, disabled env no-op, exception isolation, JSONL emission).
+
+### Notes
+- Lane: code-change. Disjoint from Copilot Team active surface.
+
 ## [Unreleased] — HAMR Wave 7 child A: cross-team instruction integration (#951, EPIC #860)
 
 ### Added

--- a/scripts/global/hamr-provider-wrapper.js
+++ b/scripts/global/hamr-provider-wrapper.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// hamr-provider-wrapper.js — HAMR Wave 7 child B (#952).
+// Opt-in shim: any provider call routes through cacheHeaders + appendCacheStat + spillover.
+// Pure library — does NOT modify provider call sites (Copilot Team boundary preserved).
+'use strict';
+const { cacheHeaders } = require('./litellm-client');
+const { appendCacheStat } = require('./cache-stats-emit');
+const ADAPTERS = require('./token-provider-adapters');
+const { maybeSpillover } = require('./header-spillover');
+const { pickStickyProvider } = require('./sticky-route');
+
+const HTTP_OK_DEFAULT = 200;
+
+function isDisabled() {
+  return process.env.MEGINGJORD_HAMR_DISABLED === '1';
+}
+
+function emitStatSafe(provider, payload) {
+  try {
+    const adapter = ADAPTERS[provider];
+    if (!adapter) return;
+    const tokenRecord = adapter(payload || {}, { provider });
+    appendCacheStat({
+      provider, model: tokenRecord.model ?? null,
+      cache_read_tokens: tokenRecord.cache_read_tokens ?? 0,
+      input_tokens: tokenRecord.input_tokens ?? 0,
+      output_tokens: tokenRecord.output_tokens ?? 0,
+    });
+  } catch { /* never let stats break the call */ }
+}
+
+/** Wrap any provider call with HAMR cost levers + observability.
+ * @param {string} provider - 'anthropic'|'openai'|'gemini'|'groq'|'cerebras'|'openrouter'.
+ * @param {Function} callFn - async fn that performs the provider call; receives `{headers, bodyExtras}`.
+ * @param {object} [opts] - { tier, previousProvider, ttlSeconds, cacheKey, request }.
+ * @returns {Promise<{ok: boolean, value?: object, sticky?: object, spillover?: object, error?: string}>} Wrapped result.
+ */
+async function wrapProviderCall(provider, callFn, opts = {}) {
+  if (isDisabled()) {
+    const value = await callFn({ headers: {}, bodyExtras: {} });
+    return { ok: true, value, sticky: null, spillover: null, hamr_disabled: true };
+  }
+  const sticky = opts.tier
+    ? pickStickyProvider(opts.tier, { previousProvider: opts.previousProvider })
+    : null;
+  const effectiveProvider = sticky?.provider || provider;
+  const hints = cacheHeaders(effectiveProvider, opts);
+  let response;
+  try { response = await callFn(hints); }
+  catch (err) { return { ok: false, error: err?.message || 'provider_call_failed', sticky, spillover: null }; }
+  emitStatSafe(effectiveProvider, response);
+  const respShape = { status: response?.status ?? response?.response?.status ?? HTTP_OK_DEFAULT, headers: response?.headers ?? new Map() };
+  const spillover = maybeSpillover(effectiveProvider, respShape);
+  return { ok: true, value: response, sticky, spillover };
+}
+
+if (require.main === module) {
+  console.log(JSON.stringify({ exports: ['wrapProviderCall'], hamr_disabled: isDisabled() }));
+}
+
+module.exports = { wrapProviderCall, isDisabled };

--- a/tests/hamr-provider-wrapper.spec.js
+++ b/tests/hamr-provider-wrapper.spec.js
@@ -1,0 +1,72 @@
+// hamr-provider-wrapper tests (#952).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const WRAP = require(path.resolve(__dirname, '..', 'scripts', 'global', 'hamr-provider-wrapper.js'));
+
+test('wrapProviderCall passes cacheHeaders hints to callFn', async () => {
+  let received = null;
+  const result = await WRAP.wrapProviderCall('anthropic', (hints) => {
+    received = hints;
+    return { id: 'r1', usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 70 } };
+  });
+  expect(result.ok).toBe(true);
+  expect(received.headers['anthropic-beta']).toContain('prompt-caching');
+});
+
+test('wrapProviderCall returns spillover decision on rate-limited response', async () => {
+  const result = await WRAP.wrapProviderCall('anthropic', () => ({
+    status: 429, headers: new Map([['retry-after', '30']]),
+    usage: { input_tokens: 0, output_tokens: 0 },
+  }));
+  expect(result.ok).toBe(true);
+  expect(result.spillover.spillover_needed).toBe(true);
+});
+
+test('wrapProviderCall returns no-spillover on healthy response', async () => {
+  const result = await WRAP.wrapProviderCall('groq', () => ({
+    status: 200, headers: new Map(),
+    usage: { prompt_tokens: 100, completion_tokens: 50, prompt_cache_hit_tokens: 30 },
+  }));
+  expect(result.spillover.spillover_needed).toBe(false);
+});
+
+test('wrapProviderCall surfaces sticky decision when tier is provided', async () => {
+  const result = await WRAP.wrapProviderCall('anthropic', () => ({
+    status: 200, headers: new Map(), usage: { input_tokens: 10, output_tokens: 5 },
+  }), { tier: 'haiku', previousProvider: 'anthropic' });
+  expect(result.sticky).not.toBeNull();
+  expect(['anthropic', 'openrouter']).toContain(result.sticky.provider);
+});
+
+test('wrapProviderCall obeys MEGINGJORD_HAMR_DISABLED=1 (no-op)', async () => {
+  const orig = process.env.MEGINGJORD_HAMR_DISABLED;
+  process.env.MEGINGJORD_HAMR_DISABLED = '1';
+  try {
+    const result = await WRAP.wrapProviderCall('anthropic', () => ({ ok: true }));
+    expect(result.hamr_disabled).toBe(true);
+    expect(result.spillover).toBeNull();
+  } finally {
+    if (orig === undefined) delete process.env.MEGINGJORD_HAMR_DISABLED;
+    else process.env.MEGINGJORD_HAMR_DISABLED = orig;
+  }
+});
+
+test('wrapProviderCall catches provider exception and returns ok:false', async () => {
+  const result = await WRAP.wrapProviderCall('openai', () => { throw new Error('network down'); });
+  expect(result.ok).toBe(false);
+  expect(result.error).toContain('network down');
+});
+
+test('emitStatSafe writes to cache-stats.jsonl on successful call', async () => {
+  const statsFile = path.join(os.homedir(), '.megingjord', 'cache-stats.jsonl');
+  const sizeBefore = fs.existsSync(statsFile) ? fs.statSync(statsFile).size : 0;
+  await WRAP.wrapProviderCall('cerebras', () => ({
+    status: 200, headers: new Map(),
+    usage: { prompt_tokens: 1000, completion_tokens: 50, prompt_cache_hit_tokens: 800 },
+  }));
+  const sizeAfter = fs.existsSync(statsFile) ? fs.statSync(statsFile).size : 0;
+  expect(sizeAfter).toBeGreaterThan(sizeBefore);
+});


### PR DESCRIPTION
## Summary

Wave 7 child B — opt-in shim wrapping any provider call with HAMR cost levers.

- `scripts/global/hamr-provider-wrapper.js` (NEW, ≤100 lines) — `wrapProviderCall(provider, callFn, opts)`.
- `tests/hamr-provider-wrapper.spec.js` — 7 tests.

## Hand-offs

COLLABORATOR_HANDOFF on #952 at #issuecomment-4383444990 (>60s before this PR).

Refs #952
Refs Epic #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)