### PR TITLE
fix(hooks): R9.2 pre-push allows --delete refspecs #989

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] — Tooling A1: R9.2 hook --delete refspec fix (#989, EPIC #987)
+
+### Fixed
+- `scripts/hooks/pre-push-branch-check.sh`: skips branch-mismatch check when local_sha is the all-zeros delete sentinel. Branch deletions (`git push origin --delete <branch>`) no longer trip the R9.2 hook.
+- `tests/r92-hooks.spec.js`: 1 new test for delete refspec; 7/7 total pass.
+
+### Notes
+- Strict-superset preserved: real-push mismatch detection unchanged.
+- Audit log records `is_delete: true|false` for transparency.
+
 ## [Unreleased] — Wave 8 child 2: cascade-policy-overrides consumer (#977, EPIC #968)
 
 ### Changed

--- a/scripts/hooks/pre-push-branch-check.sh
+++ b/scripts/hooks/pre-push-branch-check.sh
@@ -8,20 +8,25 @@ current_branch=$(git rev-parse --abbrev-ref HEAD)
 audit_log="${HOME}/.megingjord/branch-ops-audit.log"
 mkdir -p "$(dirname "$audit_log")"
 
+DELETE_SHA="0000000000000000000000000000000000000000"
 violations=0
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   [ -z "${local_ref:-}" ] && continue
   local_branch=${local_ref#refs/heads/}
   remote_branch=${remote_ref#refs/heads/}
-  if [ "$local_branch" != "$current_branch" ]; then
+  # A1 fix (#989): skip mismatch check on branch-delete refspec.
+  # Git sets local_sha to all-zeros when pushing a delete (e.g., `git push --delete`).
+  is_delete="false"
+  [ "$local_sha" = "$DELETE_SHA" ] && is_delete="true"
+  if [ "$is_delete" = "false" ] && [ "$local_branch" != "$current_branch" ]; then
     echo "❌ R9.2.1 violation: pushing $local_branch but HEAD is $current_branch"
     echo "    cwd: $(pwd)"
     echo "    refspec: $local_ref → $remote_ref"
     violations=$((violations + 1))
   fi
-  printf '{"ts":%s,"op":"pre-push","cwd":"%s","head":"%s","local_ref":"%s","remote_ref":"%s","local_sha":"%s","violation":%s}\n' \
-    "$(date +%s%3N)" "$(pwd)" "$current_branch" "$local_ref" "$remote_ref" "$local_sha" \
-    "$([ "$local_branch" != "$current_branch" ] && echo true || echo false)" >> "$audit_log"
+  printf '{"ts":%s,"op":"pre-push","cwd":"%s","head":"%s","local_ref":"%s","remote_ref":"%s","local_sha":"%s","is_delete":%s,"violation":%s}\n' \
+    "$(date +%s%3N)" "$(pwd)" "$current_branch" "$local_ref" "$remote_ref" "$local_sha" "$is_delete" \
+    "$([ "$is_delete" = "false" ] && [ "$local_branch" != "$current_branch" ] && echo true || echo false)" >> "$audit_log"
 done
 
 if [ "$violations" -gt 0 ]; then

--- a/tests/r92-hooks.spec.js
+++ b/tests/r92-hooks.spec.js
@@ -30,6 +30,14 @@ test('pre-push hook exits 1 when local branch ≠ HEAD', () => {
   expect(result.stdout.toString()).toContain('R9.2.1 violation');
 });
 
+// A1 fix (#989): branch-delete refspec uses all-zeros local_sha.
+test('pre-push hook exits 0 on branch-delete refspec (all-zero local_sha)', () => {
+  const stdin = 'refs/heads/some-other-branch 0000000000000000000000000000000000000000 refs/heads/some-other-branch deadbeef\n';
+  const result = spawnSync(PRE_PUSH, [], { input: stdin, cwd: REPO_ROOT });
+  expect(result.status).toBe(0);
+  expect(result.stdout.toString()).not.toContain('R9.2.1 violation');
+});
+
 test('audit script writes JSON-line on post-checkout branch op', () => {
   const auditLog = path.join(process.env.HOME, '.megingjord', 'branch-ops-audit.log');
   const beforeLines = fs.existsSync(auditLog) ? fs.readFileSync(auditLog, 'utf8').split('\n').length : 0;


### PR DESCRIPTION
Tooling A1 — R&D #988 defect.

scripts/hooks/pre-push-branch-check.sh — skips branch-mismatch when local_sha is the all-zeros delete sentinel. Fixes blocked branch-cleanup operations.

Tests: 7/7 pass (1 new for delete refspec).

COLLABORATOR_HANDOFF on #989 at #issuecomment-4385037005.

Refs #989
Refs Epic #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)