### PR TITLE
feat(governance): generated JSON contract for goal definitions #1121

### DIFF
--- a/.changes/unreleased/1121.md
+++ b/.changes/unreleased/1121.md
@@ -1,0 +1,6 @@
+## [Unreleased] — #1121: generated JSON contract for goal definitions
+
+### Added
+- `scripts/global/goals-contract-generate.js` — parses `instructions/harness-goals.instructions.md` and emits `generated/goals-contract.json` (priority_order + definitions, with source SHA + timestamp). Per #1105 D-007.
+- `generated/goals-contract.json` — derived view; "GENERATED — do not edit" header. Used by drift-lint (#1122) and other automation; Markdown remains canonical source.
+- `package.json` `goals:regen` script.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ npm run deploy:both:apply
 | `docs:lint` | `node scripts/docs-lint.js` |
 | `format` | `prettier --write .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js` |
 | `format:check` | `prettier --check .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js` |
+| `goals:regen` | `node scripts/global/goals-contract-generate.js` |
 | `governance:audit` | `node scripts/global/governance-audit.js` |
 | `governance:drift` | `node scripts/global/governance-drift-classifier.js --json` |
 | `governance:epic` | `node scripts/global/epic-evidence.js` |

--- a/generated/goals-contract.json
+++ b/generated/goals-contract.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": 1,
+  "generated_utc": "2026-05-08T19:08:47.284Z",
+  "source_path": "instructions/harness-goals.instructions.md",
+  "source_sha256_prefix": "788d2fbb9edf4e69",
+  "priority_order": [
+    {
+      "id": "G1",
+      "name": "Governance"
+    },
+    {
+      "id": "G2",
+      "name": "Quality"
+    },
+    {
+      "id": "G3",
+      "name": "Zero Cost"
+    },
+    {
+      "id": "G4",
+      "name": "Privacy"
+    },
+    {
+      "id": "G5",
+      "name": "Portability"
+    },
+    {
+      "id": "G6",
+      "name": "Resilience"
+    },
+    {
+      "id": "G7",
+      "name": "Throughput"
+    },
+    {
+      "id": "G8",
+      "name": "Observability"
+    },
+    {
+      "id": "G9",
+      "name": "Interoperability"
+    }
+  ],
+  "definitions": {
+    "G1": {
+      "name": "Governance",
+      "text": "policy, role, provenance, and ticket controls are non-negotiable"
+    },
+    "G2": {
+      "name": "Quality",
+      "text": "maximize correctness and engineering value of outcomes"
+    },
+    "G3": {
+      "name": "Zero Cost",
+      "text": "prefer local/fleet/free lanes before paid providers"
+    },
+    "G4": {
+      "name": "Privacy",
+      "text": "keep sensitive context local unless explicit override exists"
+    },
+    "G5": {
+      "name": "Portability",
+      "text": "avoid user-specific coupling; settings-driven behavior preferred"
+    },
+    "G6": {
+      "name": "Resilience",
+      "text": "graceful degradation and fallback paths for partial outages"
+    },
+    "G7": {
+      "name": "Throughput",
+      "text": "acceptable speed after higher-priority goals are satisfied"
+    },
+    "G8": {
+      "name": "Observability",
+      "text": "decisions and outcomes are visible, auditable, and attributable"
+    },
+    "G9": {
+      "name": "Interoperability",
+      "text": "preserve compatibility across agent surfaces and runtimes"
+    }
+  },
+  "notes": [
+    "GENERATED — do not edit. Regenerate via `npm run goals:regen`.",
+    "Markdown source is canonical; JSON is a derived view for linting/automation.",
+    "Direct edits to this file are blocked by CI (verify-goals-contract gate)."
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "wiki:lint": "node scripts/wiki/lint.js",
     "wiki:search": "node scripts/wiki/search.js",
     "worktree:start": "bash scripts/worktree-session-start.sh",
-    "governance:audit": "node scripts/global/governance-audit.js"
+    "governance:audit": "node scripts/global/governance-audit.js",
+    "goals:regen": "node scripts/global/goals-contract-generate.js"
   },
   "keywords": [
     "devops",

--- a/scripts/global/goals-contract-generate.js
+++ b/scripts/global/goals-contract-generate.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+'use strict';
+/* Generate JSON contract from instructions/harness-goals.instructions.md
+ * Per #1121 / #1105 D-007. Markdown is canonical source; JSON is derived
+ * view for programmatic linting (#1122) and machine-readable tools.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const SOURCE = path.resolve(__dirname, '../../instructions/harness-goals.instructions.md');
+const OUT = path.resolve(__dirname, '../../generated/goals-contract.json');
+
+function parse(md) {
+  const priority = [];
+  const definitions = {};
+  // Priority order: extract from the canonical sentence (which may span lines).
+  // Strategy: collapse whitespace, take all G<n> Name tokens in document order;
+  // dedupe keeping first occurrence, take the first 9.
+  const flat = md.replace(/\s+/g, ' ');
+  const tokens = [...flat.matchAll(/(G[1-9])\s+([A-Z][A-Za-z]+(?:\s[A-Z][A-Za-z]+)?)\s*(?=[>.])/g)];
+  for (const t of tokens) {
+    if (priority.length === 9) break;
+    if (!priority.find((p) => p.id === t[1])) {
+      priority.push({ id: t[1], name: t[2].trim() });
+    }
+  }
+  // Definitions from `- G<n> Name: text` bullets
+  for (const line of md.split('\n')) {
+    const dm = line.match(/^- (G[1-9])\s+([A-Z][A-Za-z]+(?:\s[A-Z][A-Za-z]+)?):\s+(.+?)\.?\s*$/);
+    if (dm) definitions[dm[1]] = { name: dm[2].trim(), text: dm[3].trim() };
+  }
+  return { priority, definitions };
+}
+
+function main() {
+  const md = fs.readFileSync(SOURCE, 'utf8');
+  const sourceSha = crypto.createHash('sha256').update(md).digest('hex').slice(0, 16);
+  const { priority, definitions } = parse(md);
+  const contract = {
+    schema_version: 1,
+    generated_utc: new Date().toISOString(),
+    source_path: 'instructions/harness-goals.instructions.md',
+    source_sha256_prefix: sourceSha,
+    priority_order: priority,
+    definitions,
+    notes: [
+      'GENERATED — do not edit. Regenerate via `npm run goals:regen`.',
+      'Markdown source is canonical; JSON is a derived view for linting/automation.',
+      'Direct edits to this file are blocked by CI (verify-goals-contract gate).',
+    ],
+  };
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, JSON.stringify(contract, null, 2) + '\n');
+  console.log(`✅ goals-contract written: ${OUT} (${priority.length} goals)`);
+}
+
+if (require.main === module) main();
+module.exports = { parse };


### PR DESCRIPTION
## Summary

Per #1105 D-007: parses harness-goals.instructions.md and emits generated/goals-contract.json. Markdown remains canonical; JSON is derived for programmatic linting (#1122) and automation. `npm run goals:regen` regenerates.

Refs #1121

🤖 Generated with [Claude Code](https://claude.com/claude-code)