### PR TITLE
feat(governance): PII/secret redaction at instrumentation #1358

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] — #1358: PII/secret redaction for harness logs (Epic #1339 C7)
+
+### Added
+- `scripts/global/log-redaction.js` — instrumentation-time redaction (prevent, not scrub). Exports `redactString`, `redactEvent` (recursive), `wrapWrite` (instrumentation wrapper), `sanitizeForLLM` (pre-prompt-injection hook), `hashShort` (deterministic SHA-256 prefix). Per R&D Thread 5 + G4 Privacy goal.
+- `config/redaction-patterns.json` — 9 patterns covering Anthropic/OpenAI keys, GitHub PAT (classic + fine-grained), AWS access key, JWT, Bearer tokens, email (hashed), IPv4. v1 schema with `version`/`description`/`patterns` shape.
+- `tests/log-redaction.spec.js` — 9 tdd-pyramid tests covering all pattern matches, recursive event redaction, write-wrapper hook, LLM-prompt sanitization, hash determinism.
+
 ## [Unreleased] — #1357: retention + rotation policy for *.jsonl logging surfaces (Epic #1339 C6)
 
 ### Added

--- a/config/redaction-patterns.json
+++ b/config/redaction-patterns.json
@@ -1,0 +1,60 @@
+{
+  "version": 1,
+  "description": "Redaction patterns for harness logging. Used by scripts/global/log-redaction.js. Each entry: {id, regex, action, replacement?}. Actions: redact|hash|drop.",
+  "patterns": [
+    {
+      "id": "anthropic-key",
+      "regex": "sk-ant-[a-zA-Z0-9_-]{32,}",
+      "action": "redact",
+      "replacement": "<ANTHROPIC_KEY_REDACTED>"
+    },
+    {
+      "id": "openai-key",
+      "regex": "sk-(?!ant-)[a-zA-Z0-9_-]{32,}",
+      "action": "redact",
+      "replacement": "<OPENAI_KEY_REDACTED>"
+    },
+    {
+      "id": "github-pat",
+      "regex": "gh[pousr]_[a-zA-Z0-9]{36,}",
+      "action": "redact",
+      "replacement": "<GITHUB_PAT_REDACTED>"
+    },
+    {
+      "id": "github-fine-grained-pat",
+      "regex": "github_pat_[a-zA-Z0-9_]{60,}",
+      "action": "redact",
+      "replacement": "<GITHUB_PAT_REDACTED>"
+    },
+    {
+      "id": "aws-access-key",
+      "regex": "AKIA[0-9A-Z]{16}",
+      "action": "redact",
+      "replacement": "<AWS_ACCESS_KEY_REDACTED>"
+    },
+    {
+      "id": "jwt",
+      "regex": "eyJ[A-Za-z0-9_-]+\\.eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+",
+      "action": "redact",
+      "replacement": "<JWT_REDACTED>"
+    },
+    {
+      "id": "bearer-token",
+      "regex": "Bearer\\s+[A-Za-z0-9_.\\-+/=]{16,}",
+      "action": "redact",
+      "replacement": "Bearer <TOKEN_REDACTED>"
+    },
+    {
+      "id": "email",
+      "regex": "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+      "action": "hash",
+      "replacement": null
+    },
+    {
+      "id": "ipv4",
+      "regex": "\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b",
+      "action": "redact",
+      "replacement": "<IPV4_REDACTED>"
+    }
+  ]
+}

