### PR TITLE
feat(routing): add provider-neutral adapter boundary #1481

### DIFF
--- a/docs/provider-neutral-routing.md
+++ b/docs/provider-neutral-routing.md
@@ -1,0 +1,41 @@
+# Provider-Neutral Routing
+
+The global task router chooses a capability lane. It does not choose a runtime
+or make one provider family canonical.
+
+## Concepts
+
+- **Runtime**: the agent surface, such as Codex, Copilot, or Claude Code.
+- **Lane**: the required capability/cost tier: free, fleet, haiku, or premium.
+- **Provider**: the serving path, such as Anthropic, OpenAI-compatible, Ollama,
+  OpenRouter, LiteLLM, or fleet.
+- **Model family**: the vendor/model lineage selected by the provider adapter.
+
+## Lane Names
+
+| Lane | Capability tier | Purpose |
+|---|---|---|
+| Free | `free-auto` | Lookup, docs, simple analysis |
+| Fleet | `fleet-coding-local` | Local/fleet coding and known-pattern edits |
+| Haiku | `balanced-cloud` | Mid-complexity review, tests, single-file work |
+| Premium | `frontier-reasoning` | Architecture, security, ambiguous debugging |
+
+## Adapter Boundary
+
+Provider-specific model IDs live in
+`scripts/global/routing-provider-adapters.json`. Current adapters include
+Anthropic, OpenAI-compatible, Ollama, OpenRouter, LiteLLM, and fleet paths.
+Anthropic remains available as a default cloud adapter, but it is no longer the
+visible definition of a paid lane.
+
+## Validation
+
+Routing changes should include:
+
+- JSON parse coverage for policy and adapter files.
+- Targeted router tests for classification and dispatch behavior.
+- Drift notes when lane names or adapter semantics change.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@codex-cli
+Role: collaborator

