### PR TITLE
feat(hamr): axis_consumers per-team marker extension #978

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased] — Wave 8 child 3: axis_consumers extension on per-team markers (#978, EPIC #968)
+
+### Changed
+- `scripts/global/hamr-activate.sh`: marker now includes `axis_consumers: {governance, tooling, fleet, hamr}` (default-on). `HAMR_AXES_OFF=<csv>` env opts out specific axes.
+
+### Added
+- `tests/axis-consumers.spec.js`: 3 tests.
+
+### Notes
+- Implements convergence-design item 5.
+- All 3 team markers re-written with the new field (live-verified on disk).
+
 ## [Unreleased] — Wave 8 child 1: cascade-policy-overrides producer (#976, EPIC #968)
 
 ### Added

--- a/scripts/global/hamr-activate.sh
+++ b/scripts/global/hamr-activate.sh
@@ -48,9 +48,14 @@ case "$team" in
 esac
 if [ -n "$cfg_dir" ]; then
   mkdir -p "$cfg_dir"
-  printf '{"enabled": true, "activated_at": "%s", "activated_by": "%s", "team_runtime": "%s"}\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$team" "$cfg_dir" > "$cfg_dir/hamr-config.json"
-  echo "✅ wrote $cfg_dir/hamr-config.json"
+  # Wave 8 child 3 (#978): axis_consumers per convergence-design item 5.
+  axes_off="${HAMR_AXES_OFF:-}"
+  axis_val() { case ",$axes_off," in *,$1,*) echo false ;; *) echo true ;; esac }
+  printf '{"enabled":true,"activated_at":"%s","activated_by":"%s","team_runtime":"%s","axis_consumers":{"governance":%s,"tooling":%s,"fleet":%s,"hamr":%s}}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$team" "$cfg_dir" \
+    "$(axis_val governance)" "$(axis_val tooling)" "$(axis_val fleet)" "$(axis_val hamr)" \
+    > "$cfg_dir/hamr-config.json"
+  echo "✅ wrote $cfg_dir/hamr-config.json (axis_consumers default-on)"
 fi
 
 echo ""

--- a/tests/axis-consumers.spec.js
+++ b/tests/axis-consumers.spec.js
@@ -1,0 +1,51 @@
+// axis_consumers extension tests (#978).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const ACTIVATE = path.join(REPO_ROOT, 'scripts', 'global', 'hamr-activate.sh');
+
+test('all 3 team markers contain axis_consumers field with all 4 axes', () => {
+  for (const cfg of [
+    path.join(os.homedir(), '.claude', 'hamr-config.json'),
+    path.join(os.homedir(), '.copilot', 'hamr-config.json'),
+    path.join(os.homedir(), '.codex', 'devenv-ops', 'hamr-config.json'),
+  ]) {
+    expect(fs.existsSync(cfg)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(cfg, 'utf8'));
+    expect(parsed.axis_consumers).toBeDefined();
+    expect(typeof parsed.axis_consumers.governance).toBe('boolean');
+    expect(typeof parsed.axis_consumers.tooling).toBe('boolean');
+    expect(typeof parsed.axis_consumers.fleet).toBe('boolean');
+    expect(typeof parsed.axis_consumers.hamr).toBe('boolean');
+  }
+});
+
+test('HAMR_AXES_OFF=fleet,tooling sets those false; others true', () => {
+  const result = spawnSync('bash', [ACTIVATE], {
+    cwd: REPO_ROOT, encoding: 'utf8',
+    env: { ...process.env, HAMR_TEAM: 'claude-code', HAMR_AXES_OFF: 'fleet,tooling' },
+  });
+  expect(result.status).toBe(0);
+  const cfg = JSON.parse(fs.readFileSync(path.join(os.homedir(), '.claude', 'hamr-config.json'), 'utf8'));
+  expect(cfg.axis_consumers.fleet).toBe(false);
+  expect(cfg.axis_consumers.tooling).toBe(false);
+  expect(cfg.axis_consumers.governance).toBe(true);
+  expect(cfg.axis_consumers.hamr).toBe(true);
+  // Restore for downstream tests.
+  spawnSync('bash', [ACTIVATE], { cwd: REPO_ROOT, env: { ...process.env, HAMR_TEAM: 'claude-code' } });
+});
+
+test('hamr-provider-wrapper still recognizes enabled:true regardless of axis content', () => {
+  const WRAP = require(path.resolve(REPO_ROOT, 'scripts', 'global', 'hamr-provider-wrapper.js'));
+  const orig = process.env.MEGINGJORD_HAMR_DISABLED;
+  delete process.env.MEGINGJORD_HAMR_DISABLED;
+  try {
+    expect(WRAP.isDisabled()).toBe(false);
+  } finally {
+    if (orig !== undefined) process.env.MEGINGJORD_HAMR_DISABLED = orig;
+  }
+});


### PR DESCRIPTION
Wave 8 child 3 — convergence-design item 5.

scripts/global/hamr-activate.sh now writes axis_consumers field. HAMR_AXES_OFF env opts out specific axes. All 3 team markers updated.

Tests: 3/3 pass.

Hand-offs: COLLABORATOR_HANDOFF on #978 at #issuecomment-4384461512 (>60s before this PR).

Refs #978
Refs Epic #968