### PR TITLE
feat(governance): validate signer aliases against registry #1451

### DIFF
--- a/.changes/unreleased/1451.md
+++ b/.changes/unreleased/1451.md
@@ -1,0 +1,14 @@
+## [Unreleased] — #1451: signer-alias registry validation in megalint
+
+### Added
+- `scripts/global/megalint/signer-registry-check.js` — derives expected `Signed-by:` alias from `inventory/team-model-signatures.json` registry given Team&Model + Role; reports violation when actual alias differs. Mirrors derivation logic in `scripts/global/agent-signature.js`. Gracefully skips artifacts with missing Team&Model or Role.
+- `tests/megalint/signer-registry-check.spec.js` — 14 tests covering parseTeamModel, expectedAliasFor (4 team×model variants + fallback), extractArtifactFields, drift detection ("Cole Mason"→"Orla Mason"), case-insensitive comparison, missing-fields skip, signer-fidelity integration.
+
+### Changed
+- `scripts/global/megalint/signer-fidelity.js` — adds `checkRegistryAlias()` step alongside existing client-identity check. Both produce violations independently. Closes the systemic hole that allowed phantom "Cole Vale" closeout on Epic #1436.
+
+### Why
+Closes harness flaw discovered during Epic #1436 critical analysis: existing signer-fidelity validator rejected only one client identity (`Curtis Franks`) and accepted any other string. After Epic #1298 shipped Ed25519 cryptographic signatures, wrong textual aliases became cryptographically meaningful — wrong alias → mismatched key lookup → false provenance trail. This validator pairs with the crypto check to ensure both layers of attribution are correct.
+
+### Drift surfaced
+40+ artifacts in this 2026-05-12 session were signed with invented aliases (Cole Mason / Mira Reyes / Yara Vale) instead of registry-derived (Orla Mason / Orla Harper / Orla Reyes / Orla Vale). Documented in `feedback_signer_alias_derivation.md`.

--- a/scripts/global/megalint/signer-fidelity.js
+++ b/scripts/global/megalint/signer-fidelity.js
@@ -1,6 +1,9 @@
 'use strict';
 // signer-fidelity — rejects issue bodies using client identity for worker artifacts.
-// Epic #1407 AC4.
+// Epic #1407 AC4. Extended in #1451 with registry-derived alias check.
+
+const path = require('path');
+const { validateArtifactAlias } = require(path.join(__dirname, 'signer-registry-check.js'));
 
 const CLIENT_IDENTITIES = ['Curtis Franks'];
 
@@ -39,6 +42,13 @@ function dedupe(violations) {
   return unique;
 }
 
+function checkRegistryAlias(body, opts) {
+  if (!body) return [];
+  const result = validateArtifactAlias(body, opts || {});
+  if (result.ok) return [];
+  return [result.violation];
+}
+
 function validate(input) {
   const body = input.body || '';
   const violations = checkSignedBy(body);
@@ -49,6 +59,9 @@ function validate(input) {
       detail: `Issue body uses client identity "${aiSig}" as AI-Signature trailer`,
     });
   }
+  violations.push(...checkRegistryAlias(body, {
+    device: input.device, registryOverride: input.registryOverride,
+  }));
   const unique = dedupe(violations);
   return { ok: unique.length === 0, violations: unique };
 }

