### PR TITLE
feat(schema): anneal schema v2 #1315

### DIFF
--- a/scripts/global/anneal-event-schema.js
+++ b/scripts/global/anneal-event-schema.js
@@ -42,8 +42,8 @@ function isValidV1(event) {
   if (!event || typeof event !== 'object') {
     return { ok: false, errors: ['event must be an object'] };
   }
-  for (const f of V1_REQUIRED) {
-    if (event[f] === undefined) errors.push(`missing required v1 field: ${f}`);
+  for (const field of V1_REQUIRED) {
+    if (event[field] === undefined) errors.push(`missing required v1 field: ${field}`);
   }
   return { ok: errors.length === 0, errors };
 }
@@ -61,8 +61,8 @@ function isValidV2(event) {
     return { ok: false, errors: ['event must be an object'] };
   }
   if (event.version !== 2) errors.push('version must be 2');
-  for (const f of V2_REQUIRED) {
-    if (event[f] === undefined) errors.push(`missing required v2 field: ${f}`);
+  for (const field of V2_REQUIRED) {
+    if (event[field] === undefined) errors.push(`missing required v2 field: ${field}`);
   }
   if (event.tier !== undefined && !VALID_TIERS.includes(event.tier)) {
     errors.push(`tier must be one of ${VALID_TIERS.join('|')}`);

--- a/scripts/global/anneal-event-schema.js
+++ b/scripts/global/anneal-event-schema.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// anneal-event-schema.js — Event schema v2 validators + backward-compat shim
+// Epic #1308 — Workstream B / #1315
+// Expand-contract pattern: v2 fields are additive-only. v1 readers continue to
+// work against v2 events by ignoring unknown fields (no removal, no renaming).
+// v1 events (no `version` field) are accepted and upgraded on demand.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const INCIDENTS_FILE = path.join(process.env.HOME, '.megingjord', 'incidents.jsonl');
+
+// ─── V1 field set ────────────────────────────────────────────────────────────
+// Fields used by existing v1 readers (anneal-goal-sensor.js, anneal-review.js,
+// anneal-graph.js). Must never be removed or renamed in v2.
+const V1_REQUIRED = ['timestamp'];
+const V1_OPTIONAL = [
+  'status', 'pattern_id', 'count', 'window_start', 'evidence',
+  'suppression_until', 'updated_at',
+];
+
+// ─── V2 new fields (additive only) ───────────────────────────────────────────
+const V2_REQUIRED = ['version', 'timestamp', 'tier', 'trigger_role',
+  'trigger_type', 'severity', 'session_id'];
+const VALID_TIERS = [1, 2, 3];
+const VALID_ROLES = ['manager', 'collaborator', 'admin', 'consultant', 'system'];
+const VALID_TRIGGERS = [
+  'pattern-recurrence', 'manual-pull', 'goal-failure', 'sensor-driven',
+];
+const VALID_SEVERITIES = ['low', 'medium', 'high', 'critical'];
+
+// ─── Validators ──────────────────────────────────────────────────────────────
+
+/**
+ * Accept any object that has a `timestamp` field (v1 contract minimum).
+ * Does NOT require `version`; absence of `version` means v1.
+ * @param {object} event
+ * @returns {{ ok: boolean, errors: string[] }}
+ */
+function isValidV1(event) {
+  const errors = [];
+  if (!event || typeof event !== 'object') {
+    return { ok: false, errors: ['event must be an object'] };
+  }
+  for (const f of V1_REQUIRED) {
+    if (event[f] === undefined) errors.push(`missing required v1 field: ${f}`);
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Validate a v2 event. Unknown extra fields are allowed (forward-compat).
+ * v1 readers rely on: timestamp, status, pattern_id, count, evidence — all
+ * must be preserved when present.
+ * @param {object} event
+ * @returns {{ ok: boolean, errors: string[] }}
+ */
+function isValidV2(event) {
+  const errors = [];
+  if (!event || typeof event !== 'object') {
+    return { ok: false, errors: ['event must be an object'] };
+  }
+  if (event.version !== 2) errors.push('version must be 2');
+  for (const f of V2_REQUIRED) {
+    if (event[f] === undefined) errors.push(`missing required v2 field: ${f}`);
+  }
+  if (event.tier !== undefined && !VALID_TIERS.includes(event.tier)) {
+    errors.push(`tier must be one of ${VALID_TIERS.join('|')}`);
+  }
+  if (event.trigger_role !== undefined && !VALID_ROLES.includes(event.trigger_role)) {
+    errors.push(`trigger_role must be one of ${VALID_ROLES.join('|')}`);
+  }
+  if (event.trigger_type !== undefined && !VALID_TRIGGERS.includes(event.trigger_type)) {
+    errors.push(`trigger_type must be one of ${VALID_TRIGGERS.join('|')}`);
+  }
+  if (event.severity !== undefined && !VALID_SEVERITIES.includes(event.severity)) {
+    errors.push(`severity must be one of ${VALID_SEVERITIES.join('|')}`);
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+// ─── Shim ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Upgrade a v1 event to v2 by adding defaults for new fields.
+ * All original v1 fields are preserved exactly; new fields receive safe defaults
+ * so v2-aware consumers can always read them.
+ * @param {object} v1Event
+ * @param {Partial<object>} overrides  Optional v2-specific fields to set
+ * @returns {object} v2 event
+ */
+function upgradeV1ToV2(v1Event, overrides = {}) {
+  return Object.assign({
+    version: 2,
+    tier: 1,
+    trigger_role: 'system',
+    trigger_type: 'sensor-driven',
+    pattern_id: null,
+    severity: 'low',
+    evidence: [],
+    ticket_ref: null,
+    epic_ref: null,
+    session_id: 'legacy',
+    schema_compat: 'v1-readers-must-ignore-fields-not-in-v1',
+  }, v1Event, { version: 2 }, overrides);
+}
+
+// ─── Detect version ──────────────────────────────────────────────────────────
+
+/**
+ * Return the schema version of an event.
+ * Absence of `version` field means v1 (legacy).
+ * @param {object} event
+ * @returns {1|2|number}
+ */
+function detectVersion(event) {
+  if (!event || event.version === undefined) return 1;
+  return event.version;
+}
+
+// ─── Normalise (v1 → v2 if needed) ──────────────────────────────────────────
+
+/**
+ * Ensure any event is v2-shaped for v2-aware consumers.
+ * v2 events pass through unchanged; v1 events are upgraded.
+ * @param {object} event
+ * @param {object} [overrides]
+ * @returns {object}
+ */
+function normalise(event, overrides = {}) {
+  if (detectVersion(event) === 2) return event;
+  return upgradeV1ToV2(event, overrides);
+}
+
+// ─── Emit helper ─────────────────────────────────────────────────────────────
+
+/**
+ * Append a v2 event to the incidents.jsonl file.
+ * Validates the event before writing. Throws on invalid.
+ * @param {object} event  Must already be a valid v2 event.
+ * @param {string} [file] Override incidents file path (for tests).
+ */
+function emitEvent(event, file = INCIDENTS_FILE) {
+  const { ok, errors } = isValidV2(event);
+  if (!ok) throw new Error(`Invalid v2 event: ${errors.join('; ')}`);
+  const dir = path.dirname(file);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(file, JSON.stringify(event) + '\n', 'utf8');
+}
+
+// ─── Feed reader (mixed v1/v2) ───────────────────────────────────────────────
+
+/**
+ * Read incidents.jsonl and return all events, each normalised to v2.
+ * Skips unparseable lines. Compatible with v1-only feeds.
+ * @param {string} [file] Override incidents file path (for tests).
+ * @returns {object[]}
+ */
+function readEvents(file = INCIDENTS_FILE) {
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, 'utf8')
+    .split('\n').filter(Boolean)
+    .map(line => { try { return JSON.parse(line); } catch { return null; } })
+    .filter(Boolean)
+    .map(ev => normalise(ev));
+}
+
+module.exports = {
+  isValidV1,
+  isValidV2,
+  upgradeV1ToV2,
+  detectVersion,
+  normalise,
+  emitEvent,
+  readEvents,
+  VALID_TIERS,
+  VALID_ROLES,
+  VALID_TRIGGERS,
+  VALID_SEVERITIES,
+  INCIDENTS_FILE,
+};

--- a/scripts/global/anneal-event-schema.spec.js
+++ b/scripts/global/anneal-event-schema.spec.js
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+// anneal-event-schema.spec.js — Contract tests for event schema v2 / backward compat
+// Epic #1308 — Workstream B / #1315
+// Test runner: Node built-in assert (no external deps required).
+// Run: node scripts/global/anneal-event-schema.spec.js
+'use strict';
+
+const assert = require('assert');
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const {
+  isValidV1, isValidV2, upgradeV1ToV2, detectVersion, normalise,
+  emitEvent, readEvents,
+  VALID_TIERS, VALID_ROLES, VALID_TRIGGERS, VALID_SEVERITIES,
+} = require('./anneal-event-schema');
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+let passed = 0; let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  ✓ ${name}`); passed++; }
+  catch (e) { console.error(`  ✗ ${name}\n      ${e.message}`); failed++; }
+}
+
+// Minimal valid v1 event (matches fields used by anneal-goal-sensor.js)
+const V1_MIN = { timestamp: '2026-01-01T00:00:00Z', status: 'proposed',
+  pattern_id: 'p-001', count: 3, window_start: '2026-01-01T00:00:00Z',
+  evidence: ['#100'], suppression_until: null };
+
+// Minimal valid v2 event
+const V2_MIN = {
+  version: 2, timestamp: '2026-01-01T00:00:00Z', tier: 1,
+  trigger_role: 'collaborator', trigger_type: 'manual-pull',
+  pattern_id: 'p-001', severity: 'medium', evidence: ['#100'],
+  ticket_ref: '#100', epic_ref: '#1308', session_id: 'ses-abc',
+  schema_compat: 'v1-readers-must-ignore-fields-not-in-v1',
+};
+
+// ─── isValidV1 ───────────────────────────────────────────────────────────────
+console.log('\n[isValidV1]');
+test('accepts minimal v1 event', () => {
+  assert.deepStrictEqual(isValidV1(V1_MIN).ok, true);
+});
+test('accepts v2 event as v1 (unknown fields ignored)', () => {
+  assert.deepStrictEqual(isValidV1(V2_MIN).ok, true);
+});
+test('rejects null', () => {
+  assert.deepStrictEqual(isValidV1(null).ok, false);
+});
+test('rejects event missing timestamp', () => {
+  const e = { ...V1_MIN }; delete e.timestamp;
+  assert.deepStrictEqual(isValidV1(e).ok, false);
+});
+test('accepts event with only timestamp (absolute minimum)', () => {
+  assert.deepStrictEqual(isValidV1({ timestamp: '2026-01-01T00:00:00Z' }).ok, true);
+});
+
+// ─── isValidV2 ───────────────────────────────────────────────────────────────
+console.log('\n[isValidV2]');
+test('accepts valid v2 event', () => {
+  assert.deepStrictEqual(isValidV2(V2_MIN).ok, true);
+});
+test('rejects event without version field', () => {
+  const e = { ...V2_MIN }; delete e.version;
+  assert.deepStrictEqual(isValidV2(e).ok, false);
+});
+test('rejects wrong version number', () => {
+  assert.deepStrictEqual(isValidV2({ ...V2_MIN, version: 1 }).ok, false);
+});
+test('rejects invalid tier', () => {
+  assert.deepStrictEqual(isValidV2({ ...V2_MIN, tier: 9 }).ok, false);
+});
+test('rejects invalid trigger_role', () => {
+  assert.deepStrictEqual(isValidV2({ ...V2_MIN, trigger_role: 'robot' }).ok, false);
+});
+test('rejects invalid trigger_type', () => {
+  assert.deepStrictEqual(isValidV2({ ...V2_MIN, trigger_type: 'unknown' }).ok, false);
+});
+test('rejects invalid severity', () => {
+  assert.deepStrictEqual(isValidV2({ ...V2_MIN, severity: 'extreme' }).ok, false);
+});
+test('accepts unknown extra fields (forward-compat)', () => {
+  assert.deepStrictEqual(isValidV2({ ...V2_MIN, future_field: 'x' }).ok, true);
+});
+test('accepts all valid tier values', () => {
+  for (const t of VALID_TIERS) {
+    assert.ok(isValidV2({ ...V2_MIN, tier: t }).ok, `tier ${t} should be valid`);
+  }
+});
+test('accepts all valid severities', () => {
+  for (const s of VALID_SEVERITIES) {
+    assert.ok(isValidV2({ ...V2_MIN, severity: s }).ok, `severity ${s} should be valid`);
+  }
+});
+
+// ─── upgradeV1ToV2 ───────────────────────────────────────────────────────────
+console.log('\n[upgradeV1ToV2]');
+test('preserves all v1 fields', () => {
+  const up = upgradeV1ToV2(V1_MIN);
+  for (const [k, v] of Object.entries(V1_MIN)) {
+    assert.deepStrictEqual(up[k], v, `field ${k} should be preserved`);
+  }
+});
+test('upgraded event passes isValidV2', () => {
+  const up = upgradeV1ToV2(V1_MIN);
+  const { ok, errors } = isValidV2(up);
+  assert.ok(ok, `validation errors: ${errors.join(', ')}`);
+});
+test('overrides take effect', () => {
+  const up = upgradeV1ToV2(V1_MIN, { tier: 2, severity: 'high' });
+  assert.strictEqual(up.tier, 2);
+  assert.strictEqual(up.severity, 'high');
+});
+test('version is always 2 regardless of override attempt', () => {
+  const up = upgradeV1ToV2({ ...V1_MIN, version: 1 });
+  assert.strictEqual(up.version, 2);
+});
+
+// ─── detectVersion ───────────────────────────────────────────────────────────
+console.log('\n[detectVersion]');
+test('v1 event returns 1', () => assert.strictEqual(detectVersion(V1_MIN), 1));
+test('v2 event returns 2', () => assert.strictEqual(detectVersion(V2_MIN), 2));
+test('undefined event returns 1', () => assert.strictEqual(detectVersion(undefined), 1));
+
+// ─── normalise ───────────────────────────────────────────────────────────────
+console.log('\n[normalise]');
+test('v2 event passes through unchanged', () => {
+  assert.deepStrictEqual(normalise(V2_MIN), V2_MIN);
+});
+test('v1 event is upgraded to v2', () => {
+  const n = normalise(V1_MIN);
+  assert.strictEqual(n.version, 2);
+  assert.deepStrictEqual(isValidV2(n).ok, true);
+});
+
+// ─── emitEvent + readEvents (file I/O integration) ───────────────────────────
+console.log('\n[emitEvent / readEvents]');
+const TMP = path.join(os.tmpdir(), `anneal-schema-test-${Date.now()}.jsonl`);
+test('emitEvent writes a v2 event to file', () => {
+  emitEvent(V2_MIN, TMP);
+  const lines = fs.readFileSync(TMP, 'utf8').split('\n').filter(Boolean);
+  assert.strictEqual(lines.length, 1);
+  assert.deepStrictEqual(JSON.parse(lines[0]).version, 2);
+});
+test('emitEvent rejects invalid v2 event', () => {
+  assert.throws(() => emitEvent({ timestamp: '2026-01-01T00:00:00Z' }, TMP));
+});
+test('readEvents returns empty array for non-existent file', () => {
+  assert.deepStrictEqual(readEvents('/tmp/no-such-file-' + Date.now()), []);
+});
+test('readEvents normalises v1 events to v2', () => {
+  const tmp2 = TMP + '.v1';
+  fs.writeFileSync(tmp2, JSON.stringify(V1_MIN) + '\n', 'utf8');
+  const events = readEvents(tmp2);
+  assert.strictEqual(events.length, 1);
+  assert.strictEqual(events[0].version, 2);
+  fs.unlinkSync(tmp2);
+});
+test('readEvents handles mixed v1/v2 feed', () => {
+  const tmp3 = TMP + '.mixed';
+  fs.writeFileSync(tmp3, [
+    JSON.stringify(V1_MIN),
+    JSON.stringify(V2_MIN),
+  ].join('\n') + '\n', 'utf8');
+  const events = readEvents(tmp3);
+  assert.strictEqual(events.length, 2);
+  assert.ok(events.every(e => e.version === 2));
+  fs.unlinkSync(tmp3);
+});
+test('readEvents skips unparseable lines', () => {
+  const tmp4 = TMP + '.bad';
+  fs.writeFileSync(tmp4, 'not-json\n' + JSON.stringify(V2_MIN) + '\n', 'utf8');
+  const events = readEvents(tmp4);
+  assert.strictEqual(events.length, 1);
+  fs.unlinkSync(tmp4);
+});
+
+// ─── Contract: anneal-goal-sensor.js v1 reader compatibility ─────────────────
+// anneal-goal-sensor.js reads: timestamp, status
+// It filters events by timestamp > cutoff and status === 'resolved'|'suppressed'
+console.log('\n[contract: anneal-goal-sensor.js compatibility]');
+test('v2 event has timestamp and status fields (v1 reader can read)', () => {
+  const up = upgradeV1ToV2({ ...V1_MIN, status: 'resolved' });
+  assert.ok(up.timestamp, 'timestamp present');
+  assert.strictEqual(up.status, 'resolved');
+});
+test('v2 event without status field does not break v1 reader (status is optional in v1)', () => {
+  const up = upgradeV1ToV2({ timestamp: '2026-01-01T00:00:00Z' });
+  // v1 reader filters on status; undefined is not === 'resolved' — safe.
+  assert.ok(!['resolved', 'suppressed'].includes(up.status));
+});
+
+// ─── Contract: anneal-review.js v1 reader compatibility ──────────────────────
+// anneal-review.js reads: status, pattern_id, count, window_start, evidence
+console.log('\n[contract: anneal-review.js compatibility]');
+test('v2-upgraded event preserves pattern_id, count, window_start, evidence', () => {
+  const up = upgradeV1ToV2(V1_MIN);
+  assert.strictEqual(up.pattern_id, V1_MIN.pattern_id);
+  assert.strictEqual(up.count, V1_MIN.count);
+  assert.strictEqual(up.window_start, V1_MIN.window_start);
+  assert.deepStrictEqual(up.evidence, V1_MIN.evidence);
+});
+
+// ─── Cleanup + summary ────────────────────────────────────────────────────────
+if (fs.existsSync(TMP)) fs.unlinkSync(TMP);
+console.log(`\n${'─'.repeat(50)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+if (failed > 0) { console.error('FAIL'); process.exit(1); }
+console.log('PASS');

--- a/scripts/global/anneal-event-schema.spec.js
+++ b/scripts/global/anneal-event-schema.spec.js
@@ -23,14 +23,17 @@ function test(name, fn) {
   catch (e) { console.error(`  ✗ ${name}\n      ${e.message}`); failed++; }
 }
 
+// Shared timestamp fixture (avoids magic-number warnings)
+const TS_FIXTURE = '2026-01-01T00:00:00Z';
+
 // Minimal valid v1 event (matches fields used by anneal-goal-sensor.js)
-const V1_MIN = { timestamp: '2026-01-01T00:00:00Z', status: 'proposed',
-  pattern_id: 'p-001', count: 3, window_start: '2026-01-01T00:00:00Z',
+const V1_MIN = { timestamp: TS_FIXTURE, status: 'proposed',
+  pattern_id: 'p-001', count: 3, window_start: TS_FIXTURE,
   evidence: ['#100'], suppression_until: null };
 
 // Minimal valid v2 event
 const V2_MIN = {
-  version: 2, timestamp: '2026-01-01T00:00:00Z', tier: 1,
+  version: 2, timestamp: TS_FIXTURE, tier: 1,
   trigger_role: 'collaborator', trigger_type: 'manual-pull',
   pattern_id: 'p-001', severity: 'medium', evidence: ['#100'],
   ticket_ref: '#100', epic_ref: '#1308', session_id: 'ses-abc',
@@ -53,7 +56,7 @@ test('rejects event missing timestamp', () => {
   assert.deepStrictEqual(isValidV1(e).ok, false);
 });
 test('accepts event with only timestamp (absolute minimum)', () => {
-  assert.deepStrictEqual(isValidV1({ timestamp: '2026-01-01T00:00:00Z' }).ok, true);
+  assert.deepStrictEqual(isValidV1({ timestamp: TS_FIXTURE }).ok, true);
 });
 
 // ─── isValidV2 ───────────────────────────────────────────────────────────────
@@ -84,13 +87,13 @@ test('accepts unknown extra fields (forward-compat)', () => {
   assert.deepStrictEqual(isValidV2({ ...V2_MIN, future_field: 'x' }).ok, true);
 });
 test('accepts all valid tier values', () => {
-  for (const t of VALID_TIERS) {
-    assert.ok(isValidV2({ ...V2_MIN, tier: t }).ok, `tier ${t} should be valid`);
+  for (const tierVal of VALID_TIERS) {
+    assert.ok(isValidV2({ ...V2_MIN, tier: tierVal }).ok, `tier ${tierVal} should be valid`);
   }
 });
 test('accepts all valid severities', () => {
-  for (const s of VALID_SEVERITIES) {
-    assert.ok(isValidV2({ ...V2_MIN, severity: s }).ok, `severity ${s} should be valid`);
+  for (const sevVal of VALID_SEVERITIES) {
+    assert.ok(isValidV2({ ...V2_MIN, severity: sevVal }).ok, `severity ${sevVal} should be valid`);
   }
 });
 
@@ -129,9 +132,9 @@ test('v2 event passes through unchanged', () => {
   assert.deepStrictEqual(normalise(V2_MIN), V2_MIN);
 });
 test('v1 event is upgraded to v2', () => {
-  const n = normalise(V1_MIN);
-  assert.strictEqual(n.version, 2);
-  assert.deepStrictEqual(isValidV2(n).ok, true);
+  const normalised = normalise(V1_MIN);
+  assert.strictEqual(normalised.version, 2);
+  assert.deepStrictEqual(isValidV2(normalised).ok, true);
 });
 
 // ─── emitEvent + readEvents (file I/O integration) ───────────────────────────
@@ -144,7 +147,7 @@ test('emitEvent writes a v2 event to file', () => {
   assert.deepStrictEqual(JSON.parse(lines[0]).version, 2);
 });
 test('emitEvent rejects invalid v2 event', () => {
-  assert.throws(() => emitEvent({ timestamp: '2026-01-01T00:00:00Z' }, TMP));
+  assert.throws(() => emitEvent({ timestamp: TS_FIXTURE }, TMP));
 });
 test('readEvents returns empty array for non-existent file', () => {
   assert.deepStrictEqual(readEvents('/tmp/no-such-file-' + Date.now()), []);
@@ -186,7 +189,7 @@ test('v2 event has timestamp and status fields (v1 reader can read)', () => {
   assert.strictEqual(up.status, 'resolved');
 });
 test('v2 event without status field does not break v1 reader (status is optional in v1)', () => {
-  const up = upgradeV1ToV2({ timestamp: '2026-01-01T00:00:00Z' });
+  const up = upgradeV1ToV2({ timestamp: TS_FIXTURE });
   // v1 reader filters on status; undefined is not === 'resolved' — safe.
   assert.ok(!['resolved', 'suppressed'].includes(up.status));
 });


### PR DESCRIPTION
## Summary
Implements the schema v2 foundation for Epic #1308 Workstream B.

## Changes
- scripts/global/anneal-event-schema.js — isValidV1, isValidV2, upgradeV1ToV2, detectVersion, normalise, emitEvent, readEvents; additive expand-contract compatibility model
- scripts/global/anneal-event-schema.spec.js — 33 contract tests for v1/v2 compatibility, mixed-feed normalisation, and reader safety

## Verification
- node scripts/global/anneal-event-schema.spec.js → 33/33 pass
- npm run lint → pass (100-line gate)
- pre-push readability gate → 418/420 pass

## Governance
Refs #1315
Refs Epic #1308
[skip-doc-gate]

## Provenance
Alias: Soren Harper
Team&Model: copilot:claude-sonnet-4-6@github