### PR TITLE
feat(governance): megalint validators + tests #1420

### DIFF
--- a/.changes/unreleased/1420.md
+++ b/.changes/unreleased/1420.md
@@ -1,0 +1,16 @@
+## [Unreleased] — #1420: megalint validators + tests (D-1407-01)
+
+### Added
+- `scripts/global/megalint/` — schema-aware governance lint orchestrator + 7 domain-decomposed pure-function validators per Epic #1407 Option A:
+  - `manager-handoff.js` — validates MANAGER_HANDOFF schema (scope, lane, test_strategy, acceptance, gates)
+  - `collaborator-handoff.js` — validates COLLABORATOR_HANDOFF signer fields; lightweight lanes skip
+  - `admin-handoff.js` — validates ADMIN_HANDOFF signer + name-only independence vs Collaborator (closes a gap in existing `baton-independence.js` that captured trailing role suffixes)
+  - `consultant-closeout.js` — validates CONSULTANT_CLOSEOUT requires G1-9 rubric + verification timestamp + verdict (AC7)
+  - `signer-fidelity.js` — rejects client-identity (`Curtis Franks`) in issue-body `Signed-by:` / `AI-Signature:` fields
+  - `body-ac-truthfulness.js` — verifies AC checkbox state for terminal-status tickets
+  - `epic-ac-traceability.js` — verifies Epic body contains child-ticket references when ≥3 ACs declared
+  - `index.js` — orchestrator dispatching to all 7 validators
+- `tests/megalint/` — 32 golden-file tests across 3 spec files; all passing.
+
+### Why
+Phase-1 of Epic #1407. Closes AC1+AC2. Validators are pure functions (no CI wiring in this child) so they can be unit-tested deterministically and composed by later workflow children (D-1407-02, D-1407-03, D-1407-04). Each validator addresses a specific defect category measured empirically in Phase-0 audits #1402-1404.

--- a/scripts/global/megalint/admin-handoff.js
+++ b/scripts/global/megalint/admin-handoff.js
@@ -1,0 +1,59 @@
+'use strict';
+// admin-handoff — validates ADMIN_HANDOFF signer + independence vs Collaborator.
+
+const path = require('path');
+const { roleIdentity } = require(path.join(__dirname, '..', 'baton-independence.js'));
+
+const LIGHTWEIGHT = ['lane:docs-research', 'lane:docs-only', 'lane:trivial'];
+
+function findAdminHandoff(comments) {
+  return [...(comments || [])].reverse().find(c => (c.body || '').includes('ADMIN_HANDOFF'));
+}
+
+function findCollaboratorHandoff(comments) {
+  return [...(comments || [])].reverse().find(c => (c.body || '').includes('COLLABORATOR_HANDOFF'));
+}
+
+function nameOnly(commentBody) {
+  const match = (commentBody || '').match(/Signed-by\s*:\s*([^·,\n]+?)(?=\s*[·,\n]|$)/i);
+  return match ? match[1].trim().toLowerCase() : null;
+}
+
+function checkSignerFields(body) {
+  const violations = [];
+  if (!/Signed-by:/i.test(body)) violations.push({ rule: 'missing-signer', detail: 'ADMIN_HANDOFF missing Signed-by field' });
+  if (!/Team&Model:/i.test(body)) violations.push({ rule: 'missing-team-model', detail: 'ADMIN_HANDOFF missing Team&Model field' });
+  if (!/Role:\s*admin/i.test(body)) violations.push({ rule: 'missing-role-admin', detail: 'ADMIN_HANDOFF missing Role: admin field' });
+  return violations;
+}
+
+function checkIndependence(adminBody, collaboratorHandoff) {
+  if (!collaboratorHandoff) return [];
+  const collabName = nameOnly(collaboratorHandoff.body);
+  const adminName = nameOnly(adminBody);
+  if (collabName && adminName && collabName === adminName) {
+    return [{ rule: 'admin-signer-not-independent',
+      detail: `ADMIN_HANDOFF signer "${adminName}" matches COLLABORATOR_HANDOFF signer — independent verification requires a distinct identity` }];
+  }
+  return [];
+}
+
+function validate(input) {
+  if (LIGHTWEIGHT.includes(input.lane)) {
+    return { ok: true, violations: [], reason: 'lightweight-lane-skip' };
+  }
+  const comments = input.comments || [];
+  const handoff = findAdminHandoff(comments);
+  if (!handoff) {
+    return { ok: false, violations: [{ rule: 'missing-admin-handoff',
+      detail: 'ADMIN_HANDOFF comment not found on issue' }], found: false };
+  }
+  const violations = [
+    ...checkSignerFields(handoff.body || ''),
+    ...checkIndependence(handoff.body, findCollaboratorHandoff(comments)),
+  ];
+  const signer = roleIdentity({ body: handoff.body, author: handoff.user && handoff.user.login });
+  return { ok: violations.length === 0, violations, found: true, signer };
+}
+
+module.exports = { validate, findAdminHandoff };

