### PR TITLE
docs(codex): harden AGENTS and config guidance #1482

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -3,6 +3,11 @@
 - Treat this file as the global Megingjord baseline for Codex runtime.
 - Repo-local `AGENTS.md` files override this baseline when they conflict.
 - Respect Megingjord governance from `~/.codex/config.toml`, `~/.codex/hooks.json`, and `~/.codex/rules/`.
+- Treat repo `.codex/config.toml` and `.codex/runtime.config.toml` as source
+  assets; deploy or install them through governed workflow only.
+- Keep project-local Codex guidance in `AGENTS.md`; use
+  `project_doc_fallback_filenames` only for compatibility when `AGENTS.md` is
+  missing.
 - Preserve Team&Model signing on governed issue, PR, commit, and doc artifacts.
 - Use installed Megingjord skills from `$HOME/.agents/skills/` when relevant.
 - Always use the OpenAI developer documentation MCP server if you need to work with the OpenAI API, ChatGPT Apps SDK, Codex, or related docs without me having to explicitly ask.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,1 +1,3 @@
+# Project-scoped Codex config loads only after project trust. Keep this file
+# minimal so AGENTS.md remains the canonical review/governance surface.
 project_doc_fallback_filenames = [".github/copilot-instructions.md", "CLAUDE.md"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,16 @@ This repo is the **development workbench** for the DevEnv Ops Harness runtimes:
 - Repo-local overrides may tighten the format, but must not remove provenance.
 - See `instructions/team-model-signing.instructions.md`.
 
+## Review guidelines
+
+- In Codex PR reviews, treat ticket lifecycle, baton order, signer
+  fidelity, isolated worktrees, and runtime-home edits as release-blocking
+  governance risks.
+- Verify governed changes include matching docs, research, wiki, or drift
+  notes when behavior or operator workflow changes.
+- When Codex behavior is uncertain, use official OpenAI Codex docs instead of
+  inferring from Claude or Copilot compatibility.
+
 ## HAMR cross-team routing
 
 - All 3 teams route governed provider calls through HAMR (`https://hamr.chf3198.workers.dev`).

--- a/research/codex-agents-config-hardening-2026-05-13.md
+++ b/research/codex-agents-config-hardening-2026-05-13.md
@@ -1,0 +1,37 @@
+# Codex AGENTS and Config Hardening
+
+## Ticket
+
+- Issue: #1482 under Epic #1480.
+- Scope: Codex instruction and config surfaces only.
+- Non-conflict: no routing, workflow, or active Claude/Copilot implementation files changed.
+
+## OpenAI Codex Basis
+
+- Official Codex GitHub review docs say Codex searches repositories for
+  `AGENTS.md`, follows Review guidelines there, and applies the closest
+  `AGENTS.md` to each changed file.
+- Official Codex config docs say user config lives in `~/.codex/config.toml`;
+  project-scoped overrides may live in `.codex/config.toml`, but load only after
+  project trust.
+- The same config reference defines `project_doc_fallback_filenames` as
+  additional filenames to try only when `AGENTS.md` is missing.
+
+## Decision
+
+1. Add Codex review guidance to top-level `AGENTS.md`, because that is the
+   documented review surface Codex uses in GitHub.
+2. Keep `.codex/AGENTS.md` focused on Codex runtime governance and source versus
+   deployed-runtime boundaries.
+3. Keep `.codex/config.toml` minimal and single-sourced; fallback filenames stay
+   compatibility-only, not canonical governance.
+
+## Validation Plan
+
+- Markdown lint for touched Markdown.
+- TOML parse for Codex config files.
+- Repo lint and git diff checks.
+
+Signed-by: Quill Mason
+Team&Model: codex:gpt-5.4@codex-cli
+Role: collaborator


### PR DESCRIPTION
## Summary

- Add Codex-specific Review guidelines to top-level AGENTS.md so Codex GitHub review applies Megingjord governance checks directly.
- Harden the Codex runtime baseline in .codex/AGENTS.md around source-versus-deployed config boundaries and fallback behavior.
- Document the official OpenAI Codex docs basis and keep .codex/config.toml single-sourced/minimal.

## Validation

- npx markdownlint-cli2 AGENTS.md .codex/AGENTS.md research/codex-agents-config-hardening-2026-05-13.md
- python3 TOML parse for .codex/config.toml and .codex/runtime.config.toml
- git diff --check
- npm run lint
- pre-push format:check and lint:readability:ci

Refs #1482

Signed-by: Quill Mason
Team&Model: codex:gpt-5.4@codex-cli
Role: collaborator
