### PR TITLE
feat(megalint): merge-evidence rule (advisory) #1498

### DIFF
--- a/.changes/unreleased/1498.md
+++ b/.changes/unreleased/1498.md
@@ -1,0 +1,20 @@
+## [Unreleased] — #1498: merge-evidence megalint rule (Epic #1486 Phase-1a)
+
+### Added
+- `scripts/global/megalint/merge-evidence.js` — new pure-function validator that flags issues closed as `status:done` with zero merged PRs on main referencing them. Respects lightweight lanes (`lane:docs-research`/`docs-only`/`trivial`/`research`), `type:epic` (Epics evaluated via children), `status:cancelled` (goal invalidated, not delivered), and the override label `merge-evidence-override:approved`. Returns `{ok, violations[], skipped?, mergedPRCount}`.
+- `tests/megalint-merge-evidence.spec.js` — 11 Playwright tests covering every skip-path, the violation case, the pass case, and `index.js` `run()`/`runAll()` integration.
+
+### Changed
+- `scripts/global/megalint/index.js` — register `merge-evidence` in the `VALIDATORS` map so it dispatches from `run()` and `runAll()` alongside the existing 7 rules.
+
+### Why
+Phase-1a of Epic #1486 Path D (Hybrid). The Phase-0 audit found 25 of 50 most recent `status:done` tickets had no linked merged PR — a delivery-integrity gap that every existing PR-anchored gate (`evidence-completeness`, `closeout-schema`, `epic-close-readiness`, `post-merge-automation`) misses, because direct `gh issue close` skips them all. This rule is the pure-function foundation. Phase-1b will wire it into a workflow callsite that supplies `mergedPRRefs` and posts advisory comments; Phase-1c promotes to required after a soak window.
+
+### Out of scope (this PR)
+- Workflow callsite that queries merged PRs and posts comments (Phase-1b).
+- Backfill reconciler for existing offenders (Phase-1b).
+- Promotion to required gate (Phase-1c).
+- Per-team dashboard panel (Phase-1d).
+
+### Eat-own-dogfood evidence
+This PR itself is the kind of artifact the rule is designed to detect when missing: `Refs #1498` in body + merged-to-main commit. Once Phase-1b is wired up, the rule will retroactively pass on #1498.

--- a/scripts/global/megalint/index.js
+++ b/scripts/global/megalint/index.js
@@ -11,6 +11,7 @@ const consultant = require('./consultant-closeout.js');
 const signer = require('./signer-fidelity.js');
 const truthfulness = require('./body-ac-truthfulness.js');
 const traceability = require('./epic-ac-traceability.js');
