### PR TITLE
D-1245-03: Enforce R&D phase-gate policy in ticket lifecycle

### DIFF
--- a/scripts/global/issue-transition.js
+++ b/scripts/global/issue-transition.js
@@ -16,6 +16,7 @@ const ROLE_FOR = {
   review: 'consultant',
 };
 const { verifyEpicEvidence } = require('./epic-evidence');
+const { checkTransition, logBypass } = require('./phase-gate');
 
 const [,, issue, fromStatus, toStatus, ...extras] = process.argv;
 const force = extras.includes('--force');
@@ -56,6 +57,15 @@ if (toStatus === 'done' && labels.includes('type:epic')) {
     console.error('Use --force only for explicit emergency override.');
     process.exit(1);
   }
+}
+if (toStatus === 'in-progress') {
+  const failures = checkTransition({ number: Number(issue), body: data.body || '' });
+  if (failures.length && !force) {
+    failures.forEach(item => console.error(item));
+    console.error('Use --force only for explicit emergency override.');
+    process.exit(1);
+  }
+  if (failures.length && force) logBypass({ issue: Number(issue), fromStatus, toStatus }, failures);
 }
 
 const next = labels.filter(label => !label.startsWith('status:') && !label.startsWith('role:'));

--- a/scripts/global/phase-gate.js
+++ b/scripts/global/phase-gate.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const parentRx = /##\s+Parent Epic\s*\n#(\d+)/i;
+const depRx = /##\s+Depends On\s*\n((?:#\d+(?:[^\n]*)\n?)*)/i;
+const refRx = /#(\d+)/g;
+const actor = () => process.env.GITHUB_ACTOR || process.env.USER || 'unknown';
+const auditFile = () => path.join(process.env.HOME || '.', '.megingjord', 'phase-gate-bypass.jsonl');
+const ghJson = args => JSON.parse(execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 }).trim());
+const refs = text => [...String(text || '').matchAll(refRx)].map(match => Number(match[1]));
+const parseBody = body => ({
+  parentEpic: Number(String(body || '').match(parentRx)?.[1] || 0),
+  dependsOn: refs(String(body || '').match(depRx)?.[1] || ''),
+});
+const done = issue => issue.state === 'CLOSED' || (issue.labels || []).some(label => label.name === 'status:done');
+
+function listChildren(epic, gh = ghJson) {
+  return gh(['issue', 'list', '--state', 'all', '--limit', '500', '--json', 'number,title,body,state,labels'])
+    .filter(item => parseBody(item.body).parentEpic === Number(epic));
+}
+
+function checkCreation(parentEpic, gh = ghJson) {
+  if (!parentEpic) return [];
+  const rd = listChildren(parentEpic, gh).find(item => /phase-0 r&d/i.test(item.title) || new RegExp(`^D-${parentEpic}-01:`).test(item.title));
+  if (!rd) return [`epic #${parentEpic}: missing Phase-0 R&D child ticket`];
+  return done(rd) ? [] : [`epic #${parentEpic}: Phase-0 R&D gate not complete (#${rd.number})`];
+}
+
+function checkTransition(issue, gh = ghJson) {
+  const failures = [];
+  const meta = parseBody(issue.body);
+  failures.push(...checkCreation(meta.parentEpic, gh));
+  meta.dependsOn.forEach(number => {
+    const dep = gh(['issue', 'view', String(number), '--json', 'number,state,labels']);
+    if (!done(dep)) failures.push(`issue #${issue.number}: dependency #${number} not complete`);
+  });
+  return failures;
+}
+
+function logBypass(context, failures) {
+  const file = auditFile();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.appendFileSync(file, `${JSON.stringify({ ts: new Date().toISOString(), actor: actor(), context, failures })}\n`);
+}
+
+module.exports = { parseBody, checkCreation, checkTransition, logBypass, listChildren };

--- a/scripts/global/ticket-create.js
+++ b/scripts/global/ticket-create.js
@@ -2,6 +2,7 @@
 'use strict';
 const { execSync } = require('child_process');
 const readline = require('readline');
