### PR TITLE
docs(wiki): resolve 80 broken wikilinks via 34 stub pages #1207

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased] — #1207: wiki-orphan-check fix — resolve 80 broken wikilinks (tool-002 PASS)
+
+### Added
+- 34 stub wiki concept pages under `wiki/concepts/` resolving all `[[X]] (not found)` broken wikilinks reported by `npm run wiki:lint`. Includes 3 high-leverage pages (`cascade-dispatch`, `free-router`, `megingjord-harness`) plus 31 stubs for HAMR, caching, routing, security, and gate concepts referenced from existing research pages.
+
+### Changed
+- `wiki/index.md` — registered 4 representative new pages in the Concepts section (`megingjord-harness`, `cascade-dispatch`, `free-router`, `harness-logging-inventory` had already been added in #1352).
+- `scripts/global/consultant-checks.js` `tool-002` (wiki-orphan-check) now **PASSES** (was FAIL with 80 broken-wikilink instances across 34 unique missing targets).
+
+### Notes
+- Picked up from the Codex Team's planned-next queue. Codex was rate-limited mid-session and had identified this as the highest-priority safe-parallel work after #1286 (Codex's FDPR) shipped.
+- 99 `wiki:lint` "missing from index.md" issues remain (separate class — orphan source-page registration, not broken wikilinks). Out of scope for #1207 (`tool-002` is specifically the broken-wikilink check). Tracked for follow-up.
+
 ## [Unreleased] — #1360: codify observability standard (Epic #1339 C9 capstone)
 
 ### Added

--- a/wiki/concepts/1h-extended-cache-cadence.md
+++ b/wiki/concepts/1h-extended-cache-cadence.md
@@ -1,0 +1,21 @@
+---
+title: "1h Extended Cache Cadence"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [hamr, cache]
+sources: []
+related: ["[[anthropic-prompt-cache]]", "[[hamr-bundle]]"]
+status: stub
+---
+
+# 1h Extended Cache Cadence
+
+Refresh interval for HAMR-cached responses with 1h TTL extension flag.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[anthropic-prompt-cache]]
+- [[hamr-bundle]]

--- a/wiki/concepts/3-tier-degraded-hamr.md
+++ b/wiki/concepts/3-tier-degraded-hamr.md
@@ -1,0 +1,21 @@
+---
+title: "3-Tier Degraded HAMR"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [hamr, resilience]
+sources: []
+related: ["[[hamr-failover-map]]", "[[hamr-bundle]]"]
+status: stub
+---
+
+# 3-Tier Degraded HAMR
+
+Failover state where HAMR runs from 3 tiers (primary, secondary, local) with reduced cross-team coverage.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[hamr-failover-map]]
+- [[hamr-bundle]]

--- a/wiki/concepts/anthropic-prompt-cache.md
+++ b/wiki/concepts/anthropic-prompt-cache.md
@@ -1,0 +1,21 @@
+---
+title: "Anthropic Prompt Cache"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [cache, anthropic]
+sources: []
+related: ["[[1h-extended-cache-cadence]]", "[[ephemeral-vs-extended-cache]]"]
+status: stub
+---
+
+# Anthropic Prompt Cache
+
+Anthropic SDK ephemeral-cache control headers; reduces input-token billing for repeated context.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[1h-extended-cache-cadence]]
+- [[ephemeral-vs-extended-cache]]

--- a/wiki/concepts/bundle-rebuild-cadence.md
+++ b/wiki/concepts/bundle-rebuild-cadence.md
@@ -1,0 +1,21 @@
+---
+title: "Bundle Rebuild Cadence"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [hamr, cache]
+sources: []
+related: ["[[hamr-bundle]]", "[[anthropic-prompt-cache]]"]
+status: stub
+---
+
+# Bundle Rebuild Cadence
+
+Frequency at which HAMR rebuilds the shared instruction bundle delivered to provider calls.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[hamr-bundle]]
+- [[anthropic-prompt-cache]]

