### PR TITLE
feat(governance): env-configurable worktree-collision threshold #1439

### DIFF
--- a/.changes/unreleased/1439.md
+++ b/.changes/unreleased/1439.md
@@ -1,0 +1,16 @@
+## [Unreleased] — #1439: worktree-collision threshold made env-configurable
+
+### Changed
+- `scripts/global/git-state-drift-sensor.js` — `max_concurrent_worktrees` threshold changed from 1 → 5 (default). Override via `GIT_DRIFT_MAX_CONCURRENT_WORKTREES` env var. Status name changed from `'isolated'` → `'within-limit'` for clarity (signals count is acceptable, not that it's 1).
+- Guidance string for `worktree:collision` now references the canonical layout document and the env-var override.
+- `research/concurrent-agent-worktrees-2026-04-24.md` — documented the canonical 4-5 worktree layout (main + 3 team sandboxes + optional SDK auto-worktree) + the new threshold.
+- `tests/git-state-drift.test.js` — updated regex to match the new `'within-limit'` status name.
+
+### Why
+Closes Epic #1439 (P2 governance drift). The original sensor flagged ANY count > 1 as a collision — incompatible with the multi-team operational pattern (one worktree per AI team is the design, not an exception). New threshold of 5 matches the legitimate floor documented in `concurrent-agent-worktrees-2026-04-24.md`.
+
+### Follow-ups filed (stale-worktree triage; not blocking #1439)
+- #1457 — triage `devenv-ops-claude-code` (#641 unmerged commits)
+- #1458 — triage locked `.claude/worktrees/agent-aabc060d7cbc65f74` (#668 unmerged)
+
+After both stale worktrees retire, `npm run governance:audit` returns 0 violations on the canonical 5-worktree layout.

--- a/research/concurrent-agent-worktrees-2026-04-24.md
+++ b/research/concurrent-agent-worktrees-2026-04-24.md
@@ -11,11 +11,16 @@ This repo can support parallel AI teams, but not from the same live checkout.
 
 ## Recommended layout
 
-- `/home/curtisfranks/devenv-ops` → clean `main`
+- `/home/curtisfranks/devenv-ops` → clean `main` (integration checkout)
 - `/home/curtisfranks/devenv-ops-codex` → Codex session
 - `/home/curtisfranks/devenv-ops-copilot` → Copilot session
 - `/home/curtisfranks/devenv-ops-claude-code` → Claude Code session
-- `/home/curtisfranks/devenv-ops-rescue` → quarantined mixed state when a collision happens
+- `/home/curtisfranks/devenv-ops/.claude/worktrees/<auto>` → Claude Code SDK auto-worktree (locked; managed by SDK)
+- `/home/curtisfranks/devenv-ops-rescue` → quarantined mixed state when a collision happens (transient)
+
+## Canonical concurrent-worktree count (per #1439)
+
+**Legitimate floor: 4-5 worktrees** (main + 3 team sandboxes + optional auto-managed SDK worktree). The `git-state-drift-sensor.js` `max_concurrent_worktrees` threshold is **5 by default** (env-overridable via `GIT_DRIFT_MAX_CONCURRENT_WORKTREES`). Counts ≤5 are normal; counts ≥6 indicate an unexpected extra and should be investigated. Session-feature-branch worktrees (e.g., `devenv-ops-cc-<N>`) are transient and may legitimately push the count above the floor while active — clean up at session end.
 
 ## Setup
 

--- a/scripts/global/git-state-drift-sensor.js
+++ b/scripts/global/git-state-drift-sensor.js
@@ -3,10 +3,14 @@
 const { execSync } = require('child_process');
 const MAX_BEHIND = Number(process.env.GIT_DRIFT_MAX_BEHIND || 5);
 const FRESHNESS_HR = Number(process.env.GIT_DRIFT_FRESHNESS_HOURS || 24);
+// Per #1439: legitimate multi-team floor is 5 (main + 4 team sandboxes:
+// codex + copilot + claude-code + .claude/worktrees auto-managed). Override
+// via GIT_DRIFT_MAX_CONCURRENT_WORKTREES env var.
+const MAX_WORKTREES = Number(process.env.GIT_DRIFT_MAX_CONCURRENT_WORKTREES || 5);
 const VALID_PFX = ['main', 'sandbox', 'release', 'hotfix', 'feat', 'fix'];
 const POLICY = {
-  thresholds: { max_behind_commits: MAX_BEHIND, freshness_hours: FRESHNESS_HR, max_concurrent_worktrees: 1 },
-  pass_statuses: { freshness: ['fresh'], worktree: ['isolated'], target: ['compliant', 'unknown'] },
+  thresholds: { max_behind_commits: MAX_BEHIND, freshness_hours: FRESHNESS_HR, max_concurrent_worktrees: MAX_WORKTREES },
+  pass_statuses: { freshness: ['fresh'], worktree: ['within-limit'], target: ['compliant', 'unknown'] },
   escalation: {
     fail_when_violation_count_gte: 1,
     actions: ['run npm run git-state:drift', 'reconcile branch prefix and upstream target', 'prune/close excess worktrees'],
@@ -22,7 +26,7 @@ const guidance = (signal, status) => {
     'freshness:orphaned': 'Set upstream and rebase against origin/main or approved target.',
     'freshness:stale': `Rebase/merge to keep behind count <= ${MAX_BEHIND}.`,
     'freshness:old': `Push or refresh commits within ${FRESHNESS_HR}h freshness window.`,
-    'worktree:collision': 'Close redundant worktrees or isolate work to one active worktree.',
+    'worktree:collision': `Close redundant worktrees (limit ${MAX_WORKTREES}; override via GIT_DRIFT_MAX_CONCURRENT_WORKTREES). Canonical layout: main + per-team sandboxes per the concurrent-agent-worktrees runbook in research/.`,
     'target:invalid-target': 'Retarget branch to an allowed base branch for its prefix.',
   };
   return map[key] || 'Reconcile branch/worktree state to satisfy governance policy.';
@@ -42,8 +46,10 @@ const freshness = () => {
 const worktree = () => {
   try {
     const count = run('git worktree list --porcelain').split('\n').filter(line => line.startsWith('worktree ')).length;
-    if (count <= 1) return { status: 'isolated', detail: 'single worktree' };
-    return { status: 'collision', detail: `${count} concurrent worktrees` };
+    if (count <= MAX_WORKTREES) {
+      return { status: 'within-limit', detail: `${count} worktrees (≤${MAX_WORKTREES} allowed)` };
+    }
+    return { status: 'collision', detail: `${count} concurrent worktrees (limit ${MAX_WORKTREES})` };
   } catch { return { status: 'unknown', detail: 'unavailable' }; }
 };
 const target = () => {

--- a/tests/git-state-drift.test.js
+++ b/tests/git-state-drift.test.js
@@ -28,9 +28,9 @@ function withTempRepo(setup, run) {
 test('git-state-drift: freshness returns a status field', () => {
   assert.ok(freshness().status, 'should have status field');
 });
-test('git-state-drift: worktree detects single vs multi worktree', () => {
+test('git-state-drift: worktree detects within-limit vs collision', () => {
   const result = worktree();
-  assert.match(result.status, /isolated|collision|unknown/, 'status should be isolated, collision, or unknown');
+  assert.match(result.status, /within-limit|collision|unknown/, 'status should be within-limit, collision, or unknown');
 });
 test('git-state-drift: target validates branch naming compliance', () => {
   const result = target();


### PR DESCRIPTION
## Summary

Closes #1439. Changes sensor threshold from 1 → 5 (env-overridable), compatible with multi-team worktree pattern.

Refs #1439

## Changes
- `scripts/global/git-state-drift-sensor.js` — threshold 1 → 5 default; env override; status renamed `isolated` → `within-limit`
- `research/concurrent-agent-worktrees-2026-04-24.md` — documented canonical layout + new threshold
- `tests/git-state-drift.test.js` — matches new status name

## AC results
| AC | Status |
|---|---|
| AC1 Audit + classify 6 worktrees | ✅ |
| AC2 Retire stale | ⚠️ Blocked on unmerged commits → #1457 + #1458 follow-ups |
| AC3 Document canonical | ✅ |
| AC4 Threshold change | ✅ |
| AC5 Resolution | ✅ via threshold + follow-ups |
| AC6 0 violations | ⚠️ 1 transient (resolves via #1457/#1458) |

## Test plan
- [x] `node tests/git-state-drift.test.js` passes
- [x] `npm run lint` clean (312 files)
- [x] readability 420/420 at-cap

## Baton
- COLLABORATOR_HANDOFF on #1439 (>70s before this PR)
- ADMIN_HANDOFF pending
- CONSULTANT_CLOSEOUT pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)