### PR TITLE
docs(governance): preserve workspace trust #1026

### DIFF
--- a/raw/articles/vscode-copilot-allow-prompts-2026-05-05.md
+++ b/raw/articles/vscode-copilot-allow-prompts-2026-05-05.md
@@ -4,12 +4,15 @@
 Repeated "Allow" prompts are primarily caused by trust/approval boundaries:
 - file operations outside the trusted workspace path
 - conservative tool approval mode (`Default Approvals`)
+- terminal writes detected outside workspace scope
 
 ## Primary sources
 - https://code.visualstudio.com/docs/editor/workspace-trust
 - https://code.visualstudio.com/docs/copilot/agents/overview
 - https://code.visualstudio.com/docs/copilot/agents/agent-tools
 - https://code.visualstudio.com/docs/copilot/chat/review-code-edits
+- https://code.visualstudio.com/docs/copilot/reference/copilot-settings
+- https://code.visualstudio.com/docs/copilot/security
 
 ## Findings
 1. Workspace Trust is shared across VS Code and Agents app; untrusted contexts disable or restrict agent actions.
@@ -18,9 +21,12 @@ Repeated "Allow" prompts are primarily caused by trust/approval boundaries:
 4. `chat.permissions.default` persists preferred approval mode.
 5. Tool approvals can be tuned with pre/post approval controls.
 6. Sensitive edits can still require review through `chat.tools.edits.autoApprove` rules.
+7. `chat.tools.terminal.blockDetectedFileWrites` supports `outsideWorkspace` to force approval on out-of-bound writes.
+8. VS Code security guidance confirms built-in agent tools are workspace-limited by design.
 
 ## Operational policy for this repo
 - Keep all writes under `/home/curtisfranks/devenv-ops`.
 - Do not write directly to `~/.copilot/`, `~/.codex/`, `~/.agents/skills/`.
+- Do not write to `/tmp` during agent execution in this repo; use repo-local scratch paths only if needed.
 - Use repo-mediated deploy scripts for runtime propagation.
 - Keep strict review for sensitive paths.

--- a/research/dashboard-liveness-workspace-trust-2026-05-05.md
+++ b/research/dashboard-liveness-workspace-trust-2026-05-05.md
@@ -2,10 +2,10 @@
 title: "Dashboard liveness closure + Copilot allowance avoidance — 2026-05-05"
 type: research
 created: 2026-05-05
-updated: 2026-05-05
+updated: 2026-05-06
 status: complete
 tags: [dashboard, vscode, copilot, workspace-trust, approvals, epic-849]
-sources: ["https://code.visualstudio.com/docs/editor/workspace-trust", "https://code.visualstudio.com/docs/copilot/agents/overview", "https://code.visualstudio.com/docs/copilot/agents/agent-tools", "https://code.visualstudio.com/docs/copilot/chat/review-code-edits"]
+sources: ["https://code.visualstudio.com/docs/editor/workspace-trust", "https://code.visualstudio.com/docs/copilot/agents/overview", "https://code.visualstudio.com/docs/copilot/agents/agent-tools", "https://code.visualstudio.com/docs/copilot/chat/review-code-edits", "https://code.visualstudio.com/docs/copilot/reference/copilot-settings", "https://code.visualstudio.com/docs/copilot/security"]
 ---
 
 # Dashboard liveness closure + Copilot allowance avoidance — 2026-05-05