--- a/scripts/global/megalint/body-ac-truthfulness.js
+++ b/scripts/global/megalint/body-ac-truthfulness.js
@@ -1,0 +1,44 @@
+'use strict';
+// body-ac-truthfulness — verifies AC checkbox state matches CLOSEOUT narrative claims.
+// Epic #1407 AC5. For terminal-state (status:done) issues, all AC checkboxes
+// in the body must be ticked. Resolves the 20% defect rate measured in #1404.
+
+function countCheckboxes(body) {
+  const lines = (body || '').split('\n');
+  let total = 0, ticked = 0, unticked = 0;
+  for (const line of lines) {
+    if (/^[\s-]*\[\s\]\s+AC[\d:\s-]/i.test(line)) { total++; unticked++; }
+    else if (/^[\s-]*\[x\]\s+AC[\d:\s-]/i.test(line)) { total++; ticked++; }
+  }
+  return { total, ticked, unticked };
+}
+
+function validate(input) {
+  const body = input.body || '';
+  const labels = input.labels || [];
+  const state = input.state || 'open';
+  const violations = [];
+
+  const counts = countCheckboxes(body);
+  const isTerminal = labels.includes('status:done') || labels.includes('status:cancelled');
+
+  // For closed/terminal tickets with declared ACs, all must be ticked.
+  if ((state === 'closed' || isTerminal) && counts.unticked > 0) {
+    // status:cancelled is permitted to have unticked ACs (goal invalidated).
+    if (!labels.includes('status:cancelled')) {
+      violations.push({
+        rule: 'unticked-ac-on-terminal',
+        detail: `${counts.unticked} of ${counts.total} ACs remain unticked on terminal ticket. `
+          + 'Tick each AC before applying status:done, OR rescope via cancellation.',
+        total: counts.total, ticked: counts.ticked, unticked: counts.unticked,
+      });
+    }
+  }
+
+  // Advisory: open tickets with status:done should match terminal rules
+  // (caught above) but we don't error on in-progress unticked-AC.
+
+  return { ok: violations.length === 0, violations, counts };
+}
+
+module.exports = { validate, countCheckboxes };

--- a/scripts/global/megalint/collaborator-handoff.js
+++ b/scripts/global/megalint/collaborator-handoff.js
@@ -1,0 +1,44 @@
+'use strict';
+// collaborator-handoff — validates COLLABORATOR_HANDOFF signer + content.
+
+const path = require('path');
+const { roleIdentity } = require(path.join(__dirname, '..', 'baton-independence.js'));
+
+const LIGHTWEIGHT = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:config-only'];
+
+function findCollaboratorHandoff(comments) {
+  return (comments || []).reverse().find(c => (c.body || '').includes('COLLABORATOR_HANDOFF'));
+}
+
+function checkSignerFields(body) {
+  const violations = [];
+  if (!/Signed-by:/i.test(body)) {
+    violations.push({ rule: 'missing-signer',
+      detail: 'COLLABORATOR_HANDOFF missing Signed-by field' });
+  }
+  if (!/Team&Model:/i.test(body)) {
+    violations.push({ rule: 'missing-team-model',
+      detail: 'COLLABORATOR_HANDOFF missing Team&Model field' });
+  }
+  if (!/Role:\s*collaborator/i.test(body)) {
+    violations.push({ rule: 'missing-role-collaborator',
+      detail: 'COLLABORATOR_HANDOFF missing Role: collaborator field' });
+  }
+  return violations;
+}
+
+function validate(input) {
+  if (LIGHTWEIGHT.includes(input.lane)) {
+    return { ok: true, violations: [], reason: 'lightweight-lane-skip' };
+  }
+  const handoff = findCollaboratorHandoff(input.comments || []);
+  if (!handoff) {
+    return { ok: false, violations: [{ rule: 'missing-collaborator-handoff',
+      detail: 'COLLABORATOR_HANDOFF comment not found on issue' }], found: false };
+  }
+  const violations = checkSignerFields(handoff.body || '');
+  const signer = roleIdentity({ body: handoff.body, author: handoff.user && handoff.user.login });
+  return { ok: violations.length === 0, violations, found: true, signer };
+}
+
+module.exports = { validate, findCollaboratorHandoff };