--- a/wiki/concepts/capability-probe.md
+++ b/wiki/concepts/capability-probe.md
@@ -1,0 +1,21 @@
+---
+title: "Capability Probe"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [routing, fleet]
+sources: []
+related: ["[[fleet-config]]", "[[cascade-dispatch]]"]
+status: stub
+---
+
+# Capability Probe
+
+GET request that returns a node's declared capabilities (models, GPU, tokens/sec).
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[fleet-config]]
+- [[cascade-dispatch]]

--- a/wiki/concepts/cascade-dispatch.md
+++ b/wiki/concepts/cascade-dispatch.md
@@ -1,0 +1,52 @@
+---
+title: "Cascade Dispatch"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [routing, fleet, governance]
+sources: []
+related: ["[[free-router]]", "[[fleet-architecture]]", "[[model-routing]]", "[[harness-goals]]"]
+status: draft
+---
+
+# Cascade Dispatch
+
+Bounded escalation pattern that routes a prompt through cost-ascending tiers
+(Free → Fleet → Haiku → Premium) and stops at the first tier that produces a
+sufficient response.
+
+## Purpose
+
+Enforces the harness Goal Constitution priority **G3 Zero Cost** without
+sacrificing **G2 Quality**: avoid paying premium-tier tokens when a free or
+fleet tier can answer adequately.
+
+## Implementation
+
+`scripts/global/cascade-dispatch.js` orchestrates the escalation chain:
+
+1. **Ollama (Fleet)** — first attempt via `litellm-client` against fleet
+   hardware (qwen2.5-coder, starcoder2, etc.).
+2. **Heuristic gate** — `assessQuality(content, hints)` checks whether the
+   response satisfies basic shape requirements (code present when expected,
+   JSON parseable when expected, minimum length).
+3. **Judge gate** — `judgeResponse(content)` for nuanced quality checks via
+   `local-judge` when heuristic gate is ambiguous.
+4. **Escalation signal** — if both gates fail, return `escalate=true` with a
+   `suggested_tier` (haiku before premium per policy).
+
+## Policy source
+
+`scripts/global/model-routing-policy.json` defines the capability matrix and
+tier ordering. The router never skips haiku to reach premium.
+
+## Observability
+
+Each dispatch records telemetry via `model-routing-telemetry` for downstream
+analysis (`dashboard/js/cost-monitor.js`).
+
+## See also
+
+- `[[free-router]]` — the higher-level lane selector that invokes cascade
+- `[[fleet-architecture]]` — physical substrate the cascade dispatches to
+- `[[model-routing]]` — overall routing strategy

--- a/wiki/concepts/cf-worker-latency.md
+++ b/wiki/concepts/cf-worker-latency.md
@@ -1,0 +1,21 @@
+---
+title: "CF Worker Latency"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [hamr, observability]
+sources: []
+related: ["[[hamr-substrate-overhead]]", "[[tailscale-fleet-rtt]]"]
+status: stub
+---
+
+# CF Worker Latency
+
+P95 latency budget for Cloudflare Worker hop in HAMR (~50ms target).
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[hamr-substrate-overhead]]
+- [[tailscale-fleet-rtt]]

--- a/wiki/concepts/deterministic-top-k-extractive.md
+++ b/wiki/concepts/deterministic-top-k-extractive.md
@@ -1,0 +1,20 @@
+---
+title: "Deterministic Top-K Extractive"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [retrieval, governance]
+sources: []
+related: ["[[reuse-refactor-replace-merge-rubric]]"]
+status: stub
+---
+
+# Deterministic Top-K Extractive
+
+Deterministic top-K extractive retrieval pattern for evidence selection — avoids LLM nondeterminism in audit paths.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[reuse-refactor-replace-merge-rubric]]

