### PR TITLE
D-1245-02: Parallel git preflight guardrail

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "governance:epic": "node scripts/global/epic-evidence.js",
     "governance:epics": "node scripts/global/epic-close-validator.js",
     "governance:no-sync-http": "node scripts/global/no-sync-http-handlers.js",
+    "git:preflight": "bash scripts/global/parallel-git-preflight.sh",
     "governance:reconcile": "node scripts/global/ticket-reconcile.js --json",
     "governance:verify": "node scripts/global/governance-verify.js --json",
     "governance:weekly": "node scripts/global/governance-weekly-report.js",

--- a/scripts/global/parallel-git-preflight.sh
+++ b/scripts/global/parallel-git-preflight.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+log() { echo "[$(ts)] $*"; }
+
+mode="manual"
+local_ref=""
+remote_ref=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode) mode="${2:-manual}"; shift 2 ;;
+    --local-ref) local_ref="${2:-}"; shift 2 ;;
+    --remote-ref) remote_ref="${2:-}"; shift 2 ;;
+    *) log "WARN: unknown arg '$1'"; shift ;;
+  esac
+done
+
+errors=0
+warnings=0
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[[ -n "$repo_root" ]] || { log "ERROR: not in git repository"; exit 1; }
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo DETACHED)"
+
+fail() { log "ERROR: $*"; errors=$((errors + 1)); }
+warn() { log "WARN: $*"; warnings=$((warnings + 1)); }
+
+valid='^(main|master|sandbox/[a-z0-9._-]+|(feat|fix|chore|docs|style|test|refactor|perf|release|hotfix)/[a-z0-9._-]+)$'
+[[ "$branch" =~ $valid ]] || fail "branch '$branch' violates naming policy"
+
+worktree_count="$(git worktree list --porcelain | awk -v b="refs/heads/$branch" '/^branch /{if($2==b)c++} END{print c+0}')"
+[[ "$worktree_count" -le 1 ]] || fail "branch '$branch' is active in $worktree_count worktrees"
+
+upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+if [[ -z "$upstream" ]]; then
+  warn "no upstream configured for '$branch'"
+else
+  counts="$(git rev-list --left-right --count "$upstream...HEAD")"
+  behind="$(awk '{print $1}' <<<"$counts")"
+  ahead="$(awk '{print $2}' <<<"$counts")"
+  [[ "$behind" -eq 0 ]] || fail "branch behind upstream by $behind commit(s)"
+  [[ "$ahead" -lt 50 ]] || warn "branch ahead by $ahead commit(s); consider rebasing"
+fi
+
+if [[ -n "$local_ref" ]] && [[ "$local_ref" != "refs/heads/$branch" ]]; then
+  fail "local ref '$local_ref' does not match HEAD '$branch'"
+fi
+
+if [[ -n "$remote_ref" ]]; then
+  target="${remote_ref#refs/heads/}"
+  case "$branch" in
+    release/*|hotfix/*) [[ "$target" == "main" ]] || fail "'$branch' must target main" ;;
+    sandbox/*) [[ "$target" == sandbox/* ]] || fail "'$branch' must target sandbox/*" ;;
+    feat/*|fix/*|chore/*|docs/*|style/*|test/*|refactor/*|perf/*)
+      [[ "$target" != "main" && "$target" != "master" ]] || fail "feature branches cannot target $target"
+      ;;
+  esac
+fi
+
+audit_log="$HOME/.megingjord/git-preflight.log"
+mkdir -p "$(dirname "$audit_log")"
+printf '{"ts":"%s","mode":"%s","cwd":"%s","branch":"%s","local_ref":"%s","remote_ref":"%s","errors":%s,"warnings":%s}\n' \
+  "$(ts)" "$mode" "$(pwd)" "$branch" "$local_ref" "$remote_ref" "$errors" "$warnings" >> "$audit_log"
+
+if [[ "$errors" -gt 0 ]]; then
+  log "preflight failed ($errors errors, $warnings warnings)"
+  exit 1
+fi
+if [[ "$warnings" -gt 0 ]]; then
+  log "preflight warning state ($warnings warning(s))"
+  exit 2
+fi
+log "preflight passed"
+exit 0

--- a/scripts/hooks/pre-push-branch-check.sh
+++ b/scripts/hooks/pre-push-branch-check.sh
@@ -5,19 +5,40 @@
 set -euo pipefail
 
 current_branch=$(git rev-parse --abbrev-ref HEAD)
+repo_root=$(git rev-parse --show-toplevel)
+preflight="$repo_root/scripts/global/parallel-git-preflight.sh"
 audit_log="${HOME}/.megingjord/branch-ops-audit.log"
 mkdir -p "$(dirname "$audit_log")"
 
+if [ -x "$preflight" ]; then
+  set +e
+  "$preflight" --mode pre-push
+  rc=$?
+  set -e
+  if [ "$rc" -eq 1 ]; then
+    echo "Refusing push: parallel git preflight failed."
+    exit 1
+  fi
+fi
+
 DELETE_SHA="0000000000000000000000000000000000000000"
 violations=0
-while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+while IFS=' ' read -r local_ref local_sha remote_ref _remote_sha; do
   [ -z "${local_ref:-}" ] && continue
   local_branch=${local_ref#refs/heads/}
-  remote_branch=${remote_ref#refs/heads/}
   # A1 fix (#989): skip mismatch check on branch-delete refspec.
   # Git sets local_sha to all-zeros when pushing a delete (e.g., `git push --delete`).
   is_delete="false"
   [ "$local_sha" = "$DELETE_SHA" ] && is_delete="true"
+  if [ "$is_delete" = "false" ] && [ -x "$preflight" ]; then
+    set +e
+    "$preflight" --mode pre-push --local-ref "$local_ref" --remote-ref "$remote_ref"
+    preflight_rc=$?
+    set -e
+    if [ "$preflight_rc" -eq 1 ]; then
+      violations=$((violations + 1))
+    fi
+  fi
   if [ "$is_delete" = "false" ] && [ "$local_branch" != "$current_branch" ]; then
     echo "❌ R9.2.1 violation: pushing $local_branch but HEAD is $current_branch"
     echo "    cwd: $(pwd)"

--- a/scripts/worktree-session-start.sh
+++ b/scripts/worktree-session-start.sh
@@ -27,6 +27,16 @@ root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [[ -n "$root" ]] || die "not inside a git repository"
 
 cd "$root"
+preflight="$root/scripts/global/parallel-git-preflight.sh"
+if [[ -x "$preflight" ]]; then
+  set +e
+  "$preflight" --mode pre-work
+  preflight_rc=$?
+  set -e
+  [[ "$preflight_rc" -eq 1 ]] && die "parallel git preflight failed"
+  [[ "$preflight_rc" -eq 2 ]] && log "pre-work preflight warnings present"
+fi
+
 log "syncing sandbox launcher branch: $sandbox"
 
 git fetch origin --prune


### PR DESCRIPTION
## Summary
Implements Phase-A ticket #1248 for Epic #1245 by adding deterministic preflight controls for parallel git work.

## What changed
- Added `parallel-git-preflight.sh` for:
  - branch naming policy validation
  - worktree ownership collision detection
  - branch freshness check vs upstream
  - local/remote target mapping checks
  - deterministic audit log output to `~/.megingjord/git-preflight.log`
- Integrated preflight into pre-push hook (`pre-push-branch-check.sh`)
- Integrated preflight into pre-work flow (`worktree-session-start.sh`)
- Added npm operator entry point: `npm run git:preflight`

## Validation
- `shellcheck scripts/global/parallel-git-preflight.sh scripts/hooks/pre-push-branch-check.sh scripts/worktree-session-start.sh`
- `npm run git:preflight`
- synthetic pre-push stdin smoke test against `pre-push-branch-check.sh`

## Ticket
Refs #1248
Parent Epic #1245

## Team&Model
Signed-by: Curtis Franks
Team&Model: copilot:gpt-5.3-codex@github
Role: collaborator
