### PR TITLE
feat(governance): merge-evidence workflow + daily reconciler #1500

### DIFF
--- a/.changes/unreleased/1500.md
+++ b/.changes/unreleased/1500.md
@@ -1,0 +1,19 @@
+## [Unreleased] — #1500: merge-evidence workflow + daily reconciler (Epic #1486 Phase-1b)
+
+### Added
+- `scripts/global/merge-evidence-reconciler.js` — batches closed-issue items through the megalint `merge-evidence` rule and returns a remediation plan (violations / skipped / passed). Configurable `batchSize` (default 20) protects rate limits. Exports `reconcile`, `buildComment`, `DEFAULT_BATCH_SIZE`, `COMMENT_MARKER`, `VIOLATION_LABEL`.
+- `.github/workflows/merge-evidence-check.yml` — live workflow on `issues.closed` with `status:done`. Searches for merged PRs referencing the issue via GitHub search API, runs the rule, posts an advisory comment + applies `governance:close-without-merge` label on violation. Idempotent via comment marker. WARN-ONLY.
+- `.github/workflows/merge-evidence-cron.yml` — daily cron at 03:15 UTC + `workflow_dispatch` for manual runs. Configurable `since_days` (default 7) and `batch_size` (default 20). Calls the reconciler over closed `status:done` issues in the lookback window, applies advisory comments + labels.
+- `tests/merge-evidence-reconciler.spec.js` — 12 Playwright tests covering empty input, pass/violation buckets, batch-size cap (default + override), lightweight-lane skip, override-label suppression, type:epic skip, label-shape flexibility (strings or objects), input validation (throws on non-array), `buildComment` content, and silent-skip of malformed items.
+- New repository label `governance:close-without-merge` (color #FF6F61) — applied by both workflows on violation.
+
+### Why
+Phase-1b of Epic #1486 Path D. Phase-1a (#1498) shipped the pure rule; Phase-1b wires it into two callsites that supply `mergedPRRefs` from GitHub. The live workflow catches new offenders at close-time; the cron reconciler backfills the trailing 7-day window so future-only enforcement doesn't strand history. Both stay advisory through the soak phase; Phase-1c will promote to required gate once false-positive rate is calibrated.
+
+### Out of scope (this PR)
+- Promotion to required gate (Phase-1c).
+- Dashboard panel (Phase-1d).
+- Bulk remediation of pre-soak historical offenders (Phase-1e — research first).
+
+### Eat-own-dogfood
+On merge, the live workflow becomes active. Future `status:done` closures without merge evidence will get flagged automatically. The cron's first scheduled run (next 03:15 UTC) will surface a calibration sample of trailing 7-day offenders.

--- a/.github/workflows/merge-evidence-check.yml
+++ b/.github/workflows/merge-evidence-check.yml
@@ -1,0 +1,59 @@
+# Epic #1486 Phase-1b — live merge-evidence advisory on issue close.
+# Fires on issues.closed; queries merged PRs referencing the issue; runs the
+# megalint merge-evidence rule; posts an advisory comment + applies the
+# governance:close-without-merge label on violation. WARN-ONLY.
+name: merge-evidence-check
+on:
+  issues:
+    types: [closed]
+permissions:
+  contents: read
+  issues: write
+jobs:
+  merge-evidence-check:
+    runs-on: ubuntu-latest
+    if: contains(toJson(github.event.issue.labels.*.name), 'status:done')
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const rule = require('./scripts/global/megalint/merge-evidence.js');
+            const reconciler = require('./scripts/global/merge-evidence-reconciler.js');
+            const { owner, repo } = context.repo;
+            const issue = context.payload.issue;
+            const labels = (issue.labels || []).map(l => l.name);
+            // Quick skip via rule (returns skipped reason without GH search)
+            const dryResult = rule.validate({ state: 'closed', labels, mergedPRRefs: [] });
+            if (dryResult.skipped) {
+              core.info(`skip: ${dryResult.skipped}`);
+              return;
+            }
+            // Query merged PRs referencing this issue (PR body or commit messages)
+            const results = await github.paginate(
+              github.rest.search.issuesAndPullRequests,
+              { q: `repo:${owner}/${repo} is:pr is:merged #${issue.number}`, per_page: 30 }
+            );
+            const mergedPRRefs = results.map(r => ({ number: r.number, title: r.title }));
+            const result = rule.validate({ state: 'closed', labels, mergedPRRefs });
+            if (result.ok) {
+              core.info(`pass: ${mergedPRRefs.length} merged PR(s) found`);
+              return;
+            }
+            // Check for existing advisory (idempotency)
+            const existing = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: issue.number, per_page: 100,
+            });
+            if (existing.some(c => c.body && c.body.includes(reconciler.COMMENT_MARKER))) {
+              core.info('advisory already posted; skipping');
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: issue.number,
+              body: reconciler.buildComment({ number: issue.number }),
+            });
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: issue.number,
+              labels: [reconciler.VIOLATION_LABEL],
+            }).catch(e => core.warning(`label apply failed: ${e.message}`));
+            core.info('advisory posted + label applied');

