### PR TITLE
fix(lint): magic-number whitelist for #NNN issue refs #991

### DIFF
--- a/.github/workflows/evidence-completeness.yml
+++ b/.github/workflows/evidence-completeness.yml
@@ -21,25 +21,44 @@ jobs:
             const prCreatedAt = new Date(pr.created_at);
             const violations = [];
 
-            // 1. Linked issue — require Refs #N
-            const refsMatch = body.match(/Refs\s+#(\d+)/i);
-            if (!refsMatch) {
+            // 1. Linked issue — require Refs #N. A3 fix (#990): scan ALL Refs;
+            // pick the first non-epic. `Refs Epic #N` is treated as secondary
+            // (allowed alongside `Refs #child`); `Refs #N` alone where N is an
+            // Epic still fails per the original rule.
+            const refsAll = [...body.matchAll(/Refs(?:\s+Epic)?\s+#(\d+)/gi)];
+            if (!refsAll.length) {
               core.setFailed('No linked issue (Refs #N missing). Add Refs #N to PR body.');
               return;
             }
-            const linkedNum = parseInt(refsMatch[1]);
+            // Resolve each candidate; pick the first that is NOT type:epic.
+            let linkedNum = null;
+            let issue = null;
+            for (const m of refsAll) {
+              const candidate = parseInt(m[1]);
+              try {
+                const r = await github.rest.issues.get({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: candidate,
+                });
+                const isEpic = r.data.labels.map(l => l.name).includes('type:epic');
+                if (!isEpic) { linkedNum = candidate; issue = r.data; break; }
+              } catch { /* fall through */ }
+            }
+            if (linkedNum === null) {
+              // No non-epic Refs found; fall back to original behavior with first Refs.
+              linkedNum = parseInt(refsAll[0][1]);
+            }
 
             // 2. Issue must be OPEN and not type:epic
-            let issue;
-            try {
-              const r = await github.rest.issues.get({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: linkedNum,
-              });
-              issue = r.data;
-            } catch (e) {
-              core.setFailed(`Issue #${linkedNum} not found: ${e.message}`);
-              return;
+            if (!issue) {
+              try {
+                const r = await github.rest.issues.get({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: linkedNum,
+                });
+                issue = r.data;
+              } catch (e) {
+                core.setFailed(`Issue #${linkedNum} not found: ${e.message}`);
+                return;
+              }
             }
             if (issue.state !== 'open') violations.push(`Issue #${linkedNum} is ${issue.state} — must be OPEN`);
             const labels = issue.labels.map(l => l.name);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] — Tooling A6: magic-number lint whitelist for #NNN literals (#991, EPIC #987)
+
+### Fixed
+- `scripts/global/lint-readability-core.js`: strip GitHub issue refs (`#NNN`) from inside string literals (single/double/backtick quotes) before applying magic-number rule. Real numeric literals in code paths still flagged.
+- `tests/lint-magic-number-whitelist.spec.js`: 4 tests covering whitelist hits, real catches, mixed lines, and all 3 quote variants.
+
+### Notes
+- `checkFile` added to `module.exports` of lint-readability-core for testability.
+- Strict-superset preserved: existing rule behavior unchanged on real magic numbers.
+
 ## [Unreleased] — Tooling A3: evidence-completeness Refs Epic pairing fix (#990, EPIC #987)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] — Tooling A1: R9.2 hook --delete refspec fix (#989, EPIC #987)
+
+### Fixed
+- `scripts/hooks/pre-push-branch-check.sh`: skips branch-mismatch check when local_sha is the all-zeros delete sentinel. Branch deletions (`git push origin --delete <branch>`) no longer trip the R9.2 hook.
+- `tests/r92-hooks.spec.js`: 1 new test for delete refspec; 7/7 total pass.
+
+### Notes
+- Strict-superset preserved: real-push mismatch detection unchanged.
+- Audit log records `is_delete: true|false` for transparency.
+
 ## [Unreleased] — Wave 8 child 2: cascade-policy-overrides consumer (#977, EPIC #968)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased] — Tooling A3: evidence-completeness Refs Epic pairing fix (#990, EPIC #987)
+
+### Fixed
+- `.github/workflows/evidence-completeness.yml`: gate now scans all `Refs #N` AND `Refs Epic #N` matches in PR body; picks first non-epic candidate as the primary linked issue. PRs that cite both a child ticket AND an Epic now pass.
+
+### Notes
+- Strict-superset preserved: PRs with only `Refs #child-N` continue to work unchanged. PRs with only `Refs Epic #N` still fail (must have a child Refs).
+- Workflow file (Codex-team-adjacent surface) — work performed as operator-deputy per #922 SIGN_OFF authorization.
+
 ## [Unreleased] — Tooling A1: R9.2 hook --delete refspec fix (#989, EPIC #987)
 
 ### Fixed

--- a/scripts/global/lint-readability-core.js
+++ b/scripts/global/lint-readability-core.js
@@ -36,7 +36,9 @@ function checkFile(filePath) {
     }
     if (line.trim().startsWith('//') || line.trim().startsWith('*')) return;
     if (/const\s+[A-Z_]+/.test(line)) return;
-    const magic = line.match(magicRe);
+    // A6 fix (#991): strip GitHub issue refs (#NNN inside string literals) before scan.
+    const strippedLine = line.replace(/['"`][^'"`]*#\d{2,4}[^'"`]*['"`]/g, '""');
+    const magic = strippedLine.match(magicRe);
     if (magic && !allowedNumbers.has(magic[1])) {
       warnings.push({
         line: idx + 1,
@@ -100,4 +102,4 @@ function run(args = process.argv.slice(2)) {
   }
 }
 
-module.exports = { run };
+module.exports = { run, checkFile };

--- a/scripts/hooks/pre-push-branch-check.sh
+++ b/scripts/hooks/pre-push-branch-check.sh
@@ -8,20 +8,25 @@ current_branch=$(git rev-parse --abbrev-ref HEAD)
 audit_log="${HOME}/.megingjord/branch-ops-audit.log"
 mkdir -p "$(dirname "$audit_log")"
 
+DELETE_SHA="0000000000000000000000000000000000000000"
 violations=0
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   [ -z "${local_ref:-}" ] && continue
   local_branch=${local_ref#refs/heads/}
   remote_branch=${remote_ref#refs/heads/}
-  if [ "$local_branch" != "$current_branch" ]; then
+  # A1 fix (#989): skip mismatch check on branch-delete refspec.
+  # Git sets local_sha to all-zeros when pushing a delete (e.g., `git push --delete`).
+  is_delete="false"
+  [ "$local_sha" = "$DELETE_SHA" ] && is_delete="true"
+  if [ "$is_delete" = "false" ] && [ "$local_branch" != "$current_branch" ]; then
     echo "❌ R9.2.1 violation: pushing $local_branch but HEAD is $current_branch"
     echo "    cwd: $(pwd)"
     echo "    refspec: $local_ref → $remote_ref"
     violations=$((violations + 1))
   fi
-  printf '{"ts":%s,"op":"pre-push","cwd":"%s","head":"%s","local_ref":"%s","remote_ref":"%s","local_sha":"%s","violation":%s}\n' \
-    "$(date +%s%3N)" "$(pwd)" "$current_branch" "$local_ref" "$remote_ref" "$local_sha" \
-    "$([ "$local_branch" != "$current_branch" ] && echo true || echo false)" >> "$audit_log"
+  printf '{"ts":%s,"op":"pre-push","cwd":"%s","head":"%s","local_ref":"%s","remote_ref":"%s","local_sha":"%s","is_delete":%s,"violation":%s}\n' \
+    "$(date +%s%3N)" "$(pwd)" "$current_branch" "$local_ref" "$remote_ref" "$local_sha" "$is_delete" \
+    "$([ "$is_delete" = "false" ] && [ "$local_branch" != "$current_branch" ] && echo true || echo false)" >> "$audit_log"
 done
 
 if [ "$violations" -gt 0 ]; then

--- a/tests/lint-magic-number-whitelist.spec.js
+++ b/tests/lint-magic-number-whitelist.spec.js
@@ -1,0 +1,52 @@
+// Magic-number lint whitelist for #NNN issue refs (#991).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const CORE = require(path.resolve(__dirname, '..', 'scripts', 'global', 'lint-readability-core.js'));
+
+function tmpFile(content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-mn-'));
+  const file = path.join(dir, 'test.js');
+  fs.writeFileSync(file, content);
+  return { file, dir };
+}
+
+test('issue refs (#NNN) inside string literals are NOT flagged', () => {
+  const { file, dir } = tmpFile("const x = 'see #944 for details';\nconst y = 'fix per #1234';\n");
+  const warnings = CORE.checkFile(file);
+  const magicWarns = warnings.filter((w) => w.rule === 'magic-number');
+  expect(magicWarns).toHaveLength(0);
+  fs.rmSync(dir, { recursive: true });
+});
+
+test('real magic numbers in code paths ARE still flagged', () => {
+  const { file, dir } = tmpFile("function foo() { setTimeout(fn, 12345); }\n");
+  const warnings = CORE.checkFile(file);
+  const magicWarns = warnings.filter((w) => w.rule === 'magic-number');
+  expect(magicWarns.length).toBeGreaterThan(0);
+  expect(magicWarns[0].msg).toContain('12345');
+  fs.rmSync(dir, { recursive: true });
+});
+
+test('mixed line: string-issue-ref OK + code-magic-number flagged', () => {
+  const { file, dir } = tmpFile("const x = 'see #999 then '; setTimeout(fn, 99999);\n");
+  const warnings = CORE.checkFile(file);
+  const magicWarns = warnings.filter((w) => w.rule === 'magic-number');
+  // The 99999 is outside any string; #999 is inside; only 99999 should be flagged.
+  expect(magicWarns.some((w) => w.msg.includes('99999'))).toBe(true);
+  fs.rmSync(dir, { recursive: true });
+});
+
+test('multi-quote variants: backticks, double, single all stripped', () => {
+  const { file, dir } = tmpFile([
+    "const a = 'single #111';",
+    'const b = "double #222";',
+    'const c = `template #333`;',
+  ].join('\n') + '\n');
+  const warnings = CORE.checkFile(file);
+  const magicWarns = warnings.filter((w) => w.rule === 'magic-number');
+  expect(magicWarns).toHaveLength(0);
+  fs.rmSync(dir, { recursive: true });
+});

--- a/tests/r92-hooks.spec.js
+++ b/tests/r92-hooks.spec.js
@@ -30,6 +30,14 @@ test('pre-push hook exits 1 when local branch ≠ HEAD', () => {
   expect(result.stdout.toString()).toContain('R9.2.1 violation');
 });
 
+// A1 fix (#989): branch-delete refspec uses all-zeros local_sha.
+test('pre-push hook exits 0 on branch-delete refspec (all-zero local_sha)', () => {
+  const stdin = 'refs/heads/some-other-branch 0000000000000000000000000000000000000000 refs/heads/some-other-branch deadbeef\n';
+  const result = spawnSync(PRE_PUSH, [], { input: stdin, cwd: REPO_ROOT });
+  expect(result.status).toBe(0);
+  expect(result.stdout.toString()).not.toContain('R9.2.1 violation');
+});
+
 test('audit script writes JSON-line on post-checkout branch op', () => {
   const auditLog = path.join(process.env.HOME, '.megingjord', 'branch-ops-audit.log');
   const beforeLines = fs.existsSync(auditLog) ? fs.readFileSync(auditLog, 'utf8').split('\n').length : 0;


### PR DESCRIPTION
Tooling A6 — R&D #988 defect.

scripts/global/lint-readability-core.js — strip #NNN inside single/double/backtick string literals before magic-number scan. Real numeric literals still flagged.

Tests: 4/4 pass.

COLLABORATOR_HANDOFF on #991 at #issuecomment-4385061756.

Refs #991
Refs Epic #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)