--- a/scripts/global/megalint/consultant-closeout.js
+++ b/scripts/global/megalint/consultant-closeout.js
@@ -1,0 +1,45 @@
+'use strict';
+// consultant-closeout — validates CONSULTANT_CLOSEOUT schema.
+// Epic #1407 AC7: requires verification-timestamp + G1-9 rubric atop signer fields.
+
+function findConsultantCloseout(comments) {
+  return (comments || []).reverse().find(c => (c.body || '').includes('CONSULTANT_CLOSEOUT'));
+}
+
+function checkSignerFields(body) {
+  const violations = [];
+  if (!/Signed-by:/i.test(body)) violations.push({ rule: 'missing-signer', detail: 'CONSULTANT_CLOSEOUT missing Signed-by field' });
+  if (!/Team&Model:/i.test(body)) violations.push({ rule: 'missing-team-model', detail: 'CONSULTANT_CLOSEOUT missing Team&Model field' });
+  if (!/Role:\s*consultant/i.test(body)) violations.push({ rule: 'missing-role-consultant', detail: 'CONSULTANT_CLOSEOUT missing Role: consultant field' });
+  return violations;
+}
+
+function checkEvidenceFields(body) {
+  const violations = [];
+  if (!/G[1-9]\s*[=:]/i.test(body)) {
+    violations.push({ rule: 'missing-rubric',
+      detail: 'CONSULTANT_CLOSEOUT missing G1-9 goal-lens rubric (e.g., "G1=9, G2=8, ...")' });
+  }
+  if (!/verification[ _-]?timestamp/i.test(body)) {
+    violations.push({ rule: 'missing-verification-timestamp',
+      detail: 'CONSULTANT_CLOSEOUT missing verification-timestamp field' });
+  }
+  if (!/(verdict|approve|approved)/i.test(body)) {
+    violations.push({ rule: 'missing-verdict',
+      detail: 'CONSULTANT_CLOSEOUT missing explicit verdict / approve statement' });
+  }
+  return violations;
+}
+
+function validate(input) {
+  const closeout = findConsultantCloseout(input.comments || []);
+  if (!closeout) {
+    return { ok: false, violations: [{ rule: 'missing-consultant-closeout',
+      detail: 'CONSULTANT_CLOSEOUT comment not found on issue' }], found: false };
+  }
+  const body = closeout.body || '';
+  const violations = [...checkSignerFields(body), ...checkEvidenceFields(body)];
+  return { ok: violations.length === 0, violations, found: true };
+}
+
+module.exports = { validate, findConsultantCloseout };