--- a/.github/workflows/merge-evidence-cron.yml
+++ b/.github/workflows/merge-evidence-cron.yml
@@ -1,0 +1,69 @@
+# Epic #1486 Phase-1b — daily reconciler. Scans recently-closed status:done
+# tickets, batches them through the merge-evidence rule, posts advisory +
+# applies governance:close-without-merge label on offenders. WARN-ONLY.
+# Manual trigger via workflow_dispatch with optional since-days input.
+name: merge-evidence-cron
+on:
+  schedule:
+    - cron: '15 3 * * *'
+  workflow_dispatch:
+    inputs:
+      since_days:
+        description: 'Lookback window in days (default 7)'
+        type: string
+        default: '7'
+      batch_size:
+        description: 'Max issues processed per run (default 20)'
+        type: string
+        default: '20'
+permissions:
+  contents: read
+  issues: write
+jobs:
+  merge-evidence-cron:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const reconciler = require('./scripts/global/merge-evidence-reconciler.js');
+            const { owner, repo } = context.repo;
+            const sinceDays = parseInt(process.env.SINCE_DAYS || '7', 10);
+            const batchSize = parseInt(process.env.BATCH_SIZE || '20', 10);
+            const since = new Date(Date.now() - sinceDays * 86400e3).toISOString().slice(0, 10);
+            core.info(`scanning closed status:done issues since ${since}, batch=${batchSize}`);
+            const closed = await github.paginate(github.rest.search.issuesAndPullRequests, {
+              q: `repo:${owner}/${repo} is:issue is:closed label:status:done closed:>=${since}`,
+              per_page: 50,
+            });
+            core.info(`candidates: ${closed.length}`);
+            const items = [];
+            for (const issue of closed.slice(0, batchSize * 2)) {
+              const prs = await github.paginate(github.rest.search.issuesAndPullRequests, {
+                q: `repo:${owner}/${repo} is:pr is:merged #${issue.number}`, per_page: 5,
+              });
+              items.push({
+                issue: { ...issue, state: 'closed' },
+                mergedPRRefs: prs.map(p => ({ number: p.number })),
+              });
+            }
+            const plan = reconciler.reconcile(items, { batchSize });
+            core.info(`plan: violations=${plan.violations.length} skipped=${plan.skipped.length} passed=${plan.passed.length} remaining=${plan.remaining}`);
+            for (const v of plan.violations) {
+              const existing = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: v.number, per_page: 100,
+              });
+              if (existing.some(c => c.body && c.body.includes(plan.marker))) continue;
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: v.number,
+                body: reconciler.buildComment({ number: v.number }),
+              });
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: v.number, labels: [plan.label],
+              }).catch(e => core.warning(`label apply failed on #${v.number}: ${e.message}`));
+            }
+            core.info(`cron complete; processed=${plan.processed}`);
+        env:
+          SINCE_DAYS: ${{ github.event.inputs.since_days || '7' }}
+          BATCH_SIZE: ${{ github.event.inputs.batch_size || '20' }}

