### PR TITLE
feat(gov): Epic-aware label-lint + dormant/deferred #1078

### DIFF
--- a/.github/workflows/label-lint.yml
+++ b/.github/workflows/label-lint.yml
@@ -45,6 +45,8 @@ jobs:
             const statusLabels = currentLabels.filter(l => l.startsWith('status:'));
             const roleLabels   = currentLabels.filter(l => l.startsWith('role:'));
             const laneLabels   = currentLabels.filter(l => l.startsWith('lane:'));
+            const isEpic       = currentLabels.includes('type:epic');
+            const EPIC_ONLY_STATES = ['status:dormant', 'status:deferred'];
             const violations   = [];
             if (statusLabels.length === 0) {
               violations.push('**Rule 1**: No `status:` label found. Every issue must have exactly one.');
@@ -57,8 +59,11 @@ jobs:
             if (statusLabels.includes('status:done') && roleLabels.length > 0) {
               violations.push(`**Rule 3**: \`status:done\` issues must not have a \`role:\` label. Remove: ${roleLabels.join(', ')}.`);
             }
-            if (statusLabels.includes('status:backlog') && roleLabels.length > 0) {
-              violations.push(`**Rule 4**: \`status:backlog\` issues must not have a \`role:\` label. Remove: ${roleLabels.join(', ')}.`);
+            if (statusLabels.includes('status:backlog') && roleLabels.length > 0 && !isEpic) {
+              violations.push(`**Rule 4**: \`status:backlog\` child issues must not have a \`role:\` label. Remove: ${roleLabels.join(', ')}.`);
+            }
+            if (isEpic && statusLabels.includes('status:backlog') && !roleLabels.includes('role:manager')) {
+              violations.push('**Rule E2**: Epic at `status:backlog` requires `role:manager` (Epic invariant).');
             }
             if (statusLabels.includes('status:triage') && !roleLabels.includes('role:manager')) {
               violations.push('**Rule 5**: `status:triage` issues must have `role:manager`. Epics always carry this label.');
@@ -81,11 +86,21 @@ jobs:
               'status:review':      'role:consultant',
             };
             for (const [status, required] of Object.entries(STATUS_ROLE_REQUIRED)) {
-              if (statusLabels.includes(status) && !roleLabels.includes(required)) {
+              if (statusLabels.includes(status) && !roleLabels.includes(required) && !isEpic) {
                 violations.push(`**Rule 8**: \`${status}\` requires \`${required}\`. Add it.`);
               }
             }
-            const isEpic = currentLabels.includes('type:epic');
+            if (isEpic && statusLabels.includes('status:in-progress') && !roleLabels.includes('role:manager')) {
+              violations.push('**Rule E3**: Epic at `status:in-progress` requires `role:manager` (Epic carries manager throughout lifecycle).');
+            }
+            for (const epicState of EPIC_ONLY_STATES) {
+              if (statusLabels.includes(epicState) && !isEpic) {
+                violations.push(`**Rule E5**: \`${epicState}\` is Epic-only. Non-Epic tickets cannot use it.`);
+              }
+              if (statusLabels.includes(epicState) && isEpic && !roleLabels.includes('role:manager')) {
+                violations.push(`**Rule E5**: Epic at \`${epicState}\` requires \`role:manager\`.`);
+              }
+            }
             if (isEpic && statusLabels.includes('status:ready')) {
               violations.push('**Rule 9**: Epics cannot be at `status:ready` — that status is for child tickets only.');
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased] — Epic #1074: Epic-vs-child governance differentiation
+
+### Added
+- **2 new GitHub labels**: `status:dormant` and `status:deferred` — Epic-only states for paused-active and externally-blocked goals (#1077).
+- `instructions/epic-governance.instructions.md` — new Epic-only state diagram with `dormant` + `deferred` rows + transition rules + 90-day `EPIC_REVIEW` cadence (#1079).
+- `instructions/ticket-driven-work.instructions.md` — taxonomy table updated to v1.1 (10-status; 2 Epic-only). Manager role-required notes for Epic in `backlog` and `in-progress` (#1080).
+- `.github/workflows/label-lint.yml` — Epic-aware rule overrides:
+  - Rule 4 skips Epics (Epic invariant: always carries `role:manager`)
+  - Rule E2: Epic at `status:backlog` requires `role:manager`
+  - Rule 8 skips Epics; Rule E3: Epic at `status:in-progress` requires `role:manager` (not `role:collaborator`)
+  - Rule E5: `status:dormant`/`status:deferred` are Epic-only; require `role:manager` (#1078).
+
+### Closed via this Epic
+- R&D #1075: research/epic-vs-child-governance-2026-05-07.md (183 lines) — full state taxonomy + transition rules + label-lint Epic-aware rule design + migration impact analysis (#759/#760 candidates for re-classification; #966 stays cancelled per contract conflict).
+
 ## [Unreleased] — Epic #949 closeout (GPU-node priority-1 routing)
 
 ### Added

--- a/instructions/epic-governance.instructions.md
+++ b/instructions/epic-governance.instructions.md
@@ -17,11 +17,21 @@ applyTo: "**"
 | `backlog` | Created; no children started |
 | `triage` | Manager scoping children; at least one child exists |
 | `in-progress` | First child ticket moves to `status:in-progress` |
+| `dormant` | Active goal; no current work; awaits external trigger or 90d review |
+| `deferred` | Active goal; externally blocked; no ETA |
 | `review` | All children are terminal (closed); epic-level closeout pending |
 | `done` + closed | CONSULTANT_CLOSEOUT emitted on epic; all children confirmed terminal |
-| `cancelled` | Manager authority; all children must be cancelled or closed first |
+| `cancelled` | Manager authority; **goal invalidated** (NOT used for stalled work) |
 
 Epic status is advanced by the Manager agent at each gate — it does **not** auto-advance.
+
+### Epic-only states (dormant + deferred)
+
+- `dormant`: Manager pauses an Epic when a milestone closes and no immediate next step exists. Comment must name the trigger that would resume work.
+- `deferred`: Manager marks Epic blocked by external constraint (e.g., third-party beta, plan tier). Comment must name the blocker + ETA condition.
+- Both require `role:manager` (Epic invariant).
+- Both receive a 90-day review: Manager posts an `EPIC_REVIEW` comment with verdict (stay-dormant, reclassify, or cancel).
+- Transitions: `in-progress ↔ dormant`, `in-progress ↔ deferred`, `dormant ↔ deferred`, `dormant → triage` on resume, `deferred → in-progress` when blocker clears, `dormant → cancelled` only after review affirms goal no longer applies.
 
 ## Epic Progress Comment Protocol
 

--- a/instructions/ticket-driven-work.instructions.md
+++ b/instructions/ticket-driven-work.instructions.md
@@ -19,18 +19,20 @@ applyTo: "**"
 | Doc | Documentation | `type:doc` |
 | Research | Investigation/spike | `type:research` |
 
-## Label taxonomy (v1.0 — agent-typed 8-status)
+## Label taxonomy (v1.1 — agent-typed 10-status; 2 Epic-only)
 
 | Status | Active Agent | Gate Condition |
 |---|---|---|
-| `status:backlog` | — | Queued; unassigned |
+| `status:backlog` | — (Epic: `role:manager`) | Queued; unassigned |
 | `status:triage` | `role:manager` | Manager scoping AC + gates |
 | `status:ready` | — | MANAGER_HANDOFF emitted; awaiting Collaborator pickup |
-| `status:in-progress` | `role:collaborator` | Implementation active |
+| `status:in-progress` | `role:collaborator` (Epic: `role:manager`) | Implementation active |
 | `status:testing` | `role:admin` | COLLABORATOR_HANDOFF emitted; CI/gates running |
 | `status:review` | `role:consultant` | ADMIN_HANDOFF emitted; critique + closeout active |
 | `status:done` | — | CONSULTANT_CLOSEOUT emitted; issue closes |
-| `status:cancelled` | — | Abandoned; Manager authority; reason required |
+| `status:cancelled` | — | Abandoned; Manager authority; **goal invalidated** |
+| `status:dormant` | `role:manager` | **Epic-only**: paused; 90d review |
+| `status:deferred` | `role:manager` | **Epic-only**: blocked, no ETA |
 
 - **Priority**: `priority:P1` (urgent) · `priority:P2` (normal) · `priority:P3` (low)
 - **Area**: `area:dashboard` · `area:hooks` · `area:skills` · `area:instructions` · `area:agents` · `area:scripts` · `area:infra`
@@ -94,4 +96,4 @@ When PR/merge proof is unavailable, use explicit exception fields in evidence bl
 
 ## Epic Rules
 
-See `epic-governance.instructions.md` for epic status advancement, role label, progress tracking, and close conditions.
+See `epic-governance.instructions.md` for epic state diagram + close conditions.


### PR DESCRIPTION
## Summary

Closes 3 dev children of Epic #1074 (Section F children B/C/D):
- `.github/workflows/label-lint.yml` — Epic-aware rule overrides (E2/E3/E5 + Rule 4/8 Epic skips)
- `instructions/epic-governance.instructions.md` — state diagram + transitions + 90d review
- `instructions/ticket-driven-work.instructions.md` — taxonomy v1.1 with 2 Epic-only rows

Child A (label creation) shipped separately as one-shot CLI (no PR needed).

## Refs

Refs #1078. Closes #1079 + #1080 transitively (single PR for B+C+D bundle).

## Test plan

- [x] YAML valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `npm run lint` clean (no new failures)
- [x] Both instruction files ≤100 lines (74 + 99)
- [x] label-lint logic gated by `isEpic` detection at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)