### PR TITLE
feat(scripts): add dependency graph aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ npm run deploy:both:apply
 | `deploy:claude:apply` | `bash scripts/deploy.sh --apply --target claude` |
 | `deploy:codex` | `bash scripts/deploy.sh --target codex` |
 | `deploy:codex:apply` | `bash scripts/deploy.sh --apply --target codex` |
+| `deps:aggregate` | `node scripts/global/dep-graph-aggregate.js` |
 | `docs:anchors` | `node scripts/global/docs-anchors.js` |
 | `docs:compile` | `node scripts/docs-compile.js` |
 | `docs:exec` | `node scripts/global/docs-exec.js` |

--- a/docs/howto/dependency-graph.md
+++ b/docs/howto/dependency-graph.md
@@ -1,0 +1,36 @@
+# Dependency Graph Aggregation
+
+Use the deterministic dependency graph aggregator to build the Layer 1 graph for
+Epic #1125.
+
+```bash
+npm run deps:aggregate
+```
+
+By default, the command reads GitHub issues through `gh issue list`, parses
+explicit relationship lines, and writes:
+
+```text
+planning/dep-graph.json
+```
+
+For smaller probes or CI fixtures, limit the issue count and write outside the
+repo:
+
+```bash
+npm run deps:aggregate -- --limit 20 --out /tmp/dep-graph.json
+```
+
+The graph includes:
+
+- `nodes`: issue number, title, state, labels, update time, and dependency
+  summary metadata when available.
+- `edges`: explicit text or GitHub-native dependency edges.
+- `mismatches`: same issue pair with conflicting edge types.
+
+The command is read-only against GitHub. It does not mutate issues, labels, or
+native dependency relationships.
+
+Signed-by: Nova Harper
+Team&Model: codex:gpt-5@codex-cli
+Role: collaborator

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "capability:show": "node scripts/global/capability-show.js",
     "cost-report": "node scripts/global/cost-report.js",
     "cost:baseline": "node scripts/global/cost-baseline.js",
+    "deps:aggregate": "node scripts/global/dep-graph-aggregate.js",
     "deploy": "bash scripts/deploy.sh",
     "deploy:apply": "bash scripts/deploy.sh --apply",
     "deploy:both": "bash scripts/deploy.sh --target both",

