### PR TITLE
feat(scripts): add dependency health audit #1199

### DIFF
--- a/docs/howto/dependency-graph.md
+++ b/docs/howto/dependency-graph.md
@@ -63,6 +63,19 @@ graph with edge types and proposal status annotations, critical path summary,
 cycle summary, pending proposals, and stale review decisions. It is deterministic
 for the same graph, proposal, and decision inputs.
 
+Include dependency health in the daily governance audit:
+
+```bash
+npm run governance:audit
+```
+
+The audit reads the same graph, proposal, and decision files. It writes
+`dependency_health` into `/tmp/governance-audit.json` with cycle count,
+critical-path length, unresolved mismatch count, stale proposal age, and
+augmentation cost/fallback counters. Missing dependency files produce warnings in
+the audit JSON instead of failing the command before aggregation has run. Any
+detected cycle is also promoted to a governance violation.
+
 Signed-by: Nova Harper
 Team&Model: codex:gpt-5@codex-cli
 Role: collaborator

--- a/scripts/global/dep-graph-health.js
+++ b/scripts/global/dep-graph-health.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+'use strict';
+/* eslint-disable jsdoc/require-jsdoc */
+const fs = require('node:fs');
+const path = require('node:path');
+const Renderer = require('./dep-graph-render');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const DEFAULTS = {
+  graph: path.join(ROOT, 'planning', 'dep-graph.json'),
+  proposals: path.join(ROOT, 'planning', 'dep-proposals.json'),
+  decisions: path.join(ROOT, 'planning', 'dep-decisions.json'),
+};
+const DAY_MS = 24 * 60 * 60 * 1000;
+const STALE_DAYS = 7;
+
+function readJson(file, fallback, warnings, label) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch {
+    warnings.push(`missing or unreadable ${label}: ${file}`); return fallback;
+  }
+}
+function asList(items) { return Array.isArray(items) ? items : []; }
+function keyOf(item) { return item.cache_key || [item.from, item.to, item.edge_type || item.type].join(':'); }
+function ageDays(item, now) {
+  const stamp = item.proposed_at || item.generated_at || item.decided_at || null;
+  const time = stamp ? new Date(stamp).getTime() : Number.NaN;
+  return Number.isFinite(time) ? Math.max(0, Math.floor((now - time) / DAY_MS)) : null;
+}
+function proposalState(proposals, decisions, now) {
+  const decided = new Map(asList(decisions.decisions).map(item => [item.cache_key, item.status]));
+  const pending = [], stale = [];
+  for (const item of asList(proposals.proposals)) {
+    const status = decided.get(keyOf(item)) || item.status || 'pending';
+    if (status !== 'pending' && status !== 'proposed') continue;
+    const age = ageDays(item, now);
+    pending.push({ cache_key: keyOf(item), age_days: age });
+    if (age !== null && age >= STALE_DAYS) stale.push({ cache_key: keyOf(item), age_days: age });
+  }
+  return { pending, stale, max_age_days: pending.reduce((m, item) => Math.max(m, item.age_days || 0), 0) };
+}
+function costCounters(proposals) {
+  const items = [...asList(proposals.proposals), ...asList(proposals.skipped)];
+  return items.reduce((totals, item) => {
+    const lane = item.model?.lane || String(item.model?.id || '').split(':')[0] || 'unknown';
+    totals.requests += 1;
+    totals.tokens += item.token_usage?.total_tokens || item.usage?.total_tokens || 0;
+    totals.cost_usd += item.cost_usd || item.model?.cost_usd || 0;
+    if (item.status === 'fallback' || item.fallback) totals.fallbacks += 1;
+    totals.by_lane[lane] = (totals.by_lane[lane] || 0) + 1;
+    return totals;
+  }, { requests: 0, tokens: 0, cost_usd: 0, fallbacks: 0, by_lane: {} });
+}
+function compute(opts = {}) {
+  const warnings = [], now = opts.now ? new Date(opts.now).getTime() : Date.now();
+  const graph = readJson(opts.graph || DEFAULTS.graph, { nodes: [], edges: [] }, warnings, 'dependency graph');
+  const proposals = readJson(opts.proposals || DEFAULTS.proposals, { proposals: [], skipped: [] }, warnings, 'dependency proposals');
+  const decisions = readJson(opts.decisions || DEFAULTS.decisions, { decisions: [] }, warnings, 'dependency decisions');
+  const cycles = Renderer.cycles(graph), criticalPath = Renderer.criticalPath(graph);
+  const proposal = proposalState(proposals, decisions, now);
+  const cost = costCounters(proposals);
+  cost.cost_usd = +cost.cost_usd.toFixed(6);
+  return {
+    schema_version: 1,
+    warnings,
+    cycles,
+    cycle_count: cycles.length,
+    critical_path: criticalPath,
+    critical_path_length: criticalPath.length,
+    unresolved_mismatch_count: asList(graph.edges).filter(edge => edge.mismatch).length,
+    proposals: {
+      pending_count: proposal.pending.length,
+      stale_count: proposal.stale.length,
+      max_pending_age_days: proposal.max_age_days,
+      stale: proposal.stale,
+    },
+    cost,
+    status: cycles.length ? 'violation' : 'ok',
+  };
+}
+
+module.exports = { compute, DEFAULTS, STALE_DAYS };

