### PR TITLE
feat(governance): unified event schema v3 + backward-compat shim #1353

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased] — #1353: unified event schema v3 + backward-compat shim (Epic #1339 C2)
+
+### Added
+- `scripts/global/event-schema-v3.js` — unified v3 schema generalizing the anneal v2 precedent to all `*.jsonl` logging surfaces. Required fields: `ts`, `version`, `service`, `env`, `event`, plus recommended `trace_id`/`session_id` and optional `_summary` (≤200 chars). OpenTelemetry GenAI `gen_ai.*` namespace detection via `isOtelGenAI()` per R&D Thread 1.
+- `tests/event-schema-v3.spec.js` — 10 contract tests covering: detectVersion, v3 validation, env enum, _summary length, v1 upgrade with field preservation, v2 anneal upgrade preserving tier/trigger_role/severity, normalize identity, OTel detection, emit+read round-trip, mixed v1/v2/v3 feed normalization, invalid-event throw.
+
+### Changed
+- Backward compatibility: v1 events (no `version` field) and v2 anneal events (`version: 2`) upgrade-on-read to v3 with surface context. Existing v1/v2 readers (`anneal-goal-sensor.js`, `anneal-review.js`) continue to work unchanged since v3 preserves all prior fields additively.
+
 ## [Unreleased] — #1352: harness + HAMR logging surface inventory (Epic #1339 C1)
 
 ### Added