+const { checkCreation, logBypass } = require('./phase-gate');
 
 const rl = readline.createInterface({
   input: process.stdin,
@@ -13,16 +14,29 @@ function prompt(question) {
 }
 
 async function createTicket() {
+  const force = process.argv.includes('--force');
   console.log('\n📋 Ticket Creation Wizard\n');
 
   const title = await prompt('Title: ');
   const desc = await prompt('Description (short): ');
   const type = await prompt('Type (epic|story|task|bug|doc): ');
   const points = await prompt('Story Points (or skip): ');
+  const parentEpic = await prompt('Parent Epic # (or skip): ');
+  const dependsOn = await prompt('Depends On issue #s comma-separated (or skip): ');
 
   const labels = [`scrum:${type}`, 'status:backlog'];
   let body = desc;
   if (points) body += `\n\n**Story Points**: ${points}`;
+  if (parentEpic) body += `\n\n## Parent Epic\n#${parentEpic.replace(/[^0-9]/g, '')}`;
+  if (dependsOn) body += `\n\n## Depends On\n${dependsOn.split(',').map(item => `#${item.replace(/[^0-9]/g, '')}`).join(', ')}`;
+
+  const failures = checkCreation(Number(parentEpic.replace(/[^0-9]/g, '') || 0));
+  if (failures.length && !force) {
+    failures.forEach(item => console.error(`❌ ${item}`));
+    rl.close();
+    process.exit(1);
+  }
+  if (failures.length && force) logBypass({ action: 'ticket-create', parentEpic: Number(parentEpic || 0) }, failures);
 
   try {
     const cmd = [

--- a/tests/phase-gate.test.js
+++ b/tests/phase-gate.test.js
@@ -1,0 +1,52 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const gate = require('../scripts/global/phase-gate.js');
+
+const gh = map => args => {
+  if (args[0] === 'issue' && args[1] === 'list') return map.list;
+  if (args[0] === 'issue' && args[1] === 'view') return map.views[args[2]];
+  throw new Error(`unexpected gh args: ${args.join(' ')}`);
+};
+
+test('creation allowed when parent epic R&D is done', () => {
+  const mock = gh({
+    list: [{ number: 10, title: 'D-2000-01: Phase-0 R&D', body: '## Parent Epic\n#2000', state: 'CLOSED', labels: [] }],
+    views: {},
+  });
+  assert.deepEqual(gate.checkCreation(2000, mock), []);
+});
+
+test('creation denied when parent epic R&D missing or open', () => {
+  const missing = gh({ list: [], views: {} });
+  assert.match(gate.checkCreation(2001, missing)[0], /missing Phase-0 R&D/i);
+  const open = gh({
+    list: [{ number: 11, title: 'D-2001-01: Phase-0 R&D', body: '## Parent Epic\n#2001', state: 'OPEN', labels: [] }],
+    views: {},
+  });
+  assert.match(gate.checkCreation(2001, open)[0], /gate not complete/i);
+});
+
+test('transition denied when dependency is not complete', () => {
+  const mock = gh({
+    list: [{ number: 12, title: 'D-3000-01: Phase-0 R&D', body: '## Parent Epic\n#3000', state: 'CLOSED', labels: [] }],
+    views: { '99': { number: 99, state: 'OPEN', labels: [] } },
+  });
+  const failures = gate.checkTransition({ number: 101, body: '## Parent Epic\n#3000\n\n## Depends On\n#99' }, mock);
+  assert.match(failures.join('\n'), /dependency #99 not complete/i);
+});
+
+test('bypass audit log records actor and failures', () => {
+  const home = fs.mkdtempSync(path.join(process.cwd(), 'tmp-phase-gate-'));
+  const oldHome = process.env.HOME;
+  process.env.HOME = home;
+  process.env.USER = 'tester';
+  gate.logBypass({ issue: 55, toStatus: 'in-progress' }, ['failure']);
+  const file = path.join(home, '.megingjord', 'phase-gate-bypass.jsonl');
+  const entry = JSON.parse(fs.readFileSync(file, 'utf8').trim());
+  assert.equal(entry.actor, 'tester');
+  assert.equal(entry.context.issue, 55);
+  process.env.HOME = oldHome;
+});


### PR DESCRIPTION
## Summary
Implements D-1245-03 for Epic #1245 by enforcing R&D and dependency phase gates in ticket lifecycle tooling.

## What changed
- Added `scripts/global/phase-gate.js` for:
  - parent epic Phase-0 R&D completion checks
  - dependency completion checks for `status:in-progress`
  - audited bypass logging to `~/.megingjord/phase-gate-bypass.jsonl`
- Updated `scripts/global/issue-transition.js` to block invalid `in-progress` transitions unless `--force`
- Updated `scripts/global/ticket-create.js` to block child creation under epics until Phase-0 R&D is complete
- Added focused test coverage in `tests/phase-gate.test.js`

## Validation
- `node --test tests/phase-gate.test.js`
- `node scripts/global/issue-transition.js 1249 backlog in-progress --dry-run`
- live creation-gate smoke test for Epic #1245

## Ticket
Refs #1249
Parent Epic #1245

## Team&Model
Signed-by: Curtis Franks
Team&Model: copilot:gpt-5.3-codex@github
Role: collaborator
