### PR TITLE
feat(governance): signer-lint workflow + backfill #1422

### DIFF
--- a/.changes/unreleased/1422.md
+++ b/.changes/unreleased/1422.md
@@ -1,0 +1,14 @@
+## [Unreleased] — #1422: signer-lint workflow + 7-ticket backfill (D-1407-03)
+
+### Added
+- `.github/workflows/signer-lint.yml` — fires on `issues.opened/edited/reopened`. Uses `scripts/global/megalint/signer-fidelity.js` (#1420) to detect client-identity (`Curtis Franks`) in body `Signed-by:` / `AI-Signature:` fields. Posts/updates/deletes a marker-comment (`<!-- megalint-signer-fidelity -->`) parallel to label-lint pattern. **Advisory mode** (`core.warning`) for 2-week soak before promotion to required per #1406 risk register.
+- `tests/signer-lint-wiring.spec.js` — 4 wiring tests covering YAML structure, advisory mode, validator behavior.
+
+### Changed (AC9 backfill executed)
+- Issue body `Signed-by:` field corrected from `Curtis Franks` (client identity, violation) to derived worker alias per `inventory/team-model-signatures.json`:
+  - #1245 (Epic), #1248-1251 (D-1245 children) — Curtis Franks → **Nova Mason** (Copilot Manager default)
+  - #1427, #1428 — Curtis Franks → **Soren Mason** (Copilot Claude-Sonnet Manager per registry sonnet pattern)
+- Total: 7 OPEN issue bodies remediated. After this commit + #1349-closeout backfill, OPEN-ticket client-identity-in-body count = **0**.
+
+### Why
+Phase-1 AC4+AC9 of Epic #1407. Closes the 20-instance signer-fidelity defect set surfaced in #1403 audit, and prevents recurrence via the new lint. Advisory mode chosen for soak; promotion to required after 2-week observation period per #1406 Decision Brief Option A.

--- a/.github/workflows/signer-lint.yml
+++ b/.github/workflows/signer-lint.yml
@@ -1,0 +1,78 @@
+name: Signer Lint
+# Rejects issue bodies that use client identity ("Curtis Franks") for worker
+# artifacts. Epic #1407 AC4. Per team-model-signing.instructions.md, client
+# identity is reserved for client consultation/UAT, never worker sign-off.
+# Uses marker-comment pattern parallel to label-lint.yml.
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  signer-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const { validate } = require('./scripts/global/megalint/signer-fidelity.js');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNum = context.payload.issue.number;
+            const marker = '<!-- megalint-signer-fidelity -->';
+
+            const issue = (await github.rest.issues.get({
+              owner, repo, issue_number: issueNum,
+            })).data;
+
+            const result = validate({ body: issue.body || '' });
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: issueNum, per_page: 100,
+            });
+            const lintComment = comments.find(c => (c.body || '').includes(marker));
+
+            if (result.ok) {
+              if (lintComment) {
+                await github.rest.issues.deleteComment({
+                  owner, repo, comment_id: lintComment.id,
+                });
+              }
+              console.log(`Issue #${issueNum}: signer-fidelity OK`);
+              return;
+            }
+
+            const body = [
+              marker, '',
+              '## ⚠️ Signer Fidelity Violation', '',
+              `Issue #${issueNum} body uses a **client identity** in a Signed-by / AI-Signature field.`,
+              'Client identity is reserved for client consultation and UAT only; worker',
+              'artifacts must use a derived worker alias per `instructions/team-model-signing.instructions.md`.',
+              '',
+              '**Violations**:', '',
+              result.violations.map(v => `- \`${v.rule}\` — ${v.detail}`).join('\n'),
+              '',
+              '**Suggested fix**: replace `Signed-by: Curtis Franks` with the appropriate',
+              'worker alias from `inventory/team-model-signatures.json` (e.g., `Nova Mason` for',
+              'Copilot Manager, `Cole Mason` for Claude Code Manager).',
+              '',
+              '_Posted by signer-lint workflow (advisory — promotes to required after 2-week soak)._',
+            ].join('\n');
+
+            if (lintComment) {
+              if (lintComment.body !== body) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: lintComment.id, body,
+                });
+              }
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issueNum, body,
+              });
+            }
+            core.warning(`Signer fidelity violation on #${issueNum}: ${result.violations.length} rule(s)`);

