### PR TITLE
feat(scripts): add dependency graph augmentor

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ npm run deploy:both:apply
 | `deploy:codex` | `bash scripts/deploy.sh --target codex` |
 | `deploy:codex:apply` | `bash scripts/deploy.sh --apply --target codex` |
 | `deps:aggregate` | `node scripts/global/dep-graph-aggregate.js` |
+| `deps:augment` | `node scripts/global/dep-graph-augment.js` |
 | `docs:anchors` | `node scripts/global/docs-anchors.js` |
 | `docs:compile` | `node scripts/docs-compile.js` |
 | `docs:exec` | `node scripts/global/docs-exec.js` |

--- a/docs/howto/dependency-graph.md
+++ b/docs/howto/dependency-graph.md
@@ -31,6 +31,15 @@ The graph includes:
 The command is read-only against GitHub. It does not mutate issues, labels, or
 native dependency relationships.
 
+Generate AI-assisted proposals after the graph exists:
+
+```bash
+npm run deps:augment -- --graph planning/dep-graph.json
+```
+
+The augmentor writes `planning/dep-proposals.json`, records confidence and
+cache metadata, and never mutates issues.
+
 Signed-by: Nova Harper
 Team&Model: codex:gpt-5@codex-cli
 Role: collaborator

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cost-report": "node scripts/global/cost-report.js",
     "cost:baseline": "node scripts/global/cost-baseline.js",
     "deps:aggregate": "node scripts/global/dep-graph-aggregate.js",
+    "deps:augment": "node scripts/global/dep-graph-augment.js",
     "deploy": "bash scripts/deploy.sh",
     "deploy:apply": "bash scripts/deploy.sh --apply",
     "deploy:both": "bash scripts/deploy.sh --target both",

--- a/scripts/global/dep-graph-augment.js
+++ b/scripts/global/dep-graph-augment.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+'use strict';
+/* eslint-disable jsdoc/require-jsdoc */
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { execFileSync } = require('node:child_process');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const GRAPH = path.join(ROOT, 'planning', 'dep-graph.json');
+const OUT = path.join(ROOT, 'planning', 'dep-proposals.json');
+const PROMPT_VERSION = 'dep-proposal-v1';
+const DEFAULT_MODEL = 'fleet:cascade-dispatch';
+const DEFAULT_THRESHOLD = 0.85;
+const STOP = new Set(['add', 'build', 'fix', 'the', 'and', 'for', 'with', 'into']);
+
+function sha(value) {
+  return crypto.createHash('sha256').update(String(value || '')).digest('hex').slice(0, 16);
+}
+function labels(node) {
+  return (node.labels || []).filter(l => /^(area|type):/.test(l)).sort();
+}
+function words(title) {
+  const found = String(title || '').toLowerCase().match(/[a-z0-9]{4,}/g) || [];
+  return new Set(found.filter(w => !STOP.has(w)));
+}
+function cacheKey(a, b, model = DEFAULT_MODEL) {
+  const issueHash = n => sha([n.id, n.title, labels(n).join(','), n.body || n.body_hash || ''].join('|'));
+  return sha([PROMPT_VERSION, model, issueHash(a), issueHash(b)].join('|'));
+}
+function hasEdge(graph, from, to) {
+  return (graph.edges || []).some(e => e.from === from && e.to === to);
+}
+function candidatePairs(graph, opts = {}) {
+  const nodes = [...(graph.nodes || [])].filter(n => n.state !== 'CLOSED').sort((a, b) => a.id - b.id);
+  const pairs = [];
+  for (let i = 0; i < nodes.length; i += 1) for (let j = i + 1; j < nodes.length; j += 1) {
+    const [a, b] = [nodes[i], nodes[j]];
+    if (hasEdge(graph, a.id, b.id) || hasEdge(graph, b.id, a.id)) continue;
+    const sharedLabels = labels(a).filter(l => labels(b).includes(l));
+    const overlap = [...words(a.title)].filter(w => words(b.title).has(w));
+    if (sharedLabels.length || overlap.length) pairs.push({ a, b, reason: { sharedLabels, overlap } });
+  }
+  return pairs.slice(0, opts.limit || 40);
+}
+function prompt(pair) {
+  return `Return JSON only: {"edge_type":"depends-on|blocks|coupled-with|none","confidence":0-1,"rationale":"...","evidence_spans":["..."]}\nA #${pair.a.id}: ${pair.a.title}\nB #${pair.b.id}: ${pair.b.title}`;
+}
+function parseResult(raw, threshold = DEFAULT_THRESHOLD) {
+  try {
+    const text = typeof raw === 'string' ? raw : raw.content || JSON.stringify(raw);
+    const match = text.match(/\{[\s\S]*\}/);
+    const parsed = JSON.parse(match ? match[0] : text);
+    const type = parsed.edge_type || parsed.type;
+    const confidence = Number(parsed.confidence);
+    if (!['depends-on', 'blocks', 'coupled-with', 'none'].includes(type) || Number.isNaN(confidence)) throw new Error('invalid');
+    const status = type !== 'none' && confidence >= threshold ? 'proposed' : 'skipped';
+    return { status, edge_type: type, confidence, rationale: parsed.rationale || '', evidence_spans: parsed.evidence_spans || [] };
+  } catch {
+    return { status: 'fallback', edge_type: 'none', confidence: 0, rationale: 'invalid model output', evidence_spans: [] };
+  }
+}
+function runCascade(p) {
+  const cmd = [path.join(__dirname, 'cascade-dispatch.js'), '--prompt', p, '--json'];
+  return JSON.parse(execFileSync(process.execPath, cmd, { encoding: 'utf8' }));
+}
+function readJson(file, fallback) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return fallback; }
+}
+async function augment(graph, opts = {}) {
+  const threshold = opts.threshold || DEFAULT_THRESHOLD;
+  const model = opts.model || DEFAULT_MODEL;
+  const cache = readJson(opts.cache || '', { items: {} });
+  const classify = opts.classify || (p => runCascade(p));
+  const results = [];
+  for (const pair of candidatePairs(graph, opts)) {
+    const key = cacheKey(pair.a, pair.b, model);
+    const parsed = parseResult(cache.items?.[key] || await classify(prompt(pair), pair), threshold);
+    results.push({ from: pair.a.id, to: pair.b.id, cache_key: key, model: { id: model, prompt_version: PROMPT_VERSION }, candidate_reason: pair.reason, ...parsed });
+  }
+  return { schema_version: 1, generated_at: new Date().toISOString(), threshold, proposals: results.filter(r => r.status === 'proposed'), skipped: results.filter(r => r.status !== 'proposed') };
+}
+async function main() {
+  const args = process.argv.slice(2);
+  const val = (flag, d) => args.includes(flag) ? args[args.indexOf(flag) + 1] : d;
+  const result = await augment(readJson(val('--graph', GRAPH), { nodes: [], edges: [] }), { limit: Number(val('--limit', 40)), threshold: Number(val('--threshold', DEFAULT_THRESHOLD)), cache: val('--cache', '') });
+  const outFile = val('--out', OUT);
+  fs.mkdirSync(path.dirname(outFile), { recursive: true });
+  fs.writeFileSync(outFile, `${JSON.stringify(result, null, 2)}\n`);
+  console.log(JSON.stringify(result, null, 2));
+}
+if (require.main === module) main().catch(e => { console.error(e.message); process.exit(1); });
+module.exports = { candidatePairs, cacheKey, parseResult, augment };

