### PR TITLE
feat(megalint): merge-evidence PR-gate (required) #1506

### DIFF
--- a/.changes/unreleased/1506.md
+++ b/.changes/unreleased/1506.md
@@ -1,0 +1,19 @@
+## [Unreleased] — #1506: merge-evidence PR-gate promotion (Epic #1486 Phase-1c)
+
+### Added
+- `scripts/global/megalint/merge-evidence-pr-gate.js` — new pure-function validator that runs at PR-merge time. Checks `prBody` for a GitHub auto-close keyword (`Closes`/`Fixes`/`Resolves` and their tense variants, case-insensitive) matching `input.issueNumber`. Respects lightweight lanes (`lane:docs-research`/`docs-only`/`trivial`/`research`), `type:epic`, and the override label `merge-evidence-override:approved` per the `[skip-changelog]` precedent.
+- `tests/megalint-merge-evidence-pr-gate.spec.js` — 13 Playwright tests: all 9 close-keyword variants × case-insensitivity, multi-issue matching, lightweight + epic + override skips, missing-issue-context no-op, empty/null body handling, VALIDATORS registration, `runAll()` integration.
+
+### Changed
+- `scripts/global/megalint/index.js` — register `merge-evidence-pr-gate` (validator count: 8 → 9).
+- `.github/workflows/closeout-lint.yml` — add `prBody: body` to megalint input; invoke `merge-evidence-pr-gate` validator alongside existing manager-handoff + consultant-closeout checks; surface skip reason in summary line; fail PR on violation.
+
+### Why
+Phase-1c of Epic #1486 Path D. Phase-1a (#1499) shipped the pure rule; Phase-1b (#1503) wired it into advisory comments via cron + live-event workflows. This phase promotes it to **required** at PR-merge time: every non-lightweight, non-epic PR must commit to atomically closing its linked issue via GitHub's auto-close keywords, OR carry the operator-approved override label. This closes the audit-identified gap where issues reached `status:done` without any commit referencing them on main.
+
+### Out of scope (this PR)
+- Per-team dashboard panel (Phase-1d).
+- Backfill audit of historical offenders (Phase-1e).
+
+### Eat-own-dogfood
+This PR's body includes `Closes #1506` — the rule passes on itself. If I had only written `Refs #1506`, this PR would fail the new gate.

--- a/.github/workflows/closeout-lint.yml
+++ b/.github/workflows/closeout-lint.yml
@@ -42,6 +42,7 @@ jobs:
             const input = {
               comments, lane, labels,
               body: issue.body || '',
+              prBody: body,
               state: issue.state,
               isEpic: labels.includes('type:epic'),
               issueNumber: linkedIssue,
@@ -50,6 +51,7 @@ jobs:
 
             const mh = megalint.run('manager-handoff', input);
             const cl = megalint.run('consultant-closeout', input);
+            const pg = megalint.run('merge-evidence-pr-gate', input);
 
             const violations = [];
             if (mh.found && !mh.ok) {
@@ -62,9 +64,15 @@ jobs:
                 violations.push(`CONSULTANT_CLOSEOUT: ${v.rule} — ${v.detail}`);
               }
             }
+            if (!pg.ok) {
+              for (const v of pg.violations) {
+                violations.push(`MERGE_EVIDENCE_PR_GATE: ${v.rule} — ${v.detail}`);
+              }
+            }
 
             const summary = `closeout-schema: manager-handoff=${mh.found ? (mh.ok ? 'PASS' : 'FAIL') : 'absent'} `
