### PR TITLE
feat(governance): SSE live-streaming pipeline #1354

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] — #1354: SSE live-streaming pipeline (Epic #1339 C3)
+
+### Added
+- `scripts/global/jsonl-tail.js` — chokidar-based JSONL tail with offset tracking, rotation awareness (shrunken-file reset; add-event reset), and backpressure (sliding-window drop with `dropped:N` callback). Exports `tail()`, `readFromOffset()`, `parseLines()` for testability.
+- `tests/jsonl-tail.spec.js` — 6 tdd-pyramid tests: append emission, offset tracking, shrunken-file reset, malformed-JSON onError, close() teardown, state-exposing accessors.
+- `tests/sse-stream.spec.js` — 5 integration tests: surface subscription → broadcast, fallback event type, multi-client fanout, failing-client removal, tailLines parser.
+
+### Changed
+- `scripts/sse-handler.js` — replaced inline `fs.watch` + offset bookkeeping with the shared `jsonl-tail` module. **Multi-surface support**: now subscribes to `events.jsonl` + `incidents.jsonl` + `cache-stats.jsonl` automatically. Added `subscribeSurface(file, defaultEventType)` API for additional surfaces. Backpressure surfaces via `dropped` SSE event.
+
 ## [Unreleased] — #1361: token-cost benchmark — variants A/B/C compared (Epic #1339 C10)
 
 ### Added

--- a/scripts/global/jsonl-tail.js
+++ b/scripts/global/jsonl-tail.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// jsonl-tail.js — chokidar-based JSONL tail with offset tracking, rotation
+// awareness, and backpressure. Epic #1339 / #1354. Per R&D Thread 3.
+'use strict';
+
+const fs = require('fs');
+const chokidar = require('chokidar');
+
+const DEFAULT_MAX_BUFFER = 1000;
+
+function readFromOffset(file, offset) {
+  const stat = fs.statSync(file);
+  // Rotation/truncate detection: shrunken file resets offset
+  let startAt = offset;
+  if (stat.size < offset) startAt = 0;
+  if (stat.size === startAt) return { content: '', newOffset: startAt };
+  const buf = Buffer.alloc(stat.size - startAt);
+  const fd = fs.openSync(file, 'r');
+  fs.readSync(fd, buf, 0, buf.length, startAt);
+  fs.closeSync(fd);
+  return { content: buf.toString('utf-8'), newOffset: stat.size };
+}
+
+function parseLines(content, onEvent, onError) {
+  const lines = content.split('\n').filter(Boolean);
+  for (const line of lines) {
+    try { onEvent(JSON.parse(line)); }
+    catch (err) { onError({ kind: 'parse', line, error: err.message }); }
+  }
+}
+
+function bufferAndDrain(state, line) {
+  if (state.buffer.length >= state.maxBuffer) {
+    state.buffer.shift();
+    state.dropped++;
+    state.onDrop(state.dropped);
+  }
+  state.buffer.push(line);
+  drainBuffer(state);
+}
+
+function drainBuffer(state) {
+  if (state.processing) return;
+  state.processing = true;
+  while (state.buffer.length > 0) {
+    const event = state.buffer.shift();
+    try { state.onLine(event); }
+    catch (err) { state.onError({ kind: 'handler', error: err.message }); }
+  }
+  state.processing = false;
+}
+
+function pumpNewContent(state) {
+  if (!fs.existsSync(state.file)) {
+    state.offset = 0;
+    return;
+  }
+  try {
+    const { content, newOffset } = readFromOffset(state.file, state.offset);
+    state.offset = newOffset;
+    if (content) parseLines(content, (event) => bufferAndDrain(state, event), state.onError);
+  } catch (err) {
+    state.onError({ kind: 'io', file: state.file, error: err.message });
+  }
+}
+
+/**
+ * Tail a JSONL file. Calls onLine(event) for each newly appended line.
+ * Returns a handle with close()/getOffset()/getDropped()/getBufferDepth().
+ */
+function tail(file, onLine, opts = {}) {
+  const state = {
+    file,
+    onLine,
+    onDrop: opts.onDrop || (() => {}),
+    onError: opts.onError || (() => {}),
+    maxBuffer: opts.maxBuffer || DEFAULT_MAX_BUFFER,
+    offset: fs.existsSync(file) ? fs.statSync(file).size : 0,
+    buffer: [],
+    processing: false,
+    dropped: 0,
+  };
+  // chokidar handles rotation (unlink + add) better than fs.watch
+  const watcher = chokidar.watch(file, { persistent: false, ignoreInitial: true });
+  const handle = () => pumpNewContent(state);
+  watcher.on('change', handle);
+  watcher.on('add', () => { state.offset = 0; handle(); });
+  return {
+    close: () => watcher.close(),
+    getOffset: () => state.offset,
+    getDropped: () => state.dropped,
+    getBufferDepth: () => state.buffer.length,
+  };
+}
+
+module.exports = {
+  tail, DEFAULT_MAX_BUFFER,
+  readFromOffset, parseLines,  // exported for testability
+};

