### PR TITLE
fix(dashboard): derive agent heartbeat vendor

### DIFF
--- a/dashboard/js/multi-agent-sessions.js
+++ b/dashboard/js/multi-agent-sessions.js
@@ -12,6 +12,13 @@ const AGENT_HEARTBEAT_KEY = 'agent_heartbeats';
 const MAX_VISIBLE = 3;
 const MAX_HEARTBEAT_AGE_SEC = 300;
 
+function getSelfVendor() {
+  const raw = String(window.__AGENT_VENDOR || window.__AGENT_RUNTIME || '').toLowerCase();
+  if (VENDOR_ICONS[raw]) return raw;
+  const agentId = String(window.__AGENT_ID || '').toLowerCase();
+  return Object.keys(VENDOR_ICONS).find(v => agentId.startsWith(v)) || 'copilot';
+}
+
 function getAgentSessionsFromStorage() {
   try {
     const raw = localStorage.getItem(AGENT_HEARTBEAT_KEY);
@@ -28,10 +35,13 @@ function updateAgentHeartbeat(session) {
 }
 
 function broadcastSelfHeartbeat() {
+  const vendor = getSelfVendor();
+  const branch = window.__AGENT_BRANCH || 'unknown';
+  const idBranch = window.__AGENT_BRANCH || 'main';
   const self = {
-    vendor: 'copilot',
-    agentId: 'copilot-' + (window.__AGENT_BRANCH || 'main'),
-    branch: window.__AGENT_BRANCH || 'unknown',
+    vendor,
+    agentId: window.__AGENT_ID || `${vendor}-${idBranch}`,
+    branch,
     ticket: window.__AGENT_TICKET || '',
     activity: 'monitoring',
     ts: Date.now(),

--- a/tests/multi-agent-sessions.spec.js
+++ b/tests/multi-agent-sessions.spec.js
@@ -1,0 +1,35 @@
+const { test, expect } = require('@playwright/test');
+
+async function readSelfHeartbeat(page, globals = {}) {
+  return page.evaluate(async (vars) => {
+    localStorage.removeItem('agent_heartbeats');
+    delete window.__AGENT_VENDOR;
+    delete window.__AGENT_RUNTIME;
+    delete window.__AGENT_ID;
+    delete window.__AGENT_BRANCH;
+    Object.assign(window, vars);
+    const sessions = await window.fetchAgentSessions();
+    return sessions[0];
+  }, globals);
+}
+
+test.describe('multi-agent session heartbeat', () => {
+  test('attributes Codex sessions from runtime globals', async ({ page }) => {
+    await page.goto('/');
+    const session = await readSelfHeartbeat(page, {
+      __AGENT_VENDOR: 'codex',
+      __AGENT_BRANCH: 'sandbox/codex',
+    });
+    expect(session.vendor).toBe('codex');
+    expect(session.agentId).toBe('codex-sandbox/codex');
+    expect(session.branch).toBe('sandbox/codex');
+  });
+
+  test('keeps Copilot as default self heartbeat vendor', async ({ page }) => {
+    await page.goto('/');
+    const session = await readSelfHeartbeat(page);
+    expect(session.vendor).toBe('copilot');
+    expect(session.agentId).toBe('copilot-main');
+    expect(session.branch).toBe('unknown');
+  });
+});


### PR DESCRIPTION
Refs #1010
Closes #1010
Refs Epic #1005

## Summary
- Derive dashboard self-heartbeat vendor from runtime globals or agent id.
- Preserve Copilot as the default when no runtime metadata is present.
- Add Playwright coverage for Codex and default attribution.

## Validation
- `npx playwright test tests/multi-agent-sessions.spec.js` -> 2 passed.
- `npm run -s lint` -> pass.
- Pre-push checks passed.

Signed-by: Curtis Franks
Team&Model: codex:gpt-5.5
