### PR TITLE
feat(hamr): per-team opt-in configuration #963

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased] — HAMR Wave 7 follow-up: per-team opt-in configuration (#963, EPIC #860)
+
+### Added
+- `~/.claude/hamr-config.json`, `~/.copilot/hamr-config.json`, `~/.codex/devenv-ops/hamr-config.json` (NEW): per-team opt-in markers `{enabled, activated_at, activated_by, team_runtime}`. Written by `HAMR_TEAM=<team> npm run hamr:activate`.
+- `tests/hamr-team-optin.spec.js`: 5 tests covering TEAM_CONFIG_PATHS, readTeamConfig, isDisabled precedence, marker presence, env-override semantics.
+
+### Changed
+- `scripts/global/hamr-provider-wrapper.js`: `isDisabled()` now also reads first-found team config marker; respects `enabled: false` even when env unset. Exports `readTeamConfig`, `TEAM_CONFIG_PATHS`. Env var `MEGINGJORD_HAMR_DISABLED=1` still wins (air-gap escape hatch preserved).
+- `scripts/global/hamr-activate.sh`: 4-step → 5-step. New step 5 writes per-team marker based on `HAMR_TEAM=claude-code|copilot|codex`.
+- `tests/hamr-activate.spec.js`: updated to 5-step expectations.
+- `tests/hamr-worker.spec.js`: 3 stale-stub tests replaced with current production assertions (Wave 3 mailbox 400/401 paths + Wave 4/6 /quota schema v2 + stale field).
+
+### Notes
+- Lane: code-change.
+- All 3 teams now opted in (markers present + `enabled: true`).
+- Full suite: 166/166 pass.
+
 ## [Unreleased] — HAMR Wave 7 child F: cross-team integration test suite (#956, EPIC #860)
 
 ### Added

--- a/scripts/global/hamr-activate.sh
+++ b/scripts/global/hamr-activate.sh
@@ -9,17 +9,17 @@ echo "▶ HAMR activation for: $repo_root"
 
 step() { echo ""; echo "── $1 ──"; }
 
-step "1/4 install R9.2 git hooks (#934)"
+step "1/5 install R9.2 git hooks (#934)"
 bash "$repo_root/scripts/global/install-hooks.sh"
 
-step "2/4 install 6h periodic-push cron (#953)"
+step "2/5 install 6h periodic-push cron (#953)"
 if command -v crontab >/dev/null 2>&1; then
   bash "$repo_root/scripts/global/install-cron.sh" || echo "⚠ cron install failed; manual: crontab -e"
 else
   echo "⏭ crontab not available — skipping (run hamr-periodic-push.sh manually)"
 fi
 
-step "3/4 check operator key + Anthropic API key"
+step "3/5 check operator key + Anthropic API key"
 missing=()
 [ -z "${OPERATOR_KEY_SEED_B64:-}" ] && [ ! -f "${HOME}/.megingjord/keys/operator-ed25519.pem" ] && missing+=(OPERATOR_KEY_SEED_B64)
 [ -z "${ANTHROPIC_API_KEY:-}" ] && missing+=(ANTHROPIC_API_KEY)
@@ -30,12 +30,27 @@ else
   echo "   set in .env or shell profile; HAMR Worker push will skip until set"
 fi
 
-step "4/4 verify Worker reachable"
+step "4/5 verify Worker reachable"
 url="${HAMR_URL:-https://hamr.chf3198.workers.dev}"
 if curl -sf -o /dev/null "$url/healthz"; then
   echo "✅ Worker /healthz reachable: $url"
 else
   echo "⚠ Worker unreachable at $url — set MEGINGJORD_HAMR_DISABLED=1 if intentional"
+fi
+
+step "5/5 write per-team opt-in marker"
+team="${HAMR_TEAM:-claude-code}"
+case "$team" in
+  claude-code) cfg_dir="$HOME/.claude" ;;
+  copilot)     cfg_dir="$HOME/.copilot" ;;
+  codex)       cfg_dir="$HOME/.codex/devenv-ops" ;;
+  *)           echo "⚠ unknown HAMR_TEAM=$team; skipping marker"; cfg_dir="" ;;
+esac
+if [ -n "$cfg_dir" ]; then
+  mkdir -p "$cfg_dir"
+  printf '{"enabled": true, "activated_at": "%s", "activated_by": "%s", "team_runtime": "%s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$team" "$cfg_dir" > "$cfg_dir/hamr-config.json"
+  echo "✅ wrote $cfg_dir/hamr-config.json"
 fi
 
 echo ""