--- a/wiki/concepts/dpop-binding.md
+++ b/wiki/concepts/dpop-binding.md
@@ -1,0 +1,20 @@
+---
+title: "DPoP Binding"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [security, hamr]
+sources: []
+related: ["[[governance-artifact-signing]]"]
+status: stub
+---
+
+# DPoP Binding
+
+Demonstrating Proof of Possession (RFC 9449) used for HAMR `/mcp` endpoint authentication.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[governance-artifact-signing]]

--- a/wiki/concepts/ephemeral-vs-extended-cache.md
+++ b/wiki/concepts/ephemeral-vs-extended-cache.md
@@ -1,0 +1,21 @@
+---
+title: "Ephemeral vs Extended Cache"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [cache, cost]
+sources: []
+related: ["[[anthropic-prompt-cache]]", "[[1h-extended-cache-cadence]]"]
+status: stub
+---
+
+# Ephemeral vs Extended Cache
+
+Tradeoff between 5-minute default cache (`ephemeral`) and 1-hour extended cache for repeated harness prompts.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[anthropic-prompt-cache]]
+- [[1h-extended-cache-cadence]]

--- a/wiki/concepts/fleet-config.md
+++ b/wiki/concepts/fleet-config.md
@@ -1,0 +1,21 @@
+---
+title: "Fleet Config"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [fleet, routing]
+sources: []
+related: ["[[fleet-architecture]]", "[[cascade-dispatch]]"]
+status: stub
+---
+
+# Fleet Config
+
+Tailscale-aware fleet resolution (`scripts/global/fleet-config.js`); returns reachable inference nodes by capability tier.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[fleet-architecture]]
+- [[cascade-dispatch]]

--- a/wiki/concepts/fleet-model-upgrades-implementation-2026-05-01.md
+++ b/wiki/concepts/fleet-model-upgrades-implementation-2026-05-01.md
@@ -1,0 +1,20 @@
+---
+title: "Fleet Model Upgrades 2026-05-01"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [fleet, history]
+sources: []
+related: ["[[fleet-config]]"]
+status: stub
+---
+
+# Fleet Model Upgrades 2026-05-01
+
+Implementation snapshot from 2026-05-01: fleet model upgrades (qwen2.5-coder rollout, starcoder2 fallback).
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[fleet-config]]

--- a/wiki/concepts/free-router.md
+++ b/wiki/concepts/free-router.md
@@ -1,0 +1,53 @@
+---
+title: "Free Router"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [routing, governance]
+sources: []
+related: ["[[cascade-dispatch]]", "[[model-routing]]", "[[harness-goals]]", "[[fleet-architecture]]"]
+status: draft
+---
+
+# Free Router
+
+Lane-selection layer that determines which cost tier a task should target
+*before* the work begins. Distinct from `[[cascade-dispatch]]`, which executes
+the chosen tier and escalates on failure.
+
+## Purpose
+
+Implements the harness Goal Constitution priority order:
+**G1 Governance > G2 Quality > G3 Zero Cost** by classifying tasks into the
+lowest-adequate-cost lane up front, rather than running expensive tiers
+speculatively.
+
+## Lanes (cost-ascending)
+
+| Lane | Substrate | Use |
+|---|---|---|
+| **Free** | Auto-tier / lookup | Q&A, docs, boilerplate; zero tokens |
+| **Fleet** | Ollama via `[[cascade-dispatch]]` | Known-pattern coding, config gen, log analysis |
+| **Haiku** | claude-haiku-4-5 | Single-file refactors, test gen, code review |
+| **Premium** | claude-sonnet-4-6 | Multi-file architecture, security, ambiguous debugging |
+
+## Direct-to-premium
+
+Bypasses the cascade for: security review, vulnerability audit, architecture
+design, incident response, cross-system tradeoff analysis, concurrency analysis.
+
+## Policy source
+
+Same as cascade-dispatch: `scripts/global/model-routing-policy.json`.
+Authoritative instruction: `instructions/global-task-router.instructions.md`.
+
+## Telemetry
+
+Lane decisions are recorded so the routing engine can force fleet-lane usage
+when premium share exceeds 20% over 7 days (`npm run routing:report`).
+
+## See also
+
+- `[[cascade-dispatch]]` — execution layer below the router
+- `[[model-routing]]` — overarching strategy
+- `[[harness-goals]]` — G3 Zero Cost rationale