--- a/scripts/global/governance-audit.js
+++ b/scripts/global/governance-audit.js
@@ -1,15 +1,11 @@
 #!/usr/bin/env node
-// governance-audit.js — Productized Manager-side ticket audit (#837).
-// Composes deterministic governance checks + optional fleet-LLM ticket review.
-// Output: /tmp/governance-audit.json + 1-line stdout summary.
 'use strict';
 
 const { execSync } = require('node:child_process');
 const fs = require('node:fs');
-const path = require('node:path');
 
 const REPORT_FILE = '/tmp/governance-audit.json';
-const HAMR = (() => { try { return require('./hamr-provider-wrapper'); } catch { return null; } })();
+const DEP_HEALTH = require('./dep-graph-health');
 const CHECKS = ['governance:drift', 'governance:verify', 'governance:reconcile', 'governance:worktrees'];
 const TIMEOUT_MS = 60_000;
 const RAW_PREVIEW_MAX = 500;
@@ -62,14 +58,15 @@ async function audit(opts = {}) {
   const violations = detectViolations(tickets);
   let hamrSensor = null;
   try { hamrSensor = require('./hamr-utilization-sensor').compute(); } catch { /* sensor optional */ }
-  if (hamrSensor && hamrSensor.status === 'violation') {
-    violations.push({ ticket: 'HAMR', rule: 'utilization-floor',
-      detail: `production_hamr_utilization_rate_7d=${hamrSensor.rate?.toFixed(2)} below floor ${hamrSensor.thresholds.violation}` });
+  const hamrRules = { violation: ['utilization-floor', 'floor'], escalation: ['utilization-escalation', 'escalation'] };
+  if (hamrSensor && hamrRules[hamrSensor.status]) {
+    const [rule, label] = hamrRules[hamrSensor.status], limit = hamrSensor.thresholds[hamrSensor.status];
+    violations.push({ ticket: 'HAMR', rule,
+      detail: `production_hamr_utilization_rate_7d=${hamrSensor.rate?.toFixed(2)} below ${label} ${limit}` });
   }
-  if (hamrSensor && hamrSensor.status === 'escalation') {
-    violations.push({ ticket: 'HAMR', rule: 'utilization-escalation',
-      detail: `production_hamr_utilization_rate_7d=${hamrSensor.rate?.toFixed(2)} below escalation ${hamrSensor.thresholds.escalation}` });
-  }
+  const dependencyHealth = DEP_HEALTH.compute(opts.dependencyHealth || {});
+  dependencyHealth.cycles.forEach(cycle =>
+    violations.push({ ticket: 'DEP-GRAPH', rule: 'dependency-cycle', detail: cycle }));
   const summary = {
     schema_version: 1,
     started_at: startedAt,
@@ -78,6 +75,7 @@ async function audit(opts = {}) {
     open_tickets: tickets.length,
     violations,
     hamr_utilization: hamrSensor,
+    dependency_health: dependencyHealth,
     overall: violations.length === 0 && checks.every(c => c.ok) ? 'PASS' : 'FAIL',
   };
   fs.writeFileSync(REPORT_FILE, JSON.stringify(summary, null, 2));
@@ -89,14 +87,12 @@ if (require.main === module) {
     const status = s.overall;
     const failed = s.checks.filter(c => !c.ok).length;
     console.log(`governance-audit: ${status} | open=${s.open_tickets} violations=${s.violations.length} failed-checks=${failed} → ${REPORT_FILE}`);
-    if (s.violations.length) {
-      const MAX_PRINTED = 10;
-      for (const violation of s.violations.slice(0, MAX_PRINTED)) {
-        console.log(`  ! #${violation.ticket} ${violation.rule}: ${violation.detail}`);
-      }
+    const MAX_PRINTED = 10;
+    for (const violation of s.violations.slice(0, MAX_PRINTED)) {
+      console.log(`  ! #${violation.ticket} ${violation.rule}: ${violation.detail}`);
     }
     process.exit(status === 'PASS' ? 0 : 1);
   }).catch(err => { console.error('governance-audit error:', err.message); process.exit(2); });
 }
 
-module.exports = { audit, runCheck, listOpenTickets, detectViolations, REPORT_FILE, CHECKS };
+module.exports = { audit, runCheck, listOpenTickets, detectViolations, REPORT_FILE, CHECKS, DEP_HEALTH };

--- a/tests/dep-graph-health.spec.js
+++ b/tests/dep-graph-health.spec.js
@@ -1,0 +1,68 @@
+'use strict';
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const H = require(path.resolve(__dirname, '../scripts/global/dep-graph-health.js'));
+
+function writeJson(dir, name, data) {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+  return file;
+}
+function fixture(tmp, graph) {
+  const proposals = {
+    proposals: [
+      { from: 4, to: 5, edge_type: 'depends-on', cache_key: 'old', proposed_at: '2026-05-01T00:00:00.000Z',
+        model: { id: 'fleet:cascade-dispatch', lane: 'fleet' }, token_usage: { total_tokens: 10 }, cost_usd: 0 },
+    ],
+    skipped: [{ status: 'fallback', model: { id: 'haiku:sonnet', lane: 'haiku' }, cost_usd: 0.002 }],
+  };
+  return {
+    graph: writeJson(tmp, 'graph.json', graph),
+    proposals: writeJson(tmp, 'proposals.json', proposals),
+    decisions: writeJson(tmp, 'decisions.json', { decisions: [] }),
+  };
+}
+
+test.describe('dep-graph-health (#1199)', () => {
+  test('flags cycles as violations and counts mismatches', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dep-health-'));
+    const files = fixture(tmp, { nodes: [{ id: 1 }, { id: 2 }], edges: [
+      { from: 1, to: 2, type: 'blocks', mismatch: true }, { from: 2, to: 1, type: 'blocks' },
+    ] });
+    const result = H.compute({ ...files, now: '2026-05-09T00:00:00.000Z' });
+    expect(result.status).toBe('violation');
+    expect(result.cycles).toEqual(['1 -> 2 -> 1']);
+    expect(result.unresolved_mismatch_count).toBe(1);
+  });
+
+  test('computes deterministic critical path for acyclic graphs', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dep-health-'));
+    const files = fixture(tmp, { nodes: [{ id: 1 }, { id: 2 }, { id: 3 }], edges: [
+      { from: 1, to: 2, type: 'blocks' }, { from: 2, to: 3, type: 'blocks' },
+    ] });
+    const result = H.compute({ ...files, now: '2026-05-09T00:00:00.000Z' });
+    expect(result.critical_path).toEqual([1, 2, 3]);
+    expect(result.critical_path_length).toBe(3);
+  });
+
+  test('reports stale proposals plus free cost and fallback counters', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dep-health-'));
+    const files = fixture(tmp, { nodes: [], edges: [] });
+    const result = H.compute({ ...files, now: '2026-05-09T00:00:00.000Z' });
+    expect(result.proposals.stale_count).toBe(1);
+    expect(result.proposals.max_pending_age_days).toBe(8);
+    expect(result.cost).toMatchObject({ requests: 2, tokens: 10, cost_usd: 0.002, fallbacks: 1 });
+    expect(result.cost.by_lane).toEqual({ fleet: 1, haiku: 1 });
+  });
+
+  test('missing files degrade to warnings', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dep-health-'));
+    const result = H.compute({ graph: path.join(tmp, 'missing.json'), proposals: path.join(tmp, 'none.json'),
+      decisions: path.join(tmp, 'decisions.json'), now: '2026-05-09T00:00:00.000Z' });
+    expect(result.warnings.length).toBe(3);
+    expect(result.status).toBe('ok');
+    expect(result.critical_path).toEqual([]);
+  });
+});

