### PR TITLE
chore(governance): reword task-router fleet phrasing #1116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — #1116: reword global-task-router fleet phrasing
+
+### Changed
+- `instructions/global-task-router.instructions.md:3` — replace "Local fleet is second-highest priority goal" with "Fleet is the highest zero-cost execution lane after Free/Auto, subject to Governance (G1) and Quality (G2)." Per #1105 D-004 (CX-RD C3 HIGH-severity finding). Disambiguates cost-lane from goal-priority.
+
 ## [Unreleased] — #1117: normalize ZeroCost spelling in session_context.py
 
 ### Fixed

--- a/instructions/global-task-router.instructions.md
+++ b/instructions/global-task-router.instructions.md
@@ -1,6 +1,6 @@
 ---
 name: Global Task Router
-description: Route work through local-first cascade lanes with capability matrix. Local fleet is second-highest priority goal.
+description: Route work through local-first cascade lanes with capability matrix. Fleet is the highest zero-cost execution lane after Free/Auto, subject to Governance (G1) and Quality (G2).
 applyTo: "**"
 ---
 


### PR DESCRIPTION
## Summary

Reword `instructions/global-task-router.instructions.md:3` per #1105 D-004 promoted decision. Replaces "Local fleet is second-highest priority goal" with explicit lane-vs-priority language. Codex Team CX-RD C3 HIGH-severity finding.

Lane: docs-research. COLLABORATOR_HANDOFF and ADMIN_HANDOFF posted as N/A on the linked issue per role-baton-routing research-lane carve-out.

## Test plan

- [x] Wording disambiguates cost-lane from goal-priority
- [x] CHANGELOG updated
- [x] CI gates green

Refs #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)