### PR TITLE
docs(research): add Copilot Epic #1271 R&D plan and wiki artifacts

### DIFF
--- a/raw/articles/epic-1271-cp-rd-plan-2026-05-09.md
+++ b/raw/articles/epic-1271-cp-rd-plan-2026-05-09.md
@@ -1,0 +1,48 @@
+---
+title: "Epic #1271 Copilot Team R&D Plan: Epic-state truthfulness"
+type: research
+created: 2026-05-09
+status: ingested
+---
+
+# Epic #1271 Copilot Team R&D Plan
+
+## Problem statement
+
+Epic-state truthfulness fails when Manager closeout narrative says “complete” but AC state, dependency state, or measurement windows still show unresolved work. The failure is a reconciliation failure across narrative, governance labels, and evidence artifacts.
+
+## Core recommendations
+
+1. Deterministic AC reconciler (`epic-ac-reconciler`) to map each AC to evidence adapters.
+2. Narrative-state lint that blocks “complete” language when reconciler reports unresolved ACs.
+3. Time-window state machine (`status:measuring`, `recheck_after`) for ACs requiring delayed evidence.
+4. Dependency graph + cycle detection for cross-Epic AC dependencies.
+5. Required `EPIC_RESCOPE` artifact for AC changes/waivers with governance metadata.
+6. Consultant-only final verification (Manager cannot self-certify final completion).
+7. GHS truthfulness sensor for “declared-complete-but-AC-unmet” drift.
+
+## Web evidence highlights (2025–2026)
+
+- https://github.blog/changelog/2026-03-12-issue-fields-structured-issue-metadata-is-in-public-preview
+- https://github.blog/changelog/2026-03-19-hierarchy-view-in-github-projects-is-now-generally-available
+- https://github.blog/changelog/2026-04-02-improved-search-for-github-issues-is-now-generally-available
+- https://github.blog/changelog/2026-04-09-release-info-in-issue-sidebar-and-project-defaults
+- https://github.blog/changelog/2026-05-07-repository-rulesets-user-bypass-and-branch-renaming
+- https://github.blog/changelog/2025-12-19-you-can-now-require-reviews-before-closing-dependabot-alerts-with-delegated-alert-dismissal
+- https://forum.asana.com/t/new-advanced-search-for-projects/1132444
+- https://linear.app/changelog/2026-02-13-advanced-filters-and-share-issues-in-private-teams
+- https://arxiv.org/abs/2508.11867v1
+- https://arxiv.org/abs/2602.12875v1
+
+## Priority order
+
+1. AC reconciler + GHS truthfulness sensor
+2. `EPIC_RESCOPE` hard gate + Consultant close authority
+3. Narrative-state lint
+4. Time-window state machine + dependency cycle checker
+
+## Related pages
+
+- [[epic-ac-reconciliation]]
+- [[epic-state-truthfulness]]
+- [[harness-goal-controls]]

