### PR TITLE
feat(governance): add harness goal lens #1030

### DIFF
--- a/hooks/scripts/goal_lens.py
+++ b/hooks/scripts/goal_lens.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: inject lightweight G1-G9 decision lens context."""
+import json
+import re
+import sys
+
+GOALS = (
+    "G1 Governance > G2 Quality > G3 Zero Cost > G4 Privacy > "
+    "G5 Portability > G6 Resilience > G7 Throughput > "
+    "G8 Observability > G9 Interoperability"
+)
+
+DECISION_RE = re.compile(
+    r"\b(decide|decision|choose|tradeoff|priority|prioritize|rank|route|"
+    r"policy|architecture|design|should we|which option|compare)\b",
+    re.IGNORECASE,
+)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    prompt = str(payload.get("prompt", ""))
+    if not prompt:
+        return 0
+
+    base = f"Goal lens: {GOALS}."
+    if DECISION_RE.search(prompt):
+        base += (
+            " Decision check: justify any lower-priority override with explicit evidence."
+        )
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": base,
+        }
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/instructions/harness-goals.instructions.md
+++ b/instructions/harness-goals.instructions.md
@@ -1,0 +1,31 @@
+---
+name: Harness Goal Constitution
+description: Canonical priority-ordered goals (G1-G9) and lightweight decision lens for all governed work.
+applyTo: "**"
+---
+# Harness Goal Constitution (Priority-Ordered)
+
+G1 Governance > G2 Quality > G3 Zero Cost > G4 Privacy > G5 Portability >
+G6 Resilience > G7 Throughput > G8 Observability > G9 Interoperability.
+
+## Definitions
+
+- G1 Governance: policy, role, provenance, and ticket controls are non-negotiable.
+- G2 Quality: maximize correctness and engineering value of outcomes.
+- G3 Zero Cost: prefer local/fleet/free lanes before paid providers.
+- G4 Privacy: keep sensitive context local unless explicit override exists.
+- G5 Portability: avoid user-specific coupling; settings-driven behavior preferred.
+- G6 Resilience: graceful degradation and fallback paths for partial outages.
+- G7 Throughput: acceptable speed after higher-priority goals are satisfied.
+- G8 Observability: decisions and outcomes are visible, auditable, and attributable.
+- G9 Interoperability: preserve compatibility across agent surfaces and runtimes.
+
+## Decision Lens (lightweight, required)
+
+For any design/routing/tooling decision, briefly verify in this order:
+1) Is it governance-compliant? 2) Does it improve or preserve quality?
+3) Can it run at zero cost first? 4) Is privacy preserved by default?
+5) Is it portable? 6) Is degradation safe? 7) Is it fast enough?
+8) Is it observable? 9) Does it remain interoperable?
+
+If a lower-priority goal wins over a higher one, record explicit rationale.


### PR DESCRIPTION
## Summary

- add `hooks/scripts/goal_lens.py` so the hook inventory merged in #1047 has its referenced UserPromptSubmit script
- add `instructions/harness-goals.instructions.md` as the canonical G1-G9 goal constitution artifact
- keep LiteLLM/Substrate local diffs out of this PR

## Validation

- `wc -l hooks/scripts/goal_lens.py instructions/harness-goals.instructions.md` = 46 + 30 lines
- `git diff --check -- hooks/scripts/goal_lens.py instructions/harness-goals.instructions.md`
- `python3 -m py_compile hooks/scripts/goal_lens.py`
- sample hook invocation returned the G1-G9 goal lens and decision-rationale reminder
- `npx markdownlint-cli2 instructions/harness-goals.instructions.md`
- pre-push format/readability checks passed

Refs #1030
Closes #1030
Refs #1024

Signed-by: Curtis Franks
Team&Model: codex:gpt-5.5