--- a/scripts/global/megalint/epic-ac-traceability.js
+++ b/scripts/global/megalint/epic-ac-traceability.js
@@ -1,0 +1,55 @@
+'use strict';
+// epic-ac-traceability — verifies Epic body contains child-ticket references.
+// Epic #1407 AC6.
+
+const MIN_ACS_FOR_REFS = 3;
+
+function countAcs(body) {
+  return ((body || '').match(/^[\s-]*\[[\sx]\]\s+AC[\d:\s-]/gim) || []).length;
+}
+
+function findChildRefs(body) {
+  const matches = (body || '').match(/#(\d+)/g) || [];
+  return [...new Set(matches.map(m => parseInt(m.slice(1), 10)))];
+}
+
+function checkRefPresence(acCount, refs) {
+  if (acCount >= MIN_ACS_FOR_REFS && refs.length === 0) {
+    return [{
+      rule: 'epic-body-missing-child-refs',
+      detail: `Epic with ${acCount} ACs has zero child-ticket #N references in body. `
+        + 'Add a "Child tickets" section listing #N references per AC, or document explicit deferral.',
+      ac_count: acCount,
+    }];
+  }
+  return [];
+}
+
+function checkKnownChildren(refs, linkedChildren) {
+  if (linkedChildren.length === 0) return [];
+  const mentioned = linkedChildren.filter(n => refs.includes(n));
+  if (mentioned.length === 0) {
+    return [{
+      rule: 'epic-body-missing-known-children',
+      detail: `Epic has ${linkedChildren.length} child(ren) [${linkedChildren.join(', ')}] but body references none`,
+    }];
+  }
+  return [];
+}
+
+function validate(input) {
+  const isEpic = (input.labels || []).includes('type:epic');
+  if (!isEpic) return { ok: true, violations: [], reason: 'not-an-epic' };
+
+  const body = input.body || '';
+  const issueNumber = input.issueNumber || null;
+  const acCount = countAcs(body);
+  const refs = findChildRefs(body).filter(n => n !== issueNumber);
+  const violations = [
+    ...checkRefPresence(acCount, refs),
+    ...checkKnownChildren(refs, input.linkedChildren || []),
+  ];
+  return { ok: violations.length === 0, violations, ac_count: acCount, refs };
+}
+
+module.exports = { validate, countAcs, findChildRefs };

--- a/scripts/global/megalint/index.js
+++ b/scripts/global/megalint/index.js
@@ -1,0 +1,51 @@
+'use strict';
+// megalint — schema-aware governance lint orchestrator. Epic #1407.
+// Dispatches to 7 domain-decomposed validators. Each validator is a pure
+// function returning {ok, violations[]}. Caller (CI workflow) decides whether
+// each violation is advisory or blocking based on context.
+
+const manager = require('./manager-handoff.js');
+const collaborator = require('./collaborator-handoff.js');
+const admin = require('./admin-handoff.js');
+const consultant = require('./consultant-closeout.js');
+const signer = require('./signer-fidelity.js');
+const truthfulness = require('./body-ac-truthfulness.js');
+const traceability = require('./epic-ac-traceability.js');
+
+const VALIDATORS = {
+  'manager-handoff': manager,
+  'collaborator-handoff': collaborator,
+  'admin-handoff': admin,
+  'consultant-closeout': consultant,
+  'signer-fidelity': signer,
+  'body-ac-truthfulness': truthfulness,
+  'epic-ac-traceability': traceability,
+};
+
+function runAll(input) {
+  const results = {};
+  for (const [name, validator] of Object.entries(VALIDATORS)) {
+    try {
+      results[name] = validator.validate(input);
+    } catch (err) {
+      results[name] = { ok: false, violations: [{ rule: 'validator-error',
+        detail: `${name} threw: ${err.message}` }] };
+    }
+  }
+  const allViolations = [];
+  for (const [name, result] of Object.entries(results)) {
+    for (const violation of (result.violations || [])) {
+      allViolations.push({ validator: name, ...violation });
+    }
+  }
+  return { ok: allViolations.length === 0, results, violations: allViolations };
+}
+
+function run(validatorName, input) {
+  if (!VALIDATORS[validatorName]) {
+    throw new Error(`Unknown validator: ${validatorName}. Known: ${Object.keys(VALIDATORS).join(', ')}`);
+  }
+  return VALIDATORS[validatorName].validate(input);
+}
+
+module.exports = { runAll, run, VALIDATORS };

--- a/scripts/global/megalint/manager-handoff.js
+++ b/scripts/global/megalint/manager-handoff.js
@@ -1,0 +1,54 @@
+'use strict';
+// manager-handoff — validates MANAGER_HANDOFF schema fields per role-baton-routing.
+// Epic #1407 AC3; subsumes #1335.
+
+const REQUIRED_FIELDS = ['scope', 'lane', 'test_strategy', 'acceptance', 'gates'];
+
+function findManagerHandoff(comments) {
+  return (comments || []).reverse().find(c => (c.body || '').includes('MANAGER_HANDOFF'));
+}
+
+function extractField(body, field) {
+  const pattern = new RegExp(`(?:^|\\n)[-*]?\\s*${field}\\s*:\\s*([^\\n]+)`, 'i');
+  const match = body.match(pattern);
+  return match ? match[1].trim() : null;
+}
+
+function checkRequiredFields(handoffBody) {
+  const violations = [];
+  for (const field of REQUIRED_FIELDS) {
+    if (!extractField(handoffBody, field)) {
+      violations.push({ rule: `missing-${field}`,
+        detail: `MANAGER_HANDOFF missing required field '${field}:' per role-baton-routing schema` });
+    }
+  }
+  return violations;
+}
+
+function checkLaneConsistency(handoffBody, expectedLane) {
+  if (!expectedLane) return [];
+  const declared = extractField(handoffBody, 'lane');
+  if (declared && declared !== expectedLane && !declared.includes(expectedLane)) {
+    return [{ rule: 'lane-mismatch',
+      detail: `MANAGER_HANDOFF lane='${declared}' but issue has label='${expectedLane}'` }];
+  }
+  return [];
+}
+
+function validate(input) {
+  const handoff = findManagerHandoff(input.comments || []);
+  if (!handoff) {
+    const violations = input.isEpic
+      ? [{ rule: 'epic-manager-handoff-missing',
+          detail: 'Epic must have a MANAGER_HANDOFF comment defining scope' }]
+      : [];
+    return { ok: violations.length === 0, violations, found: false };
+  }
+  const violations = [
+    ...checkRequiredFields(handoff.body),
+    ...checkLaneConsistency(handoff.body, input.lane),
+  ];
+  return { ok: violations.length === 0, violations, found: true };
+}
+
+module.exports = { validate, findManagerHandoff, extractField, REQUIRED_FIELDS };

--- a/scripts/global/megalint/signer-fidelity.js
+++ b/scripts/global/megalint/signer-fidelity.js
@@ -1,0 +1,56 @@
+'use strict';
+// signer-fidelity — rejects issue bodies using client identity for worker artifacts.
+// Epic #1407 AC4.
+
+const CLIENT_IDENTITIES = ['Curtis Franks'];
+
+function findSignerField(body, fieldName = 'Signed-by') {
+  const pattern = new RegExp(`${fieldName}\\s*:\\s*([^\\n·,]+?)(?=\\s*[·,\\n]|$)`, 'i');
+  const match = (body || '').match(pattern);
+  return match ? match[1].trim() : null;
+}
+
+function isClientIdentity(name) {
+  if (!name) return false;
+  return CLIENT_IDENTITIES.some(c => name.trim().toLowerCase() === c.toLowerCase());
+}
+
+function checkSignedBy(body) {
+  const violations = [];
+  const matches = [...body.matchAll(/Signed-by\s*:\s*([^\n·,]+?)(?=\s*[·,\n]|$)/gi)];
+  for (const match of matches) {
+    if (isClientIdentity(match[1].trim())) {
+      violations.push({
+        rule: 'client-identity-as-signer',
+        detail: `Issue body uses client identity "${match[1].trim()}" as Signed-by — workers must use a worker alias per team-model-signing.instructions.md`,
+      });
+    }
+  }
+  return violations;
+}
+
+function dedupe(violations) {
+  const seen = new Set();
+  const unique = [];
+  for (const violation of violations) {
+    const key = `${violation.rule}::${violation.detail}`;
+    if (!seen.has(key)) { seen.add(key); unique.push(violation); }
+  }
+  return unique;
+}
+
+function validate(input) {
+  const body = input.body || '';
+  const violations = checkSignedBy(body);
+  const aiSig = findSignerField(body, 'AI-Signature');
+  if (isClientIdentity(aiSig)) {
+    violations.push({
+      rule: 'client-identity-as-ai-signature',
+      detail: `Issue body uses client identity "${aiSig}" as AI-Signature trailer`,
+    });
+  }
+  const unique = dedupe(violations);
+  return { ok: unique.length === 0, violations: unique };
+}
+
+module.exports = { validate, isClientIdentity, findSignerField, CLIENT_IDENTITIES };

--- a/tests/megalint/baton-handoffs.spec.js
+++ b/tests/megalint/baton-handoffs.spec.js
@@ -1,0 +1,75 @@
+// megalint/{collaborator,admin,consultant}-* tests (#1420, Epic #1407 AC1).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const dir = path.resolve(__dirname, '..', '..', 'scripts', 'global', 'megalint');
+const Coll = require(path.join(dir, 'collaborator-handoff.js'));
+const Adm = require(path.join(dir, 'admin-handoff.js'));
+const Cons = require(path.join(dir, 'consultant-closeout.js'));
+
+const collaboratorBody = `**COLLABORATOR_HANDOFF — Orla Harper**
+work done.
+Signed-by: Orla Harper · Team&Model: claude-code:opus-4-7@anthropic · Role: collaborator`;
+const adminBody = `**ADMIN_HANDOFF — Mira Reyes**
+ready.
+Signed-by: Mira Reyes · Team&Model: claude-code:opus-4-7@anthropic · Role: admin`;
+const consultantBody = `**CONSULTANT_CLOSEOUT — Yara Vale**
+Rubric: G1=9, G2=9, G3=10, G4=10, G5=10, G6=9, G7=8, G8=8, G9=9. Mean 9.0.
+verdict: approve
+verification timestamp: 2026-05-12T11:30Z
+Signed-by: Yara Vale · Team&Model: claude-code:opus-4-7@anthropic · Role: consultant`;
+
+test('collaborator: full handoff passes; signer extracted', () => {
+  const r = Coll.validate({ comments: [{ body: collaboratorBody }] });
+  expect(r.ok).toBe(true);
+  expect(r.signer).toContain('Orla');
+});
+
+test('collaborator: lightweight lane skips check', () => {
+  const r = Coll.validate({ comments: [], lane: 'lane:docs-only' });
+  expect(r.ok).toBe(true);
+  expect(r.reason).toBe('lightweight-lane-skip');
+});
+
+test('collaborator: missing handoff fails', () => {
+  const r = Coll.validate({ comments: [{ body: 'no marker' }] });
+  expect(r.ok).toBe(false);
+});
+
+test('admin: full handoff passes; signer-independence verified', () => {
+  const r = Adm.validate({
+    comments: [{ body: collaboratorBody }, { body: adminBody }],
+  });
+  expect(r.ok).toBe(true);
+});
+
+test('admin: same signer as collaborator fails independence check', () => {
+  const sameSigner = adminBody.replace(/Mira Reyes/g, 'Orla Harper');
+  const r = Adm.validate({
+    comments: [{ body: collaboratorBody }, { body: sameSigner }],
+  });
+  expect(r.ok).toBe(false);
+  expect(r.violations.some(v => v.rule === 'admin-signer-not-independent')).toBe(true);
+});
+
+test('consultant: full closeout with rubric + timestamp + verdict passes', () => {
+  const r = Cons.validate({ comments: [{ body: consultantBody }] });
+  expect(r.ok).toBe(true);
+});
+
+test('consultant: missing G1-9 rubric fails', () => {
+  const body = consultantBody.replace(/Rubric:.+\n/, '');
+  const r = Cons.validate({ comments: [{ body }] });
+  expect(r.violations.some(v => v.rule === 'missing-rubric')).toBe(true);
+});
+
+test('consultant: missing verification timestamp fails', () => {
+  const body = consultantBody.replace(/verification timestamp:.+\n/, '');
+  const r = Cons.validate({ comments: [{ body }] });
+  expect(r.violations.some(v => v.rule === 'missing-verification-timestamp')).toBe(true);
+});
+
+test('consultant: missing verdict fails', () => {
+  const body = consultantBody.replace(/verdict:.+\n/, '');
+  const r = Cons.validate({ comments: [{ body }] });
+  expect(r.violations.some(v => v.rule === 'missing-verdict')).toBe(true);
+});

--- a/tests/megalint/body-and-traceability.spec.js
+++ b/tests/megalint/body-and-traceability.spec.js
@@ -1,0 +1,95 @@
+// megalint/{signer-fidelity,body-ac-truthfulness,epic-ac-traceability,index} tests.
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const dir = path.resolve(__dirname, '..', '..', 'scripts', 'global', 'megalint');
+const Sig = require(path.join(dir, 'signer-fidelity.js'));
+const AC = require(path.join(dir, 'body-ac-truthfulness.js'));
+const Trace = require(path.join(dir, 'epic-ac-traceability.js'));
+const Idx = require(path.join(dir, 'index.js'));
+
+test('signer-fidelity: Curtis Franks Signed-by rejected', () => {
+  const r = Sig.validate({ body: 'Signed-by: Curtis Franks\nTeam&Model: claude-code:opus-4-7' });
+  expect(r.ok).toBe(false);
+  expect(r.violations[0].rule).toBe('client-identity-as-signer');
+});
+
+test('signer-fidelity: worker alias accepted', () => {
+  const r = Sig.validate({ body: 'Signed-by: Nova Mason\nTeam&Model: copilot:gpt-5.3-codex@github' });
+  expect(r.ok).toBe(true);
+});
+
+test('signer-fidelity: AI-Signature trailer with client identity rejected', () => {
+  const r = Sig.validate({ body: 'AI-Signature: Curtis Franks' });
+  expect(r.ok).toBe(false);
+  expect(r.violations[0].rule).toBe('client-identity-as-ai-signature');
+});
+
+test('signer-fidelity: multiple Curtis-Franks occurrences deduplicated', () => {
+  const body = 'Signed-by: Curtis Franks\nElsewhere\nSigned-by: Curtis Franks';
+  const r = Sig.validate({ body });
+  expect(r.violations.length).toBe(1);
+});
+
+test('body-ac: closed ticket with unticked ACs fails', () => {
+  const body = '- [ ] AC1: foo\n- [x] AC2: bar';
+  const r = AC.validate({ body, labels: ['status:done'], state: 'closed' });
+  expect(r.ok).toBe(false);
+  expect(r.violations[0].rule).toBe('unticked-ac-on-terminal');
+});
+
+test('body-ac: closed ticket with all ticked ACs passes', () => {
+  const body = '- [x] AC1\n- [x] AC2';
+  const r = AC.validate({ body, labels: ['status:done'], state: 'closed' });
+  expect(r.ok).toBe(true);
+});
+
+test('body-ac: cancelled state permits unticked ACs', () => {
+  const r = AC.validate({
+    body: '- [ ] AC1', labels: ['status:cancelled'], state: 'closed',
+  });
+  expect(r.ok).toBe(true);
+});
+
+test('body-ac: open tickets are advisory (no fail)', () => {
+  const r = AC.validate({ body: '- [ ] AC1', labels: ['status:in-progress'], state: 'open' });
+  expect(r.ok).toBe(true);
+});
+
+test('body-ac: countCheckboxes counts ticked + unticked', () => {
+  const c = AC.countCheckboxes('- [x] AC1\n- [ ] AC2\n- [ ] AC3');
+  expect(c).toEqual({ total: 3, ticked: 1, unticked: 2 });
+});
+
+test('epic-traceability: Epic with 5 ACs and 0 refs fails', () => {
+  const body = '- [ ] AC1\n- [ ] AC2\n- [ ] AC3\n- [ ] AC4\n- [ ] AC5';
+  const r = Trace.validate({ body, labels: ['type:epic'], issueNumber: 99 });
+  expect(r.ok).toBe(false);
+  expect(r.violations[0].rule).toBe('epic-body-missing-child-refs');
+});
+
+test('epic-traceability: Epic with child refs passes', () => {
+  const body = '- [ ] AC1\n- [ ] AC2\n- [ ] AC3\nChildren: #100, #101, #102';
+  const r = Trace.validate({ body, labels: ['type:epic'], issueNumber: 99 });
+  expect(r.ok).toBe(true);
+});
+
+test('epic-traceability: non-Epic is not validated', () => {
+  const r = Trace.validate({ body: '- [ ] AC1', labels: ['type:task'] });
+  expect(r.ok).toBe(true);
+  expect(r.reason).toBe('not-an-epic');
+});
+
+test('epic-traceability: self-ref does not count', () => {
+  const body = '- [ ] AC1\n- [ ] AC2\n- [ ] AC3\nThis is #99';
+  const r = Trace.validate({ body, labels: ['type:epic'], issueNumber: 99 });
+  expect(r.ok).toBe(false);
+});
+
+test('index.runAll: dispatches to all 7 validators', () => {
+  const result = Idx.runAll({ comments: [], body: '', labels: [] });
+  expect(Object.keys(result.results).length).toBe(7);
+});
+
+test('index.run: unknown validator throws', () => {
+  expect(() => Idx.run('bogus', {})).toThrow(/Unknown validator/);
+});

--- a/tests/megalint/manager-handoff.spec.js
+++ b/tests/megalint/manager-handoff.spec.js
@@ -1,0 +1,60 @@
+// megalint/manager-handoff tests (#1420, Epic #1407 AC1).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const V = require(path.resolve(__dirname, '..', '..', 'scripts', 'global', 'megalint', 'manager-handoff.js'));
+
+const fullHandoff = `**MANAGER_HANDOFF — Cole Mason**
+- scope: build foo
+- lane: lane:code-change
+- test_strategy: tdd-pyramid
+- acceptance: AC1-5
+- gates: lint, test-evidence`;
+
+test('validate: full MANAGER_HANDOFF passes with all 5 fields', () => {
+  const r = V.validate({ comments: [{ body: fullHandoff }] });
+  expect(r.ok).toBe(true);
+  expect(r.found).toBe(true);
+});
+
+test('validate: missing test_strategy reports the violation', () => {
+  const body = fullHandoff.replace(/test_strategy:.+\n/, '');
+  const r = V.validate({ comments: [{ body }] });
+  expect(r.ok).toBe(false);
+  expect(r.violations.some(v => v.rule === 'missing-test_strategy')).toBe(true);
+});
+
+test('validate: missing gates field reports violation', () => {
+  const body = fullHandoff.replace(/gates:.+/, '');
+  const r = V.validate({ comments: [{ body }] });
+  expect(r.violations.some(v => v.rule === 'missing-gates')).toBe(true);
+});
+
+test('validate: no MANAGER_HANDOFF on non-Epic returns ok=true', () => {
+  const r = V.validate({ comments: [{ body: 'something else' }] });
+  expect(r.ok).toBe(true);
+  expect(r.found).toBe(false);
+});
+
+test('validate: no MANAGER_HANDOFF on Epic fails', () => {
+  const r = V.validate({ comments: [{ body: 'something else' }], isEpic: true });
+  expect(r.ok).toBe(false);
+  expect(r.violations[0].rule).toBe('epic-manager-handoff-missing');
+});
+
+test('validate: lane mismatch detected', () => {
+  const r = V.validate({ comments: [{ body: fullHandoff }], lane: 'lane:research' });
+  expect(r.ok).toBe(false);
+  expect(r.violations.some(v => v.rule === 'lane-mismatch')).toBe(true);
+});
+
+test('extractField: pulls value with various prefix formats', () => {
+  expect(V.extractField('- scope: foo', 'scope')).toBe('foo');
+  expect(V.extractField('scope: bar', 'scope')).toBe('bar');
+  expect(V.extractField('* scope:   baz', 'scope')).toBe('baz');
+});
+
+test('REQUIRED_FIELDS exposes 5 fields', () => {
+  expect(V.REQUIRED_FIELDS.length).toBe(5);
+  expect(V.REQUIRED_FIELDS).toContain('scope');
+  expect(V.REQUIRED_FIELDS).toContain('test_strategy');
+});


### PR DESCRIPTION
## Summary

Phase-1 foundation of Epic #1407. Builds 7 pure-function governance lint validators + orchestrator under `scripts/global/megalint/` plus 32 golden-file tests. No CI wiring in this child — pure validators only; wiring deferred to D-1407-02..04.

Refs #1420 #1407

## Artifacts

- `scripts/global/megalint/{index, manager-handoff, collaborator-handoff, admin-handoff, consultant-closeout, signer-fidelity, body-ac-truthfulness, epic-ac-traceability}.js` — 8 files, all under 100-line cap, all functions ≤30 lines (helper-extracted).
- `tests/megalint/{manager-handoff, baton-handoffs, body-and-traceability}.spec.js` — 32 tests, all passing.

## AC coverage

- AC1 ✅ orchestrator + 7 domain-decomposed validators
- AC2 ✅ golden-file tests per validator

## Mid-flight finding

`scripts/global/baton-independence.js` `roleIdentity()` captures everything after `Signed-by:` up to newline — including trailing `· Team&Model: ... · Role: ...` suffixes. This means same-name handoffs with different role tags falsely pass independence checks. Megalint `admin-handoff.js` adds name-only comparison as a tighter check. The pre-existing function is not modified (could affect other workflows); megalint supersedes it for this surface.

## Test plan

- [x] 32/32 megalint tests passing
- [x] `npm run lint` — 431 files within 100-line cap
- [x] readability gate — 419 ≤ 420 cap (no regression)
- [x] All validators are pure functions (deterministic; no fs/network)

## Baton

- COLLABORATOR_HANDOFF on #1420 (posted >70s before this PR)
- ADMIN_HANDOFF pending
- CONSULTANT_CLOSEOUT pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)