--- a/instructions/global-task-router.instructions.md
+++ b/instructions/global-task-router.instructions.md
@@ -11,14 +11,23 @@ Policy source: `scripts/global/model-routing-policy.json` (capability_matrix fie
 ## Lane order (cost-ascending mandate)
 
 1. **Free** — Auto tier. Lookup, analysis, docs, Q&A, boilerplate. Zero tokens.
-2. **Fleet** — Ollama local (qwen2.5:7b-instruct). Medium implementation, known-pattern
+2. **Fleet** — `fleet-coding-local`. Medium implementation, known-pattern
    coding, config gen, log analysis. Zero tokens. **Execute via cascade-dispatch.**
-3. **Haiku** — claude-haiku-4-5-20251001. Single-file refactors, test gen, code review.
-4. **Premium** — claude-sonnet-4-6. Multi-file architecture, security, ambiguous debugging.
+3. **Haiku** — `balanced-cloud`. Single-file refactors, test gen, code review.
+4. **Premium** — `frontier-reasoning`. Multi-file architecture, security,
+   ambiguous debugging.
 
 Codex, Copilot, and Claude Code sessions all use the same lane policy. A lane
-selects required capability and cost tier; provider IDs and telemetry adapters
-are implementation details owned by HAMR and `model-routing-policy.json`.
+selects required capability and cost tier. Runtime, provider, model family, and
+lane are separate concepts:
+
+- **Runtime**: Codex, Copilot, Claude Code, or another agent surface.
+- **Provider**: Anthropic, OpenAI-compatible, Ollama, OpenRouter, LiteLLM, or fleet.
+- **Model family**: vendor/model lineage selected by an adapter.
+- **Lane**: free, fleet, haiku, or premium capability/cost tier.
+
+Provider IDs and telemetry adapters are implementation details owned by HAMR,
+`model-routing-policy.json`, and `routing-provider-adapters.json`.
 
 ## Capability matrix (use for ticket assignment and lane selection)
 
@@ -47,4 +56,7 @@ If fleet signals `escalation_needed=true`: use the `suggested_tier` (haiku first
 
 ## Cost/observability mechanics within each lane
 
-This file selects the **lane**. Cost levers (caching, spillover, sticky-route, batching) and observability (cache-hit gate, /quota, /mcp doctor:probe) live in HAMR, not here. See `instructions/hamr-routing.instructions.md`. Do not duplicate HAMR mechanics in this file or make lane policy runtime-specific.
+This file selects the **lane**. Cost levers (caching, spillover, sticky-route,
+batching) and observability (cache-hit gate, /quota, /mcp doctor:probe) live in
+HAMR, not here. See `instructions/hamr-routing.instructions.md`. Do not
+duplicate HAMR mechanics in this file or make lane policy runtime-specific.

--- a/research/provider-neutral-routing-boundary-2026-05-13.md
+++ b/research/provider-neutral-routing-boundary-2026-05-13.md
@@ -1,0 +1,47 @@
+# Provider-Neutral Routing Boundary
+
+## Ticket
+
+- Issue: #1481 under Epic #1480.
+- Scope: routing policy, provider adapter map, tests, and operator docs.
+- Non-conflict: avoided merge-evidence work, dashboard panels, and active
+  Claude/Copilot worktrees.
+
+## Change
+
+- Lanes now expose capability-tier names:
+  - `free-auto`
+  - `fleet-coding-local`
+  - `balanced-cloud`
+  - `frontier-reasoning`
+- Provider-specific model IDs moved behind
+  `scripts/global/routing-provider-adapters.json`.
+- Anthropic remains the current default adapter for Haiku/Premium lanes, while
+  OpenAI-compatible, OpenRouter, LiteLLM, Ollama, and fleet paths are explicit
+  adapter options.
+
+## Drift Review
+
+drift_status: found
+
+impacted_docs:
+- `instructions/global-task-router.instructions.md`: lane names and provider
+  boundary needed correction.
+- `research/provider-neutral-routing-boundary-2026-05-13.md`: decision record
+  needed for #1481.
+
+not_applicable:
+- Dashboard UX docs: no visual/dashboard behavior changed.
+- Runtime deploy docs: no deployed runtime homes changed.
+- Release notes: no release was cut in this ticket.
+
+## Validation Plan
+
+- JSON parse for routing policy files.
+- Targeted Playwright tests for free router and fleet dispatch routing.
+- `npm run lint`.
+- `git diff --check`.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@codex-cli
+Role: collaborator

--- a/scripts/global/free-router.js
+++ b/scripts/global/free-router.js
@@ -15,9 +15,9 @@ const SIGNAL_DOCS = /\b(docs?|readme|comment|describe|explain)\b/i;
 const TIERS = {
   FIM: { tier: 'fleet-fim', model: 'starcoder2:3b', host: '36gbwinresource' },
   REFACTOR: { tier: 'fleet-coder', model: 'qwen2.5-coder:7b', host: '36gbwinresource' },
-  REASONING: { tier: 'premium', model: 'claude-sonnet', host: 'cloud' },
+  REASONING: { tier: 'premium', model: 'frontier-reasoning', host: 'provider-adapter' },
   DOCS: { tier: 'free-cloud', model: 'groq-llama-3.3-70b', host: 'cloud' },
-  DEFAULT: { tier: 'haiku', model: 'claude-haiku', host: 'cloud' },
+  DEFAULT: { tier: 'haiku', model: 'balanced-cloud', host: 'provider-adapter' },
 };
 
 function _capability() {

--- a/scripts/global/model-routing-engine.js
+++ b/scripts/global/model-routing-engine.js
@@ -6,6 +6,7 @@ const os = require('os');
 const { readTelemetry, summarize } = require('./model-routing-telemetry');
 
 const FILE = path.join(__dirname, 'model-routing-policy.json');
+const ADAPTER_FILE = path.join(__dirname, 'routing-provider-adapters.json');
 const POLICY_OVERRIDES = path.join(os.homedir(), '.megingjord', 'cascade-policy-overrides.json');
 
 // Wave 8 child 2 (#977): convergence-design item 4 consumer side.
@@ -18,6 +19,8 @@ function loadOverrides() {
 }
 
 function loadPolicy() { return JSON.parse(fs.readFileSync(FILE, 'utf8')); }
+
+function loadAdapters() { return JSON.parse(fs.readFileSync(ADAPTER_FILE, 'utf8')); }
 
 function score(text, words) {
   return (words || []).reduce((n, w) => n + (text.includes(w) ? 1 : 0), 0);
@@ -46,16 +49,20 @@ function shouldRollback(policy) {
 
 function resolveRouting(prompt, route) {
   const policy = loadPolicy();
-  const rollbackApplied = shouldRollback(policy);
+  const rollbackApplied = route.disableRollback ? false : shouldRollback(policy);
   let lane = rollbackApplied ? policy.rollback.forceLane : route.lane;
   const cx = route.complexity ?? 0.5;
   const thresh = policy.complexityThresholds || {};
   if (lane === 'premium' && cx < (thresh.premium ?? 0.7)) lane = cx < (thresh.haiku ?? 0.3) ? 'fleet' : 'haiku';
   const model = policy.models[lane] || policy.models.fallback;
+  const adapter = loadAdapters().lanes?.[lane] || {};
   const overrides = loadOverrides();
   return {
     lane,
-    modelId: model.id,
+    modelId: adapter.capabilityTier || model.id,
+    providerModelId: adapter.defaultModelId || model.id,
+    providerPath: adapter.defaultProvider || model.endpoint || null,
+    adapterId: adapter.defaultAdapter || null,
     multiplier: model.mult,
     taskClass: classifyTask(prompt, policy.taskClasses),
     rollbackApplied,
@@ -65,4 +72,4 @@ function resolveRouting(prompt, route) {
   };
 }
 
-module.exports = { resolveRouting, loadPolicy, loadOverrides };
+module.exports = { resolveRouting, loadPolicy, loadAdapters, loadOverrides };

--- a/scripts/global/model-routing-policy.json
+++ b/scripts/global/model-routing-policy.json
@@ -1,6 +1,7 @@
 {
   "version": "2.2.0",
   "defaultLane": "fleet",
+  "adapterPolicy": "routing-provider-adapters.json",
   "complexityThresholds": {
     "_doc": "Numeric complexity score gates. fleet=[0,0.3), haiku=[0.3,0.7), premium=[0.7,1.0]",
     "haiku": 0.3,
@@ -16,11 +17,11 @@
     "fleetOn": ["medium", "repeated", "workflow", "generate", "coverage"]
   },
   "models": {
-    "free":    { "id": "auto",                       "mult": 0,    "costPer1kTokens": 0 },
-    "fleet":   { "id": "qwen2.5:7b-instruct",        "mult": 0,    "costPer1kTokens": 0,      "endpoint": "ollama" },
-    "haiku":   { "id": "claude-haiku-4-5-20251001",  "mult": 0.08, "costPer1kTokens": 0.00088 },
-    "premium": { "id": "claude-sonnet-4-6",           "mult": 1,    "costPer1kTokens": 0.009   },
-    "fallback":{ "id": "claude-haiku-4-5-20251001",  "mult": 0.08, "costPer1kTokens": 0.00088 }
+    "free":    { "id": "free-auto",             "mult": 0,    "costPer1kTokens": 0 },
+    "fleet":   { "id": "fleet-coding-local",    "mult": 0,    "costPer1kTokens": 0,      "endpoint": "ollama" },
+    "haiku":   { "id": "balanced-cloud",        "mult": 0.08, "costPer1kTokens": 0.00088 },
+    "premium": { "id": "frontier-reasoning",    "mult": 1,    "costPer1kTokens": 0.009   },
+    "fallback":{ "id": "balanced-cloud",        "mult": 0.08, "costPer1kTokens": 0.00088 }
   },
   "capability_matrix": {
     "_doc": "Per-dimension tier thresholds. Manager uses this for ticket assignment.",

--- a/scripts/global/routing-provider-adapters.json
+++ b/scripts/global/routing-provider-adapters.json
@@ -1,0 +1,35 @@
+{
+  "version": "1.0.0",
+  "description": "Provider adapters for provider-neutral lane capability tiers.",
+  "runtimeKinds": ["codex", "copilot", "claude-code"],
+  "lanes": {
+    "free": {
+      "capabilityTier": "free-auto",
+      "defaultAdapter": "openai-compatible:mini",
+      "defaultProvider": "openai-compatible",
+      "defaultModelId": "gpt-5-mini",
+      "adapters": ["openai-compatible:mini", "openrouter:free", "litellm:free"]
+    },
+    "fleet": {
+      "capabilityTier": "fleet-coding-local",
+      "defaultAdapter": "ollama:qwen-coder",
+      "defaultProvider": "ollama",
+      "defaultModelId": "qwen2.5:7b-instruct",
+      "adapters": ["ollama:qwen-coder", "fleet:heavy-coding", "fleet:coding"]
+    },
+    "haiku": {
+      "capabilityTier": "balanced-cloud",
+      "defaultAdapter": "anthropic:haiku",
+      "defaultProvider": "anthropic",
+      "defaultModelId": "claude-haiku-4-5-20251001",
+      "adapters": ["anthropic:haiku", "openai-compatible:small", "openrouter:small", "litellm:small"]
+    },
+    "premium": {
+      "capabilityTier": "frontier-reasoning",
+      "defaultAdapter": "anthropic:sonnet",
+      "defaultProvider": "anthropic",
+      "defaultModelId": "claude-sonnet-4-6",
+      "adapters": ["anthropic:sonnet", "openai-compatible:frontier", "openrouter:frontier", "litellm:frontier"]
+    }
+  }
+}

--- a/scripts/global/task-router-dispatch.js
+++ b/scripts/global/task-router-dispatch.js
@@ -39,7 +39,7 @@ async function buildDecision(route, resolved) {
       return { action: 'fleet-solo-fallback', reason: 'No fleet nodes reachable' };
     }
     if (!prompt) return { action: 'route-fleet', reason: 'no prompt to dispatch' };
-    const selectedModel = model || resolved.modelId || route.recommendedModel;
+    const selectedModel = model || resolved.providerModelId || route.recommendedModel;
     const primaryUrl = resolveFleetUrl(route);
     let chat = await tryOllama(primaryUrl, selectedModel);
     // Graceful fallback on 502/504 or network error
@@ -58,13 +58,15 @@ async function buildDecision(route, resolved) {
 async function main() {
   const route = classifyPrompt(prompt);
   const resolved = resolveRouting(prompt, route);
-  const effectiveRoute = { ...route, lane: resolved.lane, recommendedModel: resolved.modelId };
+  const effectiveRoute = { ...route, lane: resolved.lane,
+    recommendedModel: resolved.modelId, providerModel: resolved.providerModelId };
   const decision = await buildDecision(effectiveRoute, resolved);
   const outcome = decision.action === 'fleet-unavailable' ? 'fail' : 'ok';
-  recordTelemetry({ lane: resolved.lane, model: resolved.modelId, multiplier: resolved.multiplier,
+  recordTelemetry({ lane: resolved.lane, model: resolved.providerModelId,
+    multiplier: resolved.multiplier,
     taskClass: resolved.taskClass, complexityScore: route.complexity ?? null,
     rollbackApplied: resolved.rollbackApplied, outcome, execute: true });
-  recordCostEvent(resolved.lane, resolved.modelId, { outcome });
+  recordCostEvent(resolved.lane, resolved.providerModelId, { outcome });
   const result = { route: effectiveRoute, routing: resolved, decision };
   if (json) {
     console.log(JSON.stringify(result, null, 2));

--- a/scripts/global/task-router-policy.json
+++ b/scripts/global/task-router-policy.json
@@ -5,7 +5,7 @@
   "lanes": {
     "free": {
       "backend": "auto",
-      "recommendedModel": "gpt-5-mini",
+      "recommendedModel": "free-auto",
       "keywords": [
         "search", "grep", "find", "explain", "read", "docs",
         "rename", "boilerplate", "simple", "small", "single-file"
@@ -13,7 +13,7 @@
     },
     "fleet": {
       "backend": "ollama",
-      "recommendedModel": "qwen2.5:7b-instruct",
+      "recommendedModel": "fleet-coding-local",
       "selection": "capability-tags",
       "keywords": [
         "multi-file", "tests", "refactor", "implement", "migration",
@@ -22,8 +22,8 @@
       ]
     },
     "premium": {
-      "backend": "anthropic",
-      "recommendedModel": "claude-sonnet-4-6",
+      "backend": "provider-adapter",
+      "recommendedModel": "frontier-reasoning",
       "keywords": [
         "architecture", "ambiguous", "complex", "hard", "risk",
         "security", "performance", "concurrency", "incident", "design"

--- a/tests/fleet-dispatch.spec.js
+++ b/tests/fleet-dispatch.spec.js
@@ -50,6 +50,18 @@ test('task-router-policy defaultLane is fleet', () => {
   expect(policy.defaultLane).toBe('fleet');
 });
 
+test('provider adapters keep premium lane provider-neutral', () => {
+  const { resolveRouting, loadAdapters } = require('../scripts/global/model-routing-engine.js');
+  const resolved = resolveRouting('security audit architecture risk', {
+    lane: 'premium', complexity: 0.9, disableRollback: true
+  });
+  const adapters = loadAdapters();
+  expect(resolved.modelId).toBe('frontier-reasoning');
+  expect(resolved.providerPath).toBe('anthropic');
+  expect(adapters.lanes.premium.adapters).toContain('openai-compatible:frontier');
+  expect(adapters.lanes.premium.adapters).toContain('litellm:frontier');
+});
+
 // AC4: fleet keywords include action verbs that agents use
 test('task-router classifies "implement a function" as fleet', () => {
   const { classifyPrompt } = require('../scripts/global/task-router.js');

--- a/tests/free-router.spec.js
+++ b/tests/free-router.spec.js
@@ -28,7 +28,10 @@ test('classifier picks fleet-fim on completion-style task', () => {
 
 test('classifier picks reasoning tier on architecture task', () => {
   const { classify, TIERS } = require(ROUTER);
-  expect(classify('design the authentication architecture').tier).toBe('premium');
+  const route = classify('design the authentication architecture');
+  expect(route.tier).toBe('premium');
+  expect(route.model).toBe('frontier-reasoning');
+  expect(route.host).toBe('provider-adapter');
 });
 
 test('classifier picks fleet-coder on refactor task', () => {


### PR DESCRIPTION
## Summary

- Replace visible provider-specific lane outputs with provider-neutral capability tiers (`free-auto`, `fleet-coding-local`, `balanced-cloud`, `frontier-reasoning`).
- Add `routing-provider-adapters.json` so Anthropic, OpenAI-compatible, Ollama, OpenRouter, LiteLLM, and fleet mappings are explicit adapters rather than universal lane defaults.
- Update router dispatch/engine tests plus docs to distinguish runtime, provider, model family, and lane.

## Validation

- JSON parse for routing-provider-adapters, task-router-policy, and model-routing-policy
- npx markdownlint-cli2 docs/provider-neutral-routing.md instructions/global-task-router.instructions.md research/provider-neutral-routing-boundary-2026-05-13.md
- npx playwright test tests/free-router.spec.js tests/fleet-dispatch.spec.js (14 passed, 1 skipped live endpoint)
- npm run lint
- git diff --check
- pre-push format:check and lint:readability:ci

Closes #1481
Refs #1481

Signed-by: Quill Harper
Team&Model: codex:gpt-5.4@codex-cli
Role: collaborator