--- a/scripts/global/dep-graph-aggregate.js
+++ b/scripts/global/dep-graph-aggregate.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+'use strict';
+/* eslint-disable jsdoc/require-jsdoc */
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const OUT = path.join(ROOT, 'planning', 'dep-graph.json');
+const DEFAULT_LIMIT = 200;
+const REL = {
+  'depends-on': 'depends-on',
+  'blocked-by': 'blocked-by',
+  blocks: 'blocks',
+  'coupled-with': 'coupled-with',
+  refs: 'refs',
+  'future-coupled': 'future-coupled',
+};
+function issueNums(text) {
+  return [...String(text || '').matchAll(/#(\d+)/g)].map(m => Number(m[1]));
+}
+function normLabel(label) {
+  return String(label || '').toLowerCase().replace(/\s+/g, '-');
+}
+function labels(issue) {
+  return (issue.labels || []).map(l => (typeof l === 'string' ? l : l.name)).filter(Boolean);
+}
+function parseTextEdges(issue) {
+  const edges = [];
+  for (const line of String(issue.body || '').split(/\r?\n/)) {
+    const m = line.match(/^\s*(?:[-*]\s*)?(Depends-on|Blocks|Blocked-by|Coupled-with|Refs|Future-Coupled)\s*:?\s+(.+)$/i);
+    if (!m) continue;
+    const type = REL[normLabel(m[1])];
+    for (const to of issueNums(m[2])) {
+      if (to !== issue.number) edges.push(edge(issue.number, to, type, 'text', line.trim()));
+    }
+  }
+  return edges;
+}
+function edge(from, to, type, source, raw = '') {
+  return { from: Number(from), to: Number(to), type, source: [source], raw, mismatch: false };
+}
+function nativeEdges(issue) {
+  const items = issue.native_edges || issue.nativeEdges || issue.issue_dependencies || [];
+  return items.map(e => edge(e.from || issue.number, e.to || e.number, e.type || 'github-dependency', 'github_api'));
+}
+function mergeEdges(edges) {
+  const byKey = new Map();
+  for (const e of edges) {
+    const key = `${e.from}:${e.to}:${e.type}`;
+    const existing = byKey.get(key);
+    if (existing) existing.source = [...new Set([...existing.source, ...e.source])];
+    else byKey.set(key, { ...e, source: [...e.source] });
+  }
+  const merged = [...byKey.values()].sort((a, b) => a.from - b.from || a.to - b.to || a.type.localeCompare(b.type));
+  const pairs = new Map();
+  for (const e of merged) {
+    const key = `${e.from}:${e.to}`;
+    const types = pairs.get(key) || new Set();
+    types.add(e.type); pairs.set(key, types);
+  }
+  const mismatches = [];
+  for (const e of merged) {
+    if ((pairs.get(`${e.from}:${e.to}`) || new Set()).size > 1) {
+      e.mismatch = true;
+      mismatches.push({ from: e.from, to: e.to, types: [...pairs.get(`${e.from}:${e.to}`)].sort() });
+    }
+  }
+  return { edges: merged, mismatches };
+}
+function buildGraph(issues, meta = {}) {
+  const nodes = issues.map(i => ({
+    id: i.number, title: i.title, state: i.state, labels: labels(i),
+    updated_at: i.updatedAt || i.updated_at || null,
+    native_dependency_summary: i.issue_dependencies_summary || null,
+  })).sort((a, b) => a.id - b.id);
+  const allEdges = issues.flatMap(i => [...parseTextEdges(i), ...nativeEdges(i)]);
+  const { edges, mismatches } = mergeEdges(allEdges);
+  return { schema_version: 1, generated_at: new Date().toISOString(), ...meta, nodes, edges, mismatches };
+}
+function fetchIssues(limit) {
+  const fields = 'number,title,state,labels,body,updatedAt,url';
+  const out = execFileSync('gh', ['issue', 'list', '--state', 'all', '--limit', String(limit), '--json', fields], { encoding: 'utf8' });
+  return JSON.parse(out);
+}
+function main() {
+  const args = process.argv.slice(2);
+  const limit = Number(args[args.indexOf('--limit') + 1] || DEFAULT_LIMIT);
+  const outFile = args.includes('--out') ? args[args.indexOf('--out') + 1] : OUT;
+  const graph = buildGraph(fetchIssues(limit), { source: 'gh issue list', limit });
+  fs.mkdirSync(path.dirname(outFile), { recursive: true });
+  fs.writeFileSync(outFile, `${JSON.stringify(graph, null, 2)}\n`);
+  console.log(JSON.stringify(graph, null, 2));
+}
+
+if (require.main === module) main();
+module.exports = { issueNums, parseTextEdges, nativeEdges, mergeEdges, buildGraph };

--- a/tests/dep-graph-aggregate.spec.js
+++ b/tests/dep-graph-aggregate.spec.js
@@ -1,0 +1,49 @@
+'use strict';
+const { test, expect } = require('@playwright/test');
+const path = require('node:path');
+const A = require(path.resolve(__dirname, '../scripts/global/dep-graph-aggregate.js'));
+
+test.describe('dep-graph-aggregate (#1195)', () => {
+  test('parseTextEdges extracts explicit body relationships', () => {
+    const edges = A.parseTextEdges({
+      number: 10,
+      body: ['Depends-on: #1 #2', '- Blocks: #3', 'Refs #4', 'Coupled-with: #10'].join('\n'),
+    });
+    expect(edges.map(e => [e.from, e.to, e.type])).toEqual([
+      [10, 1, 'depends-on'],
+      [10, 2, 'depends-on'],
+      [10, 3, 'blocks'],
+      [10, 4, 'refs'],
+    ]);
+  });
+
+  test('buildGraph merges text and native API edges', () => {
+    const graph = A.buildGraph([
+      {
+        number: 10,
+        title: 'A',
+        state: 'OPEN',
+        labels: [{ name: 'type:task' }],
+        body: 'Depends-on: #1',
+        native_edges: [{ from: 10, to: 1, type: 'depends-on' }],
+      },
+    ]);
+    expect(graph.nodes[0].labels).toEqual(['type:task']);
+    expect(graph.edges).toHaveLength(1);
+    expect(graph.edges[0].source.sort()).toEqual(['github_api', 'text']);
+  });
+
+  test('mergeEdges flags pair/type mismatches', () => {
+    const graph = A.buildGraph([
+      {
+        number: 10,
+        title: 'A',
+        state: 'OPEN',
+        body: 'Depends-on: #1',
+        native_edges: [{ from: 10, to: 1, type: 'blocks' }],
+      },
+    ]);
+    expect(graph.edges.every(e => e.mismatch)).toBe(true);
+    expect(graph.mismatches[0]).toEqual({ from: 10, to: 1, types: ['blocks', 'depends-on'] });
+  });
+});


### PR DESCRIPTION
Refs #1195
Closes #1195

## Summary
- Adds deterministic dependency graph aggregation CLI.
- Parses text issue relationships and future/native dependency metadata.
- Emits canonical graph JSON with mismatch flags.
- Adds focused tests and operator docs.

## Validation
- npm run lint
- npx playwright test tests/dep-graph-aggregate.spec.js
- npm run deps:aggregate -- --limit 20 --out /tmp/dep-graph-1195.json
- npx eslint -c lint-configs/eslint.config.devenv.js scripts/global/dep-graph-aggregate.js
- npx markdownlint-cli2 docs/howto/dependency-graph.md
- npm run format:check
- git diff --check
- node scripts/lint-readability.js --max-warnings=420

## Notes
- Visual QA: N/A, no UI/dashboard/browser surface changed.
- No HAMR, #1130, or #1133 implementation files touched.

Signed-by: Nova Reyes
Team&Model: codex:gpt-5@codex-cli
Role: admin