### PR TITLE
feat(governance): anneal-trigger-router skill + baton pivot #1310

### DIFF
--- a/.claude/commands/anneal-trigger-router.md
+++ b/.claude/commands/anneal-trigger-router.md
@@ -1,0 +1,84 @@
+---
+description: "Classify drift signals and trigger phrases (pull anneal, andon, drift anneal #N, report drift) into tier 1/2/3 routes. Authority-aware dispatcher for distributed self-anneal."
+argument-hint: "[signal|trigger-phrase]"
+---
+
+# Anneal Trigger Router
+
+## Purpose
+
+Classify drift signals — from sensors, manual pulls, or Consultant goal-failure escalations — into a routing decision per the three-tier model in `instructions/workflow-resilience.instructions.md`. See also `wiki/concepts/distributed-self-anneal.md` and `wiki/concepts/andon-pull-protocol.md`.
+
+## Trigger phrases (auto-discovered via this skill's `description:` field)
+
+- `pull anneal`
+- `andon`
+- `drift anneal #N` (with ticket reference)
+- `report drift`
+
+## Routing decision (output JSON shape)
+
+```json
+{
+  "tier": 1 | 2 | 3,
+  "action": "log-only" | "request-pivot" | "request-consultant-escalation",
+  "rationale": "string",
+  "estimated_severity": "low" | "medium" | "high" | "critical",
+  "kill_switch_trip": null | "rate-limit" | "step-counter" | "suppression" | "single-flight" | "authority"
+}
+```
+
+## Classification rules (evaluated in order)
+
+1. If `trigger_role == consultant` AND signal cites G1–G9 violation → `tier:3, action:request-consultant-escalation`.
+2. Else if `severity >= medium` AND (`recurrence >= 2 in 7d` OR `trigger_type == manual-pull`) AND no active session-pivot AND no matching suppression entry → `tier:2, action:request-pivot`.
+3. Else → `tier:1, action:log-only`.
+
+## Authority matrix
+
+| Caller role | Permitted output |
+|---|---|
+| Any | tier:1 (log-only) |
+| Any (router applies thresholds) | tier:2 (request-pivot) — router may downgrade to tier:1 |
+| Consultant only | tier:3 (escalation) — rejected from other roles |
+
+Caller emitting tier:3 outside Consultant role → router returns `action:log-only, kill_switch_trip:authority`.
+
+## Pivot semantics (executed by `role-baton-orchestrator` when router emits `request-pivot`)
+
+1. `snapshot = {role, ticket_ref, baton_phase, last_event_id, timestamp}`
+2. Emit `event:pivot-start` with snapshot.
+3. Assume Manager role; run `workflow-self-anneal` (max 3 doc proposals, max 50 step counter).
+4. File Manager ticket(s) per anneal output to backlog — docs/process only; code routes through standard baton.
+5. Emit `event:pivot-end` with files-created list.
+6. Assert `current_role == snapshot.role`; restore baton to `snapshot.ticket_ref` at `snapshot.baton_phase`.
+
+Kill-switch trip during pivot aborts cleanly; original baton state preserved. Emit `event:kill-switch-trip` with `reason`.
+
+## Kill switches (declarative)
+
+| Switch | Limit | Scope | Trip reason |
+|---|---|---|---|
+| Single-flight | 1 active pivot | per session | `single-flight` |
+| Rate-limit | 3 pivots / 24h | per session | `rate-limit` |
+| Suppression | matches #1220 entry | per pattern_id | `suppression` |
+| Step counter | 50 tool calls | per anneal protocol | `step-counter` |
+| Ticket cap | 5 / 7d | per pattern_id | `ticket-cap` |
+| Authority | non-Consultant tier:3 attempt | per call | `authority` |
+
+## Anti-patterns
+
+- Caller bypassing router and writing tier:2 events directly to `incidents.jsonl` → governance violation; flagged by Tier-1 aggregator workflow (#1313).
+- Multiple parallel pivot requests in one session → first wins; others trip `single-flight`.
+- Tier-3 escalation from a Consultant rubric that scored ≥ threshold → router rejects with `action:log-only`.
+
+## Event schema v2 reference
+
+Defined in Epic #1308 architecture contract; full field-by-field spec in `wiki/concepts/andon-pull-protocol.md`. Router emits events per that schema (`tier`, `trigger_role`, `trigger_type`, `pattern_id`, `severity`, `evidence`, `ticket_ref`, `epic_ref`, `session_id`).
+
+## See also
+
+- `role-baton-orchestrator` — executes the pivot when this router emits `action:request-pivot`
+- `role-consultant-critique` — invokes tier:3 escalation when rubric < threshold
+- `workflow-self-anneal` — bounded protocol run during the pivot
+- `wiki/concepts/distributed-self-anneal.md`, `wiki/concepts/andon-pull-protocol.md` — concept-page details

--- a/.claude/commands/role-baton-orchestrator.md
+++ b/.claude/commands/role-baton-orchestrator.md
@@ -58,7 +58,8 @@ Research tickets skip branch/PR/merge. Baton sequence:
 ## Required references
 
 - `repo-standards-router` for standards/gates.
-- `workflow-self-anneal` only for post-failure/process drift.
+- `anneal-trigger-router` classifies drift signals into tier-1/2/3 routes; when it emits `action:request-pivot`, this orchestrator executes the pivot sequence (snapshot → assume Manager → `workflow-self-anneal` → file Manager tickets → restore baton). Single-flight per session; kill-switch trip aborts cleanly, preserving baton state. See `wiki/concepts/andon-pull-protocol.md`.
+- `workflow-self-anneal` for the bounded protocol run during pivots; standalone use only for post-failure/process drift outside the router.
 - Domain skills for specialized checks (release/docs/security/profile).
 
 ## Consultant rating rubric (quick)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased] — #1310: anneal-trigger-router skill + baton-orchestrator pivot extension (Epic #1308 Workstream A)
+
+### Added
+- `.claude/commands/anneal-trigger-router.md` — new skill that classifies drift signals and trigger phrases (`pull anneal`, `andon`, `drift anneal #N`, `report drift`) into tier-1/2/3 routing decisions. Defines routing-decision JSON shape, classification rules, authority matrix (Consultant-only tier:3), pivot semantics, kill switches (single-flight, rate-limit, suppression, step-counter, ticket-cap, authority), and anti-patterns. Conforms to Epic #1308 architecture contract.
+
+### Changed
+- `.claude/commands/role-baton-orchestrator.md` — Required references section augmented to integrate `anneal-trigger-router` as the mid-flight pivot dispatcher. Specifies the pivot sequence (snapshot → assume Manager → `workflow-self-anneal` → file Manager tickets → restore baton), single-flight rule, and kill-switch-clean-abort behavior.
+
 ## [Unreleased] — #1309: codify three-tier anneal protocol (Epic #1308 Workstream A)
 
 ### Added


### PR DESCRIPTION
## Summary

New skill `anneal-trigger-router` (classifies drift signals into tier-1/2/3 routes per Epic #1308 architecture contract) plus a small extension to `role-baton-orchestrator` integrating the router as the mid-flight pivot dispatcher.

## Files

- `.claude/commands/anneal-trigger-router.md` (new, 84 lines)
- `.claude/commands/role-baton-orchestrator.md` (edit, +2 lines net, 97 total)
- `CHANGELOG.md` — entry

## Test plan

- [x] `npm run lint` — all files ≤100 lines
- [x] `npm run docs:lint` — clean
- [x] drift-lint citation via `docs-drift-maintenance` skill — posted on #1310

## Baton trail

- COLLABORATOR_HANDOFF posted on #1310 by Orla Harper
- ADMIN_HANDOFF posted on #1310 by Orla Reyes
- CONSULTANT_CLOSEOUT posted on #1310 by Orla Vale (rubric 8.4/10, APPROVED for merge)

Previous PR #1321 closed; this is a fresh PR after handoff trail was complete (per evidence-completeness 60s-predate rule).

Refs #1310
Refs Epic #1308