--- a/scripts/global/megalint/signer-registry-check.js
+++ b/scripts/global/megalint/signer-registry-check.js
@@ -1,0 +1,89 @@
+'use strict';
+// signer-registry-check — verifies Signed-by aliases match the registry-derived
+// alias for the declared Team&Model + Role. Epic flaw #1451.
+// Registry source: inventory/team-model-signatures.json (read once, cached).
+
+const fs = require('fs');
+const path = require('path');
+
+const REGISTRY_PATH = path.join(__dirname, '..', '..', '..', 'inventory', 'team-model-signatures.json');
+let cachedRegistry = null;
+
+function loadRegistry(overridePath) {
+  if (overridePath) return JSON.parse(fs.readFileSync(overridePath, 'utf-8'));
+  if (cachedRegistry) return cachedRegistry;
+  if (!fs.existsSync(REGISTRY_PATH)) return null;
+  cachedRegistry = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf-8'));
+  return cachedRegistry;
+}
+
+function parseTeamModel(teamModel) {
+  const match = (teamModel || '').match(/^([^:]+):([^@]+)@?(\S*)$/);
+  if (!match) return null;
+  return { team: match[1].toLowerCase(), model: match[2].toLowerCase(), substrate: match[3] };
+}
+
+function matchRegistryEntry(registry, team, model, device) {
+  for (const entry of registry.registry || []) {
+    const teamOk = entry.team === '*' || entry.team === team;
+    if (!teamOk) continue;
+    const modelOk = new RegExp(entry.modelPattern, 'i').test(model);
+    if (!modelOk) continue;
+    const deviceOk = !entry.devicePattern || new RegExp(entry.devicePattern, 'i').test(device || '');
+    if (deviceOk) return entry;
+  }
+  return null;
+}
+
+function expectedAliasFor({ team, model, role, device, registryOverride }) {
+  const registry = loadRegistry(registryOverride);
+  if (!registry || !team || !model || !role) return null;
+  const entry = matchRegistryEntry(registry, team, model, device);
+  const seed = entry ? entry.aliasSeed : registry.defaultAliasSeed;
+  const surname = (registry.roleSurnames || {})[role];
+  if (!seed || !surname) return null;
+  return `${seed} ${surname}`;
+}
+
+function extractArtifactFields(body) {
+  const text = body || '';
+  const signedBy = (text.match(/Signed-by\s*:\s*([^·,\n]+?)(?=\s*[·,\n]|$)/i) || [])[1];
+  const teamModel = (text.match(/Team&Model\s*:\s*(\S+)/i) || [])[1];
+  const role = (text.match(/Role\s*:\s*(\w+)/i) || [])[1];
+  return {
+    signedBy: signedBy ? signedBy.trim() : null,
+    teamModel,
+    role: role ? role.toLowerCase() : null,
+  };
+}
+
+function validateArtifactAlias(body, opts = {}) {
+  const fields = extractArtifactFields(body);
+  if (!fields.signedBy || !fields.teamModel || !fields.role) {
+    return { ok: true, skipped: 'missing-required-fields', fields };
+  }
+  const parsed = parseTeamModel(fields.teamModel);
+  if (!parsed) return { ok: true, skipped: 'unparseable-team-model', fields };
+  const expected = expectedAliasFor({
+    team: parsed.team, model: parsed.model, role: fields.role,
+    device: opts.device, registryOverride: opts.registryOverride,
+  });
+  if (!expected) return { ok: true, skipped: 'no-registry-entry', fields };
+  if (fields.signedBy.toLowerCase() === expected.toLowerCase()) {
+    return { ok: true, expected, actual: fields.signedBy };
+  }
+  return {
+    ok: false,
+    expected,
+    actual: fields.signedBy,
+    violation: {
+      rule: 'signer-alias-not-registry-derived',
+      detail: `Signed-by "${fields.signedBy}" does not match registry-derived alias "${expected}" for ${fields.teamModel} role=${fields.role}. Use scripts/global/agent-signature.js to derive correct alias.`,
+    },
+  };
+}
+
+module.exports = {
+  loadRegistry, parseTeamModel, matchRegistryEntry, expectedAliasFor,
+  extractArtifactFields, validateArtifactAlias, REGISTRY_PATH,
+};

