### PR TITLE
feat(scripts): add dependency proposal review CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ npm run deploy:both:apply
 | `deploy:codex:apply` | `bash scripts/deploy.sh --apply --target codex` |
 | `deps:aggregate` | `node scripts/global/dep-graph-aggregate.js` |
 | `deps:augment` | `node scripts/global/dep-graph-augment.js` |
+| `deps:review` | `node scripts/global/dep-proposals-review.js` |
 | `docs:anchors` | `node scripts/global/docs-anchors.js` |
 | `docs:compile` | `node scripts/docs-compile.js` |
 | `docs:exec` | `node scripts/global/docs-exec.js` |
@@ -185,14 +186,14 @@ This table is auto-generated from `package.json` by `npm run docs:compile` (#796
 
 ## Runtime mapping
 
-| Source | Runtime target |
-|---|---|
-| skills/ | ~/.copilot/skills + ~/.agents/skills |
-| instructions/ | ~/.copilot/instructions |
-| hooks/ | ~/.copilot/hooks + ~/.codex/devenv-ops/hooks |
-| scripts/global/ | ~/.copilot/scripts + ~/.codex/devenv-ops/scripts |
-| .codex/ | ~/.codex/AGENTS.md + config.toml + hooks.json + rules/ |
-| wiki/ | ~/.copilot/wiki + ~/.codex/devenv-ops/wiki |
+| Source          | Runtime target                                         |
+| --------------- | ------------------------------------------------------ |
+| skills/         | ~/.copilot/skills + ~/.agents/skills                   |
+| instructions/   | ~/.copilot/instructions                                |
+| hooks/          | ~/.copilot/hooks + ~/.codex/devenv-ops/hooks           |
+| scripts/global/ | ~/.copilot/scripts + ~/.codex/devenv-ops/scripts       |
+| .codex/         | ~/.codex/AGENTS.md + config.toml + hooks.json + rules/ |
+| wiki/           | ~/.copilot/wiki + ~/.codex/devenv-ops/wiki             |
 
 ## Issue flows
 

--- a/docs/howto/dependency-graph.md
+++ b/docs/howto/dependency-graph.md
@@ -40,6 +40,17 @@ npm run deps:augment -- --graph planning/dep-graph.json
 The augmentor writes `planning/dep-proposals.json`, records confidence and
 cache metadata, and never mutates issues.
 
+Review generated proposals without mutating GitHub:
+
+```bash
+npm run deps:review -- --proposals planning/dep-proposals.json
+```
+
+The review command records accepted, rejected, and suppressed decisions in
+`planning/dep-decisions.json`. Accepted records keep proposal and issue-title
+metadata for later approved mutation tooling. Rejected and suppressed proposals
+are tombstoned by cache key until source issue inputs change.
+
 Signed-by: Nova Harper
 Team&Model: codex:gpt-5@codex-cli
 Role: collaborator

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cost:baseline": "node scripts/global/cost-baseline.js",
     "deps:aggregate": "node scripts/global/dep-graph-aggregate.js",
     "deps:augment": "node scripts/global/dep-graph-augment.js",
+    "deps:review": "node scripts/global/dep-proposals-review.js",
     "deploy": "bash scripts/deploy.sh",
     "deploy:apply": "bash scripts/deploy.sh --apply",
     "deploy:both": "bash scripts/deploy.sh --target both",

--- a/scripts/global/dep-proposals-review.js
+++ b/scripts/global/dep-proposals-review.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+'use strict';
+/* eslint-disable jsdoc/require-jsdoc */
+const fs = require('node:fs');
+const path = require('node:path');
+const readline = require('node:readline');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const PROPOSALS = path.join(ROOT, 'planning', 'dep-proposals.json');
+const GRAPH = path.join(ROOT, 'planning', 'dep-graph.json');
+const DECISIONS = path.join(ROOT, 'planning', 'dep-decisions.json');
+const ORDER = { blocks: 0, 'depends-on': 1, 'coupled-with': 2 };
+
+function readJson(file, fallback) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return fallback; }
+}
+function keyOf(proposal) {
+  return proposal.cache_key || [proposal.from, proposal.to, proposal.edge_type].join(':');
+}
+function sortProposals(items) {
+  return [...items].sort((a, b) => (ORDER[a.edge_type] ?? 9) - (ORDER[b.edge_type] ?? 9) || b.confidence - a.confidence);
+}
+function enrich(proposal, nodes) {
+  const from = nodes.get(proposal.from) || {};
+  const to = nodes.get(proposal.to) || {};
+  return { ...proposal, from_issue: { id: proposal.from, title: from.title || '' }, to_issue: { id: proposal.to, title: to.title || '' } };
+}
+function decisionFor(proposal, action, reason, nodes) {
+  return { cache_key: keyOf(proposal), status: action, decided_at: new Date().toISOString(), reason: reason || '', proposal: enrich(proposal, nodes) };
+}
+async function promptText(query, input = process.stdin, output = process.stdout) {
+  const rl = readline.createInterface({ input, output });
+  return new Promise(resolve => rl.question(query, answer => { rl.close(); resolve(answer.trim()); }));
+}
+async function ask(proposal, nodes, opts = {}) {
+  const from = nodes.get(proposal.from) || {};
+  const to = nodes.get(proposal.to) || {};
+  const write = opts.write || (text => process.stdout.write(text));
+  write('\n#' + proposal.from + ' -> #' + proposal.to + ' ' + proposal.edge_type + ' (' + proposal.confidence + ')\n');
+  write((from.title || '') + '\n' + (to.title || '') + '\n' + (proposal.rationale || '') + '\n');
+  const answer = await (opts.ask || promptText)('[a]ccept [r]eject [s]kip s[u]ppress? ');
+  const choice = answer.toLowerCase()[0];
+  if (choice === 'a') return decisionFor(proposal, 'accepted', '', nodes);
+  if (choice === 'r') return decisionFor(proposal, 'rejected', '', nodes);
+  if (choice !== 'u') return decisionFor(proposal, 'skipped', '', nodes);
+  return decisionFor(proposal, 'suppressed', await (opts.ask || promptText)('Suppress reason: '), nodes);
+}
+async function review(opts = {}) {
+  const proposals = readJson(opts.proposals || PROPOSALS, { proposals: [] });
+  const graph = readJson(opts.graph || GRAPH, { nodes: [] });
+  const decisions = readJson(opts.decisions || DECISIONS, { schema_version: 1, decisions: [] });
+  const nodes = new Map((graph.nodes || []).map(n => [n.id, n]));
+  const seen = new Set((decisions.decisions || []).filter(d => d.status !== 'skipped').map(d => d.cache_key));
+  const pending = sortProposals(proposals.proposals || []).filter(p => !seen.has(keyOf(p)));
+  const made = [];
+  for (const proposal of pending) {
+    const decision = await ask(proposal, nodes, opts);
+    if (decision.status !== 'skipped') decisions.decisions.push(decision);
+    made.push(decision);
+  }
+  decisions.updated_at = new Date().toISOString();
+  if (opts.write !== false) {
+    const outFile = opts.decisions || DECISIONS;
+    fs.mkdirSync(path.dirname(outFile), { recursive: true });
+    fs.writeFileSync(outFile, JSON.stringify(decisions, null, 2) + '\n');
+  }
+  return { reviewed: made.length, persisted: made.filter(d => d.status !== 'skipped').length, decisions };
+}
+async function main() {
+  const args = process.argv.slice(2);
+  const val = (flag, d) => (args.includes(flag) ? args[args.indexOf(flag) + 1] : d);
+  const result = await review({ proposals: val('--proposals', PROPOSALS), graph: val('--graph', GRAPH), decisions: val('--decisions', DECISIONS) });
+  console.log(JSON.stringify({ reviewed: result.reviewed, persisted: result.persisted }, null, 2));
+}
+if (require.main === module) main().catch(e => { console.error(e.message); process.exit(1); });
+module.exports = { review, sortProposals, decisionFor };

