### PR TITLE
fix(lint): magic-number whitelist for #NNN issue refs #991

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] — Tooling A6: magic-number lint whitelist for #NNN literals (#991, EPIC #987)
+
+### Fixed
+- `scripts/global/lint-readability-core.js`: strip GitHub issue refs (`#NNN`) from inside string literals (single/double/backtick quotes) before applying magic-number rule. Real numeric literals in code paths still flagged.
+- `tests/lint-magic-number-whitelist.spec.js`: 4 tests covering whitelist hits, real catches, mixed lines, and all 3 quote variants.
+
+### Notes
+- `checkFile` added to `module.exports` of lint-readability-core for testability.
+- Strict-superset preserved: existing rule behavior unchanged on real magic numbers.
+
 ## [Unreleased] — Tooling A3: evidence-completeness Refs Epic pairing fix (#990, EPIC #987)
 
 ### Fixed

--- a/scripts/global/lint-readability-core.js
+++ b/scripts/global/lint-readability-core.js
@@ -36,7 +36,9 @@ function checkFile(filePath) {
     }
     if (line.trim().startsWith('//') || line.trim().startsWith('*')) return;
     if (/const\s+[A-Z_]+/.test(line)) return;
-    const magic = line.match(magicRe);
+    // A6 fix (#991): strip GitHub issue refs (#NNN inside string literals) before scan.
+    const strippedLine = line.replace(/['"`][^'"`]*#\d{2,4}[^'"`]*['"`]/g, '""');
+    const magic = strippedLine.match(magicRe);
     if (magic && !allowedNumbers.has(magic[1])) {
       warnings.push({
         line: idx + 1,
@@ -100,4 +102,4 @@ function run(args = process.argv.slice(2)) {
   }
 }
 
-module.exports = { run };
+module.exports = { run, checkFile };

--- a/tests/lint-magic-number-whitelist.spec.js
+++ b/tests/lint-magic-number-whitelist.spec.js
@@ -1,0 +1,52 @@
+// Magic-number lint whitelist for #NNN issue refs (#991).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const CORE = require(path.resolve(__dirname, '..', 'scripts', 'global', 'lint-readability-core.js'));
+
+function tmpFile(content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-mn-'));
+  const file = path.join(dir, 'test.js');
+  fs.writeFileSync(file, content);
+  return { file, dir };
+}
+
+test('issue refs (#NNN) inside string literals are NOT flagged', () => {
+  const { file, dir } = tmpFile("const x = 'see #944 for details';\nconst y = 'fix per #1234';\n");
+  const warnings = CORE.checkFile(file);
+  const magicWarns = warnings.filter((w) => w.rule === 'magic-number');
+  expect(magicWarns).toHaveLength(0);
+  fs.rmSync(dir, { recursive: true });
+});
+
+test('real magic numbers in code paths ARE still flagged', () => {
+  const { file, dir } = tmpFile("function foo() { setTimeout(fn, 12345); }\n");
+  const warnings = CORE.checkFile(file);
+  const magicWarns = warnings.filter((w) => w.rule === 'magic-number');
+  expect(magicWarns.length).toBeGreaterThan(0);
+  expect(magicWarns[0].msg).toContain('12345');
+  fs.rmSync(dir, { recursive: true });
+});
+
+test('mixed line: string-issue-ref OK + code-magic-number flagged', () => {
+  const { file, dir } = tmpFile("const x = 'see #999 then '; setTimeout(fn, 99999);\n");
+  const warnings = CORE.checkFile(file);
+  const magicWarns = warnings.filter((w) => w.rule === 'magic-number');
+  // The 99999 is outside any string; #999 is inside; only 99999 should be flagged.
+  expect(magicWarns.some((w) => w.msg.includes('99999'))).toBe(true);
+  fs.rmSync(dir, { recursive: true });
+});
+
+test('multi-quote variants: backticks, double, single all stripped', () => {
+  const { file, dir } = tmpFile([
+    "const a = 'single #111';",
+    'const b = "double #222";',
+    'const c = `template #333`;',
+  ].join('\n') + '\n');
+  const warnings = CORE.checkFile(file);
+  const magicWarns = warnings.filter((w) => w.rule === 'magic-number');
+  expect(magicWarns).toHaveLength(0);
+  fs.rmSync(dir, { recursive: true });
+});


### PR DESCRIPTION
Tooling A6 — R&D #988 defect.

scripts/global/lint-readability-core.js — strip #NNN inside single/double/backtick string literals before magic-number scan. Real numeric literals still flagged.

Tests: 4/4 pass.

COLLABORATOR_HANDOFF on #991 at #issuecomment-4385061756 (well > 60s before this PR).

Refs #991
Refs Epic #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)