--- a/tests/megalint/signer-registry-check.spec.js
+++ b/tests/megalint/signer-registry-check.spec.js
@@ -1,0 +1,120 @@
+// signer-registry-check tests (#1451).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const R = require(path.resolve(__dirname, '..', '..', 'scripts', 'global', 'megalint', 'signer-registry-check.js'));
+const Sig = require(path.resolve(__dirname, '..', '..', 'scripts', 'global', 'megalint', 'signer-fidelity.js'));
+
+function makeRegistry() {
+  const reg = {
+    defaultAliasSeed: 'Nova',
+    roleSurnames: { manager: 'Mason', collaborator: 'Harper', admin: 'Reyes', consultant: 'Vale' },
+    registry: [
+      { team: 'claude-code', modelPattern: 'opus', aliasSeed: 'Orla' },
+      { team: 'codex', modelPattern: 'gpt-5.*codex', aliasSeed: 'Caden' },
+      { team: 'copilot', modelPattern: 'sonnet', aliasSeed: 'Soren' },
+    ],
+  };
+  const fileP = path.join(os.tmpdir(), `reg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.json`);
+  fs.writeFileSync(fileP, JSON.stringify(reg));
+  return fileP;
+}
+
+test('parseTeamModel: standard format extracts team/model/substrate', () => {
+  const parsed = R.parseTeamModel('claude-code:opus-4-7@anthropic');
+  expect(parsed).toEqual({ team: 'claude-code', model: 'opus-4-7', substrate: 'anthropic' });
+});
+
+test('parseTeamModel: returns null on malformed input', () => {
+  expect(R.parseTeamModel('not-valid')).toBeNull();
+  expect(R.parseTeamModel(null)).toBeNull();
+});
+
+test('expectedAliasFor: claude-code:opus manager → Orla Mason', () => {
+  const file = makeRegistry();
+  const alias = R.expectedAliasFor({ team: 'claude-code', model: 'opus-4-7', role: 'manager', registryOverride: file });
+  expect(alias).toBe('Orla Mason');
+  fs.unlinkSync(file);
+});
+
+test('expectedAliasFor: claude-code:opus consultant → Orla Vale', () => {
+  const file = makeRegistry();
+  expect(R.expectedAliasFor({ team: 'claude-code', model: 'opus-4-7', role: 'consultant', registryOverride: file })).toBe('Orla Vale');
+  fs.unlinkSync(file);
+});
+
+test('expectedAliasFor: codex:gpt-5.3-codex collaborator → Caden Harper', () => {
+  const file = makeRegistry();
+  expect(R.expectedAliasFor({ team: 'codex', model: 'gpt-5.3-codex', role: 'collaborator', registryOverride: file })).toBe('Caden Harper');
+  fs.unlinkSync(file);
+});
+
+test('expectedAliasFor: unknown team×model falls back to defaultAliasSeed', () => {
+  const file = makeRegistry();
+  expect(R.expectedAliasFor({ team: 'unknown', model: 'unknown', role: 'manager', registryOverride: file })).toBe('Nova Mason');
+  fs.unlinkSync(file);
+});
+
+test('extractArtifactFields: pulls Signed-by / Team&Model / Role', () => {
+  const body = 'work\nSigned-by: Cole Mason · Team&Model: claude-code:opus-4-7@anthropic · Role: manager';
+  const fields = R.extractArtifactFields(body);
+  expect(fields.signedBy).toBe('Cole Mason');
+  expect(fields.teamModel).toBe('claude-code:opus-4-7@anthropic');
+  expect(fields.role).toBe('manager');
+});
+
+test('validateArtifactAlias: drift "Cole Mason" on claude-code:opus → violation with expected="Orla Mason"', () => {
+  const file = makeRegistry();
+  const body = 'Signed-by: Cole Mason\nTeam&Model: claude-code:opus-4-7@anthropic\nRole: manager';
+  const result = R.validateArtifactAlias(body, { registryOverride: file });
+  expect(result.ok).toBe(false);
+  expect(result.expected).toBe('Orla Mason');
+  expect(result.actual).toBe('Cole Mason');
+  expect(result.violation.rule).toBe('signer-alias-not-registry-derived');
+  fs.unlinkSync(file);
+});
+
+test('validateArtifactAlias: registry-correct "Orla Mason" passes', () => {
+  const file = makeRegistry();
+  const body = 'Signed-by: Orla Mason\nTeam&Model: claude-code:opus-4-7@anthropic\nRole: manager';
+  const result = R.validateArtifactAlias(body, { registryOverride: file });
+  expect(result.ok).toBe(true);
+  fs.unlinkSync(file);
+});
+
+test('validateArtifactAlias: cross-team drift "Caden Mason" on claude-code → violation', () => {
+  const file = makeRegistry();
+  const body = 'Signed-by: Caden Mason\nTeam&Model: claude-code:opus-4-7@anthropic\nRole: manager';
+  const result = R.validateArtifactAlias(body, { registryOverride: file });
+  expect(result.ok).toBe(false);
+  expect(result.expected).toBe('Orla Mason');
+  fs.unlinkSync(file);
+});
+
+test('validateArtifactAlias: missing Team&Model → skipped (not violation)', () => {
+  const body = 'Signed-by: Orla Mason\nRole: manager';
+  const result = R.validateArtifactAlias(body);
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('missing-required-fields');
+});
+
+test('validateArtifactAlias: case-insensitive name comparison', () => {
+  const file = makeRegistry();
+  const body = 'Signed-by: orla mason\nTeam&Model: claude-code:opus-4-7@anthropic\nRole: manager';
+  expect(R.validateArtifactAlias(body, { registryOverride: file }).ok).toBe(true);
+  fs.unlinkSync(file);
+});
+
+test('signer-fidelity: registry drift produces violation alongside client-identity check', () => {
+  const body = 'Signed-by: Cole Vale\nTeam&Model: claude-code:opus-4-7@anthropic\nRole: consultant';
+  const r = Sig.validate({ body });
+  expect(r.ok).toBe(false);
+  expect(r.violations.some(v => v.rule === 'signer-alias-not-registry-derived')).toBe(true);
+});
+
+test('signer-fidelity: registry-correct alias passes', () => {
+  const body = 'Signed-by: Orla Vale\nTeam&Model: claude-code:opus-4-7@anthropic\nRole: consultant';
+  const r = Sig.validate({ body });
+  expect(r.ok).toBe(true);
+});