--- a/tests/signer-lint-wiring.spec.js
+++ b/tests/signer-lint-wiring.spec.js
@@ -1,0 +1,36 @@
+// signer-lint wiring tests for D-1407-03 (#1422, Epic #1407 AC4).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const Sig = require(path.resolve(__dirname, '..', 'scripts', 'global', 'megalint', 'signer-fidelity.js'));
+
+test('signer-lint workflow YAML wires megalint signer-fidelity validator', () => {
+  const yaml = fs.readFileSync(
+    path.resolve(__dirname, '..', '.github', 'workflows', 'signer-lint.yml'), 'utf-8'
+  );
+  expect(yaml).toContain('require(\'./scripts/global/megalint/signer-fidelity.js\')');
+  expect(yaml).toContain('issues:');
+  expect(yaml).toContain('opened, edited, reopened');
+  expect(yaml).toContain('marker = \'<!-- megalint-signer-fidelity -->\'');
+  // Advisory mode for soak period per #1406 risk mitigation
+  expect(yaml).toContain('core.warning');
+});
+
+test('signer-lint: validator clears OK on worker-aliased body', () => {
+  const r = Sig.validate({ body: 'Signed-by: Soren Mason\nTeam&Model: copilot:claude-sonnet-4-6@github' });
+  expect(r.ok).toBe(true);
+});
+
+test('signer-lint: validator catches Curtis Franks signer', () => {
+  const r = Sig.validate({ body: 'Signed-by: Curtis Franks\nTeam&Model: copilot:claude-sonnet-4-6@github' });
+  expect(r.ok).toBe(false);
+  expect(r.violations[0].rule).toBe('client-identity-as-signer');
+});
+
+test('signer-lint: workflow has issues: trigger only (not pull_request)', () => {
+  const yaml = fs.readFileSync(
+    path.resolve(__dirname, '..', '.github', 'workflows', 'signer-lint.yml'), 'utf-8'
+  );
+  expect(yaml).toMatch(/on:\s*\n\s*issues:/);
+  expect(yaml).not.toContain('pull_request:');
+});


### PR DESCRIPTION
## Summary

Phase-1 AC4+AC9 of Epic #1407. Adds new `signer-lint.yml` workflow detecting client-identity in issue body signers, and executes the 7-OPEN-ticket backfill remediation.

Refs #1422 #1407

## Artifacts

- `.github/workflows/signer-lint.yml` (78 LOC) — fires on `issues.opened/edited/reopened`. Consumes megalint signer-fidelity validator; uses marker-comment pattern; advisory (core.warning) for 2-week soak.
- `tests/signer-lint-wiring.spec.js` — 4 wiring tests, all passing.

## AC9 backfill executed

7 OPEN issue bodies remediated (`Curtis Franks` → derived worker alias):
- #1245, #1248-1251 → `Nova Mason` (Copilot Manager default)
- #1427, #1428 → `Soren Mason` (Copilot Claude-Sonnet Manager per registry pattern)

Post-backfill: 0 OPEN tickets with client-identity-in-body (verified).

## AC coverage

- AC4 ✅ NEW signer-lint workflow on `issues.opened/edited`
- AC9 ✅ 7-OPEN-ticket backfill complete (#1343, #1344, #1345, #1346 already done at #1349 closeout)

## Test plan

- [x] 4/4 wiring tests pass
- [x] `npm run lint` clean (435 files within 100-line cap)
- [x] `gh issue list` OPEN sweep confirms 0 remaining Curtis-Franks-in-body

## Baton

- COLLABORATOR_HANDOFF on #1422 (posted >70s before this PR)
- ADMIN_HANDOFF pending
- CONSULTANT_CLOSEOUT pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)