### PR TITLE
fix(anneal): remediate persistence and queue runtime wiring (#1330)

### DIFF
--- a/.github/workflows/anneal-tier2-autofile.yml
+++ b/.github/workflows/anneal-tier2-autofile.yml
@@ -9,8 +9,33 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  tier1-prep:
+    name: tier1-prep
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json', 'npm-shrinkwrap.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
+      - run: npm ci
+      - name: Tier1 dry-run fixture
+        run: node scripts/global/anneal-tier1-aggregator.js --dry-run --out anneal-tier1.json
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+        with:
+          name: anneal-tier1-fixture
+          path: anneal-tier1.json
+
   tier2:
     name: tier2-autofile
+    needs: [tier1-prep]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -27,9 +52,12 @@ jobs:
           restore-keys: |
             npm-${{ runner.os }}-
       - run: npm ci
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v5
+        with:
+          name: anneal-tier1-fixture
       - name: Tier2 classifier fixture tests
         run: node scripts/global/anneal-tier2-autofile.spec.js
       - name: Tier2 autofile run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/global/anneal-tier2-autofile.js --apply
+        run: node scripts/global/anneal-tier2-autofile.js --apply --fixture anneal-tier1.json

--- a/dashboard/api/anneal-queue-handlers.js
+++ b/dashboard/api/anneal-queue-handlers.js
@@ -7,11 +7,16 @@ const path = require('node:path');
 
 const INCIDENTS = path.join(os.homedir(), '.megingjord', 'incidents.jsonl');
 
+function isAnnealQueueEvent(event) {
+  const tier = Number(event.tier || '0');
+  return String(event.epic_ref || '') === '#1308' && [1, 2, 3].includes(tier);
+}
+
 function readAnnealEvents() {
   if (!fs.existsSync(INCIDENTS)) return [];
   return fs.readFileSync(INCIDENTS, 'utf8').split('\n').filter(Boolean).map((line) => {
     try { return JSON.parse(line); } catch { return null; }
-  }).filter(Boolean).filter((event) => String(event.epic_ref || '') === '#1308' || Number(event.tier || '0') > Number('0'));
+  }).filter(Boolean).filter(isAnnealQueueEvent);
 }
 
 function handleAnnealQueue(_request, response) {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Megingjord — Fleet Operations Center</title>
-    <link rel="stylesheet" href="css/app.css"><link rel="stylesheet" href="css/stats.css"><link rel="stylesheet" href="css/router.css"><link rel="stylesheet" href="css/config.css"><link rel="stylesheet" href="css/views.css"><link rel="stylesheet" href="css/topology.css">
+    <link rel="stylesheet" href="css/app.css"><link rel="stylesheet" href="css/stats.css"><link rel="stylesheet" href="css/router.css"><link rel="stylesheet" href="css/config.css"><link rel="stylesheet" href="css/views.css"><link rel="stylesheet" href="css/topology.css"><link rel="stylesheet" href="css/anneal-queue.css">
     <link rel="stylesheet" href="css/baton.css"><link rel="stylesheet" href="css/ticket-log.css"><link rel="stylesheet" href="css/activity.css"><link rel="stylesheet" href="css/wiki.css"><link rel="stylesheet" href="css/wiki-metrics.css"><link rel="stylesheet" href="css/fleet-health.css"><link rel="stylesheet" href="css/governance.css"><link rel="stylesheet" href="css/context.css"><link rel="stylesheet" href="css/github.css"><link rel="stylesheet" href="css/settings.css"><link rel="stylesheet" href="css/agents.css">
     <script defer src="js/alpine.min.js"></script>
     <script src="js/health-check.js"></script><script src="js/quota-tracker.js"></script>
@@ -21,7 +21,7 @@
     <script src="js/governance-panel.js"></script><script src="js/ticket-log.js"></script>
     <script src="js/tooltips.js"></script><script src="js/app-actions.js"></script>
     <script src="js/credential-store.js"></script><script src="js/provider-presets.js"></script><script src="js/fleet-probe.js"></script><script src="js/settings-panel.js"></script><script src="js/settings-form.js"></script><script src="js/settings-actions.js"></script>
-    <script src="js/event-source.js"></script><script src="js/context-flow-events.js"></script><script src="js/token-telemetry.js"></script><script src="js/quality-parity.js"></script><script src="js/goal-health.js"></script><script src="js/token-reconcile.js"></script><script src="js/cost-monitor.js"></script><script src="js/multi-agent-sessions.js"></script><script src="js/tier-c-banner.js"></script><script src="js/agent-inventory.js"></script><script src="js/app.js"></script>
+    <script src="js/event-source.js"></script><script src="js/context-flow-events.js"></script><script src="js/token-telemetry.js"></script><script src="js/quality-parity.js"></script><script src="js/goal-health.js"></script><script src="js/token-reconcile.js"></script><script src="js/cost-monitor.js"></script><script src="js/multi-agent-sessions.js"></script><script src="js/tier-c-banner.js"></script><script src="js/agent-inventory.js"></script><script src="js/anneal-queue-panel.js"></script><script src="js/app.js"></script>
 </head>
 <body x-cloak x-data="dashboardApp()" x-init="init()">
     <a href="#main-content" class="skip-link">Skip to content</a>
@@ -71,7 +71,7 @@
         <section id="panel-goal-health" class="panel" x-show="isView('ops')">
             <h2>🎯 Goal Health <button class="shb" data-tip="goal-health" aria-label="Help: Goal Health">?</button><span class="panel-ts" x-text="panelTs.goals ? '⟳ '+panelTs.goals : ''"></span></h2><div x-html="renderGoalHealthPanel(goalHealth)"></div></section>
         <section id="panel-llm-context" class="panel" x-show="isView('ops')">
-            <h2>📐 LLM Context <button class="shb" data-tip="llm-context" aria-label="Help: LLM">?</button></h2><div x-html="renderLLMContext()"></div></section>
+            <h2>📐 LLM Context <button class="shb" data-tip="llm-context" aria-label="Help: LLM">?</button></h2><div x-html="renderLLMContext()"></div></section><section id="panel-anneal-queue" class="panel" x-show="isView('ops')"><h2>🧵 Anneal Queue <button class="shb" data-tip="governance" aria-label="Help: Anneal Queue">?</button></h2><div id="anneal-queue-target" x-init="if(typeof registerAnnealQueuePanel==='function'){registerAnnealQueuePanel($el)}"></div></section>
 
         <!-- FLEET: 6 panels (inventory + config + health) -->
         <template x-if="isView('fleet')"><section id="panel-fleet-health" class="panel">

--- a/scripts/dashboard-server.js
+++ b/scripts/dashboard-server.js
@@ -63,7 +63,7 @@ async function handleApi(req, res) {
     return jsonRes(res, usageResponse.status, usageResponse.body);
   }
   if (requestUrl === '/api/router/metrics') { try { const { getRouterMetrics } = require('./global/router-metrics'); return jsonRes(res,200,getRouterMetrics()); } catch(e){ return jsonRes(res,200,{timestamp:new Date().toISOString(),lanes:{free:0,fleet:0,premium:0}}); } }
-  if (requestUrl === '/api/wiki-health') { return jsonRes(res, 200, getWikiHealth()); }
+  if (requestUrl === '/api/anneal/queue') return require('../dashboard/api/anneal-queue-handlers').handleAnnealQueue(req, res); if (requestUrl === '/api/wiki-health') { return jsonRes(res, 200, getWikiHealth()); }
   if (requestUrl === '/api/wiki-pages') { return jsonRes(res, 200, getWikiPages()); }
   if (requestUrl === '/api/wiki-metrics') { const wikiHealth = getWikiHealth(); return jsonRes(res, 200, getWikiMetrics(wikiHealth)); }
   if (requestUrl.startsWith('/api/wiki-access')) {

--- a/scripts/global/anneal-tier1-aggregator.js
+++ b/scripts/global/anneal-tier1-aggregator.js
@@ -50,9 +50,14 @@ function sensorEvents(sensors, timestamp, sessionId) {
   }));
 }
 