--- a/scripts/sse-handler.js
+++ b/scripts/sse-handler.js
@@ -1,11 +1,18 @@
-// scripts/sse-handler.js — Server-Sent Events for dashboard live push
-// Watches .dashboard/events.jsonl and streams new events to connected clients
+// scripts/sse-handler.js — Server-Sent Events for dashboard live push.
+// Multi-surface (events.jsonl, incidents.jsonl, cache-stats.jsonl) via the
+// shared scripts/global/jsonl-tail.js (Epic #1339 / #1354).
 
 const fs = require('fs');
 const path = require('path');
+const { tail } = require('./global/jsonl-tail.js');
 
+const HOME = process.env.HOME || '/tmp';
 const EVENTS_FILE = path.resolve(__dirname, '..', '.dashboard', 'events.jsonl');
+const INCIDENTS_FILE = path.join(HOME, '.megingjord', 'incidents.jsonl');
+const CACHE_STATS_FILE = path.join(HOME, '.megingjord', 'cache-stats.jsonl');
+
 const clients = new Set();
+const activeTails = [];
 
 /** SSE endpoint handler for /api/events/stream */
 function stream(req, res) {
@@ -28,7 +35,7 @@ function broadcast(eventType, data) {
   }
 }
 
-/** Parse last N lines from events.jsonl */
+/** Parse last N lines from a jsonl file (utility for snapshot endpoints) */
 function tailLines(content, n) {
   const lines = content.trim().split('\n').slice(-n);
   const events = [];
@@ -38,31 +45,38 @@ function tailLines(content, n) {
   return events;
 }
 
-// Watch events.jsonl for new entries
-let lastSize = 0;
-function initWatcher() {
-  if (!fs.existsSync(EVENTS_FILE)) return;
-  lastSize = fs.statSync(EVENTS_FILE).size;
-  fs.watch(EVENTS_FILE, { persistent: false }, () => {
-    try {
-      const stat = fs.statSync(EVENTS_FILE);
-      if (stat.size <= lastSize) { lastSize = stat.size; return; }
-      const buf = Buffer.alloc(stat.size - lastSize);
-      const fd = fs.openSync(EVENTS_FILE, 'r');
-      fs.readSync(fd, buf, 0, buf.length, lastSize);
-      fs.closeSync(fd);
-      lastSize = stat.size;
-      const newLines = buf.toString('utf-8').trim().split('\n');
-      for (const line of newLines) {
-        try {
-          const ev = JSON.parse(line);
-          broadcast(ev.type || 'activity', ev);
-        } catch { /* skip malformed */ }
-      }
-    } catch { /* file race */ }
-  });
+/**
+ * Subscribe a jsonl surface to live SSE broadcast.
+ * Returns a tail handle so callers can close() on shutdown.
+ */
+function subscribeSurface(file, defaultEventType, opts = {}) {
+  if (!fs.existsSync(file)) {
+    // File may not exist yet; jsonl-tail handles eventual create via chokidar
+  }
+  const handle = tail(file, (event) => {
+    const eventType = event.event || event.type || defaultEventType;
+    broadcast(eventType, event);
+  }, { onDrop: (n) => broadcast('dropped', { count: n, file }), ...opts });
+  activeTails.push(handle);
+  return handle;
 }
 
-try { initWatcher(); } catch { /* no events file yet */ }
+/** Initialize default subscriptions: events.jsonl, incidents.jsonl, cache-stats.jsonl */
+function initWatchers() {
+  try { subscribeSurface(EVENTS_FILE, 'activity'); } catch { /* skip */ }
+  try { subscribeSurface(INCIDENTS_FILE, 'incident'); } catch { /* skip */ }
+  try { subscribeSurface(CACHE_STATS_FILE, 'cache-stat'); } catch { /* skip */ }
+}
 
-module.exports = { stream, broadcast, clients };
+/** Close all active tails (for tests + shutdown) */
+function closeAllSubscriptions() {
+  while (activeTails.length > 0) activeTails.pop().close();
+}
+
+try { initWatchers(); } catch { /* no surfaces yet — chokidar will pick up when created */ }
+
+module.exports = {
+  stream, broadcast, clients, tailLines,
+  subscribeSurface, closeAllSubscriptions,
+  EVENTS_FILE, INCIDENTS_FILE, CACHE_STATS_FILE,
+};

--- a/tests/jsonl-tail.spec.js
+++ b/tests/jsonl-tail.spec.js
@@ -1,0 +1,92 @@
+// jsonl-tail — tdd-pyramid tests (#1354, Epic #1339 C3).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const T = require(path.resolve(__dirname, '..', 'scripts', 'global', 'jsonl-tail.js'));
+
+const settle = (ms = 200) => new Promise(resolve => setTimeout(resolve, ms));
+
+function makeFile() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jsonl-tail-'));
+  return { dir, file: path.join(dir, 'sample.jsonl') };
+}
+
+test('tail: emits onLine for each appended event', async () => {
+  const { dir, file } = makeFile();
+  fs.writeFileSync(file, '');
+  const lines = [];
+  const handle = T.tail(file, (event) => lines.push(event));
+  await settle();
+  fs.appendFileSync(file, JSON.stringify({ event: 'a' }) + '\n' + JSON.stringify({ event: 'b' }) + '\n');
+  await settle(300);
+  handle.close();
+  expect(lines.map(l => l.event)).toContain('a');
+  expect(lines.map(l => l.event)).toContain('b');
+  fs.rmSync(dir, { recursive: true });
+});
+
+test('tail: tracks offset; only new lines after open are emitted', async () => {
+  const { dir, file } = makeFile();
+  fs.writeFileSync(file, JSON.stringify({ event: 'before' }) + '\n');
+  const lines = [];
+  const handle = T.tail(file, (event) => lines.push(event));
+  await settle();
+  fs.appendFileSync(file, JSON.stringify({ event: 'after' }) + '\n');
+  await settle(300);
+  handle.close();
+  expect(lines.map(l => l.event)).not.toContain('before');
+  expect(lines.map(l => l.event)).toContain('after');
+  fs.rmSync(dir, { recursive: true });
+});
+
+test('readFromOffset: shrunken file resets offset', () => {
+  const { dir, file } = makeFile();
+  fs.writeFileSync(file, 'AAAAA\n');
+  const r1 = T.readFromOffset(file, 0);
+  expect(r1.content).toBe('AAAAA\n');
+  // Truncate to smaller
+  fs.writeFileSync(file, 'BB\n');
+  // Saved offset was 6 from r1; new file size is 3 → should reset to 0
+  const r2 = T.readFromOffset(file, 6);
+  expect(r2.newOffset).toBe(3);
+  expect(r2.content).toBe('BB\n');
+  fs.rmSync(dir, { recursive: true });
+});
+
+test('parseLines: valid events emit; malformed JSON triggers onError', () => {
+  const events = [];
+  const errors = [];
+  T.parseLines(
+    JSON.stringify({ a: 1 }) + '\nnot-json\n' + JSON.stringify({ b: 2 }) + '\n',
+    (event) => events.push(event),
+    (err) => errors.push(err),
+  );
+  expect(events).toHaveLength(2);
+  expect(errors).toHaveLength(1);
+  expect(errors[0].kind).toBe('parse');
+});
+
+test('tail: close() stops emitting events', async () => {
+  const { dir, file } = makeFile();
+  fs.writeFileSync(file, '');
+  const lines = [];
+  const handle = T.tail(file, (event) => lines.push(event));
+  await settle();
+  handle.close();
+  fs.appendFileSync(file, JSON.stringify({ event: 'post-close' }) + '\n');
+  await settle(300);
+  expect(lines.length).toBe(0);
+  fs.rmSync(dir, { recursive: true });
+});
+
+test('tail: getOffset / getDropped / getBufferDepth exposed', () => {
+  const { dir, file } = makeFile();
+  fs.writeFileSync(file, JSON.stringify({ event: 'a' }) + '\n');
+  const handle = T.tail(file, () => {});
+  expect(typeof handle.getOffset()).toBe('number');
+  expect(handle.getDropped()).toBe(0);
+  expect(handle.getBufferDepth()).toBe(0);
+  handle.close();
+  fs.rmSync(dir, { recursive: true });
+});

--- a/tests/sse-stream.spec.js
+++ b/tests/sse-stream.spec.js
@@ -1,0 +1,88 @@
+// SSE stream — integration tests for multi-surface jsonl subscriber (#1354).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+// Note: requiring sse-handler triggers initWatchers() with default surfaces.
+// We test the exported `subscribeSurface` + `broadcast` + `clients` directly.
+
+const settle = (ms = 300) => new Promise(resolve => setTimeout(resolve, ms));
+
+function makeSurface() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sse-test-'));
+  const file = path.join(dir, 'test.jsonl');
+  return { dir, file };
+}
+
+test('subscribeSurface: appended event triggers broadcast via mock client', async () => {
+  // Mock client capturing SSE writes
+  const writes = [];
+  const mockRes = { write: (data) => writes.push(data) };
+  // Load module fresh
+  const handler = require(path.resolve(__dirname, '..', 'scripts', 'sse-handler.js'));
+  handler.clients.add(mockRes);
+  const { dir, file } = makeSurface();
+  fs.writeFileSync(file, '');
+  const handle = handler.subscribeSurface(file, 'test-event');
+  await settle();
+  fs.appendFileSync(file, JSON.stringify({ event: 'tick', data: 1 }) + '\n');
+  await settle(500);
+  handler.clients.delete(mockRes);
+  handle.close();
+  // SSE format: "event: <type>\ndata: <json>\n\n"
+  const sseMessages = writes.filter(w => w.includes('event: tick'));
+  expect(sseMessages.length).toBeGreaterThanOrEqual(1);
+  expect(sseMessages[0]).toContain('"data":1');
+  fs.rmSync(dir, { recursive: true });
+});
+
+test('subscribeSurface: defaults to provided event type when event field absent', async () => {
+  const writes = [];
+  const mockRes = { write: (data) => writes.push(data) };
+  const handler = require(path.resolve(__dirname, '..', 'scripts', 'sse-handler.js'));
+  handler.clients.add(mockRes);
+  const { dir, file } = makeSurface();
+  fs.writeFileSync(file, '');
+  const handle = handler.subscribeSurface(file, 'fallback-type');
+  await settle();
+  fs.appendFileSync(file, JSON.stringify({ payload: 42 }) + '\n');
+  await settle(500);
+  handler.clients.delete(mockRes);
+  handle.close();
+  const sseMessages = writes.filter(w => w.includes('event: fallback-type'));
+  expect(sseMessages.length).toBeGreaterThanOrEqual(1);
+  fs.rmSync(dir, { recursive: true });
+});
+
+test('broadcast: sends to all connected clients', () => {
+  const handler = require(path.resolve(__dirname, '..', 'scripts', 'sse-handler.js'));
+  const w1 = [], w2 = [];
+  const r1 = { write: (d) => w1.push(d) };
+  const r2 = { write: (d) => w2.push(d) };
+  handler.clients.add(r1);
+  handler.clients.add(r2);
+  handler.broadcast('ping', { msg: 'hi' });
+  handler.clients.delete(r1);
+  handler.clients.delete(r2);
+  expect(w1[0]).toContain('event: ping');
+  expect(w2[0]).toContain('event: ping');
+});
+
+test('broadcast: removes client whose write throws', () => {
+  const handler = require(path.resolve(__dirname, '..', 'scripts', 'sse-handler.js'));
+  const failing = { write: () => { throw new Error('disconnected'); } };
+  handler.clients.add(failing);
+  expect(handler.clients.has(failing)).toBe(true);
+  handler.broadcast('test', {});
+  expect(handler.clients.has(failing)).toBe(false);
+});
+
+test('tailLines: parses last N events from content', () => {
+  const handler = require(path.resolve(__dirname, '..', 'scripts', 'sse-handler.js'));
+  const content = JSON.stringify({ a: 1 }) + '\n' + JSON.stringify({ b: 2 }) + '\n' + JSON.stringify({ c: 3 }) + '\n';
+  const events = handler.tailLines(content, 2);
+  expect(events).toHaveLength(2);
+  expect(events[0].b).toBe(2);
+  expect(events[1].c).toBe(3);
+});


### PR DESCRIPTION
## Summary
C3 of Epic #1339. chokidar-based jsonl tail + multi-surface SSE handler. Per R&D Thread 3. 11 tests pass (6 unit + 5 integration).

## Files
- `scripts/global/jsonl-tail.js` (new, 99 lines)
- `scripts/sse-handler.js` (refactored, 82 lines, now multi-surface)
- `tests/jsonl-tail.spec.js` (new, 92 lines, 6 tests)
- `tests/sse-stream.spec.js` (new, 88 lines, 5 tests)
- `CHANGELOG.md` entry

## Test plan
- [x] `npm run lint` — 402 files within limit
- [x] All 11 tests pass

## Unblocks
C4 (#1355), C5 (#1356), C8 (#1359) all depend on this pipeline.

Refs #1354
Refs Epic #1339