--- a/scripts/global/hamr-provider-wrapper.js
+++ b/scripts/global/hamr-provider-wrapper.js
@@ -3,6 +3,9 @@
 // Opt-in shim: any provider call routes through cacheHeaders + appendCacheStat + spillover.
 // Pure library — does NOT modify provider call sites (Copilot Team boundary preserved).
 'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
 const { cacheHeaders } = require('./litellm-client');
 const { appendCacheStat } = require('./cache-stats-emit');
 const ADAPTERS = require('./token-provider-adapters');
@@ -10,9 +13,25 @@ const { maybeSpillover } = require('./header-spillover');
 const { pickStickyProvider } = require('./sticky-route');
 
 const HTTP_OK_DEFAULT = 200;
+const TEAM_CONFIG_PATHS = [
+  path.join(os.homedir(), '.claude', 'hamr-config.json'),
+  path.join(os.homedir(), '.copilot', 'hamr-config.json'),
+  path.join(os.homedir(), '.codex', 'devenv-ops', 'hamr-config.json'),
+];
+
+function readTeamConfig() {
+  for (const file of TEAM_CONFIG_PATHS) {
+    if (!fs.existsSync(file)) continue;
+    try { return { file, ...JSON.parse(fs.readFileSync(file, 'utf8')) }; } catch { /* skip malformed */ }
+  }
+  return null;
+}
 
 function isDisabled() {
-  return process.env.MEGINGJORD_HAMR_DISABLED === '1';
+  if (process.env.MEGINGJORD_HAMR_DISABLED === '1') return true;
+  const cfg = readTeamConfig();
+  if (cfg && cfg.enabled === false) return true;
+  return false;
 }
 
 function emitStatSafe(provider, payload) {
@@ -58,4 +77,4 @@ if (require.main === module) {
   console.log(JSON.stringify({ exports: ['wrapProviderCall'], hamr_disabled: isDisabled() }));
 }
 
-module.exports = { wrapProviderCall, isDisabled };
+module.exports = { wrapProviderCall, isDisabled, readTeamConfig, TEAM_CONFIG_PATHS };

--- a/tests/hamr-activate.spec.js
+++ b/tests/hamr-activate.spec.js
@@ -12,10 +12,10 @@ test('hamr-activate.sh exists and is executable', () => {
   expect(fs.statSync(ACTIVATE).mode & 0o100).toBeTruthy();
 });
 
-test('hamr-activate.sh runs all 4 steps and exits 0', () => {
+test('hamr-activate.sh runs all 5 steps and exits 0', () => {
   const result = spawnSync('bash', [ACTIVATE], { cwd: REPO_ROOT, encoding: 'utf8' });
   expect(result.status).toBe(0);
-  for (const step of ['1/4', '2/4', '3/4', '4/4']) {
+  for (const step of ['1/5', '2/5', '3/5', '4/5', '5/5']) {
     expect(result.stdout).toContain(step);
   }
   expect(result.stdout).toContain('HAMR activation complete');

--- a/tests/hamr-team-optin.spec.js
+++ b/tests/hamr-team-optin.spec.js
@@ -1,0 +1,54 @@
+// Per-team HAMR opt-in tests (#963).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const WRAP = require(path.resolve(__dirname, '..', 'scripts', 'global', 'hamr-provider-wrapper.js'));
+
+test('TEAM_CONFIG_PATHS covers all 3 team runtime homes', () => {
+  const expected = [
+    path.join(os.homedir(), '.claude', 'hamr-config.json'),
+    path.join(os.homedir(), '.copilot', 'hamr-config.json'),
+    path.join(os.homedir(), '.codex', 'devenv-ops', 'hamr-config.json'),
+  ];
+  expect(WRAP.TEAM_CONFIG_PATHS).toEqual(expected);
+});
+
+test('readTeamConfig returns first present config marker', () => {
+  const cfg = WRAP.readTeamConfig();
+  expect(cfg).not.toBeNull();
+  expect(cfg.enabled).toBe(true);
+  expect(['claude-code', 'copilot', 'codex']).toContain(cfg.activated_by);
+});
+
+test('isDisabled returns false when team config marker enabled', () => {
+  const orig = process.env.MEGINGJORD_HAMR_DISABLED;
+  delete process.env.MEGINGJORD_HAMR_DISABLED;
+  try {
+    expect(WRAP.isDisabled()).toBe(false);
+  } finally {
+    if (orig !== undefined) process.env.MEGINGJORD_HAMR_DISABLED = orig;
+  }
+});
+
+test('all 3 team config markers exist on disk', () => {
+  for (const file of WRAP.TEAM_CONFIG_PATHS) {
+    expect(fs.existsSync(file)).toBe(true);
+    const cfg = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(cfg.enabled).toBe(true);
+    expect(typeof cfg.activated_at).toBe('string');
+    expect(['claude-code', 'copilot', 'codex']).toContain(cfg.activated_by);
+  }
+});
+
+test('isDisabled honors MEGINGJORD_HAMR_DISABLED=1 over team config', () => {
+  const orig = process.env.MEGINGJORD_HAMR_DISABLED;
+  process.env.MEGINGJORD_HAMR_DISABLED = '1';
+  try {
+    expect(WRAP.isDisabled()).toBe(true);
+  } finally {
+    if (orig === undefined) delete process.env.MEGINGJORD_HAMR_DISABLED;
+    else process.env.MEGINGJORD_HAMR_DISABLED = orig;
+  }
+});

--- a/tests/hamr-worker.spec.js
+++ b/tests/hamr-worker.spec.js
@@ -54,25 +54,29 @@ test('/mcp returns 401 missing_dpop without authorization header', async ({ requ
   expect(body.reason).toBe('missing_dpop');
 });
 
-test('/mailbox/read returns 501 placeholder', async ({ request }) => {
+// /mailbox/read promoted to production by Wave 3 #918 — recipient param required.
+test('/mailbox/read rejects bare GET with 400 missing_recipient', async ({ request }) => {
   const r = await request.get(`${BASE}/mailbox/read`);
-  expect(r.status()).toBe(501);
+  expect(r.status()).toBe(400);
   const body = await r.json();
-  expect(body.placeholder).toBe(true);
-  expect(body.detail).toContain('Wave 3 child 5');
+  expect(body.error).toBe('missing_recipient');
 });
 
-test('/mailbox/write returns 501 placeholder', async ({ request }) => {
+// /mailbox/write promoted to production by Wave 3 #918 — auth required.
+test('/mailbox/write rejects unauthenticated request with 401', async ({ request }) => {
   const r = await request.post(`${BASE}/mailbox/write`, { data: {} });
-  expect(r.status()).toBe(501);
+  expect(r.status()).toBe(401);
 });
 
-test('/quota returns 200 placeholder body', async ({ request }) => {
+// /quota promoted to schema v2 by Wave 4 #927 + stale field by Wave 6 #941.
+test('/quota returns 200 schema_version 2 with placeholder:false', async ({ request }) => {
   const r = await request.get(`${BASE}/quota`);
   expect(r.status()).toBe(200);
   const body = await r.json();
-  expect(body.placeholder).toBe(true);
-  expect(body.hit_rate_7d).toBeNull();
+  expect(body.schema_version).toBe(2);
+  expect(body.placeholder).toBe(false);
+  expect(body).toHaveProperty('hit_rate_7d');
+  expect(typeof body.stale).toBe('boolean');
 });
 
 test('unknown route returns 404 JSON', async ({ request }) => {


### PR DESCRIPTION
## Summary

Wave 7 follow-up — activates HAMR for all 3 teams via per-team config markers.

- `scripts/global/hamr-activate.sh` — 5-step; writes `<team-runtime>/hamr-config.json` based on `HAMR_TEAM=claude-code|copilot|codex`.
- `scripts/global/hamr-provider-wrapper.js` — `isDisabled()` now reads team config marker; exports `readTeamConfig`, `TEAM_CONFIG_PATHS`.
- 3 stale-stub tests in `hamr-worker.spec.js` upgraded to current Wave 3/4/6 production behavior.

## Activation status

```
~/.claude/hamr-config.json              enabled: true (Claude Code Team)
~/.copilot/hamr-config.json             enabled: true (Copilot Team)
~/.codex/devenv-ops/hamr-config.json    enabled: true (Codex Team)
```

## Validation evidence

- 166/166 HAMR tests pass (Wave 1-7 + opt-in).
- All 3 team config markers verified on disk.
- Live activation runs successful for all 3 teams.

## Hand-offs

COLLABORATOR_HANDOFF on #963 at #issuecomment-4383749676 (>60s before this PR).

Refs #963
Refs Epic #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)