--- a/tests/dep-proposals-review.spec.js
+++ b/tests/dep-proposals-review.spec.js
@@ -1,0 +1,88 @@
+'use strict';
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const R = require(path.resolve(__dirname, '../scripts/global/dep-proposals-review.js'));
+
+function fixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dep-review-'));
+  const graph = path.join(dir, 'graph.json');
+  const proposals = path.join(dir, 'proposals.json');
+  const decisions = path.join(dir, 'decisions.json');
+  fs.writeFileSync(
+    graph,
+    JSON.stringify({
+      nodes: [
+        { id: 1, title: 'Add dependency API' },
+        { id: 2, title: 'Review dependency API' },
+      ],
+    })
+  );
+  fs.writeFileSync(
+    proposals,
+    JSON.stringify({
+      proposals: [
+        {
+          from: 1,
+          to: 2,
+          edge_type: 'depends-on',
+          confidence: 0.91,
+          cache_key: 'k1',
+          rationale: 'shared API',
+        },
+      ],
+    })
+  );
+  return { graph, proposals, decisions };
+}
+const choices = (...items) => {
+  let i = 0;
+  return () => items[i++] || 's';
+};
+
+test.describe('dep-proposals-review (#1197)', () => {
+  test('accept persists mutation-ready proposal data', async () => {
+    const f = fixture();
+    const result = await R.review({ ...f, ask: choices('a'), write: () => {} });
+    const decision = result.decisions.decisions[0];
+    expect(result.persisted).toBe(1);
+    expect(decision).toMatchObject({ cache_key: 'k1', status: 'accepted' });
+    expect(decision.proposal.from_issue.title).toBe('Add dependency API');
+    expect(decision.proposal.to_issue.title).toBe('Review dependency API');
+  });
+
+  test('reject tombstones until proposal cache key changes', async () => {
+    const f = fixture();
+    await R.review({ ...f, ask: choices('r'), write: () => {} });
+    const second = await R.review({ ...f, ask: choices('a'), write: () => {} });
+    expect(second.reviewed).toBe(0);
+    const data = JSON.parse(fs.readFileSync(f.decisions, 'utf8'));
+    expect(data.decisions).toHaveLength(1);
+    fs.writeFileSync(
+      f.proposals,
+      JSON.stringify({
+        proposals: [{ from: 1, to: 2, edge_type: 'depends-on', confidence: 0.91, cache_key: 'k2' }],
+      })
+    );
+    const third = await R.review({ ...f, ask: choices('a'), write: () => {} });
+    expect(third.reviewed).toBe(1);
+  });
+
+  test('suppress records reason and skip does not persist', async () => {
+    const f = fixture();
+    const suppressed = await R.review({
+      ...f,
+      ask: choices('u', 'duplicate epic scope'),
+      write: () => {},
+    });
+    expect(suppressed.decisions.decisions[0]).toMatchObject({
+      status: 'suppressed',
+      reason: 'duplicate epic scope',
+    });
+    const g = fixture();
+    const skipped = await R.review({ ...g, ask: choices('s'), write: () => {} });
+    expect(skipped).toMatchObject({ reviewed: 1, persisted: 0 });
+    expect(JSON.parse(fs.readFileSync(g.decisions, 'utf8')).decisions).toEqual([]);
+  });
+});


### PR DESCRIPTION
Refs #1197
Closes #1197

## Summary
- add `npm run deps:review` for reviewing dependency proposals
- persist accepted/rejected/suppressed decisions by proposal cache key
- document review workflow and add Playwright coverage for idempotency and suppression

## Validation
- npm run lint
- npx playwright test tests/dep-proposals-review.spec.js
- npm run deps:review -- --proposals /tmp/no-proposals-1197.json --graph /tmp/no-graph-1197.json --decisions /tmp/dep-decisions-1197b.json
- npx eslint -c lint-configs/eslint.config.devenv.js scripts/global/dep-proposals-review.js
- npx markdownlint-cli2 docs/howto/dependency-graph.md
- npm run docs:compile -- --check
- npm run format:check
- git diff --check
- node scripts/lint-readability.js --max-warnings=420

## Governance
- ADMIN_HANDOFF and ADMIN_VISUAL_QA posted on #1197 before PR creation.
- Visual QA: N/A, no UI surface changed.
- No #1130 or #1133-owned files touched.

Signed-by: Nova Reyes
Team&Model: codex:gpt-5@codex-cli
Role: admin