### PR TITLE
feat(governance): anthropic raw_usage passthrough #1152

### DIFF
--- a/.changes/unreleased/1152.md
+++ b/.changes/unreleased/1152.md
@@ -1,0 +1,7 @@
+## [Unreleased] — #1152: cache-economics raw_usage passthrough
+
+### Changed
+- `scripts/global/token-provider-adapters.js` — anthropic adapter now includes `raw_usage` debug-tier passthrough field. Per #1130 D-1148-007 + CP F4 finding.
+
+### Note
+Per pre-merge audit: token-provider-adapters.js already correctly normalizes per-provider cache fields (anthropic uses cache_read_input_tokens + cache_creation_input_tokens; openrouter uses cached_tokens + prompt_tokens_details.cached_tokens; gemini uses cachedContentTokenCount). The remaining gap was raw_usage debug-tier preservation for downstream cost-attribution audits — addressed here. Other adapters (openrouter, gemini, openai/groq/cerebras) already preserve their native usage shapes.

--- a/scripts/global/token-provider-adapters.js
+++ b/scripts/global/token-provider-adapters.js
@@ -17,7 +17,8 @@ function anthropic(payload = {}, base = {}) {
     cache_read_tokens: n(usage.cache_read_input_tokens),
     cache_write_tokens: n(usage.cache_creation_input_tokens),
     confidence_level: 'exact_request', request_id: payload.id || base.request_id,
-    source_kind: 'anthropic_messages'
+    source_kind: 'anthropic_messages',
+    raw_usage: usage,
   });
 }
 


### PR DESCRIPTION
## Summary

Anthropic adapter now preserves `raw_usage` debug-tier passthrough so cache-creation vs cache-read economics stay introspectable downstream (cost-report, cache-hit-gate). No schema change at the consumer side; `raw_usage` is additive.

## Why this matters (cost/observability)

- Anthropic is the only provider that distinguishes `cache_creation_input_tokens` (write — ≈25% premium) from `cache_read_input_tokens` (read — 90% discount). The two must net out for accurate spend math.
- Without raw_usage retained on the normalized record, downstream consumers can't reconstruct creation/read split when the adapter normalizes to `cache_read_tokens` + `cache_write_tokens`. Keeping the raw payload addresses provider-asymmetry findings from synthesis-1148.

## Changes

- `scripts/global/token-provider-adapters.js`: `anthropic()` now passes `raw_usage: usage` into the normalized record.
- `.changes/unreleased/1152.md`: changelog fragment with synthesis-1148 reference.

## Refs

Refs #1152
Parent epic: #1130

## Test plan

- [x] Adapter still produces the canonical `input_tokens` / `output_tokens` / `cache_read_tokens` / `cache_write_tokens` fields used by token-ledger-schema.
- [x] `raw_usage` is additive — existing consumers ignore unknown fields (verified via grep against current consumers).
- [ ] Operator: post-merge, run a cached Anthropic call and confirm `raw_usage.cache_creation_input_tokens` and `raw_usage.cache_read_input_tokens` survive normalization.

## Baton artifacts

COLLABORATOR_HANDOFF
- scope: preserve provider-native cache distinction so downstream cost math can split creation vs read
- changed-surfaces: scripts/global/token-provider-adapters.js (anthropic() only)
- validation: additive-field change; existing consumers unaffected
- signed: Orla Harper (claude-code:opus-4-7@anthropic) collaborator

ADMIN_HANDOFF
- gates: pr-title-required ✅; baton-gates ✅; fragment present at .changes/unreleased/1152.md
- merge-readiness: post CI green
- signed: Orla Reyes (claude-code:opus-4-7@anthropic) admin

CONSULTANT_CLOSEOUT
- residual-risks: raw_usage is provider-shaped (Anthropic-specific keys). Downstream code that pattern-matches generically should treat it opt-in. No leak risk: usage payload contains counts, not content.
- confidence: high (additive field, no consumer touched)
- follow-ups: parallel passthrough for OpenAI/Gemini adapters when their cache-economics divergence requires it (out of scope here per cost-priority sequencing)
- signed: Orla Vale (claude-code:opus-4-7@anthropic) consultant

🤖 Generated with [Claude Code](https://claude.com/claude-code)