--- a/wiki/concepts/governance-artifact-signing.md
+++ b/wiki/concepts/governance-artifact-signing.md
@@ -1,0 +1,21 @@
+---
+title: "Governance Artifact Signing"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [security, governance]
+sources: []
+related: ["[[dpop-binding]]", "[[slsa-bundle-verification]]"]
+status: stub
+---
+
+# Governance Artifact Signing
+
+Ed25519-based signing of MANAGER_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT artifacts. See Epic #1298.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[dpop-binding]]
+- [[slsa-bundle-verification]]

--- a/wiki/concepts/hamr-bundle.md
+++ b/wiki/concepts/hamr-bundle.md
@@ -1,0 +1,21 @@
+---
+title: "HAMR Bundle"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [hamr, governance]
+sources: []
+related: ["[[bundle-rebuild-cadence]]", "[[slsa-bundle-verification]]"]
+status: stub
+---
+
+# HAMR Bundle
+
+Shared instruction bundle distributed by HAMR to all team substrates; cached and signed.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[bundle-rebuild-cadence]]
+- [[slsa-bundle-verification]]

--- a/wiki/concepts/hamr-failover-map.md
+++ b/wiki/concepts/hamr-failover-map.md
@@ -1,0 +1,21 @@
+---
+title: "HAMR Failover Map"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [hamr, resilience]
+sources: []
+related: ["[[3-tier-degraded-hamr]]", "[[hamr-bundle]]"]
+status: stub
+---
+
+# HAMR Failover Map
+
+Routing table mapping HAMR failure modes to fallback substrates and tiers.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[3-tier-degraded-hamr]]
+- [[hamr-bundle]]

--- a/wiki/concepts/hamr-key-store-tiers.md
+++ b/wiki/concepts/hamr-key-store-tiers.md
@@ -1,0 +1,21 @@
+---
+title: "HAMR Key Store Tiers"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [hamr, security]
+sources: []
+related: ["[[hamr-bundle]]", "[[governance-artifact-signing]]"]
+status: stub
+---
+
+# HAMR Key Store Tiers
+
+Tiered KV store classification (current-state replace-on-write vs append-only history).
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[hamr-bundle]]
+- [[governance-artifact-signing]]

--- a/wiki/concepts/hamr-mvp-revised-child-list.md
+++ b/wiki/concepts/hamr-mvp-revised-child-list.md
@@ -1,0 +1,20 @@
+---
+title: "HAMR MVP Revised Child List"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [hamr, history]
+sources: []
+related: ["[[hamr-bundle]]"]
+status: stub
+---
+
+# HAMR MVP Revised Child List
+
+Post-pivot list of children for the HAMR Epic #1130 universal coverage rollout.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[hamr-bundle]]

--- a/wiki/concepts/hamr-substrate-overhead.md
+++ b/wiki/concepts/hamr-substrate-overhead.md
@@ -1,0 +1,21 @@
+---
+title: "HAMR Substrate Overhead"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [hamr, cost]
+sources: []
+related: ["[[cf-worker-latency]]", "[[per-call-token-economics]]"]
+status: stub
+---
+
+# HAMR Substrate Overhead
+
+Per-call overhead added by HAMR (Worker + KV + auth) compared to direct provider call.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[cf-worker-latency]]
+- [[per-call-token-economics]]

--- a/wiki/concepts/keyword-grounded-grading-bias.md
+++ b/wiki/concepts/keyword-grounded-grading-bias.md
@@ -1,0 +1,20 @@
+---
+title: "Keyword-Grounded Grading Bias"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [governance, audit]
+sources: []
+related: ["[[deterministic-top-k-extractive]]"]
+status: stub
+---
+
+# Keyword-Grounded Grading Bias
+
+Failure mode where LLM judges fixate on keyword presence rather than semantic adequacy.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[deterministic-top-k-extractive]]

