### PR TITLE
docs(codex): align runtime path docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 flowchart LR
 	A[Repo Source] --> B[skills/ instructions/ hooks/ scripts]
 	B --> C[~/.copilot runtime]
-	B --> D[~/.codex/megingjord-harness runtime]
+	B --> D[~/.codex/devenv-ops runtime]
 	B --> E[~/.agents/skills runtime]
 	C --> F[Governed agent execution]
 	D --> F
@@ -180,10 +180,10 @@ This table is auto-generated from `package.json` by `npm run docs:compile` (#796
 |---|---|
 | skills/ | ~/.copilot/skills + ~/.agents/skills |
 | instructions/ | ~/.copilot/instructions |
-| hooks/ | ~/.copilot/hooks + ~/.codex/megingjord-harness/hooks |
-| scripts/global/ | ~/.copilot/scripts + ~/.codex/megingjord-harness/scripts |
+| hooks/ | ~/.copilot/hooks + ~/.codex/devenv-ops/hooks |
+| scripts/global/ | ~/.copilot/scripts + ~/.codex/devenv-ops/scripts |
 | .codex/ | ~/.codex/AGENTS.md + config.toml + hooks.json + rules/ |
-| wiki/ | ~/.copilot/wiki + ~/.codex/megingjord-harness/wiki |
+| wiki/ | ~/.copilot/wiki + ~/.codex/devenv-ops/wiki |
 
 ## Issue flows
 


### PR DESCRIPTION
Refs #1009
Closes #1009
Refs Epic #1005

## Summary
- Replace stale README Codex managed-runtime path references with `~/.codex/devenv-ops`.
- Keep runtime behavior unchanged.

## Validation
- `grep -n "\.codex/megingjord-harness" README.md || true` returned no stale README references.
- `grep -n "\.codex/devenv-ops" README.md .github/copilot-instructions.md scripts/global/codex-runtime.js` shows aligned paths.
- `npm run -s lint` passed.
- Pre-push checks passed.

Signed-by: Curtis Franks
Team&Model: codex:gpt-5.5