--- a/scripts/global/merge-evidence-reconciler.js
+++ b/scripts/global/merge-evidence-reconciler.js
@@ -1,0 +1,54 @@
+'use strict';
+// merge-evidence-reconciler — Epic #1486 Phase-1b. Batches closed-issue
+// items through the merge-evidence rule and returns a remediation plan.
+// Pure(ish): callers provide GitHub data; this module produces decisions.
+// The caller (cron workflow) applies labels and posts comments.
+
+const rule = require('./megalint/merge-evidence.js');
+
+const DEFAULT_BATCH_SIZE = 20;
+const COMMENT_MARKER = '<!-- merge-evidence-reconciler -->';
+const VIOLATION_LABEL = 'governance:close-without-merge';
+
+function classifyItem(item, buckets) {
+  if (!item || typeof item.issue !== 'object') return;
+  const issue = item.issue;
+  const result = rule.validate({
+    state: issue.state,
+    labels: (issue.labels || []).map(l => typeof l === 'string' ? l : l.name),
+    mergedPRRefs: item.mergedPRRefs || [],
+  });
+  const entry = { number: issue.number, title: issue.title };
+  if (result.skipped) buckets.skipped.push({ ...entry, reason: result.skipped });
+  else if (!result.ok) buckets.violations.push({ ...entry, violations: result.violations });
+  else buckets.passed.push({ ...entry, mergedPRCount: result.mergedPRCount });
+}
+
+function reconcile(items, opts = {}) {
+  if (!Array.isArray(items)) throw new TypeError('items must be an array');
+  const batchSize = opts.batchSize || DEFAULT_BATCH_SIZE;
+  const batch = items.slice(0, batchSize);
+  const buckets = { violations: [], skipped: [], passed: [] };
+  for (const item of batch) classifyItem(item, buckets);
+  return {
+    processed: batch.length,
+    remaining: Math.max(0, items.length - batch.length),
+    ...buckets,
+    label: VIOLATION_LABEL,
+    marker: COMMENT_MARKER,
+  };
+}
+
+function buildComment(item) {
+  return `${COMMENT_MARKER}\n## Merge-evidence advisory\n\n`
+    + `Issue closed as \`status:done\` with no merged PR on main referencing it. `
+    + `Per Epic #1486, every non-lightweight \`status:done\` ticket should carry merge evidence.\n\n`
+    + `**To resolve:**\n`
+    + `1. If a merging PR exists but was not detected, ensure its body cites \`Refs #${item.number}\` or \`Closes #${item.number}\`.\n`
+    + `2. If closure without merge is intentional, apply label \`merge-evidence-override:approved\` and cite reason in a closing comment.\n\n`
+    + `_Advisory only — no enforcement. Phase-1c may promote to required after soak. See Epic #1486._`;
+}
+
+module.exports = {
+  reconcile, buildComment, DEFAULT_BATCH_SIZE, COMMENT_MARKER, VIOLATION_LABEL,
+};