--- a/tests/governance-audit.spec.js
+++ b/tests/governance-audit.spec.js
@@ -49,5 +49,18 @@ test('audit() returns schema_version 1 result with required fields', async () =>
   expect(r).toHaveProperty('started_at');
   expect(r).toHaveProperty('checks');
   expect(r).toHaveProperty('violations');
+  expect(r).toHaveProperty('dependency_health');
   expect(['PASS', 'FAIL']).toContain(r.overall);
+});
+
+
+test('dependency cycles become governance audit violations', async () => {
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-dep-'));
+  const graph = path.join(tmp, 'graph.json');
+  fs.writeFileSync(graph, JSON.stringify({ nodes: [{ id: 1 }, { id: 2 }],
+    edges: [{ from: 1, to: 2 }, { from: 2, to: 1 }] }));
+  const r = await A.audit({ dependencyHealth: { graph, proposals: graph, decisions: graph } });
+  expect(r.violations.some(v => v.rule === 'dependency-cycle')).toBe(true);
 });


### PR DESCRIPTION
## Summary
- Add read-only dependency health computation for graph, proposal, decision, stale-proposal, and cost/fallback state.
- Include `dependency_health` in `/tmp/governance-audit.json` and promote dependency cycles to governance violations.
- Document the governance-audit dependency-health output in the dependency graph how-to.

## Validation
- `npx playwright test tests/dep-graph-health.spec.js tests/governance-audit.spec.js`
- `npx eslint -c lint-configs/eslint.config.devenv.js scripts/global/dep-graph-health.js scripts/global/governance-audit.js tests/dep-graph-health.spec.js tests/governance-audit.spec.js`
- `npm run lint`
- `npx markdownlint-cli2 docs/howto/dependency-graph.md`
- `npm run docs:compile -- --check`
- `npm run format:check`
- `node scripts/lint-readability.js --max-warnings=420`
- `git diff --check`
- `node scripts/global/governance-audit.js` wrote `dependency_health` to `/tmp/governance-audit.json`; command exited 1 because of pre-existing live governance violations unrelated to #1199.

## Visual QA
ADMIN_VISUAL_QA: not_applicable
Reason: scripts/tests/docs only; no dashboard/browser UI changed.

## Governance
Refs #1199
Refs Epic #1125
Closes #1199
test_strategy: tdd-pyramid

Signed-by: Atlas Reed
Team&Model: codex:gpt-5.1-codex@openai
Role: admin