--- a/research/epic-1271-cp-rd-plan-2026-05-09.md
+++ b/research/epic-1271-cp-rd-plan-2026-05-09.md
@@ -1,0 +1,105 @@
+# Epic #1271 — Copilot Team R&D Plan (Phase-0)
+
+**Date**: 2026-05-09  
+**Last updated**: 2026-05-09T00:00:00Z  
+**Ticket**: #1273 (Parent: #1271)  
+**Scope**: Epic-state truthfulness (narrative vs AC/label/evidence drift)
+
+## Summary table
+
+| Area | Decision | Why |
+|---|---|---|
+| AC reconciliation | **Adopt deterministic reconciler** | Removes manual checkbox drift and narrative mismatch.
+| Time-window ACs | **Add `status:measuring` + `recheck_after`** | Prevents false “in-progress forever” loops.
+| Cross-epic deps | **Add explicit dependency graph + cycle guard** | Prevents deadlocks and hidden blockers.
+| Verification model | **Consultant-only final close verification** | Enforces independent close authority.
+| Governance sensors | **Add Epic Truthfulness sensor into GHS** | Catches drift before close events.
+
+## Section 1 — Problem framing
+
+The drift loop in #1271 is a three-layer mismatch:
+1. **Narrative layer** (Manager says “complete”),
+2. **Governance layer** (`status:*`, dependencies, role/phase controls),
+3. **Evidence layer** (AC checkboxes, measurement windows, linked child outcomes).
+
+When these diverge, the system may be “honest” in labels but still operationally misleading in closeout communication. The fix is not one gate; it is a **reconciliation pipeline** that normalizes all three layers before close authority is exercised.
+
+## Section 2 — Gap-by-gap analysis (7 gaps)
+
+| Gap | Team verdict | Rationale |
+|---|---|---|
+| 1) Manager narrative ≠ governance state | **Recommend** | Add narrative-state lint and block close comments that contradict AC state summary.
+| 2) Decorative AC checklists | **Recommend** | AC checkboxes must be machine-reconciled from evidence; no manual Manager flipping.
+| 3) Time-windowed AC trap | **Recommend + refine** | Add explicit transitional state (`status:measuring`) and enforce re-eval timestamp.
+| 4) Cross-epic dependency deadlocks | **Recommend** | Maintain DAG of issue dependencies; fail on cycles and unresolved external AC blockers.
+| 5) `EPIC_RESCOPE` spirit-only rule | **Recommend + harden** | Add required artifact template + schema checks + close gate integration.
+| 6) Manager/Consultant conflict on verification | **Recommend** | Consultant must own final AC verification; Manager forbidden from final completeness assertion.
+| 7) Close-readiness checks open children only | **Recommend** | Extend readiness workflow to parse unresolved ACs + unresolved time windows + missing rescope artifacts.
+
+## Section 3 — Proposed fixes
+
+| Fix | Implementation sketch | Effort | Risk |
+|---|---|---:|---:|
+| F1: `epic-ac-reconciler` | Parse Epic AC list; map each AC to evidence adapters (child closure, file existence, telemetry, dependency state); write reconciliation comment + checkbox update. | M | M |
+| F2: Narrative-state linter | Detect claim terms (complete/done/shipped) in Manager closeout against reconciler output; fail if unmet AC exists. | S | L |
+| F3: Time-window AC state machine | Add `status:measuring`, `recheck_after`, `measurement_source`; auto-transition to done/fail after window check. | M | M |
+| F4: Dependency graph/cycle detector | Build edge list from “depends on” AC references and linked issues; topological validation in close workflow. | M | M |
+| F5: `EPIC_RESCOPE` hard gate | Require structured artifact (reason, impacted ACs, owner, expiry); close blocked if absent where AC changed/waived. | S | L |
+| F6: Consultant close authority | Workflow enforces Consultant-only final close approval comment with rubric and evidence links. | S | L |
+| F7: GHS Epic-truthfulness sensor | Add sensor output when declared-complete + unresolved AC detected; weight as G1 Governance-first signal. | M | M |
+
+## Section 4 — Recommended priority order (goal-lens)
+
+Given **Governance > Quality > Zero Cost > ...**, ship in this order:
+
+1. **F1 + F7** (truthfulness detection + continuous signal)  
+2. **F5 + F6** (hard close authority and explicit rescope protocol)  
+3. **F2** (narrative-state lint)  
+4. **F3 + F4** (state machine + dependency graph hardening)
+
+This ordering maximizes governance certainty earliest and limits premature-close risk.
+
+## Section 5 — Open questions
+
+1. Should cross-epic dependencies be modeled in labels, issue forms, or body schema as source-of-truth?
+2. Is `status:measuring` a global status or Epic-only status subtype?
+3. What is the exception path when telemetry windows cannot run (incident outages) without creating governance deadlock?
+4. Should reconciler be “write-back” by default or “report-only” until adoption milestone?
+
+## Websearch evidence (2025–2026)
+
+Each source includes URL + relevance claim.
+
+1. https://github.blog/changelog/2026-03-12-issue-fields-structured-issue-metadata-is-in-public-preview  
+   Relevance: typed issue metadata supports deterministic AC fields and reconciliation constraints (Gap 2/7).
+2. https://github.blog/changelog/2026-03-19-hierarchy-view-in-github-projects-is-now-generally-available  
+   Relevance: hierarchy/sub-issue visibility supports dependency tracing and blocker surfacing (Gap 4).
+3. https://github.blog/changelog/2026-04-02-improved-search-for-github-issues-is-now-generally-available  
+   Relevance: semantic/hybrid issue search enables scalable drift queries across repositories (Gap 1/7).
+4. https://github.blog/changelog/2026-04-09-release-info-in-issue-sidebar-and-project-defaults  
+   Relevance: release linkage + default fields strengthens evidence synchronization and AC defaults (Gap 2/3).
+5. https://github.blog/changelog/2026-05-07-repository-rulesets-user-bypass-and-branch-renaming  
+   Relevance: explicit bypass governance maps to `EPIC_RESCOPE` and exception controls (Gap 5/6).
+6. https://github.blog/changelog/2025-12-19-you-can-now-require-reviews-before-closing-dependabot-alerts-with-delegated-alert-dismissal  
+   Relevance: review-before-dismiss model is a direct analogue for independent Consultant close verification (Gap 6).
+7. https://forum.asana.com/t/new-advanced-search-for-projects/1132444  
+   Relevance: project-level search + consistency caveats inform reconciliation timing and eventual consistency handling (Gap 1/4).
+8. https://linear.app/changelog/2026-02-13-advanced-filters-and-share-issues-in-private-teams  
+   Relevance: advanced filter composition is a practical pattern for cross-ticket drift detection dashboards (Gap 7).
+9. https://arxiv.org/abs/2508.11867v1  
+   Relevance: 2025 CI/CD governance paper formalizes policy-bounded autonomy + DORA-linked evaluation windows (Gap 3/7).
+10. https://arxiv.org/abs/2602.12875v1  
+    Relevance: 2026 SLO fulfillment research supports explicit time-window re-evaluation and control loops (Gap 3).
+
+## Actionable next steps
+
+1. Land reconciler + truthfulness sensor in a single pilot on one Epic class.
+2. Add `EPIC_RESCOPE` schema and Consultant close rule in governance workflows.
+3. Introduce `status:measuring` with timed recheck automation and reporting.
+4. Run 2-week shadow mode (report-only), then switch to blocking mode.
+
+## Team&Model signing
+
+Signed-by: Nova Mason  
+Team&Model: copilot:gpt-5.3-codex@local  
+Role: manager