--- a/tests/merge-evidence-reconciler.spec.js
+++ b/tests/merge-evidence-reconciler.spec.js
@@ -1,0 +1,114 @@
+// Tests for scripts/global/merge-evidence-reconciler.js (Epic #1486 Phase-1b, #1500).
+const { test, expect } = require('@playwright/test');
+const reconciler = require('../scripts/global/merge-evidence-reconciler');
+
+const issue = (number, labels = ['status:done', 'type:task', 'lane:code-change']) => ({
+  number, title: `Issue ${number}`, state: 'closed', labels,
+});
+
+test('#1500 AC2: empty input returns zero-result plan', () => {
+  const plan = reconciler.reconcile([]);
+  expect(plan.processed).toBe(0);
+  expect(plan.violations).toHaveLength(0);
+  expect(plan.skipped).toHaveLength(0);
+  expect(plan.passed).toHaveLength(0);
+  expect(plan.remaining).toBe(0);
+});
+
+test('#1500 AC2: items with merged PRs land in passed bucket', () => {
+  const plan = reconciler.reconcile([
+    { issue: issue(101), mergedPRRefs: [{ number: 901 }] },
+  ]);
+  expect(plan.passed).toHaveLength(1);
+  expect(plan.passed[0].number).toBe(101);
+  expect(plan.passed[0].mergedPRCount).toBe(1);
+  expect(plan.violations).toHaveLength(0);
+});
+
+test('#1500 AC2: items without merged PRs land in violations bucket', () => {
+  const plan = reconciler.reconcile([
+    { issue: issue(102), mergedPRRefs: [] },
+  ]);
+  expect(plan.violations).toHaveLength(1);
+  expect(plan.violations[0].number).toBe(102);
+  expect(plan.violations[0].violations[0].rule).toBe('merge-evidence-missing');
+});
+
+test('#1500 AC3: batch-size cap defaults to 20', () => {
+  const items = Array.from({ length: 50 }, (_, i) => ({
+    issue: issue(200 + i), mergedPRRefs: [],
+  }));
+  const plan = reconciler.reconcile(items);
+  expect(plan.processed).toBe(20);
+  expect(plan.remaining).toBe(30);
+  expect(plan.violations).toHaveLength(20);
+});
+
+test('#1500 AC3: batch-size cap is configurable via opts', () => {
+  const items = Array.from({ length: 10 }, (_, i) => ({
+    issue: issue(300 + i), mergedPRRefs: [],
+  }));
+  const plan = reconciler.reconcile(items, { batchSize: 5 });
+  expect(plan.processed).toBe(5);
+  expect(plan.remaining).toBe(5);
+});
+
+test('#1500 AC2: lightweight-lane items skipped (not flagged)', () => {
+  const plan = reconciler.reconcile([
+    { issue: issue(401, ['status:done', 'lane:docs-research']), mergedPRRefs: [] },
+    { issue: issue(402, ['status:done', 'lane:trivial']), mergedPRRefs: [] },
+  ]);
+  expect(plan.skipped).toHaveLength(2);
+  expect(plan.violations).toHaveLength(0);
+  expect(plan.skipped[0].reason).toContain('lightweight-lane');
+});
+
+test('#1500 AC2: override label suppresses violation', () => {
+  const plan = reconciler.reconcile([
+    { issue: issue(501, ['status:done', 'type:task', 'lane:code-change',
+      'merge-evidence-override:approved']), mergedPRRefs: [] },
+  ]);
+  expect(plan.skipped).toHaveLength(1);
+  expect(plan.skipped[0].reason).toBe('override-approved');
+  expect(plan.violations).toHaveLength(0);
+});
+
+test('#1500 AC2: type:epic items skipped (evaluated via children)', () => {
+  const plan = reconciler.reconcile([
+    { issue: issue(601, ['status:done', 'type:epic', 'lane:code-change']), mergedPRRefs: [] },
+  ]);
+  expect(plan.skipped[0].reason).toBe('epic-evaluated-via-children');
+});
+
+test('#1500 AC2: labels can be string array or {name} object array', () => {
+  const planA = reconciler.reconcile([
+    { issue: { number: 701, title: 't', state: 'closed', labels: ['status:done', 'lane:code-change'] }, mergedPRRefs: [] },
+  ]);
+  const planB = reconciler.reconcile([
+    { issue: { number: 702, title: 't', state: 'closed', labels: [{ name: 'status:done' }, { name: 'lane:code-change' }] }, mergedPRRefs: [] },
+  ]);
+  expect(planA.violations).toHaveLength(1);
+  expect(planB.violations).toHaveLength(1);
+});
+
+test('#1500 AC2: non-array items input throws TypeError', () => {
+  expect(() => reconciler.reconcile(null)).toThrow(TypeError);
+  expect(() => reconciler.reconcile('not-an-array')).toThrow(TypeError);
+  expect(() => reconciler.reconcile({})).toThrow(TypeError);
+});
+
+test('#1500 AC1: buildComment includes marker + issue number + override hint', () => {
+  const body = reconciler.buildComment({ number: 1500 });
+  expect(body).toContain(reconciler.COMMENT_MARKER);
+  expect(body).toContain('#1500');
+  expect(body).toContain('merge-evidence-override:approved');
+  expect(body).toContain('Refs #1500');
+  expect(body).toContain('Epic #1486');
+});
+
+test('#1500: malformed items silently skipped (no throw)', () => {
+  const plan = reconciler.reconcile([null, { not_issue: true }, { issue: 'string' }]);
+  expect(plan.processed).toBe(3);
+  expect(plan.violations).toHaveLength(0);
+  expect(plan.passed).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary

Phase-1b of Epic #1486 Path D. Wires the Phase-1a megalint `merge-evidence` rule (#1498) into two callsites that supply GitHub-derived `mergedPRRefs`. Both advisory-only; soak data feeds Phase-1c promotion decision.

## What landed

| File | Lines | Role |
|---|---|---|
| `scripts/global/merge-evidence-reconciler.js` | 56 | Pure plan generator |
| `tests/merge-evidence-reconciler.spec.js` | 114 | 12 Playwright tests |
| `.github/workflows/merge-evidence-check.yml` | 59 | Live on `issues.closed` |
| `.github/workflows/merge-evidence-cron.yml` | 69 | Daily 03:15 UTC + dispatch |
| `.changes/unreleased/1500.md` | 18 | Changelog fragment |

All files ≤ 100-line lint cap; reconciler's `reconcile()` function split into `classifyItem` helper + thin orchestrator to satisfy the 30-line readability rule. Label `governance:close-without-merge` created (color #FF6F61).

## Behavioral surface

- **Live workflow** fires on `issues.closed` with `status:done`. Skip-checks first via the rule (no GH search if already skipped). Otherwise searches `is:pr is:merged #N`, calls rule, posts advisory comment + label on violation. Idempotent via `<!-- merge-evidence-reconciler -->` marker.
- **Cron workflow** runs daily; configurable `since_days` (default 7) and `batch_size` (default 20). Lists `is:issue is:closed label:status:done closed:>=$since`, fetches merged PRs per issue, calls reconciler. Same advisory + label output.

## Test plan

- [x] `npx playwright test tests/merge-evidence-reconciler.spec.js` — 12/12 passing
- [x] `npm run lint` — all files ≤ 100 lines
- [x] `npm run format:check` — green
- [x] `npm run lint:readability:ci` — green (420-warning cap respected)
- [x] Label created in repo via `gh label create`

## Out of scope (this PR)

- Phase-1c promotion to required gate (after soak)
- Phase-1d dashboard panel
- Phase-1e backfill audit of historical offenders

Refs #1500
Refs Epic #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)