### PR TITLE
feat(governance): SKILL.md → per-team views derive script #979

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,3 +85,7 @@ AI-authored baton artifacts, PR evidence, and governance docs must include human
 ## HAMR Cross-Team Routing
 
 All governed provider calls route through HAMR (`https://hamr.chf3198.workers.dev`). Activate per-checkout: `npm run hamr:activate`. Canonical contract: `instructions/hamr-routing.instructions.md`. The Global Task Router (lane selection) and HAMR (cost/observability mechanics) are complementary — HAMR does not duplicate lane policy.
+
+## Skill Index
+
+Auto-derived from `skills/<name>/SKILL.md` frontmatter — see [`docs/skills-copilot.md`](../docs/skills-copilot.md). Regenerate via `node scripts/global/skill-views-derive.js`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,10 @@ This repo is the **development workbench** for the DevEnv Ops Harness runtimes:
 - Activate per-checkout: `npm run hamr:activate`. Verify: `npm run hamr:sync-verify`.
 - Canonical contract: `instructions/hamr-routing.instructions.md`.
 
+## Skill index
+
+Auto-derived from `skills/<name>/SKILL.md` frontmatter — see [`docs/skills-agents.md`](docs/skills-agents.md). Regenerate via `node scripts/global/skill-views-derive.js`.
+
 ## Development → Deploy workflow
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased] — Wave 8 child 4: SKILL.md → per-team views derive script (#979, EPIC #968)
+
+### Added
+- `scripts/global/skill-views-derive.js` (≤100 lines): read-only on `SKILL.md` (per Round-4 D4.1 scope cap). Scans `skills/<name>/SKILL.md` frontmatter; writes `docs/skills-agents.md` and `docs/skills-copilot.md`. Idempotent.
+- `docs/skills-agents.md`, `docs/skills-copilot.md`: derived skill index views (35 skills today).
+- `AGENTS.md`, `.github/copilot-instructions.md`: 1-line "Skill index" reference pointing to derived doc.
+- `package.json` script: `hamr:skill-views`.
+- `tests/skill-views-derive.spec.js`: 6 tests (scan, sort order, buildDoc shape, idempotency, missing-frontmatter, line-cap).
+
+### Notes
+- Implements convergence-design item 6.
+- Output written to separate `docs/skills-*.md` files to keep `AGENTS.md` and `copilot-instructions.md` ≤ 100 lines.
+
 ## [Unreleased] — Wave 8 child 3: axis_consumers extension on per-team markers (#978, EPIC #968)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ npm run deploy:both:apply
 | `hamr:log-rotate` | `node scripts/global/log-rotate.js` |
 | `hamr:policy-overrides` | `node scripts/global/cascade-policy-overrides.js` |
 | `hamr:rule-gate` | `node scripts/global/rule-coverage-gate.js` |
+| `hamr:skill-views` | `node scripts/global/skill-views-derive.js` |
 | `hamr:spillover` | `node scripts/global/header-spillover.js` |
 | `hamr:sticky-route` | `node scripts/global/sticky-route.js` |
 | `hamr:sync-verify` | `node scripts/global/hamr-sync-verify.js` |

--- a/docs/skills-agents.md
+++ b/docs/skills-agents.md
@@ -1,0 +1,39 @@
+# Skill index — agents view
+
+*Auto-generated from `skills/<name>/SKILL.md` frontmatter — DO NOT EDIT.*
+
+- **docs-drift-maintenance** — Detect and remediate documentation drift after code, config, workflow, or UX changes. Use after implementation, before merge, and before release.
+- **fleet-model-optimizer** — Analyze any fleet's inventory/devices.json and recommend optimal Ollama models per device based on hardware constraints, inference tier, and current LLM landscape. Generates pull/delete commands and a
+- **github-actions-security-hardening** — Enforce secure GitHub Actions posture with least-privilege tokens, pinned dependencies, runner risk controls, and workflow supply-chain checks.
+- **github-capability-resolver** — Resolve GitHub feature availability and policy constraints by plan, repo visibility, account type, and enabled settings before recommending governance actions.
+- **github-ops-excellence** — Define and apply expert GitHub policy profiles and control catalogs used by specialized execution skills across ticketing, review/merge, governance, and release flows.
+- **github-ops-tree-router** — Route GitHub workflow requests through a capability-first GitHub skill tree with explicit ownership boundaries and minimal overlap.
+- **github-projects-agile-linkage** — Apply Agile linkage controls in GitHub using issue types, sub-issues, dependencies, issue-branch/PR linkage, project fields, and built-in automations.
+- **github-release-incident-flow** — Govern release readiness and incident response flow in GitHub with rollback evidence, hotfix linkage, and follow-up controls.
+- **github-review-merge-admin** — Enforce review and merge administration gates with required checks, approvals, conversation resolution, rulesets, and merge queue readiness.
+- **github-ruleset-architecture** — Design and audit repository and organization ruleset architecture, including layering, bypass controls, enforcement modes, and merge queue compatibility.
+- **github-ticket-lifecycle-orchestrator** — Naming conventions and phase protocol for GitHub ticket lifecycle. Baton workflow in manager-ticket-lifecycle.
+- **global-skills-bootstrap** — Initialize a repository so global skills are always loaded first through repository instructions, local hooks, and governance presence checks.
+- **global-task-router** — Classify tasks into free, fleet, or premium lanes and persist an escalation rationale for the active session.
+- **llm-wiki-ops-portable** — Operate an LLM Wiki knowledge system in any workspace using the Karpathy pattern
+- **manager-ticket-lifecycle** — The GitHub issue IS the baton. Manager creates tickets, pre-assigns roles, enforces status transitions through the Agile workflow.
+- **mem-watchdog-ops** — Operate and tune Crostini Mem Watchdog for low-memory development sessions. Use for status triage, log interpretation, and safe threshold tuning.
+- **network-platform-resources** — Inventory of all network-accessible compute platforms, connection methods, credentials, and specs. Load this skill when a task could benefit from remote execution, offloading, or cross-platform deploy
+- **openclaw-availability-utilization** — Keep OpenClaw gateway highly available and actively used through mandatory preflight checks, execution routing, and failover controls.
+- **openclaw-universal-system** — Make OpenClaw a reusable machine-global execution system for all VS Code Copilot agent chats, regardless of repository, by standardizing routing, observability, and decision checkpoints.
+- **openrouter-free-failover** — Configure and maintain optimal OpenRouter free model failover for OpenClaw. Prioritized cascade of free models ranked by coding capability, with automatic failover on rate limits, downtime, and errors
+- **operator-identity-context** — Establishes the operator identity, access authority, and execution mandate for all agent sessions. Always load at session start. The agent is the full operator and executes responsibilities through si
+- **playwright-vision-low-resource** — Apply a low-resource operating profile for Playwright MCP + Claude Vision on constrained machines. Use this at session start, before visual QA, or after browser-context/OOM failures. Establishes bound
+- **release-version-integrity** — Validate and enforce release version integrity across tags, manifests, changelogs, and publish workflows. Use before tagging, publishing, or when release metadata drift is suspected.
+- **repo-onboarding-standards** — Onboard any repository into a standardized Copilot + CI governance baseline. Use for new repos and first-time sessions to ensure immediate standards adoption.
+- **repo-profile-governance** — Audit and harden repository profile, community health, discoverability metadata, and contribution surfaces across repos using bounded, evidence-based checks.
+- **repo-standards-router** — Classify a repository by app type and route it to the correct standards branch, policy profile, and verification gates.
+- **repo-structure-conventions** — Enforce file organization, naming conventions, and app-type-specific project layouts. Use when creating, restructuring, or onboarding a repository.
+- **role-admin-execution** — Execute operational tasks after validated implementation: runtime controls, git/PR/release flow, and governance checks.
+- **role-baton-orchestrator** — Orchestrate single-thread baton handoff across Manager -> Collaborator -> Admin -> Consultant with explicit entry/exit contracts.
+- **role-collaborator-execution** — Implement scoped changes and produce validation evidence matching manager-defined gates.
+- **role-consultant-critique** — Perform independent post-execution critique, risk scoring, and recommendation synthesis without changing implementation scope.
+- **role-manager-execution** — Define scope, constraints, acceptance criteria, and verification gates before implementation begins.
+- **secret-exposure-prevention** — Prevent secret leakage across git history, package artifacts, logs, and docs. Use when editing workflows, packaging configuration, environment files, or release automation.
+- **web-regression-governance** — Apply non-bypass visual/DOM/runtime regression governance for website-static and web-app repositories that use HTML/CSS/JS runtime behavior.
+- **workflow-self-anneal** — Run a bounded self-annealing review of operating instructions and workflow outcomes. Use this after failures, after long sessions, before merge, or when repeated mismatches appear between intended pro

--- a/docs/skills-copilot.md
+++ b/docs/skills-copilot.md
@@ -1,0 +1,39 @@
+# Skill index — Copilot view
+
+*Auto-generated from `skills/<name>/SKILL.md` frontmatter — DO NOT EDIT.*
+
+- **docs-drift-maintenance** — Detect and remediate documentation drift after code, config, workflow, or UX changes. Use after implementation, before merge, and before release.
+- **fleet-model-optimizer** — Analyze any fleet's inventory/devices.json and recommend optimal Ollama models per device based on hardware constraints, inference tier, and current LLM landscape. Generates pull/delete commands and a
+- **github-actions-security-hardening** — Enforce secure GitHub Actions posture with least-privilege tokens, pinned dependencies, runner risk controls, and workflow supply-chain checks.
+- **github-capability-resolver** — Resolve GitHub feature availability and policy constraints by plan, repo visibility, account type, and enabled settings before recommending governance actions.
+- **github-ops-excellence** — Define and apply expert GitHub policy profiles and control catalogs used by specialized execution skills across ticketing, review/merge, governance, and release flows.
+- **github-ops-tree-router** — Route GitHub workflow requests through a capability-first GitHub skill tree with explicit ownership boundaries and minimal overlap.
+- **github-projects-agile-linkage** — Apply Agile linkage controls in GitHub using issue types, sub-issues, dependencies, issue-branch/PR linkage, project fields, and built-in automations.
+- **github-release-incident-flow** — Govern release readiness and incident response flow in GitHub with rollback evidence, hotfix linkage, and follow-up controls.
+- **github-review-merge-admin** — Enforce review and merge administration gates with required checks, approvals, conversation resolution, rulesets, and merge queue readiness.
+- **github-ruleset-architecture** — Design and audit repository and organization ruleset architecture, including layering, bypass controls, enforcement modes, and merge queue compatibility.
+- **github-ticket-lifecycle-orchestrator** — Naming conventions and phase protocol for GitHub ticket lifecycle. Baton workflow in manager-ticket-lifecycle.
+- **global-skills-bootstrap** — Initialize a repository so global skills are always loaded first through repository instructions, local hooks, and governance presence checks.
+- **global-task-router** — Classify tasks into free, fleet, or premium lanes and persist an escalation rationale for the active session.
+- **llm-wiki-ops-portable** — Operate an LLM Wiki knowledge system in any workspace using the Karpathy pattern
+- **manager-ticket-lifecycle** — The GitHub issue IS the baton. Manager creates tickets, pre-assigns roles, enforces status transitions through the Agile workflow.
+- **mem-watchdog-ops** — Operate and tune Crostini Mem Watchdog for low-memory development sessions. Use for status triage, log interpretation, and safe threshold tuning.
+- **network-platform-resources** — Inventory of all network-accessible compute platforms, connection methods, credentials, and specs. Load this skill when a task could benefit from remote execution, offloading, or cross-platform deploy
+- **openclaw-availability-utilization** — Keep OpenClaw gateway highly available and actively used through mandatory preflight checks, execution routing, and failover controls.
+- **openclaw-universal-system** — Make OpenClaw a reusable machine-global execution system for all VS Code Copilot agent chats, regardless of repository, by standardizing routing, observability, and decision checkpoints.
+- **openrouter-free-failover** — Configure and maintain optimal OpenRouter free model failover for OpenClaw. Prioritized cascade of free models ranked by coding capability, with automatic failover on rate limits, downtime, and errors
+- **operator-identity-context** — Establishes the operator identity, access authority, and execution mandate for all agent sessions. Always load at session start. The agent is the full operator and executes responsibilities through si
+- **playwright-vision-low-resource** — Apply a low-resource operating profile for Playwright MCP + Claude Vision on constrained machines. Use this at session start, before visual QA, or after browser-context/OOM failures. Establishes bound
+- **release-version-integrity** — Validate and enforce release version integrity across tags, manifests, changelogs, and publish workflows. Use before tagging, publishing, or when release metadata drift is suspected.
+- **repo-onboarding-standards** — Onboard any repository into a standardized Copilot + CI governance baseline. Use for new repos and first-time sessions to ensure immediate standards adoption.
+- **repo-profile-governance** — Audit and harden repository profile, community health, discoverability metadata, and contribution surfaces across repos using bounded, evidence-based checks.
+- **repo-standards-router** — Classify a repository by app type and route it to the correct standards branch, policy profile, and verification gates.
+- **repo-structure-conventions** — Enforce file organization, naming conventions, and app-type-specific project layouts. Use when creating, restructuring, or onboarding a repository.
+- **role-admin-execution** — Execute operational tasks after validated implementation: runtime controls, git/PR/release flow, and governance checks.
+- **role-baton-orchestrator** — Orchestrate single-thread baton handoff across Manager -> Collaborator -> Admin -> Consultant with explicit entry/exit contracts.
+- **role-collaborator-execution** — Implement scoped changes and produce validation evidence matching manager-defined gates.
+- **role-consultant-critique** — Perform independent post-execution critique, risk scoring, and recommendation synthesis without changing implementation scope.
+- **role-manager-execution** — Define scope, constraints, acceptance criteria, and verification gates before implementation begins.
+- **secret-exposure-prevention** — Prevent secret leakage across git history, package artifacts, logs, and docs. Use when editing workflows, packaging configuration, environment files, or release automation.
+- **web-regression-governance** — Apply non-bypass visual/DOM/runtime regression governance for website-static and web-app repositories that use HTML/CSS/JS runtime behavior.
+- **workflow-self-anneal** — Run a bounded self-annealing review of operating instructions and workflow outcomes. Use this after failures, after long sessions, before merge, or when repeated mismatches appear between intended pro

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "hamr:log-rotate": "node scripts/global/log-rotate.js",
     "hamr:policy-overrides": "node scripts/global/cascade-policy-overrides.js",
     "hamr:rule-gate": "node scripts/global/rule-coverage-gate.js",
+    "hamr:skill-views": "node scripts/global/skill-views-derive.js",
     "hamr:spillover": "node scripts/global/header-spillover.js",
     "hamr:sticky-route": "node scripts/global/sticky-route.js",
     "hamr:sync-verify": "node scripts/global/hamr-sync-verify.js",

--- a/scripts/global/skill-views-derive.js
+++ b/scripts/global/skill-views-derive.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// skill-views-derive.js — Wave 8 child 4 (#979).
+// Read-only on SKILL.md (per Round-4 D4.1 scope cap). Scans skills/<name>/SKILL.md;
+// writes derived views to docs/skills-{agents,copilot}.md. Parent files reference these.
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SKILLS_DIR = path.join(REPO_ROOT, 'skills');
+const VIEW_DIR = path.join(REPO_ROOT, 'docs');
+const DESC_TRIM = 200;
+
+const TARGETS = [
+  { audience: 'agents', file: path.join(VIEW_DIR, 'skills-agents.md') },
+  { audience: 'copilot', file: path.join(VIEW_DIR, 'skills-copilot.md') },
+];
+
+function parseSkill(file) {
+  const text = fs.readFileSync(file, 'utf8');
+  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return null;
+  const out = { file, name: null, description: null };
+  for (const line of m[1].split('\n')) {
+    const kv = line.match(/^(\w+):\s*(.+)$/);
+    if (!kv) continue;
+    if (kv[1] === 'name') out.name = kv[2].trim().replace(/^['"]|['"]$/g, '');
+    if (kv[1] === 'description') out.description = kv[2].trim().replace(/^['"]|['"]$/g, '');
+  }
+  return out;
+}
+
+function scanSkills() {
+  if (!fs.existsSync(SKILLS_DIR)) return [];
+  const out = [];
+  for (const dir of fs.readdirSync(SKILLS_DIR)) {
+    const skillFile = path.join(SKILLS_DIR, dir, 'SKILL.md');
+    if (!fs.existsSync(skillFile)) continue;
+    const parsed = parseSkill(skillFile);
+    if (parsed && parsed.name) out.push(parsed);
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function buildDoc(audience, skills) {
+  const header = audience === 'copilot'
+    ? '# Skill index — Copilot view\n\n*Auto-generated from `skills/<name>/SKILL.md` frontmatter — DO NOT EDIT.*\n\n'
+    : '# Skill index — agents view\n\n*Auto-generated from `skills/<name>/SKILL.md` frontmatter — DO NOT EDIT.*\n\n';
+  const rows = skills.map((s) => `- **${s.name}** — ${(s.description || '(no description)').slice(0, DESC_TRIM)}`);
+  return header + rows.join('\n') + '\n';
+}
+
+function applyToTarget(target, skills) {
+  fs.mkdirSync(path.dirname(target.file), { recursive: true });
+  const next = buildDoc(target.audience, skills);
+  if (fs.existsSync(target.file) && fs.readFileSync(target.file, 'utf8') === next) {
+    return { ok: true, file: target.file, changed: false };
+  }
+  fs.writeFileSync(target.file, next);
+  return { ok: true, file: target.file, changed: true };
+}
+
+function run(opts = {}) {
+  const skills = scanSkills();
+  const targets = opts.targets || TARGETS;
+  const results = targets.map((t) => applyToTarget(t, skills));
+  return { ok: true, skill_count: skills.length, results };
+}
+
+if (require.main === module) {
+  console.log(JSON.stringify(run(), null, 2));
+}
+
+module.exports = { run, scanSkills, buildDoc, parseSkill, TARGETS };

--- a/tests/skill-views-derive.spec.js
+++ b/tests/skill-views-derive.spec.js
@@ -1,0 +1,58 @@
+// skill-views-derive tests (#979).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const DERIVE = require(path.resolve(__dirname, '..', 'scripts', 'global', 'skill-views-derive.js'));
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+test('scanSkills finds at least 10 skills with name+description', () => {
+  const skills = DERIVE.scanSkills();
+  expect(skills.length).toBeGreaterThanOrEqual(10);
+  for (const s of skills) {
+    expect(s.name).toBeTruthy();
+    expect(typeof s.name).toBe('string');
+  }
+});
+
+test('scanSkills returns alphabetical order', () => {
+  const skills = DERIVE.scanSkills();
+  const names = skills.map((s) => s.name);
+  const sorted = [...names].sort();
+  expect(names).toEqual(sorted);
+});
+
+test('buildDoc emits markdown with skill bullets', () => {
+  const doc = DERIVE.buildDoc('agents', [{ name: 'foo', description: 'bar' }, { name: 'baz', description: 'qux' }]);
+  expect(doc).toContain('# Skill index');
+  expect(doc).toContain('**foo** — bar');
+  expect(doc).toContain('**baz** — qux');
+});
+
+test('run() is idempotent — second invocation reports no change', () => {
+  const tmp1 = path.join(os.tmpdir(), `svd-${Date.now()}-1.md`);
+  const tmp2 = path.join(os.tmpdir(), `svd-${Date.now()}-2.md`);
+  const targets = [{ audience: 'agents', file: tmp1 }, { audience: 'copilot', file: tmp2 }];
+  const r1 = DERIVE.run({ targets });
+  const r2 = DERIVE.run({ targets });
+  for (const res of r1.results) expect(res.changed).toBe(true);
+  for (const res of r2.results) expect(res.changed).toBe(false);
+  fs.unlinkSync(tmp1); fs.unlinkSync(tmp2);
+});
+
+test('parseSkill handles missing frontmatter gracefully', () => {
+  const tmp = path.join(os.tmpdir(), `svd-noyaml-${Date.now()}.md`);
+  fs.writeFileSync(tmp, '# No frontmatter here');
+  expect(DERIVE.parseSkill(tmp)).toBeNull();
+  fs.unlinkSync(tmp);
+});
+
+test('docs/skills-{agents,copilot}.md are <100 lines (lint cap)', () => {
+  for (const f of ['docs/skills-agents.md', 'docs/skills-copilot.md']) {
+    const file = path.join(REPO_ROOT, f);
+    if (!fs.existsSync(file)) continue;
+    const lines = fs.readFileSync(file, 'utf8').split('\n').length;
+    expect(lines).toBeLessThan(100);
+  }
+});


### PR DESCRIPTION
Wave 8 child 4 — convergence-design item 6.

scripts/global/skill-views-derive.js scans skills/<name>/SKILL.md frontmatter; writes docs/skills-{agents,copilot}.md. Read-only on SKILL.md per Round-4 D4.1 scope cap. 35 skills enumerated. Idempotent.

AGENTS.md + .github/copilot-instructions.md add 1-line skill-index reference (kept ≤100 lines).

Tests: 6/6 pass.

Hand-offs: COLLABORATOR_HANDOFF on #979 at #issuecomment-4384473662 (>60s before this PR).

Refs #979
Refs Epic #968