--- a/wiki/concepts/epic-state-truthfulness.md
+++ b/wiki/concepts/epic-state-truthfulness.md
@@ -4,7 +4,7 @@ type: concept
 created: 2026-05-09
 updated: 2026-05-09
 tags: [governance, epic, acceptance-criteria, drift]
-sources: ["[[epic-1271-cx-rd-plan-2026-05-09]]"]
+sources: ["[[epic-1271-cx-rd-plan-2026-05-09]]", "[[epic-1271-cp-rd-plan-2026-05-09]]"]
 related: ["[[epic-governance]]", "[[governance-enforcement]]", "[[baton-protocol]]", "[[self-annealing]]", "[[harness-goal-controls]]"]
 status: draft
 ---
@@ -30,12 +30,16 @@ The Codex #1274 plan recommends seven controls:
 6. Consultant-only final Epic verification.
 7. GHS sensor for declared-complete-but-unmet-AC drift.
 
+The Copilot #1273 plan corroborates the same seven-control shape with newer
+2026 GitHub issue/project/ruleset capability references and adds explicit
+narrative-state lint as an implementation gate.
+
 The design follows the Karpathy wiki pattern by storing raw research, a source
 summary, and this distilled concept separately, then cross-linking the concept
 to existing governance pages.
 
 ## Related
 
-[[epic-1271-cx-rd-plan-2026-05-09]], [[epic-governance]],
+[[epic-1271-cx-rd-plan-2026-05-09]], [[epic-1271-cp-rd-plan-2026-05-09]], [[epic-governance]],
 [[governance-enforcement]], [[baton-protocol]], [[self-annealing]],
 [[harness-goal-controls]]

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -43,6 +43,7 @@ The LLM updates this on every ingest operation.
 ## Source Summaries
 
 - [[epic-1271-cx-rd-plan-2026-05-09]] — Epic #1271 Codex R&D plan for state truthfulness
+- [[epic-1271-cp-rd-plan-2026-05-09]] — Epic #1271 Copilot R&D plan for state truthfulness
 - [[karpathy-llm-wiki-pattern]] — Karpathy LLM Wiki Pattern
 - [[devenv-fleet-topology]] — DevEnv Fleet Topology
 - [[copilot-skills-system]] — Copilot Skills System