+const mergeEvidence = require('./merge-evidence.js');
 
 const VALIDATORS = {
   'manager-handoff': manager,
@@ -20,6 +21,7 @@ const VALIDATORS = {
   'signer-fidelity': signer,
   'body-ac-truthfulness': truthfulness,
   'epic-ac-traceability': traceability,
+  'merge-evidence': mergeEvidence,
 };
 
 function runAll(input) {

--- a/scripts/global/megalint/merge-evidence.js
+++ b/scripts/global/megalint/merge-evidence.js
@@ -1,0 +1,43 @@
+'use strict';
+// merge-evidence — Epic #1486 Phase-1a. Pure function that flags issues
+// closed as status:done with no merged PR referencing them on main. Caller
+// supplies mergedPRRefs (already filtered to merged-to-main); this rule
+// stays side-effect-free per existing megalint convention.
+
+const LIGHTWEIGHT_LANES = new Set([
+  'lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research',
+]);
+const OVERRIDE_LABEL = 'merge-evidence-override:approved';
+
+function shouldSkip(labels, state) {
+  if (state !== 'closed') return 'open-issue';
+  if (labels.includes('type:epic')) return 'epic-evaluated-via-children';
+  if (labels.includes('status:cancelled')) return 'cancelled-not-delivered';
+  if (!labels.includes('status:done')) return 'non-done-terminal';
+  if (labels.includes(OVERRIDE_LABEL)) return 'override-approved';
+  for (const label of labels) if (LIGHTWEIGHT_LANES.has(label)) return `lightweight-lane:${label}`;
+  return null;
+}
+
+function validate(input) {
+  const labels = input.labels || [];
+  const state = input.state || 'open';
+  const mergedPRRefs = input.mergedPRRefs || [];
+  const violations = [];
+
+  const skipReason = shouldSkip(labels, state);
+  if (skipReason) return { ok: true, violations, skipped: skipReason };
+
+  if (mergedPRRefs.length === 0) {
+    violations.push({
+      rule: 'merge-evidence-missing',
+      detail: 'Issue closed as status:done with no merged PR on main referencing it. '
+        + 'Either link the merging PR via Refs #N / Closes #N in the PR body, or apply '
+        + `\`${OVERRIDE_LABEL}\` if closure without merge is intentional (cite reason in closing comment).`,
+      mergedPRCount: 0,
+    });
+  }
+  return { ok: violations.length === 0, violations, mergedPRCount: mergedPRRefs.length };
+}
+
+module.exports = { validate, shouldSkip, LIGHTWEIGHT_LANES, OVERRIDE_LABEL };

--- a/tests/megalint-merge-evidence.spec.js
+++ b/tests/megalint-merge-evidence.spec.js
@@ -1,0 +1,115 @@
+// Tests for scripts/global/megalint/merge-evidence.js (Epic #1486 Phase-1a, #1498).
+const { test, expect } = require('@playwright/test');
+const rule = require('../scripts/global/megalint/merge-evidence');
+
+const closedDone = (extra = []) => ({
+  state: 'closed',
+  labels: ['status:done', 'type:task', 'lane:code-change', ...extra],
+});
+
+test('#1498 AC1: violation fires when status:done closed with no merged PR refs', () => {
+  const result = rule.validate({ ...closedDone(), mergedPRRefs: [] });
+  expect(result.ok).toBe(false);
+  expect(result.violations[0].rule).toBe('merge-evidence-missing');
+  expect(result.violations[0].mergedPRCount).toBe(0);
+});
+
+test('#1498 AC1: passes when one or more merged PRs reference the issue', () => {
+  const result = rule.validate({ ...closedDone(), mergedPRRefs: [{ number: 1493 }] });
+  expect(result.ok).toBe(true);
+  expect(result.violations).toHaveLength(0);
+  expect(result.mergedPRCount).toBe(1);
+});
+
+test('#1498 AC1: open issue is never evaluated (no violation, marked skipped)', () => {
+  const result = rule.validate({
+    state: 'open', labels: ['status:in-progress', 'type:task', 'lane:code-change'],
+    mergedPRRefs: [],
+  });
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('open-issue');
+});
+
+test('#1498 AC4: closed type:epic skipped (Epic evaluated via children)', () => {
+  const result = rule.validate({
+    state: 'closed',
+    labels: ['type:epic', 'status:done', 'lane:code-change'],
+    mergedPRRefs: [],
+  });
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('epic-evaluated-via-children');
+});
+
+test('#1498 AC4: status:cancelled skipped (goal invalidated, not delivered)', () => {
+  const result = rule.validate({
+    state: 'closed',
+    labels: ['status:cancelled', 'type:task', 'lane:code-change'],
+    mergedPRRefs: [],
+  });
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('cancelled-not-delivered');
+});
+
+test('#1498: closed without status:done (other terminal) is skipped', () => {
+  const result = rule.validate({
+    state: 'closed', labels: ['type:task', 'lane:code-change'], mergedPRRefs: [],
+  });
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('non-done-terminal');
+});
+
+test('#1498 AC5: override label suppresses the violation', () => {
+  const result = rule.validate({
+    ...closedDone(['merge-evidence-override:approved']),
+    mergedPRRefs: [],
+  });
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('override-approved');
+});
+
+test('#1498 AC3: lightweight lanes skipped (docs-research)', () => {
+  const result = rule.validate({
+    state: 'closed',
+    labels: ['status:done', 'type:task', 'lane:docs-research'],
+    mergedPRRefs: [],
+  });
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('lightweight-lane:lane:docs-research');
+});
+
+test('#1498 AC3: lightweight lanes skipped (trivial, docs-only, research)', () => {
+  for (const lane of ['lane:trivial', 'lane:docs-only', 'lane:research']) {
+    const result = rule.validate({
+      state: 'closed', labels: ['status:done', 'type:task', lane], mergedPRRefs: [],
+    });
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(`lightweight-lane:${lane}`);
+  }
+});
+
+test('#1498 AC2: rule registered in megalint VALIDATORS map and exposed via run()', () => {
+  const megalint = require('../scripts/global/megalint');
+  expect(megalint.VALIDATORS).toHaveProperty('merge-evidence');
+  const result = megalint.run('merge-evidence', {
+    state: 'closed',
+    labels: ['status:done', 'type:task', 'lane:code-change'],
+    mergedPRRefs: [],
+  });
+  expect(result.ok).toBe(false);
+  expect(result.violations[0].rule).toBe('merge-evidence-missing');
+});
+
+test('#1498: rule integrates with runAll() — appears in aggregated results', () => {
+  const megalint = require('../scripts/global/megalint');
+  const result = megalint.runAll({
+    state: 'closed',
+    labels: ['status:done', 'type:task', 'lane:code-change'],
+    body: '## Acceptance Criteria\n- [x] AC1: done',
+    comments: [],
+    mergedPRRefs: [{ number: 1493 }],
+    issueNumber: 1498,
+    ticketRef: '#1498',
+  });
+  expect(result.results['merge-evidence']).toBeDefined();
+  expect(result.results['merge-evidence'].ok).toBe(true);
+});


### PR DESCRIPTION
## Summary

Phase-1a of Epic #1486 Path D. Pure-function megalint validator that detects `status:done` issues closed with no merged PR on main referencing them — closes the gap every existing PR-anchored gate misses.

## Approach

| File | Lines | Role |
|---|---|---|
| `scripts/global/megalint/merge-evidence.js` | 43 | New pure validator |
| `scripts/global/megalint/index.js` | 53 | Register `merge-evidence` in VALIDATORS map |
| `tests/megalint-merge-evidence.spec.js` | 115 | 11 Playwright tests |
| `.changes/unreleased/1498.md` | 21 | Changelog fragment |

All files under the 100-line limit. Rule returns `{ok, violations[], skipped?, mergedPRCount}` per existing megalint convention.

## Skip surface (false-positive respect)

- `state !== 'closed'` → not yet evaluated
- `type:epic` → Epic delivery measured via children
- `status:cancelled` → goal invalidated; not a delivery
- not `status:done` → other terminal state (no false alarm)
- `merge-evidence-override:approved` → operator override path
- lightweight lanes: `lane:docs-research`, `lane:docs-only`, `lane:trivial`, `lane:research`

## Test plan

- [x] `npx playwright test tests/megalint-merge-evidence.spec.js` — 11/11 passing
- [x] `npm run lint` — all files ≤ 100 lines
- [x] Wired into `index.js` VALIDATORS map; `run()` and `runAll()` dispatch verified by tests

## Out of scope (Phase-1b)

- Workflow callsite that queries merged PRs and posts advisory comments
- Backfill reconciler
- Promotion to required (Phase-1c)
- Dashboard panel (Phase-1d)

Refs #1498
Refs Epic #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)