### PR TITLE
fix(governance): label-lint close-protection race condition #1515

### DIFF
--- a/.changes/unreleased/1515.md
+++ b/.changes/unreleased/1515.md
@@ -1,0 +1,23 @@
+## [Unreleased] — #1515: label-lint close-protection race fix
+
+### Added
+- `scripts/global/label-lint-close-protection.js` — pure decision function extracted from the inline workflow script. Decides `auto-transition` vs `reopen` vs `noop` given `{state, labels, comments}`. Exports `decide`, `hasCloseoutComment`, and the rule constants.
+- `tests/label-lint-close-protection.spec.js` — 12 Playwright tests covering both pre-close paths (`status:review` AND `status:testing`), the close-blocked reopen branch, terminal-state no-op, Epic closeout marker variant, bold/header marker variants, empty/null/malformed input safety, and isolated `hasCloseoutComment` usage.
+
+### Changed
+- `.github/workflows/label-lint.yml` — close-protection branch now delegates to the new pure function. **Behavior widened**: when a `CONSULTANT_CLOSEOUT` comment is present, the workflow auto-transitions to `status:done` from EITHER `status:review` OR `status:testing` (was: `status:review` only). The `status:testing` path is the merge-via-`Closes #N` race: GitHub fires `issues.closed` immediately on PR merge, before `post-merge-automation` has flipped `status:testing` → `status:review`.
+
+### Why
+Recurrence pattern: #1506 / #1508 / #1512 (three of my recently-merged Epic #1486 children) all auto-reopened ~9 seconds after merge by `github-actions[bot]`, leaving the harness in inconsistent state. Confirmed via the #1506 event timeline:
+
+```
+21:20:56  closed (by Closes #1506 trailer)
+21:21:05  REOPENED by github-actions[bot]
+```
+
+The race wasted ~3 minutes per merge in manual cleanup and prevented Epic #1486 from progressing to closeout cleanly. Tier-2 anneal recurrence threshold met (≥2 in 7d).
+
+### Out of scope (this PR)
+- Reordering workflow triggers (would require GitHub Actions infrastructure changes).
+- Removing the close-protection branch (legitimate prevention of bare `gh issue close` without baton trail — keep).
+- Cleanup of the three already-reopened tickets — addressed in a follow-up close pass once this fix is on main.

--- a/.github/workflows/label-lint.yml
+++ b/.github/workflows/label-lint.yml
@@ -21,54 +21,44 @@ jobs:
         with:
           script: |
             const { evaluate } = require('./scripts/global/label-rules.js');
+            const protection = require('./scripts/global/label-lint-close-protection.js');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const issueNum = context.payload.issue.number;
             const marker = '<!-- adr-010-label-lint -->';
 
-            // Phase 1: close-protection actions (auto-reopen, role-cleanup)
+            // Phase 1: close-protection actions (auto-reopen, role-cleanup).
+            // Decision logic lives in scripts/global/label-lint-close-protection.js
+            // so the race-fix (#1515) is unit-testable. Accepts status:review
+            // OR status:testing as pre-close (merge-via-Closes-#N path).
             const issue = (await github.rest.issues.get({
               owner, repo, issue_number: issueNum,
             })).data;
             const labels = issue.labels.map(l => l.name);
             const closeRoles = labels.filter(l => l.startsWith('role:'));
-            const hasTerminal = labels.includes('status:done') || labels.includes('status:cancelled');
 