@@ -13,7 +13,7 @@ sources: ["https://code.visualstudio.com/docs/editor/workspace-trust", "https://
 **Date**: 2026-05-05  
 **Ticket**: #853 (research), #1004 (implementation)  
 **Epic**: #849  
-**Last updated**: 2026-05-05T00:00:00Z
+**Last updated**: 2026-05-06T00:00:00Z
 
 ## Summary table
 
@@ -22,6 +22,7 @@ sources: ["https://code.visualstudio.com/docs/editor/workspace-trust", "https://
 | Workspace Trust | Files outside trusted folders trigger trust/untrusted prompts | Keep all edits inside workspace root (`/home/curtisfranks/devenv-ops`) |
 | Agent approvals | `Default Approvals` prompts for many tool calls | Use session permission level `Bypass Approvals` or `Autopilot` when safe |
 | Tool approvals | VS Code supports per-tool pre/post approvals | Pre-approve safe tools; keep destructive tools reviewed |
+| Terminal write boundaries | `chat.tools.terminal.blockDetectedFileWrites` can enforce approval for outside-workspace writes | Keep it at `outsideWorkspace`; avoid `/tmp` write paths |
 | Sensitive edits | `chat.tools.edits.autoApprove` can require manual approval for protected files | Keep strict rules for sensitive files; avoid external-path writes entirely |
 
 ## Detailed findings with source links
@@ -42,13 +43,22 @@ sources: ["https://code.visualstudio.com/docs/editor/workspace-trust", "https://
    `chat.tools.edits.autoApprove` can force manual review for selected paths (for example `.env` and `.vscode/*.json`) even when other edits are auto-approved.
    Source: https://code.visualstudio.com/docs/copilot/chat/review-code-edits
 
+5. **Outside-workspace write detection is configurable.**
+   Copilot settings include `chat.tools.terminal.blockDetectedFileWrites`, with `outsideWorkspace` behavior to require approval on writes beyond the workspace boundary.
+   Source: https://code.visualstudio.com/docs/copilot/reference/copilot-settings
+
+6. **Security baseline confirms workspace-limited built-in file operations.**
+   VS Code security guidance states built-in agent file operations are scoped to workspace paths by default.
+   Source: https://code.visualstudio.com/docs/copilot/security
+
 ## Practical no-prompt operating profile (Copilot Team)
 
 1. **Never write outside workspace root** during autonomous sessions.
 2. **Do not target runtime homes** such as `~/.copilot/`, `~/.codex/`, or `~/.agents/skills/` from this repo session.
-3. **Use only in-repo source-of-truth paths** and deploy through repo workflows.
-4. **Prefer session `Bypass Approvals`** only in trusted repos with known governance.
-5. **Retain sensitive-file review rules** for config/secret-bearing files.
+3. **Do not use `/tmp` write paths** for agent-generated artifacts in this repo session.
+4. **Use only in-repo source-of-truth paths** and deploy through repo workflows.
+5. **Prefer session `Bypass Approvals`** only in trusted repos with known governance.
+6. **Retain sensitive-file review rules** for config/secret-bearing files.
 
 ## Actionable next steps
 

--- a/wiki/concepts/workspace-write-boundary-discipline.md
+++ b/wiki/concepts/workspace-write-boundary-discipline.md
@@ -2,7 +2,7 @@
 title: "Workspace write-boundary discipline"
 type: concept
 created: 2026-05-05
-updated: 2026-05-05
+updated: 2026-05-06
 tags: [vscode, copilot, governance, safety]
 sources: ["[[vscode-copilot-allow-prompts-2026-05-05]]"]
 related: ["[[wiki-pattern]]", "[[governance-enforcement]]"]
@@ -12,14 +12,15 @@ status: draft
 # Workspace write-boundary discipline
 
 ## Summary
-For autonomous agent sessions, keep all writes inside the trusted workspace root to avoid trust prompts and approval interruptions. Route runtime changes through source repositories and deployment workflows, not direct edits to runtime home directories.
+For autonomous agent sessions, keep all writes inside the trusted workspace root to avoid trust prompts and approval interruptions. Route runtime changes through source repositories and deployment workflows, not direct edits to runtime home directories, and avoid `/tmp` write targets during repo work.
 
 ## Rules
 
 1. Treat workspace root as the hard write boundary.
 2. Refuse direct writes to external runtime homes during coding sessions.
-3. Use task/PR workflow to propagate changes downstream.
-4. Keep high-friction review rules for sensitive files.
+3. Refuse `/tmp` write paths for agent-created artifacts in this repo.
+4. Use task/PR workflow to propagate changes downstream.
+5. Keep high-friction review rules for sensitive files.
 
 ## Related
 

--- a/wiki/sources/vscode-copilot-allow-prompts-2026-05-05.md
+++ b/wiki/sources/vscode-copilot-allow-prompts-2026-05-05.md
@@ -2,7 +2,7 @@
 title: "VS Code Copilot allow prompts 2026-05-05"
 type: source
 created: 2026-05-05
-updated: 2026-05-05
+updated: 2026-05-06
 tags: [vscode, copilot, workspace-trust, approvals]
 sources: [raw/articles/vscode-copilot-allow-prompts-2026-05-05.md]
 related: ["[[workspace-write-boundary-discipline]]", "[[wiki-pattern]]"]
@@ -12,20 +12,22 @@ status: draft
 # VS Code Copilot allow prompts 2026-05-05
 
 ## Summary
-Workspace-trust path boundaries and agent approval settings are the two main drivers of repeated "Allow" interruptions. The stable no-prompt strategy is to keep writes inside the trusted workspace path and avoid direct edits to external runtime folders.
+Workspace-trust path boundaries and agent approval settings are the two main drivers of repeated "Allow" interruptions. The stable no-prompt strategy is to keep writes inside the trusted workspace path, avoid `/tmp` writes, and avoid direct edits to external runtime folders.
 
 ## Key findings
 
 - Workspace Trust is path-oriented and shared with the Agents app.
 - `Default Approvals` prompts more often than `Bypass Approvals`/`Autopilot`.
 - `chat.permissions.default` can persist preferred approval behavior.
+- `chat.tools.terminal.blockDetectedFileWrites` supports `outsideWorkspace` safety gates.
 - Sensitive-file review can remain strict via `chat.tools.edits.autoApprove`.
 
 ## Repo policy distilled
 
 1. Write only under workspace root.
 2. Never edit runtime homes directly from this repo session.
-3. Use source-of-truth repo + deploy scripts.
-4. Keep sensitive-file review enabled.
+3. Never emit agent artifacts to `/tmp` in this repo session.
+4. Use source-of-truth repo + deploy scripts.
+5. Keep sensitive-file review enabled.
 
 Source: raw/articles/vscode-copilot-allow-prompts-2026-05-05.md


### PR DESCRIPTION
## Summary

- preserve the four workspace-trust/Copilot research files that were dirty in the shared worktree
- keep the preservation separate from Codex Epic #1005 and from #1021/#950 research artifacts
- clear the stop-hook blocker without discarding parallel-team work

## Validation

- `git diff --name-status origin/main..origin/feat/1026-workspace-trust-preservation` shows exactly the four scoped files
- `git show --stat origin/feat/1026-workspace-trust-preservation` verifies commit `e6d9280`
- prior local checks: line-count scope check, `git diff --check`, markdownlint, pre-push format/readability

## Supersedes

- Supersedes PR #1028, closed unmerged because the collaborator handoff timestamp was 15s before PR creation rather than the required ≥60s.

Refs #1026
Closes #1026

Signed-by: Curtis Franks
Team&Model: codex:gpt-5.5