@@ -99,6 +100,7 @@ The LLM updates this on every ingest operation.
 
 ## Recent Additions
 
+- [[epic-1271-cp-rd-plan-2026-05-09]] — Epic #1271 Copilot R&D plan for state truthfulness (2026-05-09)
 - [[harness-goals]] — Harness Goal Constitution (2026-05-06)
 - [[dashboard-live-data-methodology-2026-05-05]] — Dashboard Live-Data Methodology (2026-05-05)
 - [[workspace-write-boundary-discipline]] — Workspace Write-Boundary Discipline (2026-05-05)
@@ -112,4 +114,4 @@ The LLM updates this on every ingest operation.
 
 ---
 
-**Pages**: 71 | **Last updated**: 2026-05-06
+**Pages**: 72 | **Last updated**: 2026-05-09

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -31,6 +31,12 @@ Codex completed the source summary and concept page manually using the same
 Karpathy wiki structure. New pages: `wiki/sources/epic-1271-cx-rd-plan-2026-05-09.md`
 and `wiki/concepts/epic-state-truthfulness.md`.
 
+## [2026-05-09] ingest | Epic #1271 Copilot R&D plan (#1273)
+Added raw/source coverage for Epic-state truthfulness with the same fallback
+pattern when OpenClaw ingest was unreachable. New page:
+`wiki/sources/epic-1271-cp-rd-plan-2026-05-09.md`. Updated concept linkage in
+`wiki/concepts/epic-state-truthfulness.md` and index entries in `wiki/index.md`.
+
 **Tip**: `grep "^## \[" log.md | tail -5` shows last 5 entries.
 
 ---

--- a/wiki/sources/epic-1271-cp-rd-plan-2026-05-09.md
+++ b/wiki/sources/epic-1271-cp-rd-plan-2026-05-09.md
@@ -1,0 +1,49 @@
+---
+title: "Epic #1271 Copilot R&D plan for epic-state truthfulness"
+type: source
+created: 2026-05-09
+updated: 2026-05-09
+tags: [governance, epic-governance, ac-reconciliation, four-eyes, drift-detection]
+sources: ["raw/articles/epic-1271-cp-rd-plan-2026-05-09.md"]
+related: ["[[epic-state-truthfulness]]", "[[epic-ac-reconciliation]]", "[[harness-goal-controls]]"]
+status: draft
+confidence: high
+last_verified: 2026-05-09
+sources_count: 10
+---
+
+# Epic #1271 Copilot R&D plan for epic-state truthfulness
+
+## Summary
+
+Copilot team Phase-0 research for Epic #1271 evaluates seven truthfulness gaps and recommends seven controls with phased adoption.
+
+Top recommendations:
+
+1. Deterministic AC reconciler plus a close-readiness drift sensor.
+2. Mandatory `EPIC_RESCOPE` artifact for changed or deferred ACs.
+3. Consultant-only final completion verification.
+4. Narrative-state lint to block unsupported "complete" wording.
+5. `status:measuring` time-window flow with recheck metadata.
+6. Cross-Epic dependency cycle detection.
+
+## Why this matters
+
+The plan frames the root problem as cross-layer mismatch between narrative, labels, AC checkboxes, and dependency state. It emphasizes evidence-first completion and explicit governance for deferred work.
+
+## Evidence base
+
+The source cites 10 web references from 2025–2026 covering:
+
+- GitHub issue/project/ruleset platform capabilities.
+- Delegated review-before-close controls.
+- Asana and Linear issue/project search behavior.
+- Multi-agent orchestration and uncertainty handling papers.
+
+## See also
+
+- [[epic-state-truthfulness]]
+- [[epic-ac-reconciliation]]
+- [[harness-goal-controls]]
+
+*Source: raw/articles/epic-1271-cp-rd-plan-2026-05-09.md*


### PR DESCRIPTION
## Summary\n- add Copilot team research artifact for Epic #1271\n- add raw/wiki source ingest artifacts and concept/index/log updates\n- post signed six-section R&D plan and consultant closeout on #1273\n\n## Validation\n- npm run lint (pass)\n- npm run wiki:ingest (attempted; OpenClaw ingest unreachable)\n- npm run wiki:lint (ran; reports pre-existing global wiki debt)\n- npm test (fails in this environment due to missing Playwright browser binaries)\n\nRefs #1273