### PR TITLE
docs(routing): clarify codex neutral telemetry #1012

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ This table is auto-generated from `package.json` by `npm run docs:compile` (#796
 - Default thresholds: `drift_pct=0.15`, `drift_pct_fail=0.35`, `min_samples=3`.
 - OpenRouter aggregate usage is auto-probed when `OPENROUTER_API_KEY` is set.
 - Anthropic/LiteLLM aggregate usage can be enabled with `ANTHROPIC_USAGE_URL` and `LITELLM_USAGE_URL` (plus keys).
+- OpenAI-compatible providers should be logged generically unless a narrower adapter
+  is known.
+- Codex VS Code sessions are first-class routing consumers, but do not assume they
+  expose per-request token totals; reconcile route metadata with aggregate OpenAI
+  usage or configured Codex OpenTelemetry exports.
 
 ## Public trust surfaces
 

--- a/docs/howto/fleet-routing.md
+++ b/docs/howto/fleet-routing.md
@@ -19,11 +19,15 @@ The routing pipeline has three stages:
 2. **resolve** (`model-routing-engine.js`) — applies complexity thresholds and rollback policy
 3. **dispatch** (`task-router-dispatch.js`) — executes against the resolved backend
 
+The policy is runtime-neutral. Codex, Copilot, and Claude Code sessions use the
+same lanes; HAMR and the model policy resolve provider details after the lane is
+chosen.
+
 ## Lanes
 
 | Lane | Backend | Cost | Use when |
 | --- | --- | --- | --- |
-| `free` | Claude auto-tier | $0 | Lookups, Q&A, docs, boilerplate |
+| `free` | Agent auto-tier | $0 | Lookups, Q&A, docs, boilerplate |
 | `fleet` | Ollama (qwen2.5:7b-instruct) | $0 | Medium implementation, config gen, log analysis |
 | `haiku` | claude-haiku-4-5-20251001 | ~$0.08x | Single-file refactors, test gen, code review |
 | `premium` | claude-sonnet-4-6 | 1.0x | Multi-file architecture, security, ambiguous debugging |
@@ -66,6 +70,11 @@ Output fields:
 - `routing.lane` — lane after threshold and rollback enforcement
 - `routing.complexity` — 0.0–1.0 score
 - `decision.action` — what actually happened (`route-fleet`, `recommend-haiku`, `fleet-unavailable`, etc.)
+
+Token telemetry should report exact provider usage when available. For
+OpenAI-compatible calls without a narrower adapter, record the provider as
+`openai-compatible`; for Codex sessions without per-request token totals, record
+route metadata and reconcile with aggregate usage or configured OpenTelemetry.
 
 ## Reading the Cost Report
 

--- a/instructions/global-task-router.instructions.md
+++ b/instructions/global-task-router.instructions.md
@@ -16,6 +16,10 @@ Policy source: `scripts/global/model-routing-policy.json` (capability_matrix fie
 3. **Haiku** — claude-haiku-4-5-20251001. Single-file refactors, test gen, code review.
 4. **Premium** — claude-sonnet-4-6. Multi-file architecture, security, ambiguous debugging.
 
+Codex, Copilot, and Claude Code sessions all use the same lane policy. A lane
+selects required capability and cost tier; provider IDs and telemetry adapters
+are implementation details owned by HAMR and `model-routing-policy.json`.
+
 ## Capability matrix (use for ticket assignment and lane selection)
 
 | Dimension | Fleet (local) | Haiku | Premium |
@@ -43,4 +47,4 @@ If fleet signals `escalation_needed=true`: use the `suggested_tier` (haiku first
 
 ## Cost/observability mechanics within each lane
 
-This file selects the **lane**. Cost levers (caching, spillover, sticky-route, batching) and observability (cache-hit gate, /quota, /mcp doctor:probe) live in HAMR, not here. See `instructions/hamr-routing.instructions.md`. Do not duplicate HAMR mechanics in this file.
+This file selects the **lane**. Cost levers (caching, spillover, sticky-route, batching) and observability (cache-hit gate, /quota, /mcp doctor:probe) live in HAMR, not here. See `instructions/hamr-routing.instructions.md`. Do not duplicate HAMR mechanics in this file or make lane policy runtime-specific.

--- a/instructions/hamr-routing.instructions.md
+++ b/instructions/hamr-routing.instructions.md
@@ -7,7 +7,8 @@ type: instructions
 # HAMR Routing (Wave 1-6 production)
 
 HAMR (`https://hamr.chf3198.workers.dev`) is the cross-team cost+observability layer.
-Each team — Claude Code, Copilot, Codex — is expected to route through it.
+Each team — Claude Code, Copilot, Codex — is a first-class consumer and is
+expected to route governed provider calls through it.
 Activate with `npm run hamr:activate` once per checkout.
 
 ## Producer chain (must run periodically)
@@ -33,6 +34,17 @@ const result = await wrapProviderCall('anthropic', () => sdk.messages.create(req
 
 The wrapper auto-applies `cacheHeaders(provider)` (#926), records `appendCacheStat`
 on response (#932), and returns spillover hint via `maybeSpillover` (#927) on rate-limit.
+Treat runtime and provider as separate fields: Codex is a runtime, while
+OpenAI-compatible, Anthropic, Ollama, LiteLLM, or OpenRouter are provider paths.
+
+## Token telemetry policy
+
+- Prefer exact provider usage from HAMR-wrapped responses or aggregate usage APIs.
+- Record generic OpenAI-compatible traffic as `provider=openai-compatible` unless a
+  narrower adapter is known.
+- Do not invent Codex per-request token totals. If a Codex session does not expose
+  per-request usage, record route metadata and reconcile against aggregate OpenAI
+  usage or Codex OpenTelemetry exports when configured.
 
 ## /mcp capability dispatch
 


### PR DESCRIPTION
Refs #1012
Closes #1012
Refs Epic #1005

## Summary
- clarify Codex, Copilot, and Claude Code as first-class routing consumers
- separate lane policy from provider and telemetry adapter details
- document generic OpenAI-compatible telemetry and Codex no-fake-token policy

## Validation
- npm run -s lint
- npm run -s lint:md
- npm run -s lint:readability:ci
- npm run -s docs:anchors
- npm run -s docs:exec
- git diff --check

Official reference checked: https://developers.openai.com/codex/config-reference