### PR TITLE
chore(governance): document sync-verification rollout #1118

### DIFF
--- a/.changes/unreleased/1118.md
+++ b/.changes/unreleased/1118.md
@@ -1,0 +1,5 @@
+## [Unreleased] — #1118: document sync-verification requirements in rollouts
+
+### Added
+- `instructions/feature-completion-governance.instructions.md` — Admin completion contract now requires runtime-deploy sync verification (`npm run sync:codex`, `sync:claude`, `hamr:sync-verify`) for changes touching deployed runtime artifacts. Per #1105 D-006 (CX-RD C8 HIGH-severity finding).
+- `docs/howto/baton-workflow.md` — Admin handoff template includes sync-verify evidence block; explicit N/A guidance for non-deploy changes.

--- a/docs/howto/baton-workflow.md
+++ b/docs/howto/baton-workflow.md
@@ -114,7 +114,14 @@ CI evidence:
 - collaborator-gate: pass (run #...)
 - lint-required: pass
 - All required checks green
+
+Runtime-deploy sync verification (per #1105 D-006):
+- npm run sync:codex      → ok / N/A — reason
+- npm run sync:claude     → ok / N/A — reason
+- npm run hamr:sync-verify → ok / N/A — reason
 ```
+
+**Sync-verification rule** (per `instructions/feature-completion-governance.instructions.md`): for changes that touch deployed runtime artifacts (`~/.copilot/`, `~/.codex/`, `~/.agents/skills/`, HAMR Worker), Admin closeout MUST include the three sync-verify outputs above. For wiki-only / research / docs changes that don't deploy, state explicitly: `sync-verification: N/A — change does not touch deployed runtime targets.`
 
 Rerun any failed gates after posting:
 

--- a/instructions/feature-completion-governance.instructions.md
+++ b/instructions/feature-completion-governance.instructions.md
@@ -13,6 +13,12 @@ When asked to "complete" a feature-add, all four baton roles are required. Tests
 - Publish/release work (if applicable)
 - Release integrity verification
 - Issue closure comment with released version evidence
+- **Runtime-deploy sync verification** (per #1105 D-006 / Codex Team CX-RD C8 HIGH-severity finding) — for changes that affect deployed runtime artifacts (`~/.copilot/`, `~/.codex/`, `~/.agents/skills/`), the closeout MUST include outputs of:
+  - `npm run sync:codex` (Codex runtime parity)
+  - `npm run sync:claude` (Claude Code runtime parity)
+  - `npm run hamr:sync-verify` (HAMR substrate verification)
+
+  If a change does NOT affect deployed runtime artifacts (e.g., wiki-only edits, research files), state explicitly: `sync-verification: N/A — change does not touch deployed runtime targets.`
 
 ## Documentation coverage matrix (required)
 


### PR DESCRIPTION
## Summary

Per #1105 D-006: Admin completion contract requires runtime-deploy sync verification for changes touching deployed runtime artifacts. Lane: docs-research. COLLAB and ADMIN N/A.

CHANGELOG via .changes/unreleased/1118.md (#1132 fragment pattern).

Refs #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)