--- a/tests/dep-graph-augment.spec.js
+++ b/tests/dep-graph-augment.spec.js
@@ -1,0 +1,38 @@
+'use strict';
+const { test, expect } = require('@playwright/test');
+const path = require('node:path');
+const A = require(path.resolve(__dirname, '../scripts/global/dep-graph-augment.js'));
+
+const node = (id, title, labels = ['type:task', 'area:scripts']) => ({ id, title, state: 'OPEN', labels });
+
+test.describe('dep-graph-augment (#1196)', () => {
+  test('candidate filtering avoids all-pairs analysis', () => {
+    const graph = { nodes: [node(1, 'Add graph cache'), node(2, 'Review graph cache'), node(3, 'Paint dashboard', ['area:dashboard'])], edges: [{ from: 1, to: 2 }] };
+    expect(A.candidatePairs(graph).map(p => [p.a.id, p.b.id])).toEqual([]);
+  });
+
+  test('proposed-edge path honors threshold and metadata', async () => {
+    const graph = { nodes: [node(1, 'Add dependency JSON'), node(2, 'Review dependency JSON')], edges: [] };
+    const result = await A.augment(graph, { classify: () => ({ edge_type: 'depends-on', confidence: 0.91, rationale: 'shared JSON contract', evidence_spans: ['dependency JSON'] }) });
+    expect(result.threshold).toBe(0.85);
+    expect(result.proposals[0]).toMatchObject({ from: 1, to: 2, status: 'proposed', edge_type: 'depends-on', confidence: 0.91 });
+    expect(result.proposals[0].model.prompt_version).toBe('dep-proposal-v1');
+  });
+
+  test('stale-cache path recomputes when issue hash changes', async () => {
+    const oldA = node(1, 'Old title'); const issueB = node(2, 'Shared title');
+    const oldKey = A.cacheKey(oldA, issueB);
+    let calls = 0;
+    const graph = { nodes: [node(1, 'New shared title'), issueB], edges: [] };
+    await A.augment(graph, { classify: () => { calls += 1; return { edge_type: 'none', confidence: 0.1 }; } });
+    expect(oldKey).not.toBe(A.cacheKey(graph.nodes[0], issueB));
+    expect(calls).toBe(1);
+  });
+
+  test('invalid-output path falls back without auto-accepting', async () => {
+    const graph = { nodes: [node(1, 'Add parser'), node(2, 'Review parser')], edges: [] };
+    const result = await A.augment(graph, { classify: () => 'not json' });
+    expect(result.proposals).toEqual([]);
+    expect(result.skipped[0]).toMatchObject({ status: 'fallback', edge_type: 'none' });
+  });
+});


### PR DESCRIPTION
Refs #1196
Closes #1196

## Summary
- add the AI-assisted dependency proposal augmentor CLI
- document the `npm run deps:augment` workflow
- cover no-edge, proposed-edge, stale-cache, and invalid-output paths

## Validation
- npm run lint
- npx playwright test tests/dep-graph-augment.spec.js
- npm run deps:augment -- --graph /tmp/no-graph.json --out /tmp/dep-proposals-1196.json --limit 5
- npx eslint -c lint-configs/eslint.config.devenv.js scripts/global/dep-graph-augment.js
- npx markdownlint-cli2 docs/howto/dependency-graph.md
- npm run docs:compile -- --check
- npm run format:check
- git diff --check
- node scripts/lint-readability.js --max-warnings=420

## Governance
- Replacement for unmerged PR #1209, which was closed because it was created before the collaborator timing gate matured.
- ADMIN_HANDOFF and ADMIN_VISUAL_QA are posted on #1196.
- Visual QA: N/A, CLI/docs/test-only change with no UI surface.
- No #1130 or #1133-owned files touched.

Signed-by: Nova Reyes
Team&Model: codex:gpt-5@codex-cli
Role: admin