### PR TITLE
fix(governance): tighten Epic close-readiness matcher #1306

### DIFF
--- a/.github/workflows/epic-close-readiness.yml
+++ b/.github/workflows/epic-close-readiness.yml
@@ -1,10 +1,20 @@
 name: Epic Close-Readiness Gate
 # Warns and re-opens an epic if closed while children are still open.
-# Implements #452 + #750: detect, diagnose, warn, re-open.
+# Implements #452 + #750. #1306 tightening: task-list-only matcher (no Refs/Epic prose).
+# AC3: label restoration on auto-reopen. AC4: dry-run via workflow_dispatch.
 
 on:
   issues:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Preview only (no comment, no reopen, no label changes)'
+        type: boolean
+        default: true
+      epic_number:
+        description: 'Epic number to check (required for workflow_dispatch)'
+        required: true
 
 permissions:
   issues: write
@@ -14,16 +24,15 @@ jobs:
   epic-close-readiness:
     name: epic-close-readiness
     runs-on: ubuntu-latest
-    # Only run for type:epic issues
     if: >
-      contains(
-        toJson(github.event.issue.labels.*.name),
-        'type:epic'
-      )
+      github.event_name == 'workflow_dispatch'
+      || contains(toJson(github.event.issue.labels.*.name), 'type:epic')
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Check for open children, warn, and publish diagnostics
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] — #1306: tighten Epic close-readiness matcher (task-list-only)
+
+### Changed
+- `scripts/global/epic-close-readiness-check.js` — rewrote matcher to use task-list edges only (`- [ ] #N` / `- [x] #N` in epic body) plus explicit `Parent: #N` / `Parent: URL` refs plus GitHub native `parentIssue` field. Removed prose-matching for `Refs #N`, `Closes #N`, `Epic #N`, and `Parent` mentions in PR-style text. Removed `indirect-via-#N` recursive traversal (was the second-order false-positive amplifier). Live evidence: #1103 was stuck `status:done` + OPEN for 2 days because the old matcher treated sibling Epics #1112/#1113/#1125/#1130/etc. as children via prose/indirect matching.
+- `.github/workflows/epic-close-readiness.yml` — added `workflow_dispatch` trigger with `dry_run` and `epic_number` inputs for preview mode (AC4). DRY_RUN env var propagated to script.
+
+### Added
+- `restoreEpicLabels()` in matcher — AC3: on auto-reopen, removes `status:done` and `resolution:released|completed`; re-applies `status:review`. Was previously a second-order bug (auto-reopen left issue in forbidden `status:done` + open state).
+- `tests/epic-close-readiness.spec.js` — 7 Playwright tests: task-list extraction with mixed checkbox styles, indented/nested lists, prose-mention rejection (#1306 root-cause regression test), `Parent:` text/URL detection, prose-Parent rejection, real #1103-shape body produces zero children, real #1308 body produces all 8 children.
+
 ## [Unreleased] — #1307: fix ADR-010 label-scan Epic exception via shared rule set
 
 ### Added

--- a/scripts/global/epic-close-readiness-check.js
+++ b/scripts/global/epic-close-readiness-check.js
@@ -1,18 +1,33 @@
 'use strict';
+// Epic Close-Readiness Gate logic (#452 / #750 / #1306).
+const ERROR_MSG_MAX = 1500;
+// Matcher uses task-list edges + explicit Parent: refs + GitHub native parentIssue.
+// Replaces #1306-flagged prose/`Refs`/`Epic #N` matching that produced false positives.
 
-function issueRefs(text) {
-  const nums = []; const r = /#(\d+)\b/g;
-  for (let m = r.exec(text || ''); m; m = r.exec(text || '')) nums.push(Number(m[1]));
-  return nums;
+function parseTaskListChildren(epicBody) {
+  const refs = new Set();
+  const lines = (epicBody || '').split('\n');
+  for (const line of lines) {
+    const m = line.match(/^\s*-\s*\[[ xX]\]\s+.*?#(\d+)\b/);
+    if (m) refs.add(Number(m[1]));
+  }
+  return refs;
+}
+
+function parseParentRef(issue, epicNum, owner, repo) {
+  const txt = `${issue.title || ''}\n${issue.body || ''}`;
+  if (new RegExp(`\\bParent:\\s*#${epicNum}\\b`).test(txt)) return 'parent-text';
+  const urlRe = new RegExp(`\\bParent:\\s*https://github\\.com/${owner}/${repo}/issues/${epicNum}\\b`);
+  if (urlRe.test(txt)) return 'parent-url';
+  return null;
 }
 
 async function listOpenIssues(github, owner, repo) {
   let after = null; let parentSupported = true; const nodes = [];
-  const vars = () => ({ owner, repo, after });
-  const q = withParent => `query($owner:String!,$repo:String!,$after:String){repository(owner:$owner,name:$repo){issues(first:100,states:OPEN,after:$after){nodes{number title body labels(first:20){nodes{name}}${withParent ? ' parentIssue{number}' : ''}} pageInfo{hasNextPage endCursor}}}}`;
-  while (true) {
+  const query = (wp) => `query($owner:String!,$repo:String!,$after:String){repository(owner:$owner,name:$repo){issues(first:100,states:OPEN,after:$after){nodes{number title body labels(first:20){nodes{name}}${wp ? ' parentIssue{number}' : ''}} pageInfo{hasNextPage endCursor}}}}`;
+  for (;;) {
     let data;
-    try { data = await github.graphql(q(parentSupported), vars()); }
+    try { data = await github.graphql(query(parentSupported), { owner, repo, after }); }
     catch (e) {
       if (parentSupported && /parentIssue/i.test(String(e.message))) { parentSupported = false; continue; }
       throw e;
@@ -24,56 +39,64 @@ async function listOpenIssues(github, owner, repo) {
   }
 }
 
-function directMatch(issue, epicNum, owner, repo) {
-  const txt = `${issue.title || ''}\n${issue.body || ''}`;
-  const rgx = [
-    new RegExp(`[Cc]loses\\s+#${epicNum}\\b`),
-    new RegExp(`[Rr]efs\\s+#${epicNum}\\b`),
-    new RegExp(`[Pp]arent:\\s*#${epicNum}\\b`),
-    new RegExp(`[Pp]arent:\\s*https://github.com/${owner}/${repo}/issues/${epicNum}\\b`),
-    new RegExp(`[Ee]pic\\s+#${epicNum}\\b`),
-  ];
-  const byText = rgx.some(r => r.test(txt));
-  const byLabel = (issue.labels?.nodes || []).some(l => l.name.toLowerCase() === `epic-${epicNum}`);
-  const byParent = issue.parentIssue?.number === epicNum;
-  return { byText, byLabel, byParent, matched: byText || byLabel || byParent };
+async function restoreEpicLabels(github, owner, repo, epicNum, epic) {
+  const labels = epic.labels.map(label => label.name);
+  const toRemove = [];
+  if (labels.includes('status:done')) toRemove.push('status:done');
+  for (const resolutionLabel of ['resolution:released', 'resolution:completed']) {
+    if (labels.includes(resolutionLabel)) toRemove.push(resolutionLabel);
+  }
+  for (const labelToRemove of toRemove) {
+    await github.rest.issues.removeLabel({ owner, repo, issue_number: epicNum, name: labelToRemove }).catch(() => {});
+  }
+  if (labels.includes('status:done')) {
+    await github.rest.issues.addLabels({ owner, repo, issue_number: epicNum, labels: ['status:review'] }).catch(() => {});
+  }
 }
 
 async function run({ github, context, core }) {
-  const epicNum = context.issue.number; const { owner, repo } = context.repo;
+  const dryRun = process.env.DRY_RUN === 'true';
+  const epicNum = (dryRun && context.payload.inputs?.epic_number)
+    ? Number(context.payload.inputs.epic_number)
+    : context.issue?.number;
+  if (!epicNum) { core.setFailed('No epic number provided.'); return; }
+  const { owner, repo } = context.repo;
   try {
+    const { data: epic } = await github.rest.issues.get({ owner, repo, issue_number: epicNum });
+    const taskList = parseTaskListChildren(epic.body);
     const { nodes, parentSupported } = await listOpenIssues(github, owner, repo);
-    const issues = nodes.filter(i => i.number !== epicNum);
-    const reasons = new Map(); const direct = new Set();
-    for (const i of issues) {
-      const hit = directMatch(i, epicNum, owner, repo); if (!hit.matched) continue;
-      const why = [];
-      if (hit.byText) why.push('text');
-      if (hit.byLabel) why.push('label');
-      if (hit.byParent && parentSupported) why.push('parentIssue');
-      reasons.set(i.number, why.join('+')); direct.add(i.number);
+    const open = [];
+    for (const i of nodes) {
+      if (i.number === epicNum) continue;
+      const inTL = taskList.has(i.number);
+      const isParent = parentSupported && i.parentIssue?.number === epicNum;
+      const pText = parseParentRef(i, epicNum, owner, repo);
+      if (inTL || isParent || pText) {
+        open.push({ number: i.number, title: i.title, why: inTL ? 'task-list' : (isParent ? 'parentIssue' : pText) });
+      }
     }
-    for (const i of issues) {
-      if (direct.has(i.number)) continue;
-      const ref = issueRefs(`${i.title || ''}\n${i.body || ''}`).find(n => direct.has(n));
-      if (!ref) continue;
-      direct.add(i.number); reasons.set(i.number, `indirect-via-#${ref}`);
+    if (!open.length) {
+      if (dryRun) console.log(`Epic #${epicNum}: zero open children. Close is valid.`);
+      return;
     }
-    const openChildren = issues.filter(i => direct.has(i.number));
-    if (!openChildren.length) return;
-    const lines = openChildren.map(i => `- #${i.number}: ${i.title} _(match: ${reasons.get(i.number)})_`).join('\n');
-    const body = `## Epic Close-Readiness Violation\n\nOpen child issues detected for epic #${epicNum}:\n\n${lines}\n\nParent field support: ${parentSupported ? 'enabled' : 'not available in this API context'}\n\n_Auto-reopened by Epic Close-Readiness Gate._`;
+    const lines = open.map(c => `- #${c.number}: ${c.title} _(match: ${c.why})_`).join('\n');
+    const body = `## Epic Close-Readiness Violation\n\nOpen child issues detected for epic #${epicNum}:\n\n${lines}\n\nParent field support: ${parentSupported ? 'enabled' : 'not available in this API context'}\n\n_Auto-reopened by Epic Close-Readiness Gate (task-list-only matcher, ${open.length} child${open.length === 1 ? '' : 'ren'})._\n\n**Status restoration**: \`status:done\` and \`resolution:*\` labels removed; \`status:review\` re-applied.`;
+    if (dryRun) {
+      console.log(`DRY RUN — would reopen #${epicNum} with ${open.length} children:\n${body}`);
+      return;
+    }
     await github.rest.issues.createComment({ owner, repo, issue_number: epicNum, body });
     await github.rest.issues.update({ owner, repo, issue_number: epicNum, state: 'open' });
-    core.setFailed(`Epic #${epicNum} re-opened: ${openChildren.length} open child(ren).`);
+    await restoreEpicLabels(github, owner, repo, epicNum, epic);
+    core.setFailed(`Epic #${epicNum} re-opened: ${open.length} open child(ren).`);
   } catch (error) {
-    const msg = String(error.message || error).slice(0, 1500);
+    const msg = String(error.message || error).slice(0, ERROR_MSG_MAX);
     await github.rest.issues.createComment({
       owner, repo, issue_number: epicNum,
-      body: `## Epic Close-Readiness Diagnostic Failure\n\nValidation failed due to API/runtime error:\n\n\`${msg}\`\n\nPlease re-run workflow after resolving token/permission/rate-limit issues.`
+      body: `## Epic Close-Readiness Diagnostic Failure\n\nValidation failed: \`${msg}\``
     }).catch(() => {});
     core.setFailed(`Close-readiness diagnostic failed: ${msg}`);
   }
 }
 
-module.exports = { run };
+module.exports = { run, parseTaskListChildren, parseParentRef, restoreEpicLabels };

--- a/scripts/global/label-rules.js
+++ b/scripts/global/label-rules.js
@@ -17,66 +17,66 @@ function evaluate(issue) {
   const laneLabels = labels.filter(l => l.startsWith('lane:'));
   const areaLabels = labels.filter(l => l.startsWith('area:'));
   const isEpic = labels.includes('type:epic');
-  const v = [];
+  const violations = [];
 
-  if (statusLabels.length === 0) v.push('Rule 1: missing status: label');
-  else if (statusLabels.length > 1) v.push(`Rule 1: multiple status labels (${statusLabels.join(', ')})`);
-  if (roleLabels.length > 1) v.push(`Rule 2: multiple role labels (${roleLabels.join(', ')})`);
-  if (areaLabels.length === 0) v.push('Rule 6: missing area: label');
-  else if (areaLabels.length > 1) v.push(`Rule 6: multiple area labels (${areaLabels.join(', ')})`);
+  if (statusLabels.length === 0) violations.push('Rule 1: missing status: label');
+  else if (statusLabels.length > 1) violations.push(`Rule 1: multiple status labels (${statusLabels.join(', ')})`);
+  if (roleLabels.length > 1) violations.push(`Rule 2: multiple role labels (${roleLabels.join(', ')})`);
+  if (areaLabels.length === 0) violations.push('Rule 6: missing area: label');
+  else if (areaLabels.length > 1) violations.push(`Rule 6: multiple area labels (${areaLabels.join(', ')})`);
 
   if (state === 'closed') {
     const nonArchive = roleLabels.filter(r => r !== 'role:archived');
     if (nonArchive.length > 0) {
-      v.push(`Rule 7: closed issue retains role labels (${nonArchive.join(', ')})`);
+      violations.push(`Rule 7: closed issue retains role labels (${nonArchive.join(', ')})`);
     }
     if (!statusLabels.some(s => s === 'status:done' || s === 'status:cancelled')) {
-      v.push('Rule 7b: closed issue must have status:done or status:cancelled');
+      violations.push('Rule 7b: closed issue must have status:done or status:cancelled');
     }
   }
 
   if (isEpic) {
     if (statusLabels.includes('status:backlog') && !roleLabels.includes('role:manager')) {
-      v.push('Rule E2: Epic at status:backlog requires role:manager');
+      violations.push('Rule E2: Epic at status:backlog requires role:manager');
     }
     if (statusLabels.includes('status:in-progress') && !roleLabels.includes('role:manager')) {
-      v.push('Rule E3: Epic at status:in-progress requires role:manager');
+      violations.push('Rule E3: Epic at status:in-progress requires role:manager');
     }
     if (statusLabels.includes('status:ready')) {
-      v.push('Rule 9: Epic cannot be at status:ready (child tickets only)');
+      violations.push('Rule 9: Epic cannot be at status:ready (child tickets only)');
     }
     for (const epicState of EPIC_ONLY_STATES) {
       if (statusLabels.includes(epicState) && !roleLabels.includes('role:manager')) {
-        v.push(`Rule E5: Epic at ${epicState} requires role:manager`);
+        violations.push(`Rule E5: Epic at ${epicState} requires role:manager`);
       }
     }
   } else {
     if (statusLabels.includes('status:backlog') && roleLabels.length > 0) {
-      v.push(`Rule 4: status:backlog child must not have role label (${roleLabels.join(', ')})`);
+      violations.push(`Rule 4: status:backlog child must not have role label (${roleLabels.join(', ')})`);
     }
     if (statusLabels.includes('status:done') && roleLabels.length > 0) {
-      v.push(`Rule 3: status:done must not have role label (${roleLabels.join(', ')})`);
+      violations.push(`Rule 3: status:done must not have role label (${roleLabels.join(', ')})`);
     }
     for (const [status, required] of Object.entries(STATUS_ROLE_REQUIRED)) {
       if (statusLabels.includes(status) && !roleLabels.includes(required)) {
-        v.push(`Rule 8: ${status} requires ${required}`);
+        violations.push(`Rule 8: ${status} requires ${required}`);
       }
     }
     for (const epicState of EPIC_ONLY_STATES) {
       if (statusLabels.includes(epicState)) {
-        v.push(`Rule E5: ${epicState} is Epic-only (non-Epic tickets cannot use it)`);
+        violations.push(`Rule E5: ${epicState} is Epic-only (non-Epic tickets cannot use it)`);
       }
     }
   }
 
   if (statusLabels.includes('status:triage') && !roleLabels.includes('role:manager')) {
-    v.push('Rule 5: status:triage requires role:manager');
+    violations.push('Rule 5: status:triage requires role:manager');
   }
   if (statusLabels.includes('status:ready') && laneLabels.length !== 1) {
-    v.push('Rule 10: status:ready requires exactly one lane label');
+    violations.push('Rule 10: status:ready requires exactly one lane label');
   }
 
-  return v;
+  return violations;
 }
 
 module.exports = { evaluate, STATUS_ROLE_REQUIRED, EPIC_ONLY_STATES };

--- a/tests/epic-close-readiness.spec.js
+++ b/tests/epic-close-readiness.spec.js
@@ -1,0 +1,91 @@
+// Epic Close-Readiness matcher tests (#1306).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const C = require(path.resolve(__dirname, '..', 'scripts', 'global', 'epic-close-readiness-check.js'));
+
+test('parseTaskListChildren extracts task-list-formatted refs only', () => {
+  const body = `
+- [ ] #1287 — open child
+- [x] #1288 — closed child
+- [X] #1289 — capital-X variant
+not a list line: #9999
+- not a checkbox: #8888
+`;
+  const refs = C.parseTaskListChildren(body);
+  expect(refs.has(1287)).toBe(true);
+  expect(refs.has(1288)).toBe(true);
+  expect(refs.has(1289)).toBe(true);
+  expect(refs.has(9999)).toBe(false);
+  expect(refs.has(8888)).toBe(false);
+});
+
+test('parseTaskListChildren ignores prose Refs/Closes/Epic mentions (#1306 root-cause regression)', () => {
+  const body = `## Body with prose mentions
+This Epic relates to Refs #1271, Epic #1308, Closes #500, and mentions #1112 in passing.
+Companion: #1111`;
+  const refs = C.parseTaskListChildren(body);
+  expect(refs.size).toBe(0);
+});
+
+test('parseTaskListChildren handles indented + nested checkboxes', () => {
+  const body = `
+- [ ] #100 — top-level
+  - [ ] #101 — nested
+    - [x] #102 — deeply nested
+`;
+  const refs = C.parseTaskListChildren(body);
+  expect(refs.has(100)).toBe(true);
+  expect(refs.has(101)).toBe(true);
+  expect(refs.has(102)).toBe(true);
+});
+
+test('parseParentRef detects explicit Parent: text and URL', () => {
+  expect(C.parseParentRef({ body: 'Parent: #1308' }, 1308, 'o', 'r')).toBe('parent-text');
+  expect(C.parseParentRef({ body: 'Parent: https://github.com/o/r/issues/1308' }, 1308, 'o', 'r')).toBe('parent-url');
+});
+
+test('parseParentRef rejects Refs/Epic/Closes prose for parent matching', () => {
+  expect(C.parseParentRef({ body: 'Refs #1308' }, 1308, 'o', 'r')).toBeNull();
+  expect(C.parseParentRef({ body: 'Epic #1308 progress' }, 1308, 'o', 'r')).toBeNull();
+  expect(C.parseParentRef({ body: 'Closes #1308' }, 1308, 'o', 'r')).toBeNull();
+});
+
+test('Real #1103-shape body: prose mentions of #1112/#1113/etc. produce ZERO task-list children', () => {
+  // Synthesizes the #1103 body shape that previously generated false positives.
+  // Real #1103 had children #1115-#1124 in task-list; mentioned #1112/#1113/#1130 only in prose.
+  const body = `## Summary
+Harden goals across instructions.
+
+## Initial Planned Work (Phase 0 only)
+- [ ] Child R&D ticket: #1105 — planning package.
+
+## Companion ticket
+#1111 (Allow parallel writes)
+
+## Sibling Epic
+Refs #1112, Epic #1113 was filed as a sibling.
+
+## Out of Scope
+- Anything related to #1130 (separate Epic)`;
+  const refs = C.parseTaskListChildren(body);
+  expect([...refs]).toEqual([1105]); // Only the task-list child
+});
+
+test('parseTaskListChildren handles complete real #1308 body (8 children)', () => {
+  const body = `
+### Workstream A — CC Team
+- [x] #1309 — done
+- [x] #1310 — done
+- [x] #1311 — done
+- [x] #1312 — done
+
+### Workstream B — CP Team
+- [x] #1313 — done
+- [x] #1314 — done
+- [x] #1315 — done
+- [x] #1316 — done
+
+Refs Epic #999 (sibling)`;
+  const refs = C.parseTaskListChildren(body);
+  expect([...refs].sort()).toEqual([1309, 1310, 1311, 1312, 1313, 1314, 1315, 1316]);
+});


### PR DESCRIPTION
## Summary

Replaces the prose/`Refs #N`/`Epic #N` matching + `indirect-via-#N` traversal in `epic-close-readiness-check.js` with a strict task-list-only matcher (+ explicit `Parent:` refs + GitHub native `parentIssue`). Live evidence the bug was real: #1103 was stuck in forbidden `status:done` + OPEN for 2 days due to the old matcher flagging sibling Epics #1112/#1113/#1125/#1130/etc. as children.

## Files

- `scripts/global/epic-close-readiness-check.js` (rewrite) — exports `parseTaskListChildren`, `parseParentRef`, `restoreEpicLabels`, `run`
- `.github/workflows/epic-close-readiness.yml` (edit) — adds `workflow_dispatch` with `dry_run` + `epic_number` inputs
- `tests/epic-close-readiness.spec.js` (new, 7 tests)
- `CHANGELOG.md` — entry

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run lint:readability:ci` — 416 ≤ 420 warnings (down from 421)
- [x] `npx playwright test tests/epic-close-readiness.spec.js` — 7 passed

## Baton trail (on linked issue #1306)

- MANAGER_HANDOFF (retroactive), COLLABORATOR_HANDOFF + drift-lint-equiv test evidence, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT to follow

Refs #1306