### PR TITLE
fix(governance): evidence-completeness Refs Epic pairing #990

### DIFF
--- a/.github/workflows/evidence-completeness.yml
+++ b/.github/workflows/evidence-completeness.yml
@@ -21,25 +21,44 @@ jobs:
             const prCreatedAt = new Date(pr.created_at);
             const violations = [];
 
-            // 1. Linked issue — require Refs #N
-            const refsMatch = body.match(/Refs\s+#(\d+)/i);
-            if (!refsMatch) {
+            // 1. Linked issue — require Refs #N. A3 fix (#990): scan ALL Refs;
+            // pick the first non-epic. `Refs Epic #N` is treated as secondary
+            // (allowed alongside `Refs #child`); `Refs #N` alone where N is an
+            // Epic still fails per the original rule.
+            const refsAll = [...body.matchAll(/Refs(?:\s+Epic)?\s+#(\d+)/gi)];
+            if (!refsAll.length) {
               core.setFailed('No linked issue (Refs #N missing). Add Refs #N to PR body.');
               return;
             }
-            const linkedNum = parseInt(refsMatch[1]);
+            // Resolve each candidate; pick the first that is NOT type:epic.
+            let linkedNum = null;
+            let issue = null;
+            for (const m of refsAll) {
+              const candidate = parseInt(m[1]);
+              try {
+                const r = await github.rest.issues.get({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: candidate,
+                });
+                const isEpic = r.data.labels.map(l => l.name).includes('type:epic');
+                if (!isEpic) { linkedNum = candidate; issue = r.data; break; }
+              } catch { /* fall through */ }
+            }
+            if (linkedNum === null) {
+              // No non-epic Refs found; fall back to original behavior with first Refs.
+              linkedNum = parseInt(refsAll[0][1]);
+            }
 
             // 2. Issue must be OPEN and not type:epic
-            let issue;
-            try {
-              const r = await github.rest.issues.get({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: linkedNum,
-              });
-              issue = r.data;
-            } catch (e) {
-              core.setFailed(`Issue #${linkedNum} not found: ${e.message}`);
-              return;
+            if (!issue) {
+              try {
+                const r = await github.rest.issues.get({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: linkedNum,
+                });
+                issue = r.data;
+              } catch (e) {
+                core.setFailed(`Issue #${linkedNum} not found: ${e.message}`);
+                return;
+              }
             }
             if (issue.state !== 'open') violations.push(`Issue #${linkedNum} is ${issue.state} — must be OPEN`);
             const labels = issue.labels.map(l => l.name);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased] — Tooling A3: evidence-completeness Refs Epic pairing fix (#990, EPIC #987)
+
+### Fixed
+- `.github/workflows/evidence-completeness.yml`: gate now scans all `Refs #N` AND `Refs Epic #N` matches in PR body; picks first non-epic candidate as the primary linked issue. PRs that cite both a child ticket AND an Epic now pass.
+
+### Notes
+- Strict-superset preserved: PRs with only `Refs #child-N` continue to work unchanged. PRs with only `Refs Epic #N` still fail (must have a child Refs).
+- Workflow file (Codex-team-adjacent surface) — work performed as operator-deputy per #922 SIGN_OFF authorization.
+
 ## [Unreleased] — Tooling A1: R9.2 hook --delete refspec fix (#989, EPIC #987)
 
 ### Fixed


### PR DESCRIPTION
Tooling A3 — R&D #988 defect.

.github/workflows/evidence-completeness.yml — scans ALL Refs in PR body; picks first non-epic candidate. PRs with Refs #child + Refs Epic #N now pass.

Strict-superset preserved.

COLLABORATOR_HANDOFF on #990 at #issuecomment-4385044150.

Refs #990
Refs Epic #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)