### PR TITLE
docs(governance): add harness goals wiki concept #1060

### DIFF
--- a/wiki/concepts/harness-goals.md
+++ b/wiki/concepts/harness-goals.md
@@ -1,0 +1,57 @@
+---
+title: "Harness Goal Constitution"
+type: concept
+created: 2026-05-06
+status: active
+---
+# Harness Goal Constitution
+
+## Summary
+
+The harness goal constitution is the priority-ordered decision lens for governed
+work across Claude Code, Copilot, and Codex sessions. It keeps role workflow,
+cost routing, privacy, runtime behavior, and cross-team compatibility aligned.
+
+## Canonical Order
+
+1. Governance
+2. Quality
+3. Zero Cost
+4. Privacy
+5. Portability
+6. Resilience
+7. Throughput
+8. Observability
+9. Interoperability
+
+## Decision Rule
+
+Evaluate governed decisions in order. If a lower-priority goal wins over a
+higher-priority goal, record the rationale in the ticket, PR, or closeout
+evidence.
+
+## Always-Loaded Surfaces
+
+- `.github/copilot-instructions.md`
+- `.codex/AGENTS.md`
+- `instructions/global-standards.instructions.md`
+- `instructions/harness-goals.instructions.md`
+- `hooks/scripts/goal_lens.py`
+
+## Goal Definitions
+
+- Governance: policy, role, provenance, and ticket controls are non-negotiable.
+- Quality: maximize correctness and engineering value of outcomes.
+- Zero Cost: prefer local, fleet, and free lanes before paid providers.
+- Privacy: keep sensitive context local unless explicit override exists.
+- Portability: avoid user-specific coupling; settings-driven behavior preferred.
+- Resilience: degrade gracefully and keep fallback paths for partial outages.
+- Throughput: preserve acceptable speed after higher-priority goals are met.
+- Observability: make decisions and outcomes visible, auditable, attributable.
+- Interoperability: preserve compatibility across agent surfaces and runtimes.
+
+## Sources
+
+- Epic #1024: harden harness OKR goals as always-available session context.
+- Research #1025: reconciles provisional O1-ON lists to the 9-goal order.
+- Task #1030: installs the always-loaded instruction and hook context surfaces.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -35,6 +35,7 @@ The LLM updates this on every ingest operation.
 - [[linting-governance]] — Global Linting Governance
 - [[fleet-architecture]] — Fleet Architecture Overview
 - [[workspace-write-boundary-discipline]] — Workspace Write-Boundary Discipline
+- [[harness-goals]] — Harness Goal Constitution
 
 ## Source Summaries
 
@@ -93,6 +94,7 @@ The LLM updates this on every ingest operation.
 
 ## Recent Additions
 
+- [[harness-goals]] — Harness Goal Constitution (2026-05-06)
 - [[dashboard-live-data-methodology-2026-05-05]] — Dashboard Live-Data Methodology (2026-05-05)
 - [[workspace-write-boundary-discipline]] — Workspace Write-Boundary Discipline (2026-05-05)
 - [[vscode-copilot-allow-prompts-2026-05-05]] — VS Code Copilot Allow Prompts (2026-05-05)
@@ -105,4 +107,4 @@ The LLM updates this on every ingest operation.
 
 ---
 
-**Pages**: 70 | **Last updated**: 2026-05-05
+**Pages**: 71 | **Last updated**: 2026-05-06

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -8,6 +8,13 @@ Each entry uses a parseable prefix for CLI filtering.
 Brief description of what happened.
 ```
 
+## [2026-05-06] governance | Harness Goal Constitution wiki concept (#1060, EPIC #1024)
+Added `wiki/concepts/harness-goals.md` and indexed the canonical 9-goal
+constitution: Governance, Quality, Zero Cost, Privacy, Portability, Resilience,
+Throughput, Observability, Interoperability. This completes the wiki concept
+artifact required by Epic #1024 after always-loaded instruction surfaces shipped
+in #1030.
+
 ## [2026-05-06] research | IDE Proxy Shim R&D (#1021, EPIC #1020)
 Research for Claude Code IDE proxy shim. Recommends LiteLLM proxy adoption as IDE backend (already supports Anthropic-compatible `/v1/messages`); 6-child sketch ~5d total. Latency budget ≤50ms p95 achievable. Fleet pass-rate ≥85% on complexity bands 1-2 is activation gate. Anthropic key never reaches fleet. Acceptance: ≥30% turn count routed non-Anthropic, ≥25% session cost reduction, zero quality regression on Premium-tier turns.
 


### PR DESCRIPTION
## Summary
- Add `wiki/concepts/harness-goals.md` for the canonical G1-G9 Harness Goal Constitution.
- Index the concept in `wiki/index.md` and record the update in `wiki/log.md`.
- Complete the wiki concept acceptance gap for Epic #1024.

## Validation
- `npx markdownlint-cli2 wiki/concepts/harness-goals.md wiki/index.md wiki/log.md` PASS
- `node scripts/global/docs-anchors.js` PASS
- `node scripts/global/docs-exec.js` PASS
- `git diff --check` PASS
- pre-push format/readability PASS (417 warnings <= 420 cap)

Refs #1060
Closes #1060
Refs #1024

AI-Signature: Nolan Reed
AI-Team-Model: codex:gpt-5@openai
AI-Role: admin