### PR TITLE
feat(governance): cross-team edit governance-lint warn #980

### DIFF
--- a/.github/workflows/cross-team-edit-warn.yml
+++ b/.github/workflows/cross-team-edit-warn.yml
@@ -1,0 +1,57 @@
+# Wave 8 child 5 (#980) — cross-team edit governance-lint warn.
+# Convergence-design item 7: when a PR edits both shared-surface (instructions/, inventory/, wiki/)
+# AND owned-surface (scripts/global/, dashboard/, cloudflare/hamr/), warn if PR body lacks a
+# coordinating-ticket citation. WARN-ONLY — does not block merge.
+name: cross-team-edit-warn
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+jobs:
+  cross-team-edit-warn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Detect cross-cut edits
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const number = context.payload.pull_request.number;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: number, per_page: 100
+            });
+            const sharedRe = /^(instructions\/|inventory\/|wiki\/)/;
+            const ownedRe = /^(scripts\/global\/|dashboard\/|cloudflare\/hamr\/)/;
+            let touchesShared = false, touchesOwned = false;
+            for (const f of files) {
+              if (sharedRe.test(f.filename)) touchesShared = true;
+              if (ownedRe.test(f.filename)) touchesOwned = true;
+            }
+            if (!(touchesShared && touchesOwned)) {
+              core.info('no cross-cut edits detected — no warn needed');
+              return;
+            }
+            const body = context.payload.pull_request.body || '';
+            const hasCoord = /(?:Coordinates|Coord-with|Refs Epic) #\d+/i.test(body);
+            if (hasCoord) {
+              core.info('cross-cut edits detected and coordinating ticket cited — OK');
+              return;
+            }
+            const marker = '<!-- cross-team-edit-warn -->';
+            const existing = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: number, per_page: 100
+            });
+            if (existing.some(c => c.body && c.body.includes(marker))) {
+              core.info('warn comment already posted; skipping');
+              return;
+            }
+            const comment = `${marker}\n## Cross-team edit warn\n\nThis PR touches both **shared-surface** (instructions/, inventory/, wiki/) AND **owned-surface** (scripts/global/, dashboard/, cloudflare/hamr/) without citing a coordinating ticket.\n\nPer convergence-design item 7 (Epic #922), cross-cut edits should cite a coordinating ticket using \`Coordinates #N\`, \`Coord-with #N\`, or \`Refs Epic #N\` in the PR body.\n\n_Warn only — does not block merge._`;
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: number, body: comment
+            });
+            core.info('warn comment posted');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased] — Wave 8 child 5: cross-team edit governance-lint warn (#980, EPIC #968)
+
+### Added
+- `.github/workflows/cross-team-edit-warn.yml` (≤100 lines): runs on `pull_request`. When a PR touches both shared-surface (`instructions/`, `inventory/`, `wiki/`) AND owned-surface (`scripts/global/`, `dashboard/`, `cloudflare/hamr/`) without citing a coordinating ticket (`Coordinates #N`, `Coord-with #N`, or `Refs Epic #N`), posts a warn comment. Idempotent (single comment via marker dedup). **Warn only — does not block merge.**
+
+### Notes
+- Implements convergence-design item 7.
+- Codex Team surface (governance lint adjacent) — work performed as operator-deputy.
+
 ## [Unreleased] — Wave 8 child 4: SKILL.md → per-team views derive script (#979, EPIC #968)
 
 ### Added


### PR DESCRIPTION
Wave 8 child 5 — convergence-design item 7.

.github/workflows/cross-team-edit-warn.yml warns when a PR touches both shared-surface (instructions/, inventory/, wiki/) AND owned-surface (scripts/global/, dashboard/, cloudflare/hamr/) without citing a coordinating ticket. Idempotent via marker dedup. Warn-only — does not block merge.

Hand-offs: COLLABORATOR_HANDOFF on #980 at #issuecomment-4384476918 (>60s before this PR).

Refs #980
Refs Epic #968