### PR TITLE
feat(dashboard): stress realism baton emitter #1409

### DIFF
--- a/.changes/unreleased/1409.md
+++ b/.changes/unreleased/1409.md
@@ -1,0 +1,9 @@
+## [Unreleased] — #1409: dashboard stress realism (D-1398-02)
+
+### Added
+- `dashboard/js/stress-realism.js` — emits real baton-artifact handoff strings (MANAGER → COLLABORATOR → ADMIN → CONSULTANT) with proper signer rotation (Cole/Orla/Mira/Yara). Lane-aware: code-change runs 4-role, config-only skips Collaborator, docs-only skips Admin, trivial skips both. Tracks per-handoff reliability metric (AC6). Supports concurrent-orchestration mode via `runConcurrent` with bounded concurrency (AC9).
+- `aggregateReliability()` — computes per-handoff success rate and 4-chain compounding projection (per #1395 Theme 2 reliability compounding finding: a 95% per-step rate yields ~81% across a 4-role baton).
+- `tests/stress-realism.spec.js` — 13 golden-file tests covering handoff emission, signer independence, lane variants, reliability tracking, concurrent execution, and aggregation math.
+
+### Why
+Phase-1 of Epic #1398. Closes AC3, AC6, AC9. Plugs into stress-orchestrator (#1408) via the `onTicket` hook — orchestrator can now drive realistic baton flows instead of mock state mutations.

--- a/dashboard/js/stress-realism.js
+++ b/dashboard/js/stress-realism.js
@@ -1,0 +1,86 @@
+// stress-realism — Real baton-artifact emission for stress runs. Epic #1398 AC3+AC6+AC9.
+// Hooks into stress-orchestrator (#1408) via onTicket; produces MANAGER → COLLABORATOR →
+// ADMIN → CONSULTANT handoff strings with proper schema fields. Tracks per-handoff
+// reliability (AC6). Supports concurrent-orchestration mode (AC9).
+'use strict';
+
+const HANDOFFS = ['MANAGER_HANDOFF', 'COLLABORATOR_HANDOFF', 'ADMIN_HANDOFF', 'CONSULTANT_CLOSEOUT'];
+const SIGNERS = {
+  MANAGER_HANDOFF: 'Cole Mason',
+  COLLABORATOR_HANDOFF: 'Orla Harper',
+  ADMIN_HANDOFF: 'Mira Reyes',
+  CONSULTANT_CLOSEOUT: 'Yara Vale',
+};
+const TEAM_MODEL = 'claude-code:opus-4-7@anthropic';
+
+function emitHandoff(kind, ticket) {
+  const signer = SIGNERS[kind];
+  if (!signer) throw new Error(`Unknown handoff kind: ${kind}`);
+  const role = kind.split('_')[0].toLowerCase();
+  return [
+    `**${kind} — ${signer}**`,
+    `ticket: ${ticket.id} (${ticket.lane})`,
+    `Signed-by: ${signer} · Team&Model: ${TEAM_MODEL} · Role: ${role}`,
+  ].join('\n');
+}
+
+function laneHandoffSequence(lane) {
+  // config-only skips COLLABORATOR; docs-only skips ADMIN; trivial skips both.
+  if (lane === 'config-only') return ['MANAGER_HANDOFF', 'ADMIN_HANDOFF', 'CONSULTANT_CLOSEOUT'];
+  if (lane === 'docs-only') return ['MANAGER_HANDOFF', 'COLLABORATOR_HANDOFF', 'CONSULTANT_CLOSEOUT'];
+  if (lane === 'trivial') return ['MANAGER_HANDOFF', 'CONSULTANT_CLOSEOUT'];
+  return HANDOFFS;
+}
+
+async function runRealism(ticket, opts = {}) {
+  const sequence = laneHandoffSequence(ticket.lane);
+  const reliability = { total: 0, ok: 0, fail: 0, mean_ms: 0 };
+  const events = [];
+  for (const kind of sequence) {
+    const t0 = Date.now();
+    try {
+      const artifact = emitHandoff(kind, ticket);
+      events.push({ kind, artifact, ts: new Date().toISOString() });
+      reliability.ok += 1;
+    } catch (err) {
+      reliability.fail += 1;
+      events.push({ kind, error: err.message });
+    }
+    reliability.total += 1;
+    reliability.mean_ms += Date.now() - t0;
+    if (opts.onArtifact) await opts.onArtifact(events[events.length - 1]);
+  }
+  reliability.mean_ms = reliability.total ? reliability.mean_ms / reliability.total : 0;
+  return { ticket_id: ticket.id, lane: ticket.lane, sequence, events, reliability };
+}
+
+async function runConcurrent(tickets, opts = {}) {
+  const concurrency = opts.concurrency || tickets.length;
+  const results = [];
+  for (let i = 0; i < tickets.length; i += concurrency) {
+    const batch = tickets.slice(i, i + concurrency);
+    const batchResults = await Promise.all(batch.map(t => runRealism(t, opts)));
+    results.push(...batchResults);
+  }
+  return results;
+}
+
+function aggregateReliability(results) {
+  const total = results.reduce((sum, r) => sum + r.reliability.total, 0);
+  const ok = results.reduce((sum, r) => sum + r.reliability.ok, 0);
+  const fail = results.reduce((sum, r) => sum + r.reliability.fail, 0);
+  const rate = total > 0 ? ok / total : 0;
+  const compoundReliabilityAcrossNChain = (perStep, chain) => Math.pow(perStep, chain);
+  const fourChain = compoundReliabilityAcrossNChain(rate, 4);
+  return {
+    transitions: total, ok, fail,
+    per_handoff_rate: rate,
+    four_chain_projected: fourChain,
+  };
+}
+
+module.exports = {
+  HANDOFFS, SIGNERS, TEAM_MODEL,
+  emitHandoff, laneHandoffSequence,
+  runRealism, runConcurrent, aggregateReliability,
+};

--- a/tests/stress-realism.spec.js
+++ b/tests/stress-realism.spec.js
@@ -1,0 +1,100 @@
+// stress-realism — baton-artifact emission tests (#1409, Epic #1398 AC3+AC6+AC9).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const R = require(path.resolve(__dirname, '..', 'dashboard', 'js', 'stress-realism.js'));
+
+test('emitHandoff: produces well-formed handoff with signer, role, ticket id', () => {
+  const ticket = { id: 'T-001', lane: 'code-change' };
+  const text = R.emitHandoff('MANAGER_HANDOFF', ticket);
+  expect(text).toContain('MANAGER_HANDOFF — Cole Mason');
+  expect(text).toContain('ticket: T-001 (code-change)');
+  expect(text).toContain('Signed-by: Cole Mason');
+  expect(text).toContain('Role: manager');
+});
+
+test('emitHandoff: distinct signer per kind (signer-independence)', () => {
+  const ticket = { id: 'T-002', lane: 'code-change' };
+  const signers = R.HANDOFFS.map(k => {
+    const m = R.emitHandoff(k, ticket).match(/Signed-by: ([^·]+)/);
+    return m[1].trim();
+  });
+  expect(new Set(signers).size).toBe(4);
+});
+
+test('emitHandoff: throws on unknown kind', () => {
+  expect(() => R.emitHandoff('UNKNOWN', { id: 'T', lane: 'code-change' })).toThrow(/Unknown handoff/);
+});
+
+test('laneHandoffSequence: code-change runs full 4-role baton', () => {
+  expect(R.laneHandoffSequence('code-change')).toEqual(R.HANDOFFS);
+});
+
+test('laneHandoffSequence: config-only skips Collaborator', () => {
+  const seq = R.laneHandoffSequence('config-only');
+  expect(seq).toEqual(['MANAGER_HANDOFF', 'ADMIN_HANDOFF', 'CONSULTANT_CLOSEOUT']);
+});
+
+test('laneHandoffSequence: docs-only skips Admin', () => {
+  const seq = R.laneHandoffSequence('docs-only');
+  expect(seq).toEqual(['MANAGER_HANDOFF', 'COLLABORATOR_HANDOFF', 'CONSULTANT_CLOSEOUT']);
+});
+
+test('laneHandoffSequence: trivial skips Collaborator AND Admin', () => {
+  expect(R.laneHandoffSequence('trivial')).toEqual(['MANAGER_HANDOFF', 'CONSULTANT_CLOSEOUT']);
+});
+
+test('runRealism: emits all 4 handoffs for code-change lane and tracks reliability', async () => {
+  const ticket = { id: 'T-003', lane: 'code-change' };
+  const result = await R.runRealism(ticket);
+  expect(result.events.length).toBe(4);
+  expect(result.events.map(e => e.kind)).toEqual(R.HANDOFFS);
+  expect(result.reliability.total).toBe(4);
+  expect(result.reliability.ok).toBe(4);
+  expect(result.reliability.fail).toBe(0);
+  expect(result.reliability.mean_ms).toBeGreaterThanOrEqual(0);
+});
+
+test('runRealism: invokes onArtifact hook for each emitted event', async () => {
+  const seen = [];
+  await R.runRealism({ id: 'T-004', lane: 'code-change' }, {
+    onArtifact: (ev) => { seen.push(ev.kind); }
+  });
+  expect(seen).toEqual(R.HANDOFFS);
+});
+
+test('runRealism: config-only ticket emits only 3 handoffs', async () => {
+  const result = await R.runRealism({ id: 'T-005', lane: 'config-only' });
+  expect(result.events.length).toBe(3);
+  expect(result.reliability.total).toBe(3);
+});
+
+test('runConcurrent: processes all tickets and returns one result per ticket', async () => {
+  const tickets = [
+    { id: 'T-a', lane: 'code-change' },
+    { id: 'T-b', lane: 'docs-only' },
+    { id: 'T-c', lane: 'config-only' },
+  ];
+  const results = await R.runConcurrent(tickets, { concurrency: 2 });
+  expect(results.length).toBe(3);
+  expect(results.map(r => r.ticket_id)).toEqual(['T-a', 'T-b', 'T-c']);
+});
+
+test('aggregateReliability: computes per-handoff rate + compounding projection', () => {
+  const fakeResults = [
+    { reliability: { total: 4, ok: 4, fail: 0 } },
+    { reliability: { total: 3, ok: 3, fail: 0 } },
+    { reliability: { total: 4, ok: 3, fail: 1 } },
+  ];
+  const agg = R.aggregateReliability(fakeResults);
+  expect(agg.transitions).toBe(11);
+  expect(agg.ok).toBe(10);
+  expect(agg.fail).toBe(1);
+  expect(agg.per_handoff_rate).toBeCloseTo(10 / 11);
+  expect(agg.four_chain_projected).toBeCloseTo(Math.pow(10 / 11, 4));
+});
+
+test('aggregateReliability: zero results returns zero rate without crash', () => {
+  const agg = R.aggregateReliability([]);
+  expect(agg.transitions).toBe(0);
+  expect(agg.per_handoff_rate).toBe(0);
+});


### PR DESCRIPTION
## Summary

Phase-1 of Epic #1398. Adds dashboard/js/stress-realism.js — emits real baton-artifact handoff strings with proper signer rotation. Plugs into stress-orchestrator (#1408) via the onTicket hook.

Refs #1409 #1398

## Artifacts

- `dashboard/js/stress-realism.js` (86 LOC) — `emitHandoff`, `laneHandoffSequence`, `runRealism`, `runConcurrent`, `aggregateReliability`.
- `tests/stress-realism.spec.js` (100 LOC) — 13 golden-file tests.

## AC coverage

- AC3 ✅ dashboard/js/stress-realism.js with real handoff emission, signer rotation, lane-aware variants
- AC6 ✅ per-handoff reliability metric tracked; aggregateReliability computes 4-chain compounding projection
- AC9 ✅ runConcurrent supports bounded-concurrency cross-ticket parallel execution

## Test plan

- [x] 13 golden-file tests pass
- [x] `npm run lint` clean
- [x] readability gate unchanged

## Baton

- COLLABORATOR_HANDOFF on #1409
- ADMIN_HANDOFF pending
- CONSULTANT_CLOSEOUT pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)