### PR TITLE
fix(hamr): add activation session gate #1023

### DIFF
--- a/.codex/runtime-hooks.json
+++ b/.codex/runtime-hooks.json
@@ -7,6 +7,11 @@
         "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/session_context.py\"",
         "timeout": 10,
         "statusMessage": "Loading DevEnv Ops governance context"
+      }, {
+        "type": "command",
+        "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/hamr_activation_check.py\"",
+        "timeout": 10,
+        "statusMessage": "Checking HAMR activation"
       }]
     }],
     "UserPromptSubmit": [{

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 - `baton-gates.yml` admin-gate now blocks identical `COLLABORATOR_HANDOFF` and `ADMIN_HANDOFF` signer identities, with compatibility for AI-Signature, Signed-by, AI-Team-Model, and Team&Model baton fields.
 - `scripts/global/baton-independence.js` and `tests/baton-independence.spec.js` cover same-signer failure, independent-signer pass, and legacy signing fields.
 
+## [Unreleased] — HAMR activation session gate
+
+### Added (#1023)
+- `hooks/scripts/hamr_activation_check.py` warns at SessionStart when HAMR activation is missing, disabled, malformed, or older than 24 hours without blocking offline work.
+- Copilot global standards and Codex runtime hooks now run the activation check; HAMR wrapper cache telemetry includes `executed: "hamr-provider-wrapper"`.
+
 ## [Unreleased] — Cost-reduction Phase 2 activation corrections
 
 ### Fixed (#1050, resolves #1048)

--- a/hooks/global-standards.json
+++ b/hooks/global-standards.json
@@ -17,6 +17,11 @@
         "type": "command",
         "command": "python3 ~/.copilot/hooks/scripts/session_context.py",
         "timeout": 10
+      },
+      {
+        "type": "command",
+        "command": "python3 ~/.copilot/hooks/scripts/hamr_activation_check.py",
+        "timeout": 10
       }
     ],
     "UserPromptSubmit": [

--- a/hooks/scripts/hamr_activation_check.py
+++ b/hooks/scripts/hamr_activation_check.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""SessionStart hook: warn when HAMR activation is absent, stale, or disabled."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+MAX_AGE = timedelta(hours=24)
+
+
+def candidate_paths() -> list[Path]:
+    override = os.getenv("HAMR_CONFIG_PATH")
+    if override:
+        return [Path(override).expanduser()]
+    home = Path.home()
+    paths = {
+        "claude": home / ".claude" / "hamr-config.json",
+        "copilot": home / ".copilot" / "hamr-config.json",
+        "codex": home / ".codex" / "devenv-ops" / "hamr-config.json",
+    }
+    runtime = (os.getenv("DEVENT_OPS_RUNTIME") or "copilot").lower()
+    order = [runtime, "copilot", "claude", "codex"]
+    return [paths[name] for name in dict.fromkeys(order) if name in paths]
+
+
+def read_config() -> tuple[Path | None, dict]:
+    for path in candidate_paths():
+        if not path.exists():
+            continue
+        try:
+            return path, json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return path, {"enabled": False, "error": "malformed"}
+    return None, {}
+
+
+def parse_time(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def activation_message(now: datetime | None = None) -> str:
+    now = now or datetime.now(UTC)
+    path, cfg = read_config()
+    if not path:
+        return "HAMR activation warning: no hamr-config.json found; run npm run hamr:activate before governed provider calls."
+    if cfg.get("enabled") is not True:
+        return f"HAMR activation warning: disabled or invalid config at {path}."
+    activated = parse_time(str(cfg.get("activated_at") or ""))
+    if not activated:
+        return f"HAMR activation warning: missing activated_at in {path}."
+    if now - activated > MAX_AGE:
+        return f"HAMR activation warning: stale activation at {path}; refresh with npm run hamr:activate."
+    return f"HAMR activation fresh: {path}."
+
+
+def main() -> int:
+    try:
+        json.load(sys.stdin)
+    except Exception:
+        pass
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": activation_message(),
+        }
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/instructions/hamr-routing.instructions.md
+++ b/instructions/hamr-routing.instructions.md
@@ -10,6 +10,9 @@ HAMR (`https://hamr.chf3198.workers.dev`) is the cross-team cost+observability l
 Each team — Claude Code, Copilot, Codex — is a first-class consumer and is
 expected to route governed provider calls through it.
 Activate with `npm run hamr:activate` once per checkout.
+SessionStart runs `hamr_activation_check.py` as an advisory gate. Missing,
+disabled, malformed, or >24h stale activation emits context before governed
+provider calls; offline work remains unblocked.
 
 ## Producer chain (must run periodically)
 

--- a/scripts/global/cache-stats-emit.js
+++ b/scripts/global/cache-stats-emit.js
@@ -14,7 +14,7 @@ function ensureDir() {
 }
 
 /** Append a single cache-stat record atomically.
- * Schema: {ts: epoch_ms, provider, model?, cache_read_tokens, input_tokens, output_tokens?}.
+ * Schema: {ts, provider, model?, cache_read_tokens, input_tokens, output_tokens?, executed?}.
  * Atomic strategy: write+rename on temp file when target absent; otherwise plain append
  * (POSIX append is atomic for writes < PIPE_BUF, ~4KB, which JSONL records always are).
  * @param {object} record - Must include provider, cache_read_tokens, input_tokens.
@@ -34,6 +34,7 @@ function appendCacheStat(record, opts = {}) {
     cache_read_tokens: Number(record.cache_read_tokens || 0),
     input_tokens: Number(record.input_tokens || 0),
     output_tokens: Number(record.output_tokens || 0),
+    executed: record.executed ?? null,
   };
   const line = JSON.stringify(normalized) + '\n';
   fs.appendFileSync(file, line, { encoding: 'utf8', flag: 'a' });
@@ -53,6 +54,7 @@ function fromTokenRecord(tokenRecord) {
     cache_read_tokens: Number(tokenRecord.cache_read_tokens || 0),
     input_tokens: Number(tokenRecord.input_tokens || 0),
     output_tokens: Number(tokenRecord.output_tokens || 0),
+    executed: tokenRecord.executed ?? null,
   };
 }
 

--- a/scripts/global/hamr-provider-wrapper.js
+++ b/scripts/global/hamr-provider-wrapper.js
@@ -19,6 +19,9 @@ const TEAM_CONFIG_PATHS = [
   path.join(os.homedir(), '.codex', 'devenv-ops', 'hamr-config.json'),
 ];
 
+/** Read the first available HAMR activation config across team runtimes.
+ * @returns {object|null} Parsed config with source file, or null when absent.
+ */
 function readTeamConfig() {
   for (const file of TEAM_CONFIG_PATHS) {
     if (!fs.existsSync(file)) continue;
@@ -27,6 +30,9 @@ function readTeamConfig() {
   return null;
 }
 
+/** Determine whether HAMR wrapping is disabled for the current process.
+ * @returns {boolean} True when wrapper should no-op.
+ */
 function isDisabled() {
   if (process.env.MEGINGJORD_HAMR_DISABLED === '1') return true;
   const cfg = readTeamConfig();
@@ -44,6 +50,7 @@ function emitStatSafe(provider, payload) {
       cache_read_tokens: tokenRecord.cache_read_tokens ?? 0,
       input_tokens: tokenRecord.input_tokens ?? 0,
       output_tokens: tokenRecord.output_tokens ?? 0,
+      executed: 'hamr-provider-wrapper',
     });
   } catch { /* never let stats break the call */ }
 }

--- a/tests/hamr-activation-check.spec.js
+++ b/tests/hamr-activation-check.spec.js
@@ -1,0 +1,39 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const HOOK = path.join(REPO_ROOT, 'hooks', 'scripts', 'hamr_activation_check.py');
+
+function runHook(configPath) {
+  return spawnSync('python3', [HOOK], {
+    cwd: REPO_ROOT,
+    input: '{}',
+    encoding: 'utf8',
+    env: { ...process.env, HAMR_CONFIG_PATH: configPath },
+  });
+}
+
+function contextText(result) {
+  return JSON.parse(result.stdout).hookSpecificOutput.additionalContext;
+}
+
+test('HAMR activation hook warns when config is absent', () => {
+  const missing = path.join(os.tmpdir(), `hamr-missing-${Date.now()}.json`);
+  const result = runHook(missing);
+  expect(result.status).toBe(0);
+  expect(contextText(result)).toContain('HAMR activation warning');
+});
+
+test('HAMR activation hook reports fresh activation', () => {
+  const file = path.join(os.tmpdir(), `hamr-fresh-${Date.now()}.json`);
+  fs.writeFileSync(file, JSON.stringify({
+    enabled: true,
+    activated_at: new Date().toISOString(),
+  }));
+  const result = runHook(file);
+  expect(result.status).toBe(0);
+  expect(contextText(result)).toContain('HAMR activation fresh');
+});

--- a/tests/hamr-provider-wrapper.spec.js
+++ b/tests/hamr-provider-wrapper.spec.js
@@ -69,4 +69,6 @@ test('emitStatSafe writes to cache-stats.jsonl on successful call', async () => 
   }));
   const sizeAfter = fs.existsSync(statsFile) ? fs.statSync(statsFile).size : 0;
   expect(sizeAfter).toBeGreaterThan(sizeBefore);