-            if (issue.state === 'closed' && !hasTerminal) {
-              // #1336 AC3: if a CONSULTANT_CLOSEOUT exists, auto-transition
-              // labels instead of blocking — eliminates the manual fix-up
-              // cycle that hit CP team on #1313/#1314/#1315.
-              const recentComments = await github.paginate(github.rest.issues.listComments, {
-                owner, repo, issue_number: issueNum, per_page: 100,
-              });
-              const closeoutRe = /(^|\n)\s*(?:\*\*|##\s+)?CONSULTANT_CLOSEOUT(?:_EPIC_CLOSEOUT)?\b/;
-              const hasCloseout = recentComments.some(c => closeoutRe.test(c.body || ''));
-              const inReview = labels.includes('status:review');
-              if (hasCloseout && inReview) {
-                if (labels.includes('status:review')) {
-                  await github.rest.issues.removeLabel({
-                    owner, repo, issue_number: issueNum, name: 'status:review',
-                  }).catch(() => {});
+            const recentComments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: issueNum, per_page: 100,
+            });
+            const decision = protection.decide({
+              state: issue.state, labels, comments: recentComments,
+            });
+            if (decision.action === 'auto-transition') {
+              for (const name of decision.removeLabels) {
+                if (labels.includes(name)) {
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNum, name }).catch(() => {});
                 }
-                if (labels.includes('role:consultant')) {
-                  await github.rest.issues.removeLabel({
-                    owner, repo, issue_number: issueNum, name: 'role:consultant',
-                  }).catch(() => {});
-                }
-                await github.rest.issues.addLabels({
-                  owner, repo, issue_number: issueNum,
-                  labels: ['status:done', 'resolution:completed'],
-                }).catch(() => {});
-                console.log(`#${issueNum}: auto-transitioned status:review → status:done via CONSULTANT_CLOSEOUT detection`);
-              } else {
-                await github.rest.issues.update({
-                  owner, repo, issue_number: issueNum, state: 'open',
-                });
-                await github.rest.issues.createComment({
-                  owner, repo, issue_number: issueNum,
-                  body: '❌ Close blocked: add `status:done` or `status:cancelled` before closing this issue.',
-                });
               }
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: issueNum, labels: decision.addLabels,
+              }).catch(() => {});
+              console.log(`#${issueNum}: auto-transitioned (${decision.reason}) → status:done`);
+            } else if (decision.action === 'reopen') {
+              await github.rest.issues.update({ owner, repo, issue_number: issueNum, state: 'open' });
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issueNum,
+                body: '❌ Close blocked: add `status:done` or `status:cancelled` before closing this issue.',
+              });
             }
             if (issue.state === 'closed' && closeRoles.length > 0) {
               for (const role of closeRoles) {

--- a/scripts/global/label-lint-close-protection.js
+++ b/scripts/global/label-lint-close-protection.js
@@ -1,0 +1,52 @@
+'use strict';
+// label-lint-close-protection — pure decision logic for the auto-transition
+// vs auto-reopen branch of label-lint.yml. Extracted so the race condition
+// fix (#1515) is unit-testable without a live GitHub API.
+//
+// Decision rules:
+// 1. If issue is open or already terminal → no-op.
+// 2. If issue closed without a terminal label AND a CONSULTANT_CLOSEOUT
+//    comment exists AND the pre-close status is `status:review` OR
+//    `status:testing` (the two states the baton produces just before close):
+//      → auto-transition to status:done + resolution:completed.
+// 3. Otherwise (closed without terminal, no closeout in trail) → reopen
+//    and post the "Close blocked" advisory.
+//
+// Pre-fix: rule 2 required `status:review` ONLY, missing the merge-via-
+// `Closes #N`-trailer path that fires at `status:testing`. Caused
+// reopen-on-merge friction across #1506/#1508/#1512.
+
+const CLOSEOUT_HEADER_RE = /(^|\n)\s*(?:\*\*|##\s+)?CONSULTANT_CLOSEOUT(?:_EPIC_CLOSEOUT)?\b/;
+const TERMINAL_LABELS = ['status:done', 'status:cancelled'];
+const VALID_PRE_CLOSE_LABELS = ['status:review', 'status:testing'];
+
+function hasCloseoutComment(comments) {
+  return (comments || []).some((c) => CLOSEOUT_HEADER_RE.test((c && c.body) || ''));
+}
+
+function decide({ state, labels = [], comments = [] }) {
+  if (state !== 'closed') return { action: 'noop', reason: 'issue-open' };
+  if (labels.some((l) => TERMINAL_LABELS.includes(l))) {
+    return { action: 'noop', reason: 'already-terminal' };
+  }
+  const closeoutPresent = hasCloseoutComment(comments);
+  const preCloseLabel = VALID_PRE_CLOSE_LABELS.find((l) => labels.includes(l));
+  if (closeoutPresent && preCloseLabel) {
+    return {
+      action: 'auto-transition',
+      from: preCloseLabel,
+      removeLabels: [preCloseLabel, 'role:consultant'],
+      addLabels: ['status:done', 'resolution:completed'],
+      reason: `closeout-present-from-${preCloseLabel}`,
+    };
+  }
+  return {
+    action: 'reopen',
+    reason: closeoutPresent ? 'closeout-without-valid-pre-close-label' : 'no-closeout-in-trail',
+  };
+}
+
+module.exports = {
+  decide, hasCloseoutComment,
+  CLOSEOUT_HEADER_RE, TERMINAL_LABELS, VALID_PRE_CLOSE_LABELS,
+};

--- a/tests/label-lint-close-protection.spec.js
+++ b/tests/label-lint-close-protection.spec.js
@@ -1,0 +1,122 @@
+// Tests for scripts/global/label-lint-close-protection.js (#1515).
+// Covers the race-condition fix: status:testing close → auto-transition,
+// not reopen, when CONSULTANT_CLOSEOUT exists in the comment trail.
+const { test, expect } = require('@playwright/test');
+const lib = require('../scripts/global/label-lint-close-protection');
+
+const closeoutComment = (extra = '') => ({
+  body: `## CONSULTANT_CLOSEOUT\n\nrubric_rating: 9/10\n\nVerdict: APPROVED.\n${extra}`,
+});
+
+test('#1515 AC1: status:testing close with CONSULTANT_CLOSEOUT auto-transitions (the race fix)', () => {
+  const result = lib.decide({
+    state: 'closed',
+    labels: ['type:task', 'status:testing', 'role:admin', 'priority:P1'],
+    comments: [closeoutComment()],
+  });
+  expect(result.action).toBe('auto-transition');
+  expect(result.from).toBe('status:testing');
+  expect(result.removeLabels).toContain('status:testing');
+  expect(result.removeLabels).toContain('role:consultant');
+  expect(result.addLabels).toEqual(['status:done', 'resolution:completed']);
+  expect(result.reason).toBe('closeout-present-from-status:testing');
+});
+
+test('#1515 AC1: status:review close with CONSULTANT_CLOSEOUT still auto-transitions (back-compat)', () => {
+  const result = lib.decide({
+    state: 'closed',
+    labels: ['type:task', 'status:review', 'role:consultant'],
+    comments: [closeoutComment()],
+  });
+  expect(result.action).toBe('auto-transition');
+  expect(result.from).toBe('status:review');
+  expect(result.reason).toBe('closeout-present-from-status:review');
+});
+
+test('#1515 AC2: close without CONSULTANT_CLOSEOUT triggers reopen', () => {
+  const result = lib.decide({
+    state: 'closed',
+    labels: ['type:task', 'status:in-progress', 'role:collaborator'],
+    comments: [{ body: '## MANAGER_HANDOFF\n\nNo closeout yet.' }],
+  });
+  expect(result.action).toBe('reopen');
+  expect(result.reason).toBe('no-closeout-in-trail');
+});
+
+test('#1515 AC2: closeout present but no valid pre-close label triggers reopen', () => {
+  const result = lib.decide({
+    state: 'closed',
+    labels: ['type:task', 'status:in-progress'],
+    comments: [closeoutComment()],
+  });
+  expect(result.action).toBe('reopen');
+  expect(result.reason).toBe('closeout-without-valid-pre-close-label');
+});
+
+test('#1515: open issue is a no-op', () => {
+  const result = lib.decide({
+    state: 'open',
+    labels: ['type:task', 'status:in-progress'],
+    comments: [],
+  });
+  expect(result.action).toBe('noop');
+  expect(result.reason).toBe('issue-open');
+});
+
+test('#1515: already-terminal (status:done) is a no-op even when closed', () => {
+  const result = lib.decide({
+    state: 'closed',
+    labels: ['type:task', 'status:done', 'resolution:completed'],
+    comments: [closeoutComment()],
+  });
+  expect(result.action).toBe('noop');
+  expect(result.reason).toBe('already-terminal');
+});
+
+test('#1515: status:cancelled is also terminal (no-op, no auto-transition needed)', () => {
+  const result = lib.decide({
+    state: 'closed',
+    labels: ['type:task', 'status:cancelled'],
+    comments: [],
+  });
+  expect(result.action).toBe('noop');
+  expect(result.reason).toBe('already-terminal');
+});
+
+test('#1515: Epic CONSULTANT_CLOSEOUT_EPIC_CLOSEOUT variant is also recognized', () => {
+  const result = lib.decide({
+    state: 'closed',
+    labels: ['type:epic', 'status:review', 'role:consultant'],
+    comments: [{ body: '## CONSULTANT_CLOSEOUT_EPIC_CLOSEOUT\n\nEpic-level rubric.' }],
+  });
+  expect(result.action).toBe('auto-transition');
+});
+
+test('#1515: bold-marker variant `**CONSULTANT_CLOSEOUT` is recognized', () => {
+  const result = lib.decide({
+    state: 'closed',
+    labels: ['status:testing'],
+    comments: [{ body: '**CONSULTANT_CLOSEOUT** (inline form)\n\nrubric_rating: 8/10' }],
+  });
+  expect(result.action).toBe('auto-transition');
+});
+
+test('#1515: empty/missing comments array safely handled', () => {
+  expect(lib.decide({ state: 'closed', labels: ['status:testing'] }).action).toBe('reopen');
+  expect(lib.decide({ state: 'closed', labels: ['status:testing'], comments: null }).action).toBe('reopen');
+});
+
+test('#1515: malformed comment entries are skipped (no throw)', () => {
+  const result = lib.decide({
+    state: 'closed',
+    labels: ['status:testing'],
+    comments: [null, {}, { body: null }, closeoutComment()],
+  });
+  expect(result.action).toBe('auto-transition');
+});
+
+test('#1515: hasCloseoutComment exported and usable in isolation', () => {
+  expect(lib.hasCloseoutComment([closeoutComment()])).toBe(true);
+  expect(lib.hasCloseoutComment([{ body: 'no closeout here' }])).toBe(false);
+  expect(lib.hasCloseoutComment([])).toBe(false);
+});


### PR DESCRIPTION
## Summary

Fixes the race condition where `label-lint.yml` reopens issues that GitHub auto-closes via PR-merge `Closes #N` trailer. Confirmed reproduction in the event timelines of #1506 / #1508 / #1512.

## Root cause

```
T+0   gh pr merge          → GitHub auto-closes #N (Closes trailer)
T+0   issues.closed event  → label-lint.yml fires
                             checks: hasCloseout + inReview?
                             issue is still at status:testing (post-merge-
                             automation has not flipped to status:review yet)
                             → reopen branch executes
T+5s  post-merge-automation runs → too late, label-lint already reopened
```

## Fix

Extract close-protection decision logic into a pure function and widen the auto-transition accepting set to **status:review OR status:testing**. Strictly additive — nothing in the harness depends on rejecting status:testing closures.

## What landed

| File | Lines | Role |
|---|---|---|
| `scripts/global/label-lint-close-protection.js` | 52 | Pure `decide({state, labels, comments})` function |
| `tests/label-lint-close-protection.spec.js` | 122 | 12 Playwright tests |
| `.github/workflows/label-lint.yml` | 117 | Delegates to new function (YAML exempt from 100-line cap) |
| `.changes/unreleased/1515.md` | 25 | Changelog fragment |

## Process improvement applied

Posted **all four baton artifacts BEFORE opening this PR**, per Phase-1d/1e anneal target. COLLAB→ADMIN gap 85s+; ADMIN+CONSULTANT both present before PR open.

## Eat-own-dogfood

This PR's merge will exercise the fix on issue #1515 itself: the issue is currently at `status:testing` + `role:admin`, has CONSULTANT_CLOSEOUT in trail. Post-merge, label-lint should auto-transition to `status:done` + `resolution:completed` instead of reopening.

## Test plan

- [x] `npx playwright test tests/label-lint-close-protection.spec.js` — 12/12 passing
- [x] `npm run lint` — green
- [x] `npm run format:check` — green
- [x] `npm run lint:readability:ci` — green
- [ ] On merge: verify #1515 stays closed (no reopen by github-actions[bot])

## Follow-up after merge

Apply the now-fixed close path to the three already-reopened tickets (#1506, #1508, #1512) and close Epic #1486 with its top-level closeout.

Refs #1515
Closes #1515
Refs Epic #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)