### PR DESCRIPTION
## Summary

Closes harness hole discovered during Epic #1436 critical analysis: existing `signer-fidelity` validator (#1422) rejected only `Curtis Franks` and accepted any other string. After Epic #1298 added Ed25519 signatures, wrong textual aliases became a false-provenance issue with cryptographic blast radius.

Refs #1451 #1436 #1298 #1422

## What changed

- `scripts/global/megalint/signer-registry-check.js` (new) — derives expected `Signed-by:` alias from `inventory/team-model-signatures.json` given Team&Model + Role; reports violation when actual ≠ expected
- `scripts/global/megalint/signer-fidelity.js` — adds `checkRegistryAlias()` step alongside existing client-identity check
- `tests/megalint/signer-registry-check.spec.js` (new) — 14 tests

## Self-detected drift

40+ artifacts in this session were signed with invented aliases (`Cole Mason`, `Mira Reyes`, `Yara Vale`) instead of registry-derived (`Orla Mason`, `Orla Harper`, `Orla Reyes`, `Orla Vale`). The validator built here would have caught all of them. This very PR's COLLABORATOR_HANDOFF is the first artifact signed with the correct registry-derived alias.

## Test plan

- [x] 14 new tests pass
- [x] 64/64 megalint tests pass total
- [x] `npm run lint` clean
- [x] readability under 420 cap

## Baton

- COLLABORATOR_HANDOFF on #1451 (>70s before PR)
- ADMIN_HANDOFF pending
- CONSULTANT_CLOSEOUT pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)