### PR TITLE
feat(governance): GitHub Artifact Attestations #999

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,21 @@ jobs:
       base64-subjects: ${{ needs.build.outputs.sha256 }}
       upload-assets: true
 
+  github-attest:
+    # C13 (#999): GitHub Artifact Attestations as parallel signal alongside cosign.
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with: { name: hamr-bundle, path: dist/bundles/ }
+      - uses: actions/attest-build-provenance@7668a9555bb8260244698ac4f7866b8b13d0ce20 # v2.1.0
+        with:
+          subject-path: 'dist/bundles/*'
+
   cosign-sign:
     needs: [build, slsa-attest]
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] — Tooling C13: GitHub Artifact Attestations on release workflow (#999, EPIC #987)
+
+### Added
+- `.github/workflows/release.yml`: new `github-attest` job using `actions/attest-build-provenance@v2.1.0` (pinned by SHA). Runs in parallel with existing `slsa-attest` + `cosign-sign` jobs.
+- `instructions/release-docs-hygiene.instructions.md`: step 7 — artifact attestation evidence requirement.
+
+### Notes
+- Strict-superset preserved: existing cosign path unchanged. New attestation is a parallel signal.
+- Codex Team active surface (release workflow + governance instructions) — work performed as operator-deputy per #922 SIGN_OFF authorization.
+
 ## [Unreleased] — Tooling C8: Cloudflare Workers Observability v2 adoption (#998, EPIC #987)
 
 ### Changed

--- a/instructions/release-docs-hygiene.instructions.md
+++ b/instructions/release-docs-hygiene.instructions.md
@@ -15,5 +15,6 @@ After every PR merge or deployment that changes user-facing behavior, run these 
 4. **Docs drift**: Run the `docs-drift-maintenance` skill to detect stale documentation that contradicts the new behavior.
 5. **Learnings**: If the change revealed a significant discovery, add an entry to `docs/workflow/learnings.md`.
 6. **Release integrity**: If the merge changes extension or package behavior, run `release-version-integrity` to validate tag/manifest/changelog alignment, then publish the new version.
+7. **Artifact attestation**: Tag-triggered releases MUST produce both cosign-bundle signature AND GitHub Artifact Attestation (Sigstore-backed; via `actions/attest-build-provenance`). C13 (#999) enables the parallel attestation signal alongside the existing cosign path.
 
-Do not consider a PR merge or deployment task complete until steps 1-6 are explicitly addressed (either completed or confirmed not applicable).
+Do not consider a PR merge or deployment task complete until steps 1-7 are explicitly addressed (either completed or confirmed not applicable).


### PR DESCRIPTION
Tooling C13 — R&D #988 recommendation.

.github/workflows/release.yml — new github-attest job using actions/attest-build-provenance@v2.1.0 (SHA-pinned). Strict-superset: cosign-sign + slsa-attest unchanged.

COLLABORATOR_HANDOFF on #999 at #issuecomment-4385198268.

Refs #999
Refs Epic #987