### PR TITLE
feat(worktree): auto-link node_modules in worktrees #1378

### DIFF
--- a/.changes/unreleased/1378.md
+++ b/.changes/unreleased/1378.md
@@ -1,0 +1,16 @@
+## [Unreleased] — #1378: auto-link node_modules in new worktrees
+
+### Added
+- `scripts/worktree-session-start.sh` — new `bootstrap_node_modules()` function. Discovers the main checkout via `git worktree list --porcelain`, creates a symlink `<new-worktree>/node_modules → <main>/node_modules` if missing. Idempotent (skips if already present; skips on main checkout). Called automatically after task-branch creation.
+- `scripts/worktree-bootstrap-node-modules.sh` — standalone retroactive script for pre-existing worktrees. Iterates all worktrees in `git worktree list --porcelain`, links any missing node_modules. Idempotent.
+- `npm run worktree:bootstrap` — package.json script alias.
+- `tests/worktree-bootstrap-1378.spec.js` — 11 tests covering all 5 ACs + live invocation idempotency.
+
+### Changed
+- `CLAUDE.md` — documents the auto-link pattern in the "Concurrent session safety" section.
+
+### Why
+Closes #1378 (P2 chronic friction). Every fresh worktree previously failed its first `git push` because pre-push hooks (`npm run format:check` + `npm run lint:readability:ci`) need binaries from node_modules. Manual `ln -s` workaround documented across Codex (2026-05-09) and CC (2026-05-11) sessions. Now automatic.
+
+### Eat-own-dogfood evidence
+`npm run worktree:bootstrap` was run during the test phase of this PR — linked node_modules on `/.claude/worktrees/agent-aabc060d7cbc65f74` (the locked auto-managed worktree from #1458 follow-up). One worktree fixed retroactively in production.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,3 +39,4 @@ and AI agent governance. All instructions below are binding for Claude Code sess
 - Do not share this checkout with Copilot or Codex while Claude Code is active.
 - Use a dedicated worktree + branch for Claude Code work and merge via PR.
 - See `research/concurrent-agent-worktrees-2026-04-24.md`.
+- New worktrees auto-link `node_modules` from main checkout via `scripts/worktree-session-start.sh` — no manual `npm install` needed (per #1378). For pre-existing worktrees missing `node_modules`, run `npm run worktree:bootstrap`.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ npm run deploy:both:apply
 | `adr:preview` | `log4brains preview` |
 | `agent:coord:remote` | `node scripts/global/agent-coord-remote.js` |
 | `agent:tier-c` | `node scripts/global/tier-c-guard.js` |
+| `anneal:detect` | `node scripts/global/workflow-anneal-detect.js` |
+| `anneal:review` | `node scripts/global/anneal-review.js` |
+| `anneal:rotate` | `node scripts/global/anneal-log-rotate.js` |
+| `anneal:schedule-health` | `node scripts/global/anneal-schedule-health.js` |
 | `capability:probe` | `node scripts/global/capability-probe.js` |
 | `capability:show` | `node scripts/global/capability-show.js` |
 | `cost-report` | `node scripts/global/cost-report.js` |
@@ -166,6 +170,7 @@ npm run deploy:both:apply
 | `wiki:ingest` | `node scripts/wiki/ingest.js` |
 | `wiki:lint` | `node scripts/wiki/lint.js` |
 | `wiki:search` | `node scripts/wiki/search.js` |
+| `worktree:bootstrap` | `bash scripts/worktree-bootstrap-node-modules.sh` |
 | `worktree:start` | `bash scripts/worktree-session-start.sh` |
 <!-- /docs -->
 

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "toolchain:readability:install": "node scripts/global/install-readability-toolchain.js",
     "validate:compat": "node scripts/validate-plugin-compat.js",
     "validate:triage": "node scripts/validate-plugin-triage.js",
+    "worktree:bootstrap": "bash scripts/worktree-bootstrap-node-modules.sh",
     "wiki:anneal": "node scripts/wiki/anneal.js",
     "wiki:ingest": "node scripts/wiki/ingest.js",
     "wiki:lint": "node scripts/wiki/lint.js",

--- a/scripts/worktree-bootstrap-node-modules.sh
+++ b/scripts/worktree-bootstrap-node-modules.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Retroactive node_modules bootstrap for ALL existing worktrees (#1378 AC3).
+# Idempotent — skips worktrees that already have node_modules.
+set -euo pipefail
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+main_root="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+if [[ -z "$main_root" || ! -d "$main_root/node_modules" ]]; then
+  log "ERROR: main checkout node_modules not found at $main_root"
+  log "       run 'npm install' in $main_root first"
+  exit 1
+fi
+
+linked=0
+skipped=0
+errored=0
+
+# iterate every worktree path; skip the main one.
+while IFS= read -r line; do
+  if [[ "$line" =~ ^worktree[[:space:]](.+)$ ]]; then
+    wt="${BASH_REMATCH[1]}"
+    if [[ "$wt" == "$main_root" ]]; then
+      continue
+    fi
+    if [[ ! -d "$wt" ]]; then
+      log "WARN: worktree path missing on disk: $wt"
+      errored=$((errored+1))
+      continue
+    fi
+    if [[ -e "$wt/node_modules" ]]; then
+      log "skip  $wt (already has node_modules)"
+      skipped=$((skipped+1))
+      continue
+    fi
+    ln -sf "$main_root/node_modules" "$wt/node_modules"
+    log "link  $wt/node_modules → $main_root/node_modules"
+    linked=$((linked+1))
+  fi
+done < <(git worktree list --porcelain)
+
+log "done: linked=$linked skipped=$skipped errored=$errored"

--- a/scripts/worktree-session-start.sh
+++ b/scripts/worktree-session-start.sh
@@ -5,6 +5,28 @@ log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 die() { log "ERROR: $*"; exit 1; }
 warn() { log "WARN: $*"; exit 2; }
 
+# #1378: auto-link node_modules so pre-push hooks (prettier/eslint) work in
+# fresh worktrees. Idempotent — skips if already linked.
+bootstrap_node_modules() {
+  local worktree_root="$1"
+  local main_root
+  main_root="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+  if [[ -z "$main_root" || ! -d "$main_root/node_modules" ]]; then
+    log "node_modules bootstrap: no main checkout node_modules found at $main_root; skipping"
+    return 0
+  fi
+  if [[ "$worktree_root" == "$main_root" ]]; then
+    log "node_modules bootstrap: this IS the main checkout; nothing to link"
+    return 0
+  fi
+  if [[ -e "$worktree_root/node_modules" ]]; then
+    log "node_modules bootstrap: already present at $worktree_root/node_modules; skipping"
+    return 0
+  fi
+  ln -sf "$main_root/node_modules" "$worktree_root/node_modules"
+  log "node_modules bootstrap: linked $worktree_root/node_modules → $main_root/node_modules"
+}
+
 if [[ $# -lt 1 || $# -gt 2 ]]; then
   echo "Usage: bash scripts/worktree-session-start.sh <copilot|codex|claude-code> [feat/<ticket#>-<slug>]"
   exit 1
@@ -48,5 +70,6 @@ if git show-ref --verify --quiet "refs/heads/$task_branch"; then
 fi
 
 git switch -c "$task_branch"
+bootstrap_node_modules "$root"
 log "ready on task branch: $task_branch"
 log "next: implement scoped changes and open PR with Refs #<ticket>"

--- a/tests/worktree-bootstrap-1378.spec.js
+++ b/tests/worktree-bootstrap-1378.spec.js
@@ -1,0 +1,84 @@
+// worktree node_modules bootstrap tests (#1378).
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+const { execSync, spawnSync } = require('child_process');
+
+const REPO = path.resolve(__dirname, '..');
+const SESSION_START = path.join(REPO, 'scripts', 'worktree-session-start.sh');
+const BOOTSTRAP = path.join(REPO, 'scripts', 'worktree-bootstrap-node-modules.sh');
+
+test('#1378 AC1: worktree-session-start.sh includes bootstrap_node_modules function', () => {
+  const content = fs.readFileSync(SESSION_START, 'utf-8');
+  expect(content).toContain('bootstrap_node_modules');
+  expect(content).toContain('git worktree list --porcelain');
+  expect(content).toContain('ln -sf');
+});
+
+test('#1378 AC1: bootstrap is called after task-branch creation', () => {
+  const content = fs.readFileSync(SESSION_START, 'utf-8');
+  // Must appear after `git switch -c "$task_branch"`
+  const switchPos = content.indexOf('git switch -c "$task_branch"');
+  const bootstrapCallPos = content.indexOf('bootstrap_node_modules "$root"');
+  expect(switchPos).toBeGreaterThan(0);
+  expect(bootstrapCallPos).toBeGreaterThan(switchPos);
+});
+
+test('#1378 AC1: bootstrap is idempotent (skips if node_modules already exists)', () => {
+  const content = fs.readFileSync(SESSION_START, 'utf-8');
+  expect(content).toMatch(/already present|skipping/);
+});
+
+test('#1378 AC1: bootstrap skips when this IS the main checkout (no self-link)', () => {
+  const content = fs.readFileSync(SESSION_START, 'utf-8');
+  expect(content).toMatch(/this IS the main checkout|nothing to link/);
+});
+
+test('#1378 AC2: .gitignore covers node_modules (symlink stays untracked)', () => {
+  const gitignore = fs.readFileSync(path.join(REPO, '.gitignore'), 'utf-8');
+  expect(gitignore).toMatch(/^node_modules\/?$/m);
+});
+
+test('#1378 AC3: standalone worktree-bootstrap script exists and is executable', () => {
+  const stat = fs.statSync(BOOTSTRAP);
+  expect(stat.isFile()).toBe(true);
+  // Check that the owner can execute the script (mode bit 0o100)
+  expect((stat.mode & 0o100) !== 0).toBe(true);
+});
+
+test('#1378 AC3: standalone script iterates all worktrees via porcelain output', () => {
+  const content = fs.readFileSync(BOOTSTRAP, 'utf-8');
+  expect(content).toContain('git worktree list --porcelain');
+  expect(content).toMatch(/linked=|skipped=|errored=/);
+});
+
+test('#1378 AC3: npm run worktree:bootstrap is defined', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(REPO, 'package.json'), 'utf-8'));
+  expect(pkg.scripts['worktree:bootstrap']).toContain('worktree-bootstrap-node-modules.sh');
+});
+
+test('#1378 AC3: live invocation succeeds + is idempotent (re-run = no errors)', () => {
+  const result = spawnSync('npm', ['run', 'worktree:bootstrap'], {
+    cwd: REPO, encoding: 'utf-8',
+  });
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('done: linked=');
+  // Re-run should report all skipped now
+  const result2 = spawnSync('npm', ['run', 'worktree:bootstrap'], {
+    cwd: REPO, encoding: 'utf-8',
+  });
+  expect(result2.status).toBe(0);
+  expect(result2.stdout).toContain('linked=0');
+});
+
+test('#1378 AC4: CLAUDE.md documents the auto-link pattern', () => {
+  const content = fs.readFileSync(path.join(REPO, 'CLAUDE.md'), 'utf-8');
+  expect(content).toContain('auto-link');
+  expect(content).toContain('node_modules');
+  expect(content).toContain('worktree:bootstrap');
+});
+
+test('#1378 AC5: live verification — this worktree has node_modules linked (so format:check works)', () => {
+  // The current test worktree must have node_modules for this very test to run.
+  expect(fs.existsSync(path.join(REPO, 'node_modules'))).toBe(true);
+});


### PR DESCRIPTION
## Summary

Closes #1378 (P2 chronic friction). New worktrees auto-link node_modules from main checkout; standalone retroactive script for existing worktrees.

Refs #1378

## What changes
- `scripts/worktree-session-start.sh` — adds `bootstrap_node_modules()`, called after task-branch creation
- `scripts/worktree-bootstrap-node-modules.sh` — standalone for existing worktrees
- `npm run worktree:bootstrap` — package.json alias
- `CLAUDE.md` — documents the pattern
- `tests/worktree-bootstrap-1378.spec.js` — 11 tests

## Eat-own-dogfood
Bootstrap script linked one missing node_modules in production during test run (locked Claude SDK auto-worktree from #1458 follow-up).

## AC results
| AC | Status |
|---|---|
| AC1 Auto-link in session-start | ✅ |
| AC2 .gitignore handles symlink | ✅ (already covered) |
| AC3 Standalone retroactive script | ✅ + npm alias |
| AC4 Document in CLAUDE.md | ✅ |
| AC5 Tests | ✅ 11/11 |

## Baton
- COLLABORATOR_HANDOFF on #1378 (>70s before PR)
- ADMIN_HANDOFF pending
- CONSULTANT_CLOSEOUT pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)