### PR TITLE
chore(wiki): fix Always-Loaded Surfaces claim #1115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## [Unreleased] — #1116: reword global-task-router fleet phrasing
+## [Unreleased] — #1115: fix wiki Always-Loaded Surfaces claim
 
 ### Changed
-- `instructions/global-task-router.instructions.md:3` — replace "Local fleet is second-highest priority goal" with "Fleet is the highest zero-cost execution lane after Free/Auto, subject to Governance (G1) and Quality (G2)." Per #1105 D-004 (CX-RD C3 HIGH-severity finding). Disambiguates cost-lane from goal-priority.
+- `wiki/concepts/harness-goals.md` — corrected Always-Loaded Surfaces list. `instructions/harness-goals.instructions.md` is NOT @-included by any runtime entry point; moved to new "Reachable on Demand" subsection. Per #1105 D-002 (CC + CX cross-team verification).
 
 ## [Unreleased] — #1117: normalize ZeroCost spelling in session_context.py
 

--- a/wiki/concepts/harness-goals.md
+++ b/wiki/concepts/harness-goals.md
@@ -32,11 +32,16 @@ evidence.
 
 ## Always-Loaded Surfaces
 
-- `.github/copilot-instructions.md`
-- `.codex/AGENTS.md`
-- `instructions/global-standards.instructions.md`
-- `instructions/harness-goals.instructions.md`
-- `hooks/scripts/goal_lens.py`
+These surfaces inject the priority sentence into every governed session at startup or via the goal-keyword hook:
+
+- `.github/copilot-instructions.md` (Copilot runtime)
+- `.codex/AGENTS.md` (Codex runtime)
+- `instructions/global-standards.instructions.md` (Claude Code via `CLAUDE.md` @-include)
+- `hooks/scripts/goal_lens.py` (UserPromptSubmit hook on goal-decision keywords; all runtimes)
+
+## Reachable on Demand (NOT auto-included)
+
+- `instructions/harness-goals.instructions.md` — canonical goal constitution with expanded G1..G9 definitions. Contains the full priority sentence + per-goal definitions, but is NOT @-included by any runtime entry point. Read on demand or via `goal_lens.py` keyword trigger. (Per #1105 D-001 cross-team verification: CC + CX both confirmed.)
 
 ## Goal Definitions
 


### PR DESCRIPTION
## Summary

Corrects the wiki/concepts/harness-goals.md "Always-Loaded Surfaces" list per #1105 D-002. CC and CX both verified that instructions/harness-goals.instructions.md is NOT @-included by any runtime entry point; only its priority sentence reaches sessions via global-standards inline + goal_lens.py hook. Updated the wiki to reflect actual loading paths and added a 'Reachable on Demand' subsection.

Lane: docs-research. COLLABORATOR_HANDOFF and ADMIN_HANDOFF marked N/A on linked issue per role-baton-routing research-lane carve-out.

Refs #1115

🤖 Generated with [Claude Code](https://claude.com/claude-code)