--- a/wiki/concepts/litellm-client.md
+++ b/wiki/concepts/litellm-client.md
@@ -1,0 +1,21 @@
+---
+title: "LiteLLM Client"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [fleet, routing]
+sources: []
+related: ["[[cascade-dispatch]]", "[[fleet-config]]"]
+status: stub
+---
+
+# LiteLLM Client
+
+Unified client that prefers LiteLLM gateway and falls back to direct Ollama (`scripts/global/litellm-client.js`). Triggers fallback chain via named route groups.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[cascade-dispatch]]
+- [[fleet-config]]

--- a/wiki/concepts/megingjord-harness.md
+++ b/wiki/concepts/megingjord-harness.md
@@ -1,0 +1,60 @@
+---
+title: "Megingjord Harness"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [governance, harness]
+sources: []
+related: ["[[harness-goals]]", "[[baton-protocol]]", "[[governance-enforcement]]", "[[self-annealing]]"]
+status: draft
+---
+
+# Megingjord Harness
+
+The governance and agentic-workflow harness for cross-team AI software
+engineering. Rebranded from DevEnv Ops on 2026-04-29.
+
+## Purpose
+
+Coordinate three independent AI teams (Claude Code, Copilot, Codex) plus
+human operator through a structured Agile baton workflow with deterministic
+gates, role-bound authority, and observable governance.
+
+## Core primitives
+
+- **Baton workflow** (`[[baton-protocol]]`): Manager → Collaborator → Admin →
+  Consultant, with single-active-role-per-ticket and signed handoff
+  artifacts at each transition.
+- **Goal Constitution** (`[[harness-goals]]`): priority-ordered G1..G9
+  goals that drive every decision when tradeoffs occur.
+- **Governance enforcement** (`[[governance-enforcement]]`): four-layer
+  system (instructions, hooks, skills, bootstrap) that prevents drift.
+- **Self-annealing** (`[[self-annealing]]`): bounded review pass that
+  detects and corrects drift, with three-tier escalation per Epic #1308.
+- **Cross-team routing** (`[[free-router]]` + `[[cascade-dispatch]]`):
+  cost-ascending lane selection enforcing G3 Zero Cost without sacrificing
+  G2 Quality.
+
+## Substrate
+
+Runs on three team substrates (`claude-code-cli`, `github-copilot`,
+`codex-cli`/`codex-vscode-ide`) plus shared CI/CD via GitHub Actions and
+HAMR (Cloudflare Worker for cross-team cost/observability mechanics).
+
+## Top-level instruction surfaces
+
+All bound via `CLAUDE.md`:
+
+- `role-baton-routing.instructions.md` — baton state machine
+- `epic-governance.instructions.md` — Epic-specific rules (Rule E2/E3/E5)
+- `workflow-resilience.instructions.md` — three-tier self-anneal
+- `observability.instructions.md` — logging + monitoring (Epic #1339 C9)
+- `hamr-routing.instructions.md` — HAMR mechanics
+
+## See also
+
+- `[[harness-goals]]` — the Goal Constitution
+- `[[baton-protocol]]` — workflow primitive
+- `[[governance-enforcement]]` — drift prevention
+- `[[self-annealing]]` — drift correction
+- `[[distributed-self-anneal]]` — three-tier extension

--- a/wiki/concepts/model-routing-engine.md
+++ b/wiki/concepts/model-routing-engine.md
@@ -1,0 +1,22 @@
+---
+title: "Model Routing Engine"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [routing, governance]
+sources: []
+related: ["[[free-router]]", "[[cascade-dispatch]]", "[[model-routing]]"]
+status: stub
+---
+
+# Model Routing Engine
+
+Aggregates routing telemetry and enforces premium-share ceiling (default 20% over 7d) per Goal Constitution G3.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[free-router]]
+- [[cascade-dispatch]]
+- [[model-routing]]