+  const last = fs.readFileSync(statsFile, 'utf8').trim().split('\n').pop();
+  expect(JSON.parse(last).executed).toBe('hamr-provider-wrapper');
 });


### PR DESCRIPTION
## Summary

- Add advisory SessionStart HAMR activation check for missing, disabled, malformed, or stale (>24h) activation.
- Wire the check into Copilot global standards and Codex runtime hooks.
- Populate HAMR wrapper cache telemetry with `executed: hamr-provider-wrapper`.
- Document activation behavior and add CHANGELOG trace.

## Validation

- [x] python3 -m py_compile hooks/scripts/hamr_activation_check.py
- [x] ruff check --config lint-configs/ruff.devenv.toml hooks/scripts/hamr_activation_check.py
- [x] JSON parse hooks/global-standards.json + .codex/runtime-hooks.json
- [x] npx playwright test tests/hamr-activation-check.spec.js tests/hamr-provider-wrapper.spec.js
- [x] npx eslint -c lint-configs/eslint.config.devenv.js scripts/global/cache-stats-emit.js scripts/global/hamr-provider-wrapper.js
- [x] npx markdownlint-cli2 instructions/hamr-routing.instructions.md CHANGELOG.md
- [x] git diff --check
- [x] pre-push format/readability hook

## Note

An unrelated local `config/litellm-config.yaml` diff exists in this checkout and is not part of this PR.

Refs #1023
Closes #1023

AI-Signature: Nolan Reed
AI-Team-Model: codex:gpt-5@openai
AI-Role: admin