### PR TITLE
feat(governance): Consultant Tier-3 goal-failure escalation #1311

### DIFF
--- a/.claude/commands/role-consultant-critique.md
+++ b/.claude/commands/role-consultant-critique.md
@@ -51,6 +51,16 @@ Consultant MAY reject (revert to Collaborator) **only** when:
 
 **Before rejecting**: Post a comment enumerating exactly which governance rule was violated and which artifact/evidence is missing.
 
+## Tier-3 goal-failure escalation (Epic #1308)
+
+If rubric scores below threshold against any G1–G9 goal, Consultant may invoke Manager for Tier-3 actions via `anneal-trigger-router` (`action:request-consultant-escalation`):
+
+- Reopen failed AC: return ticket to Manager; remove `status:done` if posted in error
+- Reopen failed ticket: invoke Manager baton on original or follow-up issue
+- File new self-anneal Epic: pattern is systemic across multiple tickets
+
+Each emits `event:goal-failure-escalation` with rubric evidence per Epic #1308 schema v2 (`{tier:3, trigger_role:consultant, trigger_type:goal-failure, severity, evidence, ticket_ref, epic_ref}`). Authority: Consultant only; other roles rejected with `kill_switch_trip:authority`.
+
 ## Entry criteria
 
 - `ADMIN_HANDOFF` exists (or explicit N/A with reason).

--- a/.claude/commands/role-consultant-critique.md
+++ b/.claude/commands/role-consultant-critique.md
@@ -54,12 +54,10 @@ Consultant MAY reject (revert to Collaborator) **only** when:
 ## Tier-3 goal-failure escalation (Epic #1308)
 
 If rubric scores below threshold against any G1–G9 goal, Consultant may invoke Manager for Tier-3 actions via `anneal-trigger-router` (`action:request-consultant-escalation`):
-
-- Reopen failed AC: return ticket to Manager; remove `status:done` if posted in error
-- Reopen failed ticket: invoke Manager baton on original or follow-up issue
+- Reopen failed AC or ticket: return to Manager baton; remove `status:done` if posted in error
 - File new self-anneal Epic: pattern is systemic across multiple tickets
 
-Each emits `event:goal-failure-escalation` with rubric evidence per Epic #1308 schema v2 (`{tier:3, trigger_role:consultant, trigger_type:goal-failure, severity, evidence, ticket_ref, epic_ref}`). Authority: Consultant only; other roles rejected with `kill_switch_trip:authority`.
+Each emits `event:goal-failure-escalation` per Epic #1308 schema v2 (`{tier:3, trigger_role:consultant, trigger_type:goal-failure, severity, evidence, ticket_ref, epic_ref}`). Authority: Consultant only; other roles rejected with `kill_switch_trip:authority`.
 
 ## Entry criteria
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — #1311: Consultant goal-failure escalation (Epic #1308 Workstream A)
+
+### Changed
+- `.claude/commands/role-consultant-critique.md` — added "Tier-3 goal-failure escalation (Epic #1308)" section. If rubric scores below threshold against any G1–G9 goal, Consultant may invoke Manager for Tier-3 actions via `anneal-trigger-router`: reopen failed AC, reopen failed ticket, or file new self-anneal Epic. Each emits `event:goal-failure-escalation` per Epic #1308 schema v2. Authority: Consultant only; other roles rejected with `kill_switch_trip:authority`.
+
 ## [Unreleased] — #1310: anneal-trigger-router skill + baton-orchestrator pivot extension (Epic #1308 Workstream A)
 
 ### Added


### PR DESCRIPTION
## Summary

Adds Tier-3 goal-failure escalation authority to `role-consultant-critique` skill per Epic #1308 architecture. When Consultant rubric scores below threshold against any G1–G9 harness goal, Consultant may invoke Manager via `anneal-trigger-router` to reopen failed AC/ticket OR file a new self-anneal Epic for systemic patterns.

## Files

- `.claude/commands/role-consultant-critique.md` (edit, +7 lines net, 99 total) — new "Tier-3 goal-failure escalation (Epic #1308)" section
- `CHANGELOG.md` — entry

## Test plan

- [x] `npm run lint` — 99 lines, within limit
- [x] `npm run docs:lint` — clean
- [x] drift-lint citation via `docs-drift-maintenance` skill (posted on #1311)
- [x] Tier-3 authority + emit-event contract conforms to Epic #1308 schema v2

## Baton trail

- COLLABORATOR_HANDOFF (initial + full) posted on #1311 by Orla Harper
- ADMIN_HANDOFF to be posted by Orla Reyes after CI green
- CONSULTANT_CLOSEOUT to be posted by Orla Vale after merge approval

Refs #1311
Refs Epic #1308