--- a/wiki/concepts/multi-agent-command-center-round-1.md
+++ b/wiki/concepts/multi-agent-command-center-round-1.md
@@ -1,0 +1,20 @@
+---
+title: "Multi-Agent Command Center Round 1"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [governance, history]
+sources: []
+related: ["[[megingjord-harness]]"]
+status: stub
+---
+
+# Multi-Agent Command Center Round 1
+
+First-round research artifact for multi-agent operator dashboard.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[megingjord-harness]]

--- a/wiki/concepts/per-call-token-economics.md
+++ b/wiki/concepts/per-call-token-economics.md
@@ -1,0 +1,21 @@
+---
+title: "Per-Call Token Economics"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [cost, observability]
+sources: []
+related: ["[[anthropic-prompt-cache]]", "[[ephemeral-vs-extended-cache]]"]
+status: stub
+---
+
+# Per-Call Token Economics
+
+Per-call breakdown of cache-read / input / output token billing across providers.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[anthropic-prompt-cache]]
+- [[ephemeral-vs-extended-cache]]

--- a/wiki/concepts/provenance-vs-locality.md
+++ b/wiki/concepts/provenance-vs-locality.md
@@ -1,0 +1,21 @@
+---
+title: "Provenance vs Locality"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [security, fleet]
+sources: []
+related: ["[[governance-artifact-signing]]", "[[fleet-config]]"]
+status: stub
+---
+
+# Provenance vs Locality
+
+Tradeoff between provenance-traceability (centralized signing) and locality (offline-capable nodes).
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[governance-artifact-signing]]
+- [[fleet-config]]

--- a/wiki/concepts/reuse-refactor-replace-merge-rubric.md
+++ b/wiki/concepts/reuse-refactor-replace-merge-rubric.md
@@ -1,0 +1,20 @@
+---
+title: "Reuse Refactor Replace Merge Rubric"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [governance, audit]
+sources: []
+related: ["[[deterministic-top-k-extractive]]"]
+status: stub
+---
+
+# Reuse Refactor Replace Merge Rubric
+
+Four-axis decision rubric for evaluating existing code during refactor/integration.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[deterministic-top-k-extractive]]

--- a/wiki/concepts/rule-coverage-gate.md
+++ b/wiki/concepts/rule-coverage-gate.md
@@ -1,0 +1,20 @@
+---
+title: "Rule Coverage Gate"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [governance, gates]
+sources: []
+related: ["[[two-stage-coverage-gate]]"]
+status: stub
+---
+
+# Rule Coverage Gate
+
+CI gate that ensures every governance rule has at least one test fixture.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[two-stage-coverage-gate]]

--- a/wiki/concepts/slsa-bundle-verification.md
+++ b/wiki/concepts/slsa-bundle-verification.md
@@ -1,0 +1,21 @@
+---
+title: "SLSA Bundle Verification"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [security, hamr]
+sources: []
+related: ["[[governance-artifact-signing]]", "[[hamr-bundle]]"]
+status: stub
+---
+
+# SLSA Bundle Verification
+
+SLSA provenance verification on HAMR bundle delivery (cosign + GitHub Artifact Attestation).
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[governance-artifact-signing]]
+- [[hamr-bundle]]

--- a/wiki/concepts/tailscale-fleet-rtt.md
+++ b/wiki/concepts/tailscale-fleet-rtt.md
@@ -1,0 +1,21 @@
+---
+title: "Tailscale Fleet RTT"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [fleet, observability]
+sources: []
+related: ["[[fleet-config]]", "[[cf-worker-latency]]"]
+status: stub
+---
+
+# Tailscale Fleet RTT
+
+Round-trip-time budget on Tailscale mesh between dashboard host and fleet nodes.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[fleet-config]]
+- [[cf-worker-latency]]