--- a/scripts/global/event-schema-v3.js
+++ b/scripts/global/event-schema-v3.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// event-schema-v3.js — Unified event schema v3 for all *.jsonl logging surfaces.
+// Epic #1339 / #1353. Foundation for harness + HAMR observability.
+//
+// V3 generalizes the anneal v2 schema (scripts/global/anneal-event-schema.js)
+// to cover ALL logging surfaces: incidents.jsonl, cache-stats.jsonl,
+// events.jsonl, and future surfaces. Includes OpenTelemetry GenAI namespace
+// support per R&D Thread 1.
+//
+// Backward-compat: v1 (no version) and v2 anneal events upgrade-on-read. v1/v2
+// readers ignore unknown v3 fields.
+'use strict';
+
+const V3 = 3;
+const V3_REQUIRED = ['ts', 'version', 'service', 'env', 'event'];
+const V3_RECOMMENDED = ['trace_id', 'session_id'];
+const VALID_ENVS = ['local', 'ci', 'cloudflare', 'test'];
+const SUMMARY_MAX = 200;
+const OTEL_GENAI_PREFIX = 'gen_ai.';
+
+const V2_ANNEAL_FIELDS = ['tier', 'trigger_role', 'trigger_type', 'pattern_id',
+  'severity', 'evidence', 'ticket_ref', 'epic_ref'];
+
+function detectVersion(event) {
+  if (!event || typeof event !== 'object') return 0;
+  if (event.version === undefined) return 1;
+  return event.version;
+}
+
+function isValidV3(event) {
+  const errors = [];
+  if (!event || typeof event !== 'object') {
+    return { ok: false, errors: ['event must be an object'] };
+  }
+  if (event.version !== V3) errors.push(`version must be ${V3}`);
+  for (const field of V3_REQUIRED) {
+    if (event[field] === undefined) errors.push(`missing required v3 field: ${field}`);
+  }
+  if (event.env !== undefined && !VALID_ENVS.includes(event.env)) {
+    errors.push(`env must be one of ${VALID_ENVS.join('|')}`);
+  }
+  if (event._summary !== undefined) {
+    if (typeof event._summary !== 'string') errors.push('_summary must be a string');
+    else if (event._summary.length > SUMMARY_MAX) {
+      errors.push(`_summary exceeds ${SUMMARY_MAX} chars`);
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+function upgradeToV3(event, surfaceContext = {}) {
+  const ver = detectVersion(event);
+  const ts = event.ts || event.timestamp || new Date().toISOString();
+  const base = {
+    version: V3,
+    ts,
+    service: surfaceContext.service || event.service || 'unknown',
+    env: surfaceContext.env || event.env || 'local',
+    event: surfaceContext.event || event.event || 'legacy',
+    trace_id: event.trace_id || event.session_id || null,
+    session_id: event.session_id || 'legacy',
+    surface: surfaceContext.surface || event.surface || null,
+  };
+  // Preserve v2 anneal fields if present (additive)
+  if (ver === 2) {
+    for (const f of V2_ANNEAL_FIELDS) {
+      if (event[f] !== undefined) base[f] = event[f];
+    }
+  }
+  // Preserve all v1 fields too (consumer compat)
+  return Object.assign({}, event, base, { version: V3 });
+}
+
+function normalize(event, surfaceContext = {}) {
+  if (detectVersion(event) === V3) return event;
+  return upgradeToV3(event, surfaceContext);
+}
+
+function isOtelGenAI(event) {
+  if (!event || typeof event !== 'object') return false;
+  return Object.keys(event).some(k => k.startsWith(OTEL_GENAI_PREFIX));
+}
+
+function emitV3(event, file) {
+  const { ok, errors } = isValidV3(event);
+  if (!ok) throw new Error(`Invalid v3 event: ${errors.join('; ')}`);
+  const fs = require('fs');
+  const path = require('path');
+  const dir = path.dirname(file);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(file, JSON.stringify(event) + '\n', 'utf8');
+}
+
+function readEvents(file, surfaceContext = {}) {
+  const fs = require('fs');
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, 'utf8')
+    .split('\n').filter(Boolean)
+    .map(line => { try { return JSON.parse(line); } catch { return null; } })
+    .filter(Boolean)
+    .map(ev => normalize(ev, surfaceContext));
+}
+
+module.exports = {
+  V3, V3_REQUIRED, V3_RECOMMENDED, VALID_ENVS, SUMMARY_MAX, OTEL_GENAI_PREFIX,
+  V2_ANNEAL_FIELDS,
+  detectVersion, isValidV3, upgradeToV3, normalize, isOtelGenAI,
+  emitV3, readEvents,
+};

--- a/tests/event-schema-v3.spec.js
+++ b/tests/event-schema-v3.spec.js
@@ -1,0 +1,93 @@
+// Event schema v3 — contract tests (#1353, Epic #1339 C2).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const S = require(path.resolve(__dirname, '..', 'scripts', 'global', 'event-schema-v3.js'));
+
+const minimalV3 = () => ({
+  version: 3, ts: '2026-05-11T18:00:00.000Z', service: 'test',
+  env: 'test', event: 'unit', trace_id: 'trace-1', session_id: 'session-1',
+});
+const tmpfile = (suffix) => path.join(os.tmpdir(), `event-schema-v3-${suffix}-${Date.now()}.jsonl`);
+
+test('detectVersion: handles v1 (no version), v2, v3', () => {
+  expect(S.detectVersion({ timestamp: 't' })).toBe(1);
+  expect(S.detectVersion({ version: 2 })).toBe(2);
+  expect(S.detectVersion({ version: 3 })).toBe(3);
+});
+
+test('isValidV3: minimal valid passes; missing required fails', () => {
+  expect(S.isValidV3(minimalV3()).ok).toBe(true);
+  const e = minimalV3(); delete e.service;
+  const r = S.isValidV3(e);
+  expect(r.ok).toBe(false);
+  expect(r.errors.some(x => x.includes('service'))).toBe(true);
+});
+
+test('isValidV3: env enum + _summary length enforced', () => {
+  const e = minimalV3(); e.env = 'production';
+  expect(S.isValidV3(e).errors.some(x => x.includes('env'))).toBe(true);
+  e.env = 'test'; e._summary = 'x'.repeat(201);
+  expect(S.isValidV3(e).errors.some(x => x.includes('_summary'))).toBe(true);
+});
+
+test('upgradeToV3: v1 event upgrades with defaults; preserves v1 fields', () => {
+  const v1 = { timestamp: '2026-05-11T00:00:00.000Z', pattern_id: 'p-1' };
+  const v3 = S.upgradeToV3(v1, { service: 'sensor', event: 'detect' });
+  expect(v3.version).toBe(3);
+  expect(v3.ts).toBe('2026-05-11T00:00:00.000Z');
+  expect(v3.service).toBe('sensor');
+  expect(v3.pattern_id).toBe('p-1');
+});
+
+test('upgradeToV3: v2 anneal preserves tier/trigger_role/severity', () => {
+  const v2 = {
+    version: 2, timestamp: '2026-05-11T00:00:00.000Z',
+    tier: 2, trigger_role: 'collaborator', trigger_type: 'manual-pull',
+    severity: 'high', pattern_id: 'p-x',
+  };
+  const v3 = S.upgradeToV3(v2, { service: 'anneal', event: 'pivot-start' });
+  expect(v3.version).toBe(3);
+  expect(v3.tier).toBe(2);
+  expect(v3.trigger_role).toBe('collaborator');
+  expect(v3.severity).toBe('high');
+});
+
+test('normalize: v3 passes through unchanged', () => {
+  const v3 = minimalV3();
+  expect(S.normalize(v3)).toBe(v3);
+});
+
+test('isOtelGenAI: gen_ai.* attributes detected, otherwise false', () => {
+  expect(S.isOtelGenAI({ ...minimalV3(), 'gen_ai.system': 'anthropic' })).toBe(true);
+  expect(S.isOtelGenAI(minimalV3())).toBe(false);
+});
+
+test('emitV3 + readEvents round-trip', () => {
+  const f = tmpfile('rt');
+  S.emitV3(minimalV3(), f);
+  const read = S.readEvents(f);
+  expect(read).toHaveLength(1);
+  expect(read[0].event).toBe('unit');
+  fs.unlinkSync(f);
+});
+
+test('readEvents: mixed v1/v2/v3 feed normalizes all to v3', () => {
+  const f = tmpfile('mixed');
+  fs.writeFileSync(f, [
+    JSON.stringify({ timestamp: '2026-05-11T00:00:00.000Z', pattern_id: 'p1' }),
+    JSON.stringify({ version: 2, timestamp: '2026-05-11T01:00:00.000Z', tier: 1, trigger_role: 'system' }),
+    JSON.stringify(minimalV3()),
+  ].join('\n') + '\n');
+  const read = S.readEvents(f, { service: 'mixed', event: 'legacy' });
+  expect(read).toHaveLength(3);
+  expect(read.every(e => e.version === 3)).toBe(true);
+  expect(read[0].pattern_id).toBe('p1');
+  expect(read[1].tier).toBe(1);
+  fs.unlinkSync(f);
+});
+
+test('emitV3: invalid event throws', () => {
+  expect(() => S.emitV3({ version: 3, ts: 't' }, tmpfile('inv'))).toThrow(/Invalid v3/);
+});


### PR DESCRIPTION
## Summary

C2 of Epic #1339 — unified event schema v3 generalizing the anneal v2 precedent (#1315) to cover all `*.jsonl` logging surfaces. Required + recommended + optional fields per R&D Thread 5. OpenTelemetry GenAI namespace support per R&D Thread 1.

## Files

- `scripts/global/event-schema-v3.js` (new, 109 lines)
- `tests/event-schema-v3.spec.js` (new, 93 lines, 10 contract tests)
- `CHANGELOG.md` entry

## Test plan

- [x] `npm run lint` — 397 files within limit
- [x] `npm run docs:lint` — clean
- [x] `npx playwright test tests/event-schema-v3.spec.js` — 10 passed
- [x] `tdd-pyramid` evidence: spec file in PR diff

## Baton trail

COLLABORATOR_HANDOFF (initial + full) → ADMIN_HANDOFF → CONSULTANT_CLOSEOUT to follow.

Refs #1353
Refs Epic #1339