### PR TITLE
feat(governance): consultant-checks gov-* bundle #1240 #1241 #1243

### DIFF
--- a/.changes/unreleased/1240-1241-1243.md
+++ b/.changes/unreleased/1240-1241-1243.md
@@ -1,0 +1,14 @@
+## [Unreleased] — #1240/#1241/#1243: consultant-checks gov-002/003/005 audit findings
+
+### Added
+- `scripts/global/consultant-checks-lib.js` — pure-function library with `decideGov002`, `decideGov003`, `decideGov005`, and `readWithMainFallback`. Caller (`consultant-checks.js`) wires in `fs`, `path`, and `run`. Enables deterministic unit testing without shelling to `gh` or `git`.
+- `tests/consultant-checks-lib.spec.js` — 10 tests covering all three decide functions (pass + fail paths) plus three `readWithMainFallback` cases (local hit, main-checkout fallback, both empty).
+
+### Changed
+- `scripts/global/consultant-checks.js` — gov-002, gov-003, gov-005 now delegate to the lib's pure functions. gov-003 reads `logs/fleet-health.jsonl` and `.dashboard/events.jsonl` through `readWithMainFallback`, which discovers the main checkout via `git worktree list --porcelain` (same pattern as #1378 node_modules bootstrap). Fixes false FAIL when run from a fresh feature worktree.
+
+### Why
+Closes #1240 (gov-002 artifact-gap) + #1241 (gov-003 event-coverage-check) + #1243 (gov-005 ac-evidence-completeness). The original source issues (#1199, #1200) already had their gaps backfilled organically, so gov-002 and gov-005 needed only test coverage to lock in the behavior. gov-003 was a real runtime fail: `.dashboard/events.jsonl` is a main-checkout artifact never present in feature worktrees, so consultant runs from a worktree always flagged false. Main-checkout fallback resolves this systemically.
+
+### Eat-own-dogfood evidence
+Running `node scripts/global/consultant-checks.js --issue 1199 --json` from this feature worktree (`feat/1240-gov-audit-bundle`) shows all six gov-* checks PASS, including gov-003 (was FAIL pre-patch). Same result for `--issue 1200`. The fix exercised its own AC3 inside the dev loop.

--- a/scripts/global/consultant-checks-lib.js
+++ b/scripts/global/consultant-checks-lib.js
@@ -1,0 +1,33 @@
+'use strict';
+// Pure helpers for consultant-checks.js — split out so tests can call the
+// decision logic without shelling to gh/git. Side-effects live in the CLI
+// wrapper; this module stays deterministic.
+
+const decideGov002 = comments =>
+  /MANAGER_HANDOFF/.test(comments) && /COLLABORATOR_HANDOFF/.test(comments) &&
+  /ADMIN_HANDOFF/.test(comments) && /CONSULTANT_CLOSEOUT/.test(comments);
+
+const decideGov003 = (fleetLog, eventLog) =>
+  /baton:/.test(fleetLog) || /"type":"baton:handoff"/.test(eventLog);
+
+const decideGov005 = issueBody => !/- \[ \]/.test(issueBody);
+
+// #1241: events.jsonl / fleet-health.jsonl are runtime artifacts written by
+// the main checkout; fresh worktrees never have them. When the worktree path
+// is empty, fall through to the main checkout discovered via
+// `git worktree list --porcelain` (same pattern as #1378's node_modules link).
+function readWithMainFallback({ fs, path, run, cwdRoot, relPath }) {
+  const localPath = path.join(cwdRoot, relPath);
+  let content = '';
+  try { content = fs.readFileSync(localPath, 'utf8'); } catch {}
+  if (content) return content;
+  const porcelain = run('git worktree list --porcelain') || '';
+  const line = porcelain.split('\n').find(l => l.startsWith('worktree '));
+  const mainRoot = line ? line.slice(9) : '';
+  if (mainRoot && mainRoot !== cwdRoot) {
+    try { content = fs.readFileSync(path.join(mainRoot, relPath), 'utf8'); } catch {}
+  }
+  return content;
+}
+
+module.exports = { decideGov002, decideGov003, decideGov005, readWithMainFallback };

--- a/scripts/global/consultant-checks.js
+++ b/scripts/global/consultant-checks.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
+const lib = require('./consultant-checks-lib');
 
 const args = process.argv.slice(2);
 const asJson = args.includes('--json');
