### PR TITLE
docs(governance): anneal_tier field in MANAGER_HANDOFF schema #1312

### DIFF
--- a/.claude/commands/role-manager-execution.md
+++ b/.claude/commands/role-manager-execution.md
@@ -87,4 +87,5 @@ acceptance_criteria:
 required_gates:
 planned_change_surfaces:
 risk_class:
+anneal_tier:    # tier-1|tier-2|tier-3|null — populate when ticket originated from Tier-2 anneal auto-file (Epic #1308); default null
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — #1312: anneal_tier field in MANAGER_HANDOFF schema (Epic #1308 Workstream A)
+
+### Changed
+- `instructions/role-baton-routing.instructions.md` — extended MANAGER_HANDOFF schema with optional `anneal_tier:` field (`tier-1 | tier-2 | tier-3 | null`). Populated when ticket originates from a Tier-2 anneal auto-file event per Epic #1308. Default `null` / omitted for non-anneal tickets. Backward-compatible — existing handoffs without the field remain valid. Soft-default paragraph condensed to single line for line-cap compliance.
+- `.claude/commands/role-manager-execution.md` — added `anneal_tier:` to the Output contract template with inline comment explaining when to populate.
+
 ## [Unreleased] — #1311: Consultant goal-failure escalation (Epic #1308 Workstream A)
 
 ### Changed

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -85,9 +85,9 @@ Required fields on every `MANAGER_HANDOFF` comment:
 - `test_strategy:` — one of `tdd-pyramid | tdd-trophy | contract-test | golden-file | eval-harness | visual-regression | drift-lint | peer-review | manual-verify | none`
 - `acceptance:` — AC checklist
 - `gates:` — CI/governance gates that must pass
+- `anneal_tier:` (optional) — `tier-1 | tier-2 | tier-3 | null`; populate when ticket originated from a Tier-2 anneal auto-file event per Epic #1308. Default `null` / omitted for non-anneal tickets.
 
-`test_strategy` is selected per `instructions/test-methodology-matrix.instructions.md`.
-Soft default: missing field on legacy/pre-rollout tickets is treated as `none` with a Manager-warning advisory comment. New tickets with `none` on a non-permitted lane fail the `test-evidence` gate.
+`test_strategy` selected per `instructions/test-methodology-matrix.instructions.md`; missing on legacy tickets defaults to `none` (advisory). New tickets with `none` on non-permitted lane fail `test-evidence`.
 
 ## Local Override
 


### PR DESCRIPTION
## Summary

Extends the MANAGER_HANDOFF schema with optional `anneal_tier:` field (`tier-1 | tier-2 | tier-3 | null`) per Epic #1308. Provides traceability for tickets originating from Tier-2 anneal auto-file events.

## Files

- `instructions/role-baton-routing.instructions.md` (edit, 100 lines — at cap, condensed soft-default line)
- `.claude/commands/role-manager-execution.md` (edit, 90 lines — added field to Output contract template)
- `CHANGELOG.md` — entry

## Test plan

- [x] `npm run lint` — 386 files within 100-line limit
- [x] Backward compatibility — field is optional; existing handoffs remain valid
- [x] drift-lint citation to be posted on #1312

## Baton trail

- COLLABORATOR_HANDOFF (initial) posted on #1312 by Orla Harper
- Full evidence-bearing handoffs follow

Refs #1312
Refs Epic #1308