--- a/scripts/global/log-redaction.js
+++ b/scripts/global/log-redaction.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// log-redaction.js — PII/secret redaction for harness logs.
+// Epic #1339 / #1358. Implements R&D Thread 5 "prevent at instrumentation"
+// strategy. Patterns in config/redaction-patterns.json.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const PATTERNS_FILE = path.join(__dirname, '..', '..', 'config', 'redaction-patterns.json');
+
+function loadPatterns(file = PATTERNS_FILE) {
+  if (!fs.existsSync(file)) return [];
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  return (data.patterns || []).map(pattern => ({
+    ...pattern,
+    compiled: new RegExp(pattern.regex, 'g'),
+  }));
+}
+
+let _patterns = null;
+function getPatterns() {
+  if (_patterns === null) _patterns = loadPatterns();
+  return _patterns;
+}
+
+/**
+ * Apply redaction patterns to a single string.
+ * @param {string} input
+ * @param {Array}  patterns  optional override
+ * @returns {{ text: string, hits: Array<{id, action}> }}
+ */
+function redactString(input, patterns = getPatterns()) {
+  if (typeof input !== 'string') return { text: input, hits: [] };
+  let text = input;
+  const hits = [];
+  for (const pattern of patterns) {
+    pattern.compiled.lastIndex = 0;
+    if (!pattern.compiled.test(text)) continue;
+    pattern.compiled.lastIndex = 0;
+    text = text.replace(pattern.compiled, (match) => {
+      hits.push({ id: pattern.id, action: pattern.action });
+      if (pattern.action === 'redact') return pattern.replacement || '<REDACTED>';
+      if (pattern.action === 'hash') return `<HASH:${hashShort(match)}>`;
+      if (pattern.action === 'drop') return '';
+      return match;
+    });
+  }
+  return { text, hits };
+}
+
+function hashShort(input) {
+  return crypto.createHash('sha256').update(input).digest('hex').slice(0, 12);
+}
+
+/**
+ * Apply redaction to a structured event (recursive over string fields).
+ * Returns the redacted event + aggregated hits.
+ * @param {object} event
+ * @param {Array}  patterns
+ * @returns {{ event: object, hits: Array }}
+ */
+function redactEvent(event, patterns = getPatterns()) {
+  const allHits = [];
+  function walk(node) {
+    if (typeof node === 'string') {
+      const result = redactString(node, patterns);
+      allHits.push(...result.hits);
+      return result.text;
+    }
+    if (Array.isArray(node)) return node.map(walk);
+    if (node && typeof node === 'object') {
+      const out = {};
+      for (const key of Object.keys(node)) out[key] = walk(node[key]);
+      return out;
+    }
+    return node;
+  }
+  return { event: walk(event), hits: allHits };
+}
+
+/**
+ * Wrap a write function so that any object passed through it is redacted first.
+ * Used at instrumentation site (prevent, not scrub).
+ * @param {function} writeFn  receives the (redacted) event
+ * @returns {function} new write fn
+ */
+function wrapWrite(writeFn) {
+  const patterns = getPatterns();
+  return function wrappedWrite(event) {
+    const result = redactEvent(event, patterns);
+    return writeFn(result.event);
+  };
+}
+
+/**
+ * Pre-LLM-consumption redaction hook. When log content is being included in
+ * an LLM prompt (high-risk for prompt injection via leaked secrets), pass
+ * through this hook first.
+ * @param {string} promptFragment
+ * @returns {string}
+ */
+function sanitizeForLLM(promptFragment) {
+  return redactString(promptFragment, getPatterns()).text;
+}
+
+module.exports = {
+  loadPatterns, getPatterns, redactString, redactEvent,
+  wrapWrite, sanitizeForLLM, hashShort, PATTERNS_FILE,
+};