@@ -35,18 +36,18 @@ const checks = [
   [id('gov', 2), 'governance', () => {
     if (!issue) return skip(id('gov', 2), 'governance', 'missing --issue');
     const comments = run(`gh issue view ${issue} --json comments -q '.comments[].body'`);
-    const pass = /MANAGER_HANDOFF/.test(comments) && /COLLABORATOR_HANDOFF/.test(comments) && /ADMIN_HANDOFF/.test(comments) && /CONSULTANT_CLOSEOUT/.test(comments);
+    const pass = lib.decideGov002(comments);
     return ok(id('gov', 2), 'governance', pass, pass ? 'all baton artifacts present' : 'missing baton artifact', pass ? 'artifact-complete' : 'artifact-gap', 'post missing baton artifacts');
   }],
   [id('gov', 3), 'governance', () => {
-    const fleetLog = read('logs/fleet-health.jsonl');
-    const eventLog = read('.dashboard/events.jsonl');
-    const pass = /baton:/.test(fleetLog) || /"type":"baton:handoff"/.test(eventLog);
+    const fleetLog = lib.readWithMainFallback({ fs, path, run, cwdRoot: root, relPath: 'logs/fleet-health.jsonl' });
+    const eventLog = lib.readWithMainFallback({ fs, path, run, cwdRoot: root, relPath: '.dashboard/events.jsonl' });
+    const pass = lib.decideGov003(fleetLog, eventLog);
     const evidence = pass ? 'fleet-health or dashboard baton events present' : 'no baton markers in fleet-health/events log';
     return ok(id('gov', 3), 'governance', pass, evidence, 'event-coverage-check', 'emit baton events');
   }],
   [id('gov', 4), 'governance', () => { const gitLog = run("git log --oneline -99"); const matchCount = (gitLog.match(/#\d+/g) || []).length; const total = gitLog ? gitLog.split('\n').length : 0; return ok(id('gov', 4), 'governance', total > 0 && matchCount / total >= 0.8, `${matchCount}/${total} commit refs`, 'commit-issue-linkage', 'reference issue numbers in commits'); }],
-  [id('gov', 5), 'governance', () => issue ? ok(id('gov', 5), 'governance', !/- \[ \]/.test(run(`gh issue view ${issue}`)), 'issue body checklist scanned', 'ac-evidence-completeness', 'complete unchecked ACs') : skip(id('gov', 5), 'governance', 'missing --issue')],
+  [id('gov', 5), 'governance', () => issue ? ok(id('gov', 5), 'governance', lib.decideGov005(run(`gh issue view ${issue}`)), 'issue body checklist scanned', 'ac-evidence-completeness', 'complete unchecked ACs') : skip(id('gov', 5), 'governance', 'missing --issue')],
   [id('gov', 6), 'governance', () => { const branch = run('git branch --show-current'); return ok(id('gov', 6), 'governance', /^(feat|fix|skill|hook)\//.test(branch), branch || 'unknown-branch', 'branch-naming', 'use approved branch prefix'); }],
   [id('tool', 1), 'tools', () => ok(id('tool', 1), 'tools', exists('wiki/index.md') && exists('wiki/log.md'), 'wiki index/log presence', 'wiki-growth-ready', 'maintain wiki index/log updates')],
   [id('tool', 2), 'tools', () => ok(id('tool', 2), 'tools', !/\[\[[^\]]+\]\].*\(not found\)/.test(run('npm run wiki:lint 2>&1 | cat')), 'wiki lint output scanned', 'wiki-orphan-check', 'add backlinks/cross-links')],

--- a/tests/consultant-checks-lib.spec.js
+++ b/tests/consultant-checks-lib.spec.js
@@ -1,0 +1,85 @@
+// Tests for scripts/global/consultant-checks-lib.js (#1240/#1241/#1243).
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const lib = require('../scripts/global/consultant-checks-lib');
+
+test('#1240 gov-002: passes when all four baton artifacts are present', () => {
+  const comments = 'MANAGER_HANDOFF\n---\nCOLLABORATOR_HANDOFF\n---\nADMIN_HANDOFF\n---\nCONSULTANT_CLOSEOUT';
+  expect(lib.decideGov002(comments)).toBe(true);
+});
+
+test('#1240 gov-002: fails when any baton artifact is missing', () => {
+  const noManager = 'COLLABORATOR_HANDOFF\nADMIN_HANDOFF\nCONSULTANT_CLOSEOUT';
+  const noCollab = 'MANAGER_HANDOFF\nADMIN_HANDOFF\nCONSULTANT_CLOSEOUT';
+  const noAdmin = 'MANAGER_HANDOFF\nCOLLABORATOR_HANDOFF\nCONSULTANT_CLOSEOUT';
+  const noConsultant = 'MANAGER_HANDOFF\nCOLLABORATOR_HANDOFF\nADMIN_HANDOFF';
+  expect(lib.decideGov002(noManager)).toBe(false);
+  expect(lib.decideGov002(noCollab)).toBe(false);
+  expect(lib.decideGov002(noAdmin)).toBe(false);
+  expect(lib.decideGov002(noConsultant)).toBe(false);
+  expect(lib.decideGov002('')).toBe(false);
+});
+
+test('#1241 gov-003: passes when fleet-health.jsonl has baton: marker', () => {
+  expect(lib.decideGov003('{"baton:handoff":1}', '')).toBe(true);
+});
+
+test('#1241 gov-003: passes when events.jsonl has baton:handoff type', () => {
+  expect(lib.decideGov003('', '{"type":"baton:handoff"}')).toBe(true);
+});
+
+test('#1241 gov-003: fails when neither log carries baton evidence', () => {
+  expect(lib.decideGov003('', '')).toBe(false);
+  expect(lib.decideGov003('{"telemetry":"only"}', '{"type":"system"}')).toBe(false);
+});
+
+test('#1243 gov-005: passes when issue body has no unchecked ACs', () => {
+  expect(lib.decideGov005('- [x] AC1\n- [x] AC2')).toBe(true);
+  expect(lib.decideGov005('no checklist at all')).toBe(true);
+  expect(lib.decideGov005('')).toBe(true);
+});
+
+test('#1243 gov-005: fails when issue body has any unchecked AC', () => {
+  expect(lib.decideGov005('- [ ] AC1 unchecked\n- [x] AC2')).toBe(false);
+  expect(lib.decideGov005('- [x] AC1\n- [ ] AC2 unchecked')).toBe(false);
+});
+
+test('#1241 AC1: readWithMainFallback reads local file when present', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'consultant-fallback-'));
+  const sub = path.join(tmp, 'logs');
+  fs.mkdirSync(sub, { recursive: true });
+  fs.writeFileSync(path.join(sub, 'fleet-health.jsonl'), '{"baton:handoff":"local"}\n');
+  const result = lib.readWithMainFallback({
+    fs, path, run: () => '', cwdRoot: tmp, relPath: 'logs/fleet-health.jsonl',
+  });
+  expect(result).toContain('baton:handoff');
+  expect(result).toContain('local');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('#1241 AC1: readWithMainFallback falls back to main checkout when worktree empty', () => {
+  const tmpMain = fs.mkdtempSync(path.join(os.tmpdir(), 'consultant-main-'));
+  const tmpWt = fs.mkdtempSync(path.join(os.tmpdir(), 'consultant-wt-'));
+  const sub = path.join(tmpMain, '.dashboard');
+  fs.mkdirSync(sub, { recursive: true });
+  fs.writeFileSync(path.join(sub, 'events.jsonl'), '{"type":"baton:handoff","src":"main"}\n');
+  const fakeRun = () => `worktree ${tmpMain}\nbranch refs/heads/main\n\nworktree ${tmpWt}\nbranch refs/heads/feature\n`;
+  const result = lib.readWithMainFallback({
+    fs, path, run: fakeRun, cwdRoot: tmpWt, relPath: '.dashboard/events.jsonl',
+  });
+  expect(result).toContain('baton:handoff');
+  expect(result).toContain('main');
+  fs.rmSync(tmpMain, { recursive: true, force: true });
+  fs.rmSync(tmpWt, { recursive: true, force: true });
+});
+
+test('#1241 AC1: readWithMainFallback returns empty when neither path has file', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'consultant-empty-'));
+  const result = lib.readWithMainFallback({
+    fs, path, run: () => `worktree ${tmp}\n`, cwdRoot: tmp, relPath: 'logs/missing.jsonl',
+  });
+  expect(result).toBe('');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary

Bundle close three governance audit findings:
- **#1240** (gov-002 artifact-gap) — already organically fixed; locked behavior with unit tests.
- **#1241** (gov-003 event-coverage-check) — real runtime fix: `.dashboard/events.jsonl` is a main-checkout artifact never present in feature worktrees, so consultant runs from a fresh worktree always flagged false. Added `readWithMainFallback` that discovers the main checkout via `git worktree list --porcelain` (same pattern as #1378).
- **#1243** (gov-005 ac-evidence-completeness) — already organically fixed; locked behavior with unit tests.

## Approach

Extracted three pure decide functions (`decideGov002/003/005`) and the worktree-aware reader (`readWithMainFallback`) into `scripts/global/consultant-checks-lib.js`. `consultant-checks.js` now delegates to the lib. 10 new unit tests cover all rules + fallback paths. Both files stay under the 100-line limit (71/33).

## Eat-own-dogfood

Running `node scripts/global/consultant-checks.js --issue 1199 --json` from this feature worktree (`feat/1240-gov-audit-bundle`) shows **all 6 gov-* checks PASS**, including gov-003 (which was FAIL pre-patch). Same for `--issue 1200`. The fix exercised its own AC3 inside the dev loop.

## Test plan

- [x] `npx playwright test tests/consultant-checks-lib.spec.js` — 10/10 passing
- [x] `npm run lint` — all files within 100-line limit
- [x] `npm run format:check` — green
- [x] `npm run lint:readability:ci` — green (pre-existing warnings only, none in new files)
- [x] `node scripts/global/consultant-checks.js --issue 1199 --json` — gov-002/003/005 all PASS
- [x] `node scripts/global/consultant-checks.js --issue 1200 --json` — gov-002/003/005 all PASS

## Baton artifacts

MANAGER_HANDOFF (posted on all three issues #1240/#1241/#1243), COLLABORATOR_HANDOFF below, ADMIN_HANDOFF and CONSULTANT_CLOSEOUT to follow.

---

## COLLABORATOR_HANDOFF

Implementation complete:
- Pure lib extracted; CLI wrapper unchanged in interface.
- Main-checkout fallback uses the established `git worktree list --porcelain` pattern.
- 10 unit tests pass; lint/format/readability green.
- Bundle fits under 100-line file cap.

Signed-by: Orla Harper · Team&Model: claude-code:opus-4-7@anthropic · Role: collaborator

Refs #1240
Refs #1241
Refs #1243

🤖 Generated with [Claude Code](https://claude.com/claude-code)