### PR TITLE
docs(governance): #836 doc-drift sweep across 3 surfaces

### DIFF
--- a/docs/howto/baton-workflow.md
+++ b/docs/howto/baton-workflow.md
@@ -196,7 +196,8 @@ COLLABORATOR_HANDOFF: N/A — config-only lane
 
 - `status:done` on an open issue — done must coincide with `gh issue close`
 - Any `role:*` label on a closed issue
-- `status:backlog` or `status:done` with any `role:*` label
+- `status:backlog` or `status:done` with any `role:*` label — **except Epics**, which carry `role:manager` throughout their lifecycle (label-lint Rule E2; per Epic #1074)
+- `status:dormant` or `status:deferred` on non-Epic tickets (Rule E5)
 - Skipping a role without posting an explicit N/A marker
 
 ## Quick Reference

--- a/research/adr/010-ticket-status-role-model.md
+++ b/research/adr/010-ticket-status-role-model.md
@@ -1,10 +1,11 @@
 # ADR-010: Ticket Status–Role Ownership Binding Model
 
-**Status**: Accepted
+**Status**: Accepted (amended 2026-05-07 by Epic #1074)
 **Date**: 2026-04-16
 **Author**: Manny Scope (Manager), Cody Builder (Collaborator)
 **Tickets**: #118, #133, #134
 **Supersedes**: Informal model in `manager-ticket-lifecycle` skill
+**Amended by**: Epic #1074 (Epic-vs-child governance differentiation) — adds `status:dormant` + `status:deferred` Epic-only states; carves out Epic exceptions to Rule 4 (backlog) and Rule 8 (in-progress) per label-lint Rules E2/E3/E5. Original 8-status child-ticket model unchanged for non-Epic tickets.
 
 ## Context
 

--- a/wiki/concepts/epic-governance.md
+++ b/wiki/concepts/epic-governance.md
@@ -21,11 +21,14 @@ and close conditions. Epics are parent containers; all active work happens in ch
 
 | Epic Status     | Condition to Advance             |
 |-----------------|----------------------------------|
+| `backlog`       | Created; carries `role:manager` (Rule E2) |
 | `triage`        | Scope defined, children created  |
-| `ready`         | All children triaged              |
-| `in-progress`   | ≥1 child `in-progress`           |
+| `in-progress`   | ≥1 child `in-progress`; carries `role:manager` (Rule E3) |
+| `dormant`       | Active goal, no current work; 90d EPIC_REVIEW (Rule E5; #1074) |
+| `deferred`      | Active goal, externally blocked; no ETA (Rule E5; #1074) |
 | `review`        | All children `done` or terminal  |
 | `done`/closed   | See close conditions below       |
+| `cancelled`     | Goal invalidated (NOT for stalled work) |
 
 ## Progress Comment Protocol
 


### PR DESCRIPTION
Completes residual scope of #836 after PR #1096 fixed the canonical instruction file.

Refs #836.

[skip-doc-gate] — pure docs alignment, no user-visible behavior change. Aligns 3 derived governance surfaces (howto, ADR amendment, wiki concept) with the lint reality already shipped in Epic #1074.

🤖 Generated with [Claude Code](https://claude.com/claude-code)