--- a/tests/log-redaction.spec.js
+++ b/tests/log-redaction.spec.js
@@ -1,0 +1,81 @@
+// log-redaction — tdd-pyramid tests (#1358, Epic #1339 C7).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const R = require(path.resolve(__dirname, '..', 'scripts', 'global', 'log-redaction.js'));
+
+const ANTHROPIC = 'sk-ant-abcdefghijklmnopqrstuvwxyz123456';
+const GHP = 'ghp_abcdefghijklmnopqrstuvwxyz1234567890';
+
+test('redactString: Anthropic + GitHub + JWT redacted with named markers', () => {
+  expect(R.redactString(`key=${ANTHROPIC}`).text).toContain('<ANTHROPIC_KEY_REDACTED>');
+  expect(R.redactString(`token=${GHP}`).text).toContain('<GITHUB_PAT_REDACTED>');
+  expect(R.redactString(`pat=github_pat_${'a'.repeat(60)}`).text).toContain('<GITHUB_PAT_REDACTED>');
+  const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0In0.signature';
+  expect(R.redactString(`t=${jwt}`).text).toContain('<JWT_REDACTED>');
+});
+
+test('redactString: Bearer keyword preserved; AWS key redacted', () => {
+  expect(R.redactString('Authorization: Bearer abcdef1234567890abcdef1234').text)
+    .toContain('Bearer <TOKEN_REDACTED>');
+  expect(R.redactString('aws=AKIAIOSFODNN7EXAMPLE').text).toContain('<AWS_ACCESS_KEY_REDACTED>');
+});
+
+test('redactString: email hashed deterministically; IPv4 redacted', () => {
+  const r1 = R.redactString('contact alice@example.com today');
+  const r2 = R.redactString('contact alice@example.com again');
+  expect(r1.text).toContain('<HASH:');
+  expect(r1.text).not.toContain('alice@example.com');
+  const h1 = r1.text.match(/<HASH:([^>]+)>/)[1];
+  const h2 = r2.text.match(/<HASH:([^>]+)>/)[1];
+  expect(h1).toBe(h2);
+  expect(R.redactString('client 192.168.1.42 connected').text).toContain('<IPV4_REDACTED>');
+});
+
+test('redactString: clean text unchanged, no hits; non-string passes through', () => {
+  const clean = R.redactString('Hello, world. No secrets here.');
+  expect(clean.text).toBe('Hello, world. No secrets here.');
+  expect(clean.hits).toHaveLength(0);
+  expect(R.redactString(42).text).toBe(42);
+});
+
+test('redactEvent: recursive over nested object + arrays', () => {
+  const event = {
+    version: 3,
+    payload: {
+      headers: { Authorization: 'Bearer secrettokenvalue1234567890abc' },
+      body: `contains ${ANTHROPIC}`,
+    },
+    items: [GHP],
+  };
+  const result = R.redactEvent(event);
+  expect(result.event.payload.headers.Authorization).toContain('<TOKEN_REDACTED>');
+  expect(result.event.payload.body).toContain('<ANTHROPIC_KEY_REDACTED>');
+  expect(result.event.items[0]).toContain('<GITHUB_PAT_REDACTED>');
+  expect(result.hits.length).toBeGreaterThanOrEqual(3);
+});
+
+test('redactEvent: non-secret event unchanged', () => {
+  const event = { version: 3, message: 'hello', count: 5 };
+  const result = R.redactEvent(event);
+  expect(result.event).toEqual(event);
+  expect(result.hits).toHaveLength(0);
+});
+
+test('wrapWrite: wrapped write redacts before delegating', () => {
+  let captured = null;
+  const wrapped = R.wrapWrite((event) => { captured = event; });
+  wrapped({ secret: ANTHROPIC });
+  expect(captured.secret).toContain('<ANTHROPIC_KEY_REDACTED>');
+});
+
+test('sanitizeForLLM: secrets removed before LLM consumption', () => {
+  const sanitized = R.sanitizeForLLM(`Log says: key=${ANTHROPIC} used`);
+  expect(sanitized).toContain('<ANTHROPIC_KEY_REDACTED>');
+  expect(sanitized).not.toContain('sk-ant-abcdef');
+});
+
+test('hashShort: deterministic, 12-char output, different inputs differ', () => {
+  expect(R.hashShort('foo')).toBe(R.hashShort('foo'));
+  expect(R.hashShort('foo')).not.toBe(R.hashShort('bar'));
+  expect(R.hashShort('foo')).toHaveLength(12);
+});


### PR DESCRIPTION
## Summary
C7 of Epic #1339 — instrumentation-time redaction per R&D Thread 5. 9 patterns + recursive event redaction + LLM-prompt hook. 9 tdd-pyramid tests.

## Files
- `scripts/global/log-redaction.js` (new)
- `config/redaction-patterns.json` (new — 9 patterns)
- `tests/log-redaction.spec.js` (new, 81 lines, 9 tests)
- `CHANGELOG.md` entry

## Test plan
- [x] `npm run lint` — 400 files within limit
- [x] 9 spec tests pass

Refs #1358
Refs Epic #1339