--- a/wiki/concepts/token-provider-adapters.md
+++ b/wiki/concepts/token-provider-adapters.md
@@ -1,0 +1,21 @@
+---
+title: "Token Provider Adapters"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [cache, routing]
+sources: []
+related: ["[[anthropic-prompt-cache]]", "[[per-call-token-economics]]"]
+status: stub
+---
+
+# Token Provider Adapters
+
+Adapter layer that normalizes per-provider token-usage fields into the harness telemetry schema.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[anthropic-prompt-cache]]
+- [[per-call-token-economics]]

--- a/wiki/concepts/two-stage-coverage-gate.md
+++ b/wiki/concepts/two-stage-coverage-gate.md
@@ -1,0 +1,21 @@
+---
+title: "Two-Stage Coverage Gate"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [governance, gates]
+sources: []
+related: ["[[rule-coverage-gate]]", "[[two-stage-rule-coverage-gate]]"]
+status: stub
+---
+
+# Two-Stage Coverage Gate
+
+Coverage gate that runs in advisory mode for N weeks before becoming required.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[rule-coverage-gate]]
+- [[two-stage-rule-coverage-gate]]

--- a/wiki/concepts/two-stage-rule-coverage-gate.md
+++ b/wiki/concepts/two-stage-rule-coverage-gate.md
@@ -1,0 +1,21 @@
+---
+title: "Two-Stage Rule Coverage Gate"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [governance, gates]
+sources: []
+related: ["[[rule-coverage-gate]]", "[[two-stage-coverage-gate]]"]
+status: stub
+---
+
+# Two-Stage Rule Coverage Gate
+
+Variant of two-stage gate specific to ADR-010 rule-coverage tracking.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[rule-coverage-gate]]
+- [[two-stage-coverage-gate]]

--- a/wiki/concepts/warm-connection-assumption.md
+++ b/wiki/concepts/warm-connection-assumption.md
@@ -1,0 +1,21 @@
+---
+title: "Warm Connection Assumption"
+type: concept
+created: 2026-05-11
+updated: 2026-05-11
+tags: [fleet, performance]
+sources: []
+related: ["[[tailscale-fleet-rtt]]", "[[capability-probe]]"]
+status: stub
+---
+
+# Warm Connection Assumption
+
+Assumption that Tailscale connections to fleet nodes are warm (no cold-start handshake) at dispatch time.
+
+> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+
+## See also
+
+- [[tailscale-fleet-rtt]]
+- [[capability-probe]]

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -30,6 +30,9 @@ The LLM updates this on every ingest operation.
 - [[distributed-self-anneal]] — Three-tier distributed self-anneal (Epic #1308)
 - [[andon-pull-protocol]] — Any-role pull mechanics + pivot semantics (Epic #1308)
 - [[harness-logging-inventory]] — Logging surface inventory + G1..G9 coverage map (Epic #1339)
+- [[megingjord-harness]] — Megingjord Harness top-level overview (rebranded from DevEnv Ops 2026-04-29)
+- [[cascade-dispatch]] — Bounded escalation pattern (Free → Fleet → Haiku → Premium)
+- [[free-router]] — Lane-selection layer above cascade-dispatch
 - [[wiki-pattern]] — Karpathy LLM Wiki Pattern
 - [[governance-enforcement]] — Governance Enforcement
 - [[protocol-enforcement]] — Protocol Enforcement Architecture


### PR DESCRIPTION
## Summary
Codex Team's queued #1207 work, picked up after their rate-limit. tool-002 wiki-orphan-check now PASSES.

## Files
- 34 stub pages under `wiki/concepts/`
- `wiki/index.md` registers new pages
- `CHANGELOG.md` entry

## Test plan
- [x] `npm run lint` — 412 files within limit
- [x] `npm run docs:lint` — clean
- [x] `npm run wiki:lint` — broken wikilinks 80→0
- [x] `tool-002` consultant-check: FAIL → PASS

## Drift-lint citation
docs-drift-maintenance: only wiki/ + CHANGELOG.md touched; no contradiction with existing instructions.

Refs #1207