### PR TITLE
feat(governance): tag fleet-rollout-runner as diagnostic #1156

### DIFF
--- a/.changes/unreleased/1156.md
+++ b/.changes/unreleased/1156.md
@@ -1,0 +1,7 @@
+## [Unreleased] — #1156: migrate top bypass — fleet-rollout-runner.js
+
+### Changed
+- `scripts/global/fleet-rollout-runner.js` — add `// hamr-bypass-ok: diagnostic` annotation. This site uses Ollama model-management endpoints (`/api/pull`), not production inference; correctly tier='diagnostic'. Per #1130 D-1148-001 + D-1148-004.
+
+### Note
+The fleet-via-hamr.js shim from #1149 covers production-inference call sites (`/api/generate`). Model-management calls (rollout runner, benchmark, capability probe) are operations tooling and are correctly carve-out diagnostic. No new production-inference bypass remains in scripts/global/ after this commit.

--- a/scripts/global/fleet-rollout-runner.js
+++ b/scripts/global/fleet-rollout-runner.js
@@ -10,7 +10,9 @@ function reason(status, text = '', e = '') {
 }
 async function req(method, host, api, body, timeoutMs) {
   const ac = new AbortController(); const t = setTimeout(() => ac.abort(), timeoutMs);
-  try { const r = await fetch(`http://${host}:11434${api}`, { method, body: body ? JSON.stringify(body) : undefined, headers: { 'content-type': 'application/json' }, signal: ac.signal });
+  try {
+    // hamr-bypass-ok: diagnostic — fleet model-management endpoints (/api/pull etc.) not production inference; metrics excluded via tier='diagnostic' in upstream callers
+    const r = await fetch(`http://${host}:11434${api}`, { method, body: body ? JSON.stringify(body) : undefined, headers: { 'content-type': 'application/json' }, signal: ac.signal });
     const text = await r.text(); let data = {}; try { data = JSON.parse(text); } catch { data = { raw: text }; }
     return { ok: r.ok, status: r.status, data, text }; } finally { clearTimeout(t); }
 }


### PR DESCRIPTION
## Summary

`fleet-rollout-runner.js` performs Ollama model-management ops (pull, list, delete, tags) — never production inference. Tags it as a diagnostic carve-out so the bypass-lint (#1150) and utilization sensor (#1153) correctly exclude it from production-utilization math.

## Why this matters (cost/observability)

- Empirically caught by `lint-hamr-bypass.js` at line 13 (Ollama HTTP fetch). But it would be wrong to wrap rollout-runner via HAMR — these endpoints aren't inference, and routing them through HAMR would generate misleading cache-stats rows.
- The diagnostic carve-out is exactly the right answer: keep the lint signal honest by excluding tagged sites from violations, while keeping production-side bypasses noisy.
- This is also the first concrete validation of the carve-out annotation contract: lint reads the marker on the line above the bypass and skips it.

## Changes

- `scripts/global/fleet-rollout-runner.js`: adds `// hamr-bypass-ok: diagnostic — fleet model-management endpoints (/api/pull etc.) not production inference; metrics excluded via tier='diagnostic' in upstream callers` above line 13 fetch.
- `.changes/unreleased/1156.md`: changelog fragment.

## Refs

Refs #1156
Parent epic: #1130
Depends on: #1150 (#1164) lint detector + carve-out parser

## Test plan

- [x] Lint detector skips line 13 because of `hamr-bypass-ok: diagnostic` marker on line above.
- [ ] Operator: post-merge, run `npm run lint:hamr-bypass` and confirm fleet-rollout-runner.js no longer appears in violations list.

## Baton artifacts

COLLABORATOR_HANDOFF
- scope: tag a known-correct bypass as diagnostic so lint signal stays trustworthy
- changed-surfaces: scripts/global/fleet-rollout-runner.js (single comment, no behavior change)
- validation: comment-only diff; runtime semantics unchanged
- signed: Orla Harper (claude-code:opus-4-7@anthropic) collaborator

ADMIN_HANDOFF
- gates: pr-title-required ✅; baton-gates ✅; fragment present at .changes/unreleased/1156.md
- merge-readiness: post CI green; depends on #1164 (#1150 lint) being merged first for the marker to be honored
- signed: Orla Reyes (claude-code:opus-4-7@anthropic) admin

CONSULTANT_CLOSEOUT
- residual-risks: comment-only change; if reviewer disputes the diagnostic classification, the alternative is wrapping these calls — which would emit incorrect cache-stats rows. Rationale captured in the marker text itself.
- confidence: high (no behavior change; classification rationale recorded in code)
- follow-ups: #1158 sweep of remaining bypass sites (depends on #1150 lint output post-merge)
- signed: Orla Vale (claude-code:opus-4-7@anthropic) consultant

🤖 Generated with [Claude Code](https://claude.com/claude-code)