+function buildEventKey(item) {
+  const evidence = Array.isArray(item.evidence) ? item.evidence.join('||') : '';
+  return [item.pattern_id || '', item.timestamp || '', item.trigger_type || '', item.severity || '', evidence].join('|');
+}
+
 function dedupe(newEvents, filePath) {
-  const prior = new Set(readEvents(filePath).map((item) => `${item.pattern_id}|${item.timestamp}`));
-  return newEvents.filter((item) => !prior.has(`${item.pattern_id}|${item.timestamp}`));
+  const prior = new Set(readEvents(filePath).map(buildEventKey));
+  return newEvents.filter((item) => !prior.has(buildEventKey(item)));
 }
 
 function run(argv) {

--- a/scripts/global/anneal-tier2-autofile.js
+++ b/scripts/global/anneal-tier2-autofile.js
@@ -4,7 +4,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
-const { execSync } = require('node:child_process');
+const { execFileSync } = require('node:child_process');
 const { classifyTier1 } = require('./anneal-severity-classifier');
 const { stepGate, patternRateGate, singleFlightGate, releaseSingleFlight } = require('./anneal-kill-switch');
 const { emitEvent, readEvents } = require('./anneal-event-schema');
@@ -38,8 +38,10 @@ function emitKillSwitch(reason, patternId, sessionId, timestamp) {
 function maybeCreateTicket(candidate, applyFlag) {
   const body = `MANAGER_HANDOFF\nanneal_tier: tier-2\npattern_id: ${candidate.pattern_id}\nseverity: ${candidate.severity}\ncount_7d: ${candidate.count}`;
   if (!applyFlag) return 'DRY-RUN';
-  const cmd = `gh issue create --title "Anneal Tier-2: ${candidate.pattern_id}" --label type:task --label priority:P1 --label area:scripts --label lane:code-change --body "${body}"`;
-  return execSync(cmd, { encoding: 'utf8' }).trim();
+  const args = ['issue', 'create', '--title', `Anneal Tier-2: ${candidate.pattern_id}`,
+    '--label', 'type:task', '--label', 'priority:P1', '--label', 'area:scripts',
+    '--label', 'lane:code-change', '--body', body];
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
 }
 
 function run(argv) {
@@ -53,18 +55,21 @@ function run(argv) {
   const flight = singleFlightGate(sessionId); if (!flight.ok) return emitKillSwitch(flight.reason, '', sessionId, nowIso);
   const candidates = buildCandidates(tier1).filter((item) => !isSuppressed(item.pattern_id, nowIso));
   const out = [];
-  for (const candidate of candidates) {
-    if (!stepGate(out.length + Number('1')).ok) { emitKillSwitch('step-counter', candidate.pattern_id, sessionId, nowIso); break; }
-    const gate = patternRateGate(tier2, candidate.pattern_id, Date.parse(nowIso));
-    if (!gate.ok) { emitKillSwitch(gate.reason, candidate.pattern_id, sessionId, nowIso); continue; }
-    const ticketRef = maybeCreateTicket(candidate, applyFlag);
-    emitEvent({ version: TWO, timestamp: nowIso, tier: TWO, trigger_role: 'system', trigger_type: 'sensor-driven',
-      pattern_id: candidate.pattern_id, severity: candidate.severity, evidence: [`count=${candidate.count}`],
-      ticket_ref: ticketRef, epic_ref: '#1308', session_id: sessionId,
-      schema_compat: 'v1-readers-must-ignore-fields-not-in-v1' }, INCIDENTS);
-    out.push({ pattern_id: candidate.pattern_id, severity: candidate.severity, ticket_ref: ticketRef });
+  try {
+    for (const candidate of candidates) {
+      if (!stepGate(out.length + Number('1')).ok) { emitKillSwitch('step-counter', candidate.pattern_id, sessionId, nowIso); break; }
+      const gate = patternRateGate(tier2, candidate.pattern_id, Date.parse(nowIso));
+      if (!gate.ok) { emitKillSwitch(gate.reason, candidate.pattern_id, sessionId, nowIso); continue; }
+      const ticketRef = maybeCreateTicket(candidate, applyFlag);
+      emitEvent({ version: TWO, timestamp: nowIso, tier: TWO, trigger_role: 'system', trigger_type: 'sensor-driven',
+        pattern_id: candidate.pattern_id, severity: candidate.severity, evidence: [`count=${candidate.count}`],
+        ticket_ref: ticketRef, epic_ref: '#1308', session_id: sessionId,
+        schema_compat: 'v1-readers-must-ignore-fields-not-in-v1' }, INCIDENTS);
+      out.push({ pattern_id: candidate.pattern_id, severity: candidate.severity, ticket_ref: ticketRef });
+    }
+  } finally {
+    releaseSingleFlight();
   }
-  releaseSingleFlight();
   process.stdout.write(JSON.stringify({ created: out.length, records: out }, null, TWO) + '\n');
 }
 

--- a/scripts/global/dashboard-api.js
+++ b/scripts/global/dashboard-api.js
@@ -63,6 +63,10 @@ async function handleApi(req, res, copilotHome) {
     const r = await proxyGet('https://openrouter.ai/api/v1/auth/key', { Authorization: `Bearer ${key}` });
     return jsonRes(res, r.status, r.body);
   }
+  if (u === '/api/anneal/queue') {
+    const handler = require(path.join(process.cwd(), 'dashboard', 'api', 'anneal-queue-handlers.js'));
+    return handler.handleAnnealQueue(req, res);
+  }
   if (u === '/api/host-info') return jsonRes(res, 200, getHostInfo());
   if (u === '/api/governance') {
     try {


### PR DESCRIPTION
## Summary\n- add artifact-based Tier1 -> Tier2 handoff inside Tier2 workflow to avoid runner-local persistence assumptions\n- harden Tier2 ticket creation by using argument-safe process invocation and guarantee lock cleanup\n- tighten Tier1 dedupe key and queue API event filter semantics\n- wire anneal queue API + panel assets into dashboard runtime\n\n## Validation\n- node scripts/global/anneal-event-schema.spec.js\n- node scripts/global/anneal-tier1-aggregator.spec.js\n- node scripts/global/anneal-tier2-autofile.spec.js\n- npm run lint\n\n## Governance\n- Refs #1330\n- Refs Epic #1308\n- [skip-doc-gate]