### PR TITLE
feat(routing): cascade-policy-overrides consumer #977

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] — Wave 8 child 2: cascade-policy-overrides consumer (#977, EPIC #968)
+
+### Changed
+- `scripts/global/model-routing-engine.js`: adds `loadOverrides()` that reads `~/.megingjord/cascade-policy-overrides.json` (additive; falls back when absent). `resolveRouting()` returns `{overridesApplied, overridesStale}` flags. Strict-superset preserved.
+- `tests/policy-overrides-consumer.spec.js`: 5 tests (absent/present/malformed paths + resolveRouting integration + back-compat).
+
+### Notes
+- Implements convergence-design item 4 (consumer side). Producer shipped in #976.
+- Copilot Team active surface — work performed as operator-deputy per #922 SIGN_OFF authorization.
+
 ## [Unreleased] — Wave 8 child 5: cross-team edit governance-lint warn (#980, EPIC #968)
 
 ### Added

--- a/scripts/global/model-routing-engine.js
+++ b/scripts/global/model-routing-engine.js
@@ -2,9 +2,20 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const { readTelemetry, summarize } = require('./model-routing-telemetry');
 
 const FILE = path.join(__dirname, 'model-routing-policy.json');
+const POLICY_OVERRIDES = path.join(os.homedir(), '.megingjord', 'cascade-policy-overrides.json');
+
+// Wave 8 child 2 (#977): convergence-design item 4 consumer side.
+// Read overrides if present; falls back silently when missing/malformed.
+function loadOverrides() {
+  try {
+    if (!fs.existsSync(POLICY_OVERRIDES)) return null;
+    return JSON.parse(fs.readFileSync(POLICY_OVERRIDES, 'utf8'));
+  } catch { return null; }
+}
 
 function loadPolicy() { return JSON.parse(fs.readFileSync(FILE, 'utf8')); }
 
@@ -41,14 +52,17 @@ function resolveRouting(prompt, route) {
   const thresh = policy.complexityThresholds || {};
   if (lane === 'premium' && cx < (thresh.premium ?? 0.7)) lane = cx < (thresh.haiku ?? 0.3) ? 'fleet' : 'haiku';
   const model = policy.models[lane] || policy.models.fallback;
+  const overrides = loadOverrides();
   return {
     lane,
     modelId: model.id,
     multiplier: model.mult,
     taskClass: classifyTask(prompt, policy.taskClasses),
     rollbackApplied,
-    complexity: cx
+    complexity: cx,
+    overridesApplied: overrides !== null,
+    overridesStale: overrides?.stale ?? false,
   };
 }
 
-module.exports = { resolveRouting, loadPolicy };
+module.exports = { resolveRouting, loadPolicy, loadOverrides };

--- a/tests/policy-overrides-consumer.spec.js
+++ b/tests/policy-overrides-consumer.spec.js
@@ -1,0 +1,71 @@
+// cascade-policy-overrides consumer (in model-routing-engine) tests (#977).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const ENGINE = require(path.resolve(__dirname, '..', 'scripts', 'global', 'model-routing-engine.js'));
+const OVERRIDES = path.join(os.homedir(), '.megingjord', 'cascade-policy-overrides.json');
+
+test('loadOverrides returns null when file absent', () => {
+  // Move existing temporarily if present
+  const backup = fs.existsSync(OVERRIDES) ? fs.readFileSync(OVERRIDES) : null;
+  if (backup) fs.unlinkSync(OVERRIDES);
+  try {
+    expect(ENGINE.loadOverrides()).toBeNull();
+  } finally {
+    if (backup) fs.writeFileSync(OVERRIDES, backup);
+  }
+});
+
+test('loadOverrides returns parsed JSON when file present', () => {
+  const stash = fs.existsSync(OVERRIDES) ? fs.readFileSync(OVERRIDES) : null;
+  fs.mkdirSync(path.dirname(OVERRIDES), { recursive: true });
+  fs.writeFileSync(OVERRIDES, JSON.stringify({ ts: 123, providers: { groq: { available: true } }, stale: false }));
+  try {
+    const o = ENGINE.loadOverrides();
+    expect(o.providers.groq.available).toBe(true);
+    expect(o.stale).toBe(false);
+  } finally {
+    if (stash) fs.writeFileSync(OVERRIDES, stash);
+    else fs.unlinkSync(OVERRIDES);
+  }
+});
+
+test('loadOverrides returns null on malformed JSON (graceful)', () => {
+  const stash = fs.existsSync(OVERRIDES) ? fs.readFileSync(OVERRIDES) : null;
+  fs.writeFileSync(OVERRIDES, '{not json');
+  try {
+    expect(ENGINE.loadOverrides()).toBeNull();
+  } finally {
+    if (stash) fs.writeFileSync(OVERRIDES, stash);
+    else fs.unlinkSync(OVERRIDES);
+  }
+});
+
+test('resolveRouting includes overridesApplied flag', () => {
+  const stash = fs.existsSync(OVERRIDES) ? fs.readFileSync(OVERRIDES) : null;
+  fs.mkdirSync(path.dirname(OVERRIDES), { recursive: true });
+  fs.writeFileSync(OVERRIDES, JSON.stringify({ ts: Date.now(), providers: {}, stale: false }));
+  try {
+    const r = ENGINE.resolveRouting('test prompt', { lane: 'fleet', complexity: 0.4 });
+    expect(r.overridesApplied).toBe(true);
+    expect(r.overridesStale).toBe(false);
+    expect(r.lane).toBe('fleet');
+  } finally {
+    if (stash) fs.writeFileSync(OVERRIDES, stash);
+    else fs.unlinkSync(OVERRIDES);
+  }
+});
+
+test('resolveRouting unchanged when overrides absent (back-compat)', () => {
+  const stash = fs.existsSync(OVERRIDES) ? fs.readFileSync(OVERRIDES) : null;
+  if (stash) fs.unlinkSync(OVERRIDES);
+  try {
+    const r = ENGINE.resolveRouting('test prompt', { lane: 'haiku', complexity: 0.5 });
+    expect(r.overridesApplied).toBe(false);
+    expect(r.lane).toBe('haiku');
+  } finally {
+    if (stash) fs.writeFileSync(OVERRIDES, stash);
+  }
+});


### PR DESCRIPTION
Wave 8 child 2 — convergence-design item 4 (consumer side).

scripts/global/model-routing-engine.js adds loadOverrides() reading ~/.megingjord/cascade-policy-overrides.json (additive). resolveRouting() returns overridesApplied + overridesStale flags. Falls back when absent.

Tests: 5/5 pass. Strict-superset preserved.

Copilot Team active surface — work performed as operator-deputy per #922 SIGN_OFF authorization.

Hand-offs: COLLABORATOR_HANDOFF on #977 at #issuecomment-4384481261 (>60s before this PR).

Refs #977
Refs Epic #968