-              + `consultant-closeout=${cl.found ? (cl.ok ? 'PASS' : 'FAIL') : 'absent'}`;
+              + `consultant-closeout=${cl.found ? (cl.ok ? 'PASS' : 'FAIL') : 'absent'} `
+              + `merge-evidence-pr-gate=${pg.skipped ? `SKIP:${pg.skipped}` : (pg.ok ? 'PASS' : 'FAIL')}`;
             console.log(summary);
 
             if (violations.length) {

--- a/scripts/global/megalint/index.js
+++ b/scripts/global/megalint/index.js
@@ -12,6 +12,7 @@ const signer = require('./signer-fidelity.js');
 const truthfulness = require('./body-ac-truthfulness.js');
 const traceability = require('./epic-ac-traceability.js');
 const mergeEvidence = require('./merge-evidence.js');
+const mergeEvidencePrGate = require('./merge-evidence-pr-gate.js');
 
 const VALIDATORS = {
   'manager-handoff': manager,
@@ -22,6 +23,7 @@ const VALIDATORS = {
   'body-ac-truthfulness': truthfulness,
   'epic-ac-traceability': traceability,
   'merge-evidence': mergeEvidence,
+  'merge-evidence-pr-gate': mergeEvidencePrGate,
 };
 
 function runAll(input) {

--- a/scripts/global/megalint/merge-evidence-pr-gate.js
+++ b/scripts/global/megalint/merge-evidence-pr-gate.js
@@ -1,0 +1,57 @@
+'use strict';
+// merge-evidence-pr-gate — Epic #1486 Phase-1c. PR-merge-time validator
+// that promotes merge-evidence from advisory to required. Ensures every
+// non-lightweight, non-epic PR commits to atomically closing its linked
+// issue via GitHub auto-close keywords (Closes/Fixes/Resolves), or carries
+// the merge-evidence-override:approved label on the issue.
+
+const LIGHTWEIGHT_LANES = new Set([
+  'lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research',
+]);
+const OVERRIDE_LABEL = 'merge-evidence-override:approved';
+const CLOSE_KEYWORDS_RE = /\b(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+#(\d+)/gi;
+
+function findCloseTargets(prBody) {
+  const out = new Set();
+  if (!prBody) return out;
+  for (const m of prBody.matchAll(CLOSE_KEYWORDS_RE)) out.add(parseInt(m[3], 10));
+  return out;
+}
+
+function shouldSkip(labels) {
+  if (labels.includes('type:epic')) return 'epic-bypass';
+  if (labels.includes(OVERRIDE_LABEL)) return 'override-approved';
+  for (const label of labels) if (LIGHTWEIGHT_LANES.has(label)) return `lightweight-lane:${label}`;
+  return null;
+}
+
+function validate(input) {
+  const labels = input.labels || [];
+  const issueNumber = input.issueNumber;
+  const prBody = input.prBody || '';
+  if (!issueNumber) return { ok: true, violations: [], skipped: 'no-issue-context' };
+
+  const skipReason = shouldSkip(labels);
+  if (skipReason) return { ok: true, violations: [], skipped: skipReason };
+
+  const closeTargets = findCloseTargets(prBody);
+  if (closeTargets.has(Number(issueNumber))) {
+    return { ok: true, violations: [], closeTargets: [...closeTargets] };
+  }
+  return {
+    ok: false,
+    violations: [{
+      rule: 'merge-evidence-pr-gate-missing',
+      detail: `PR body must include a GitHub auto-close keyword for issue #${issueNumber} `
+        + `(e.g. "Closes #${issueNumber}"). This commits the PR to closing the issue on merge, `
+        + `which is the merge evidence the harness will then validate. Override via `
+        + `\`${OVERRIDE_LABEL}\` on the issue if closure-without-merge is intentional.`,
+      issueNumber, closeTargetsFound: [...closeTargets],
+    }],
+  };
+}
+
+module.exports = {
+  validate, findCloseTargets, shouldSkip,
+  LIGHTWEIGHT_LANES, OVERRIDE_LABEL, CLOSE_KEYWORDS_RE,
+};

--- a/tests/megalint-merge-evidence-pr-gate.spec.js
+++ b/tests/megalint-merge-evidence-pr-gate.spec.js
@@ -1,0 +1,100 @@
+// Tests for scripts/global/megalint/merge-evidence-pr-gate.js (Epic #1486 Phase-1c, #1506).
+const { test, expect } = require('@playwright/test');
+const gate = require('../scripts/global/megalint/merge-evidence-pr-gate');
+
+const ctx = (overrides = {}) => ({
+  labels: ['type:task', 'lane:code-change'],
+  issueNumber: 1506,
+  prBody: '',
+  ...overrides,
+});
+
+test('#1506 AC1: passes when PR body cites "Closes #N" for the linked issue', () => {
+  const result = gate.validate(ctx({ prBody: 'Implements the gate.\n\nCloses #1506' }));
+  expect(result.ok).toBe(true);
+  expect(result.closeTargets).toContain(1506);
+});
+
+test('#1506 AC1: accepts Fixes / Resolves / Close / Fix / Resolve / Closed / Fixed / Resolved variants', () => {
+  for (const keyword of ['Closes', 'Close', 'Closed', 'Fixes', 'Fix', 'Fixed', 'Resolves', 'Resolve', 'Resolved']) {
+    const result = gate.validate(ctx({ prBody: `${keyword} #1506` }));
+    expect(result.ok, `keyword=${keyword}`).toBe(true);
+  }
+});
+
+test('#1506 AC1: keyword matching is case-insensitive', () => {
+  for (const variant of ['closes', 'CLOSES', 'cLoSeS', 'FIXES', 'resolves']) {
+    expect(gate.validate(ctx({ prBody: `${variant} #1506` })).ok).toBe(true);
+  }
+});
+
+test('#1506 AC1: fails when PR body lacks any auto-close keyword for the linked issue', () => {
+  const result = gate.validate(ctx({ prBody: 'Refs #1506\n\nNo close keyword present.' }));
+  expect(result.ok).toBe(false);
+  expect(result.violations[0].rule).toBe('merge-evidence-pr-gate-missing');
+  expect(result.violations[0].issueNumber).toBe(1506);
+});
+
+test('#1506 AC1: fails when PR closes wrong issue (multi-issue PR mismatch)', () => {
+  const result = gate.validate(ctx({ prBody: 'Closes #1499\nCloses #1503' }));
+  expect(result.ok).toBe(false);
+  expect(result.violations[0].closeTargetsFound).toEqual(expect.arrayContaining([1499, 1503]));
+});
+
+test('#1506 AC1: passes when PR closes multiple issues including the linked one', () => {
+  const result = gate.validate(ctx({ prBody: 'Closes #1499\nCloses #1506\nRefs #1486' }));
+  expect(result.ok).toBe(true);
+  expect(result.closeTargets).toEqual(expect.arrayContaining([1499, 1506]));
+});
+
+test('#1506 AC3: lightweight lanes skip the gate', () => {
+  for (const lane of ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research']) {
+    const result = gate.validate(ctx({ labels: ['type:task', lane], prBody: '' }));
+    expect(result.ok, `lane=${lane}`).toBe(true);
+    expect(result.skipped).toBe(`lightweight-lane:${lane}`);
+  }
+});
+
+test('#1506 AC4: type:epic issues skip the gate', () => {
+  const result = gate.validate(ctx({ labels: ['type:epic', 'lane:code-change'], prBody: '' }));
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('epic-bypass');
+});
+
+test('#1506 AC5: override label suppresses the gate', () => {
+  const result = gate.validate(ctx({
+    labels: ['type:task', 'lane:code-change', 'merge-evidence-override:approved'],
+    prBody: '',
+  }));
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('override-approved');
+});
+
+test('#1506: missing issueNumber returns skip (no-op, not error)', () => {
+  const result = gate.validate({ labels: ['lane:code-change'], prBody: 'some body' });
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('no-issue-context');
+});
+
+test('#1506: findCloseTargets returns empty Set for empty/null body', () => {
+  expect(gate.findCloseTargets('').size).toBe(0);
+  expect(gate.findCloseTargets(null).size).toBe(0);
+  expect(gate.findCloseTargets(undefined).size).toBe(0);
+});
+
+test('#1506 AC2: registered in megalint VALIDATORS map', () => {
+  const megalint = require('../scripts/global/megalint');
+  expect(megalint.VALIDATORS).toHaveProperty('merge-evidence-pr-gate');
+  const result = megalint.run('merge-evidence-pr-gate', ctx({ prBody: 'Closes #1506' }));
+  expect(result.ok).toBe(true);
+});
+
+test('#1506: runAll() includes the new validator in aggregated results', () => {
+  const megalint = require('../scripts/global/megalint');
+  const result = megalint.runAll({
+    ...ctx({ prBody: 'Closes #1506' }),
+    comments: [], state: 'open', body: '## ACs\n- [x] AC1', ticketRef: '#1506',
+  });
+  expect(result.results).toHaveProperty('merge-evidence-pr-gate');
+  expect(result.results['merge-evidence-pr-gate'].ok).toBe(true);
+});


### PR DESCRIPTION
## Summary

Phase-1c of Epic #1486 Path D. Promotes merge-evidence from advisory to **required** at PR-merge time. New megalint validator that fails PRs whose body doesn't commit to atomically closing the linked non-lightweight issue via GitHub's auto-close keywords (`Closes` / `Fixes` / `Resolves` + tense variants, case-insensitive). Override via `merge-evidence-override:approved` label on the issue, mirroring `[skip-changelog]` precedent.

## What landed

| File | Lines | Role |
|---|---|---|
| `scripts/global/megalint/merge-evidence-pr-gate.js` | 57 | New pure-function validator |
| `scripts/global/megalint/index.js` | 55 | Register validator (8 → 9 rules) |
| `.github/workflows/closeout-lint.yml` | 84 | Wire validator into PR pipeline |
| `tests/megalint-merge-evidence-pr-gate.spec.js` | 100 | 13 Playwright tests |
| `.changes/unreleased/1506.md` | 18 | Changelog fragment |

All files ≤ 100-line cap.

## Behavioral surface

```
PR opens → closeout-lint.yml fires
        ├─ extract Refs #N from PR body
        ├─ fetch issue #N
        ├─ build input { prBody, labels, lane, issueNumber, ... }
        └─ megalint.run('merge-evidence-pr-gate', input)
              ├─ skip if type:epic                        → PASS
              ├─ skip if lane in {docs-research, docs-only, trivial, research} → PASS
              ├─ skip if merge-evidence-override:approved → PASS
              ├─ scan prBody for /(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+#N/i
              ├─ if N matches issueNumber → PASS
              └─ otherwise                                → FAIL (block PR)
```

## Eat-own-dogfood

This PR body includes `Closes #1506`. The gate passes on itself. If I had only written `Refs #1506`, the new gate would block this PR.

## Test plan

- [x] `npx playwright test tests/megalint-merge-evidence-pr-gate.spec.js` — 13/13 passing (all 9 close-keyword variants, case-insensitivity, multi-issue PRs, 4 lightweight-lane skips, epic skip, override skip, missing-context no-op, empty body, VALIDATORS registration, runAll integration)
- [x] `npm run lint` — green
- [x] `npm run format:check` — green
- [x] `npm run lint:readability:ci` — green

## Out of scope (this PR)

- Phase-1d dashboard panel
- Phase-1e backfill audit

Closes #1506
Refs Epic #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)