### PR TITLE
docs(governance): codify three-tier anneal protocol #1309

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] — #1309: codify three-tier anneal protocol (Epic #1308 Workstream A)
+
+### Added
+- `wiki/concepts/distributed-self-anneal.md` — three-tier model overview (Observation / Mid-flight pivot / Consultant goal-failure escalation). Builds on Epic #1133 pattern-detection layer. Relates `[[self-annealing]]`, `[[agent-drift]]`, `[[governance-enforcement]]`, `[[ticket-audit-pattern]]`.
+- `wiki/concepts/andon-pull-protocol.md` — any-role pull mechanics, trigger phrases (`pull anneal`, `andon`, `drift anneal #N`, `report drift`), event schema v2 contract, severity classification, pivot semantics (snapshot/restore), anti-patterns.
+
+### Changed
+- `instructions/workflow-resilience.instructions.md` — added "Three-tier escalation model" section with tier definitions, authority matrix, and bounded-loop kill-switch rules (single-flight per session, 3 pivots/24h, 5 tickets/7d/pattern, 50-step counter). References new wiki concept pages.
+- `wiki/concepts/self-annealing.md` — added "Three-tier extension (Epic #1308)" section; added `[[distributed-self-anneal]]` and `[[andon-pull-protocol]]` to related-page wikilinks; updated event-bus integration reference to mention incidents.jsonl schema v2.
+- `wiki/index.md` — registered both new concept pages in Concepts section and Recent Additions; bumped page count 73→75.
+
 ## [Unreleased] — #1115: fix wiki Always-Loaded Surfaces claim
 
 ### Changed

--- a/instructions/workflow-resilience.instructions.md
+++ b/instructions/workflow-resilience.instructions.md
@@ -36,6 +36,39 @@ Ready-stall blocker note required fields: `BLOCKER_NOTE`, `owner`, `unblock_cond
 4. Propose minimal docs/workflow delta that prevents recurrence.
 5. Define objective verification gate confirming the fix works.
 
+## Three-tier escalation model
+
+Anneal triggers route through one of three tiers per Epic #1308. See `[[distributed-self-anneal]]` for full design and `[[andon-pull-protocol]]` for any-role pull mechanics. The base protocol above is the Tier-2 mid-flight pivot phase.
+
+### Tier 1 — Observation (any role)
+
+Append a drift event to `~/.megingjord/incidents.jsonl` (schema v2). No threshold, no ticket. Pure trend capture for the recurrence detector.
+
+### Tier 2 — Mid-flight pivot (auto-ticket)
+
+Triggers when `severity ≥ medium` AND (recurrence ≥ 2 in 7d OR `trigger_type == manual-pull`) AND no active session-pivot AND no matching suppression entry. Effect: orchestrator pauses current baton step, snapshots state, runs the protocol above, files Manager ticket(s) to backlog, restores baton.
+
+### Tier 3 — Consultant goal-failure escalation
+
+Authority: Consultant only. Triggered when consultant rubric finds G1–G9 goal violation post-implementation. Effect: invoke Manager to (a) reopen failed AC/ticket via baton, (b) file new self-anneal Epic for systemic patterns.
+
+### Authority matrix
+
+| Action | Authority |
+|---|---|
+| Append Tier-1 event | Any role |
+| Request Tier-2 pivot | Any role (router classifies) |
+| Invoke Tier-3 escalation | Consultant only |
+| File Manager ticket from anneal | Manager (auto-routed via Tier-2 workflow) |
+
+### Bounded-loop guards (kill switches)
+
+- Max 1 active pivot per session (single-flight)
+- Max 3 pivots per 24h per session (rate-limit)
+- Max 5 anneal tickets per 7-day window per `pattern_id` (suppression cooperation with #1220)
+- Anneal step counter aborts with `decision: defer` if >50 tool calls
+- All trips emit `event:kill-switch-trip` for dashboard observability
+
 ## Documentation drift detection
 
 Run `docs-drift-maintenance` skill after any change to:

--- a/wiki/concepts/andon-pull-protocol.md
+++ b/wiki/concepts/andon-pull-protocol.md
@@ -1,0 +1,93 @@
+---
+title: "Andon-Pull Protocol"
+type: concept
+created: 2026-05-10
+updated: 2026-05-10
+tags: [governance, anneal, baton, multi-agent]
+sources: []
+related: ["[[distributed-self-anneal]]", "[[self-annealing]]", "[[baton-protocol]]", "[[governance-enforcement]]", "[[agent-drift]]"]
+status: draft
+---
+
+# Andon-Pull Protocol
+
+Any-role mechanism for flagging drift mid-baton-execution, modeled on Toyota's Andon cord (any worker can stop the line for a defect). The pull is distinct from Tier-3 Consultant escalation — Andon is about *raising signals*; Tier-3 is about *forcing reopen authority*.
+
+## Trigger phrases
+
+The `anneal-trigger-router` skill auto-discovers via its `description:` frontmatter field (per Agent Skills Open Standard, agentskills.io). Trigger phrases:
+
+- `pull anneal`
+- `andon`
+- `drift anneal #N` (with ticket reference)
+- `report drift`
+
+## Authority matrix
+
+| Role | What they can pull | Cost | Notes |
+|---|---|---|---|
+| Manager | Any tier | normal | Full authority — also files Tier-2 auto-tickets |
+| Collaborator | Tier 1, request Tier 2 | normal | Router classifies whether request actually escalates |
+| Admin | Tier 1 (post-merge / build issues) | normal | Mostly observation; rare Tier-2 requests |
+| Consultant | Tier 1, Tier 2, **Tier 3** | privileged | Only role that can invoke Tier-3 goal-failure escalation |
+
+## Event schema v2
+
+```
+{
+  "version": 2,
+  "timestamp": "<ISO-8601 UTC>",
+  "tier": 1 | 2 | 3,
+  "trigger_role": "manager|collaborator|admin|consultant|system",
+  "trigger_type": "pattern-recurrence|manual-pull|goal-failure|sensor-driven",
+  "pattern_id": "<string-or-null>",
+  "severity": "low|medium|high|critical",
+  "evidence": ["<url-or-file-ref>", "..."],
+  "ticket_ref": "<#N-or-null>",
+  "epic_ref": "<#N-or-null>",
+  "session_id": "<string>",
+  "schema_compat": "<v1-readers-must-ignore-fields-not-in-v1>"
+}
+```
+
+Backward-compatible: missing `version` field → treated as v1. v1-aware readers (`anneal-goal-sensor.js`, `anneal-review.js`) ignore new fields. Expand-contract pattern (Confluent staff-eng best practice).
+
+## Severity classification
+
+| Severity | Examples | Tier-2 trigger? |
+|---|---|---|
+| critical | governance-rule violation, data loss, security gate bypass | yes — immediate, bypasses recurrence threshold |
+| high | repeated CI failure, drift from documented protocol | yes after 2 occurrences in 7d |
+| medium | minor process gap, single instance of inefficiency | yes after 2 occurrences in 7d |
+| low | typo, single observation, cosmetic | no — Tier 1 trend capture only |
+
+Misclassification target: <5% on the 50-event golden-file fixture (Epic #1308 AC3).
+
+## Pivot semantics (Tier 2)
+
+When Tier-2 triggers mid-flight, the baton orchestrator:
+
+1. **Snapshot** current state: `{role, ticket_ref, baton_phase, last_event_id, timestamp}`
+2. **Emit** `event:pivot-start` with snapshot
+3. **Assume** Manager role temporarily (transient)
+4. **Run** `workflow-self-anneal` (bounded: max 3 doc proposals, max 50 step counter)
+5. **File** Manager ticket(s) per anneal output (docs to anneal scope; code goes to standard baton — never bypass)
+6. **Emit** `event:pivot-end` with files-created list
+7. **Assert** `current_role == snapshot.role`; restore baton to `snapshot.ticket_ref` at `snapshot.baton_phase`
+
+Kill-switch trips during pivot **abort cleanly** — original baton state is preserved (no partial restoration).
+
+## Anti-patterns
+
+- Pulling Andon for a single low-severity typo (use Tier 1 observation, not Tier 2 pull)
+- Bypassing baton via anneal channel for code work (only docs/process route through anneal)
+- Nested pivots within pivots (single-flight rule blocks; queue but don't fire)
+- Treating Tier 2 as a fast-path for ordinary Manager tickets (use the standard Manager-creation flow)
+
+## See also
+
+- `[[distributed-self-anneal]]` — three-tier model overview
+- `[[self-annealing]]` — base protocol
+- `[[baton-protocol]]` — baton handoff fundamentals
+- `[[agent-drift]]` — root causes that justify pulling
+- Epic #1308 — implementing Epic

--- a/wiki/concepts/distributed-self-anneal.md
+++ b/wiki/concepts/distributed-self-anneal.md
@@ -1,0 +1,56 @@
+---
+title: "Distributed Self-Anneal"
+type: concept
+created: 2026-05-10
+updated: 2026-05-10
+tags: [governance, anneal, multi-agent, baton]
+sources: []
+related: ["[[self-annealing]]", "[[andon-pull-protocol]]", "[[agent-drift]]", "[[governance-enforcement]]", "[[baton-protocol]]", "[[ticket-audit-pattern]]"]
+status: draft
+---
+
+# Distributed Self-Anneal
+
+Three-tier escalation model that extends pattern-based self-anneal (Epic #1133) with **distributed any-role pull** and **mid-flight pivot orchestration**.
+
+## Why three tiers
+
+Single-agent self-reflection systematically repeats its own reasoning errors (Multi-Agent Reflexion, Shinn 2025; arxiv 2512.20845). Anneal limited to pattern-recurrence misses Collaborator-observed and Consultant-observed drift. The Toyota Andon principle: any worker can stop the line — adapted to the baton, any role can flag.
+
+Two triggers (Manager pivot + Consultant escalation) are still too few. Lightweight observations from Collaborator and Admin get lost without an explicit channel. Three tiers separates trend capture (low cost) from action (high cost).
+
+## Tier definitions
+
+| Tier | Trigger | Authority | Cost |
+|---|---|---|---|
+| **1 — Observation** | Any role appends event to `~/.megingjord/incidents.jsonl` | All roles | Zero — passive logging |
+| **2 — Mid-flight pivot** | `severity ≥ medium` AND (recurrence ≥ 2 in 7d window OR `trigger_type == manual-pull`) AND no active session-pivot AND no matching suppression entry | Any role requests; orchestrator executes | One pivot/session, rate-limited 3/24h |
+| **3 — Consultant escalation** | Consultant rubric finds G1–G9 goal violation post-implementation | Consultant only (privileged) | High-blast — reopens tickets, can file new Epic |
+
+## Event schema v2
+
+Tier-aware extension of v1 incidents.jsonl. Backward-compatible (v1 readers ignore new fields; missing `version` field treated as v1). Field-by-field contract lives in `[[andon-pull-protocol]]`.
+
+## Bounded-loop guards
+
+- Single-flight per session — only one pivot active at a time (Reflexion runaway protection)
+- Max 3 pivots per 24h per session (rate-limit)
+- Max 5 anneal tickets per 7-day window per `pattern_id` (suppression cooperation with [#1220](https://github.com/chf3198/megingjord-harness/issues/1220))
+- Anneal protocol step counter — abort with `decision: defer` if >50 tool calls (silent-bad-assumption protection per ICML 2026 FMAI workshop)
+- All trips emit `event:kill-switch-trip` (dashboard-observable per AC9 of Epic #1308)
+
+## Relationship to Epic #1133
+
+Epic #1133 builds the *pattern-detection* leg — sensors (`anneal-goal-sensor.js`), recurring-patterns catalog, suppression-registry ([#1220](https://github.com/chf3198/megingjord-harness/issues/1220)), auto-file proposals ([#1219](https://github.com/chf3198/megingjord-harness/issues/1219)), governance-audit integration ([#1222](https://github.com/chf3198/megingjord-harness/issues/1222)).
+
+This concept extends with: any-role pull, severity classifier, mid-flight pivot, Consultant escalation. Both layers share the same `incidents.jsonl` event log via schema v2 (backward-compatible).
+
+## See also
+
+- `[[andon-pull-protocol]]` — any-role pull semantics, trigger phrases, pivot mechanics
+- `[[self-annealing]]` — base protocol (Tier-2 mid-flight pivot phase)
+- `[[agent-drift]]` — root-cause taxonomy for what triggers the pull
+- `[[governance-enforcement]]` — 4-layer enforcement architecture
+- `[[ticket-audit-pattern]]` — Manager-side audit pattern (related — bottom-up audit; this is top-down distributed pull)
+- Epic #1308 — implementing Epic for this concept
+- Epic #1133 — parent infrastructure (pattern-detection leg)

--- a/wiki/concepts/self-annealing.md
+++ b/wiki/concepts/self-annealing.md
@@ -2,10 +2,10 @@
 title: "Self-Annealing Protocol"
 type: concept
 created: 2026-04-14
-updated: 2026-04-14
+updated: 2026-05-10
 tags: [governance, workflow]
 sources: []
-related: ["[[agent-drift]]", "[[baton-protocol]]", "[[governance-enforcement]]"]
+related: ["[[agent-drift]]", "[[baton-protocol]]", "[[governance-enforcement]]", "[[distributed-self-anneal]]", "[[andon-pull-protocol]]"]
 status: draft
 ---
 
@@ -27,9 +27,15 @@ Bounded review cycle that detects and corrects operational drift.
 5. Apply corrections (retroactive if needed)
 6. Document findings in Consultant CLOSEOUT
 
+## Three-tier extension (Epic #1308)
+
+The base protocol above corresponds to the Tier-2 mid-flight pivot phase. Distributed any-role pull (Tier 1) and Consultant goal-failure escalation (Tier 3) extend it. See:
+- [[distributed-self-anneal]] — three-tier model
+- [[andon-pull-protocol]] — any-role pull mechanics, severity classification, pivot semantics
+
 ## Integration Points
 - [[baton-protocol]] Consultant phase triggers review
-- Event bus provides audit trail
+- Event bus provides audit trail (`~/.megingjord/incidents.jsonl` schema v2)
 - wiki/log.md captures operational history
 
-See: [[self-annealing]], [[agent-drift-recommendations]]
+See: [[agent-drift-recommendations]], [[distributed-self-anneal]], [[andon-pull-protocol]]

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -27,6 +27,8 @@ The LLM updates this on every ingest operation.
 - [[epic-governance]] — Epic Lifecycle Governance Rules
 - [[agent-drift]] — Agent Drift
 - [[self-annealing]] — Self-Annealing Protocol
+- [[distributed-self-anneal]] — Three-tier distributed self-anneal (Epic #1308)
+- [[andon-pull-protocol]] — Any-role pull mechanics + pivot semantics (Epic #1308)
 - [[wiki-pattern]] — Karpathy LLM Wiki Pattern
 - [[governance-enforcement]] — Governance Enforcement
 - [[protocol-enforcement]] — Protocol Enforcement Architecture
@@ -101,6 +103,8 @@ The LLM updates this on every ingest operation.
 
 ## Recent Additions
 
+- [[distributed-self-anneal]] — Three-tier distributed self-anneal (2026-05-10)
+- [[andon-pull-protocol]] — Any-role pull protocol (2026-05-10)
 - [[epic-1271-codex-fdpr-2026-05-10]] — Codex FDPR for Epic #1271 (2026-05-10)
 - [[epic-1271-cp-rd-plan-2026-05-09]] — Epic #1271 Copilot R&D plan for state truthfulness (2026-05-09)
 - [[harness-goals]] — Harness Goal Constitution (2026-05-06)
@@ -116,4 +120,4 @@ The LLM updates this on every ingest operation.
 
 ---
 
-**Pages**: 73 | **Last updated**: 2026-05-10
+**Pages**: 75 | **Last updated**: 2026-05-10


### PR DESCRIPTION
## Summary

Codifies the distributed three-tier self-anneal architecture from Epic #1308. Foundation for Workstream A (#1310 #1311 #1312) and reference for Workstream B (#1313 #1314 #1315 #1316).

## Files

- `instructions/workflow-resilience.instructions.md` — added Three-tier escalation model section
- `wiki/concepts/distributed-self-anneal.md` (new) — concept page
- `wiki/concepts/andon-pull-protocol.md` (new) — concept page
- `wiki/concepts/self-annealing.md` — added Three-tier extension reference
- `wiki/index.md` — registered both new pages, bumped page count 73→75

## Test plan

- [x] `npm run lint` — all files ≤100 lines (395 files scanned)
- [x] `npm run docs:lint` — clean (0 warnings)
- [x] `npm run wiki:lint` — 148 pre-existing issues; **zero involving the two new pages**
- [x] `npm test` — 489 passed (1 pre-existing flake unrelated)

## Baton trail

**COLLABORATOR_HANDOFF** posted on #1309 by Orla Harper (claude-code:opus-4-7@anthropic).
**ADMIN_HANDOFF** to be posted by Orla Reyes after CI green.
**CONSULTANT_CLOSEOUT** to be posted by Orla Vale after merge.

Refs #1309
Refs Epic #1308