### PR TITLE
feat(megalint): three new validators #1520

### DIFF
--- a/.changes/unreleased/1520.md
+++ b/.changes/unreleased/1520.md
@@ -1,0 +1,26 @@
+## [Unreleased] — #1520: three new megalint validators (Epic #1510 Bundle 1)
+
+### Added
+- `scripts/global/megalint/lint-as-ac.js` — flags ACs that restate already-enforced lint rules (the "all files ≤ 100 lines" anti-pattern surfaced at #1500/#1508). Distinguishes ADDING a rule (legitimate AC) from RESTATING it (anti-pattern) via `ADDITIVE_HINTS` regex. Resolves Epic #1510 AC2.
+- `scripts/global/megalint/workflow-sha-pin.js` — flags GitHub Actions workflow `uses:` refs that pin to `@v3`/`@v4`/`@main`/`@latest` tags instead of full 40-char commit SHAs. Repo-owned `./.github/workflows/*` refs are allowlisted as non-third-party. Enforces the security baseline in `instructions/github-governance.instructions.md`.
+- `scripts/global/megalint/test-discoverability.js` — flags `tests/*.spec.js` files that don't import `@playwright/test`. These sit in the test directory but aren't picked up by `npm test` (Playwright runner skips them). Magic-comment opt-out (`// @megalint:test-discoverability:opt-out`) for intentional CLI-script tests. **Resolves #1489.**
+- `tests/megalint-lint-as-ac.spec.js` (11 tests), `tests/megalint-workflow-sha-pin.spec.js` (10 tests), `tests/megalint-test-discoverability.spec.js` (10 tests) — 31 unit tests covering all positive/negative paths + edge cases + VALIDATORS-map registration.
+
+### Changed
+- `scripts/global/megalint/index.js` — registers the three new validators (count: 9 → 12).
+
+### Why
+Phase-1 Bundle 1 of Epic #1510 — three high-severity rules from the Phase-0 recommendation matrix:
+- **lint-as-ac**: the user-flagged AC anti-pattern. Catches the exact #1500 AC6 / #1508 AC8 strings in synthetic tests.
+- **workflow-sha-pin**: closes the security-baseline gap where workflow YAML files reference `@vN` tags (today: `closeout-lint.yml`, `merge-evidence-check.yml`, others use SHAs already).
+- **test-discoverability**: resolves the longstanding #1489 finding about 18 bare-assert spec files in `tests/`.
+
+Satisfies Epic #1510 AC2 (anti-pattern validator) and AC3 (≥3 new lint rules).
+
+### Out of scope (this PR)
+- Wiring the new validators into a workflow callsite — follow-up in Bundle 2 or beyond.
+- Bulk fixing existing repo violations (the rules ship advisory; calibrate FP rate first).
+- Phase-1d/1e/1f/1h/1i deferred per Path C staging in the Phase-0 design.
+
+### Eat-own-dogfood
+This PR's body is structured so none of its own ACs restate enforced lint rules — the lint-as-ac validator passes on it.

--- a/scripts/global/megalint/index.js
+++ b/scripts/global/megalint/index.js
@@ -13,6 +13,9 @@ const truthfulness = require('./body-ac-truthfulness.js');
 const traceability = require('./epic-ac-traceability.js');
 const mergeEvidence = require('./merge-evidence.js');
 const mergeEvidencePrGate = require('./merge-evidence-pr-gate.js');
+const lintAsAc = require('./lint-as-ac.js');
+const workflowShaPin = require('./workflow-sha-pin.js');
+const testDiscoverability = require('./test-discoverability.js');
 
 const VALIDATORS = {
   'manager-handoff': manager,
@@ -24,6 +27,9 @@ const VALIDATORS = {
   'epic-ac-traceability': traceability,
   'merge-evidence': mergeEvidence,
   'merge-evidence-pr-gate': mergeEvidencePrGate,
+  'lint-as-ac': lintAsAc,
+  'workflow-sha-pin': workflowShaPin,
+  'test-discoverability': testDiscoverability,
 };
 
 function runAll(input) {

--- a/scripts/global/megalint/lint-as-ac.js
+++ b/scripts/global/megalint/lint-as-ac.js
@@ -1,0 +1,64 @@
+'use strict';
+// lint-as-ac — Epic #1510 Phase-1a. Flags Acceptance Criteria that
+// restate already-enforced lint rules (e.g. "AC: all files ≤ 100 lines").
+// Linting is automatic; restating it as an AC adds noise, lets authors
+// tick via reading rather than running, and doesn't generalize.
+//
+// IMPORTANT: distinguishes ADDING a lint rule (legitimate scope) from
+// RESTATING an enforced one (anti-pattern). The heuristic in §3c of the
+// Phase-0 design: ACs starting with "New rule"/"Add lint"/"Megalint
+// validator" describe the work; ACs starting with "All files ≤"/"npm run
+// lint passes" restate enforcement.
+
+const ANTI_PATTERNS = [
+  // File-size restate
+  /\b(all\s+|every\s+|each\s+)?(new\s+)?files?\s+(must\s+be\s+|are\s+|is\s+)?(≤|<=|under|below|within)\s+\d+\s*line/i,
+  // Named-tool restate (the bare tool name with no add-rule context)
+  /\b(prettier|markdownlint|ruff|shellcheck|eslint)\b\s+(clean|green|pass(es|ed)?)\b/i,
+  // Generic lint-clean restate
+  /\blint\s+(clean|green|pass(es|ed)?)\b/i,
+  // npm-script restate
+  /\b(npm\s+run\s+)?format:check\s+(green|pass(es|ed)?)\b/i,
+  // Readability/whitespace restate
+  /\b(readability|whitespace|trailing\s+whitespace)\s+(check|pass(es|ed)?)\b/i,
+];
+
+const ADDITIVE_HINTS = /\b(new\s+(rule|validator|lint|check)|add\s+(a\s+)?lint|megalint\s+validator|rule\s+(catches|detects|flags))/i;
+
+function isAcLine(line) {
+  return /^\s*-\s*\[[ x]\]\s*AC[\d:\s-]/i.test(line);
+}
+
+function extractACs(body) {
+  const lines = (body || '').split('\n');
+  let inAcSection = false;
+  const out = [];
+  for (const line of lines) {
+    if (/^#{1,4}\s*Acceptance\s+Criteria/i.test(line)) { inAcSection = true; continue; }
+    if (inAcSection && /^#{1,4}\s+/.test(line)) inAcSection = false;
+    if (inAcSection && isAcLine(line)) out.push(line);
+  }
+  return out;
+}
+
+function isAntiPattern(acLine) {
+  if (ADDITIVE_HINTS.test(acLine)) return false;
+  return ANTI_PATTERNS.some((re) => re.test(acLine));
+}
+
+function validate(input) {
+  const acs = extractACs(input.body || '');
+  const violations = [];
+  for (const ac of acs) {
+    if (isAntiPattern(ac)) {
+      violations.push({
+        rule: 'lint-as-ac',
+        detail: `AC restates an already-enforced lint rule (anti-pattern). Remove or rephrase: ${ac.trim().slice(0, 100)}`,
+        ac: ac.trim(),
+      });
+    }
+  }
+  return { ok: violations.length === 0, violations };
+}
+
+module.exports = { validate, extractACs, isAntiPattern, ANTI_PATTERNS, ADDITIVE_HINTS };

--- a/scripts/global/megalint/test-discoverability.js
+++ b/scripts/global/megalint/test-discoverability.js
@@ -1,0 +1,61 @@
+'use strict';
+// test-discoverability — Epic #1510 Phase-1g. Flags `tests/*.spec.js`
+// files that don't import `@playwright/test`, so they sit in the test
+// directory but are NOT picked up by `npm test` (which runs
+// `npx playwright test`). Resolves #1489.
+//
+// Pattern surfaced in 2026-05-13 audit: 18 of 120 spec files used bare
+// `require('assert')` and self-executed via IIFEs — not collected by
+// Playwright's runner. Authors and reviewers see them in the test dir
+// and assume coverage that doesn't exist.
+//
+// Pure function: caller supplies file path + content. Skip allowlist for
+// known-intentional script-style test files (per-path opt-out via
+// magic comment // @megalint:test-discoverability:opt-out).
+
+const PLAYWRIGHT_IMPORT_RE = /require\(\s*['"]@playwright\/test['"]\s*\)|from\s+['"]@playwright\/test['"]/;
+const OPT_OUT_RE = /@megalint:test-discoverability:opt-out/;
+const SPEC_PATH_RE = /(?:^|\/)tests\/[^/]*\.spec\.(?:js|ts)$/;
+
+function shouldEvaluate(filePath) {
+  return SPEC_PATH_RE.test(filePath || '');
+}
+
+function validateFile(filePath, content) {
+  if (!shouldEvaluate(filePath)) {
+    return { ok: true, skipped: 'not-a-spec-file' };
+  }
+  const text = content || '';
+  if (OPT_OUT_RE.test(text)) {
+    return { ok: true, skipped: 'opt-out-comment-present' };
+  }
+  if (PLAYWRIGHT_IMPORT_RE.test(text)) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    violations: [{
+      rule: 'test-not-playwright-discoverable',
+      detail: `Spec file '${filePath}' does not import '@playwright/test'. `
+        + `Playwright runner will not register tests from it; npm test will not `
+        + `execute its assertions. Convert to Playwright OR add '// @megalint:`
+        + `test-discoverability:opt-out' if this is intentionally a CLI script.`,
+      filePath,
+    }],
+  };
+}
+
+function validate(input) {
+  const files = input.testFiles || [];
+  const violations = [];
+  for (const file of files) {
+    const result = validateFile(file.path, file.content);
+    if (!result.ok) violations.push(...result.violations);
+  }
+  return { ok: violations.length === 0, violations, scanned: files.length };
+}
+
+module.exports = {
+  validate, validateFile, shouldEvaluate,
+  PLAYWRIGHT_IMPORT_RE, OPT_OUT_RE, SPEC_PATH_RE,
+};

--- a/scripts/global/megalint/workflow-sha-pin.js
+++ b/scripts/global/megalint/workflow-sha-pin.js
@@ -1,0 +1,52 @@
+'use strict';
+// workflow-sha-pin — Epic #1510 Phase-1b. Flags `actions/<name>@<tag>`
+// references in workflow YAML; the harness's GitHub Actions security
+// baseline (instructions/github-governance.instructions.md) requires
+// third-party actions pinned to full commit SHA.
+//
+// Repo-owned reusable workflow refs (`./.github/workflows/foo.yml` or
+// `<owner>/<repo>/.github/workflows/foo.yml@main`) are NOT third-party;
+// allowlist treats them as OK by default.
+//
+// Pure-function caller supplies the workflow file content; the rule does
+// not read the filesystem.
+
+const USE_LINE_RE = /^\s*-?\s*uses?:\s*([^\s#]+)/gmi;
+const SHA40_RE = /^[a-f0-9]{40}$/i;
+const REPO_OWNED_RE = /^\.\/.github\/workflows\//;
+
+function parseUseRef(ref) {
+  // Allow ./local-workflow.yml form (repo-owned).
+  if (REPO_OWNED_RE.test(ref)) return { ref, kind: 'repo-owned', ok: true };
+  // Third-party form: org/repo@ref or org/repo/path@ref
+  const match = ref.match(/^([^@\s]+)@([^\s]+)$/);
+  if (!match) return { ref, kind: 'unparseable', ok: true };
+  const [, name, version] = match;
+  const isSha = SHA40_RE.test(version);
+  return { ref, kind: 'third-party', name, version, isSha, ok: isSha };
+}
+
+function findUseRefs(yamlContent) {
+  const out = [];
+  for (const m of (yamlContent || '').matchAll(USE_LINE_RE)) out.push(m[1]);
+  return out;
+}
+
+function validate(input) {
+  const yaml = input.workflowContent || '';
+  const refs = findUseRefs(yaml).map(parseUseRef);
+  const violations = [];
+  for (const parsed of refs) {
+    if (parsed.kind !== 'third-party') continue;
+    if (parsed.ok) continue;
+    violations.push({
+      rule: 'workflow-action-not-sha-pinned',
+      detail: `Workflow uses '${parsed.ref}' (tag/version). Pin third-party actions to a full 40-char commit SHA per security baseline.`,
+      action: parsed.name,
+      version: parsed.version,
+    });
+  }
+  return { ok: violations.length === 0, violations, scanned: refs.length };
+}
+
+module.exports = { validate, parseUseRef, findUseRefs, SHA40_RE, REPO_OWNED_RE };

--- a/tests/megalint-lint-as-ac.spec.js
+++ b/tests/megalint-lint-as-ac.spec.js
@@ -1,0 +1,96 @@
+// Tests for scripts/global/megalint/lint-as-ac.js (Epic #1510 #1520).
+const { test, expect } = require('@playwright/test');
+const rule = require('../scripts/global/megalint/lint-as-ac');
+
+const body = (acs) =>
+  `## Some section\n\nOther text.\n\n## Acceptance Criteria\n\n${acs.map((a) => '- [ ] ' + a).join('\n')}\n`;
+
+test('#1520 AC1: catches the exact #1500 / #1508 pattern (all files ≤ N lines)', () => {
+  const result = rule.validate({ body: body(['AC1: All new files ≤ 100 lines.']) });
+  expect(result.ok).toBe(false);
+  expect(result.violations[0].rule).toBe('lint-as-ac');
+  expect(result.violations[0].ac).toContain('All new files ≤ 100 lines');
+});
+
+test('#1520 AC1: catches case-insensitive variants', () => {
+  const cases = [
+    'AC: all files must be under 100 line.',
+    'AC2: every file is within 80 lines.',
+    'AC3: files <= 100 lines',
+  ];
+  for (const ac of cases) {
+    const result = rule.validate({ body: body([ac]) });
+    expect(result.ok, ac).toBe(false);
+  }
+});
+
+test('#1520 AC1: catches named-tool restate', () => {
+  const cases = [
+    'AC: prettier clean',
+    'AC2: ESLint passes',
+    'AC3: markdownlint green',
+    'AC4: ruff passes',
+    'AC5: shellcheck clean',
+  ];
+  for (const ac of cases) {
+    const result = rule.validate({ body: body([ac]) });
+    expect(result.ok, ac).toBe(false);
+  }
+});
+
+test('#1520 AC1: catches generic "lint clean/green/passes" restate', () => {
+  for (const phrase of ['lint clean', 'lint green', 'lint passes', 'lint passed']) {
+    const result = rule.validate({ body: body([`AC: ${phrase}`]) });
+    expect(result.ok, phrase).toBe(false);
+  }
+});
+
+test('#1520 AC1: catches "format:check green" restate', () => {
+  const result = rule.validate({ body: body(['AC: format:check green']) });
+  expect(result.ok).toBe(false);
+});
+
+test('#1520 AC1: legitimate "new rule" ACs do NOT trigger (additive hint)', () => {
+  const cases = [
+    'AC: New rule catches files exceeding 100 lines',
+    'AC: Add a lint rule that detects 100-line files',
+    'AC: Megalint validator flags lint-clean restate',
+    'AC: New validator detects prettier-clean ACs',
+  ];
+  for (const ac of cases) {
+    const result = rule.validate({ body: body([ac]) });
+    expect(result.ok, ac).toBe(true);
+  }
+});
+
+test('#1520 AC1: ACs outside the "Acceptance Criteria" section are ignored', () => {
+  const text = `## Test plan\n\n- [ ] AC1: all files ≤ 100 lines (this is a test step, not an AC)\n`;
+  const result = rule.validate({ body: text });
+  expect(result.ok).toBe(true);
+});
+
+test('#1520 AC1: section ends when a new header starts', () => {
+  const text = `## Acceptance Criteria\n\n- [ ] AC1: New rule catches X\n\n## Test plan\n\n- [ ] All files ≤ 100 lines`;
+  const result = rule.validate({ body: text });
+  expect(result.ok).toBe(true);
+});
+
+test('#1520 AC1: ticked vs unticked ACs both evaluated', () => {
+  const text = `## Acceptance Criteria\n\n- [x] AC1: All new files ≤ 100 lines.\n- [ ] AC2: Real work item.`;
+  const result = rule.validate({ body: text });
+  expect(result.ok).toBe(false);
+  expect(result.violations[0].ac).toContain('All new files');
+});
+
+test('#1520 AC1: empty body is safe (no violations, no throw)', () => {
+  expect(rule.validate({ body: '' }).ok).toBe(true);
+  expect(rule.validate({}).ok).toBe(true);
+  expect(rule.validate({ body: null }).ok).toBe(true);
+});
+
+test('#1520 AC4: registered in megalint VALIDATORS map', () => {
+  const megalint = require('../scripts/global/megalint');
+  expect(megalint.VALIDATORS).toHaveProperty('lint-as-ac');
+  const result = megalint.run('lint-as-ac', { body: body(['AC: all files ≤ 100 lines.']) });
+  expect(result.ok).toBe(false);
+});

--- a/tests/megalint-test-discoverability.spec.js
+++ b/tests/megalint-test-discoverability.spec.js
@@ -1,0 +1,86 @@
+// Tests for scripts/global/megalint/test-discoverability.js (Epic #1510 #1520).
+const { test, expect } = require('@playwright/test');
+const rule = require('../scripts/global/megalint/test-discoverability');
+
+test('#1520 AC3: spec file with @playwright/test require() passes', () => {
+  const result = rule.validateFile(
+    'tests/foo.spec.js',
+    `const { test, expect } = require('@playwright/test');\ntest('x', () => {});`,
+  );
+  expect(result.ok).toBe(true);
+});
+
+test('#1520 AC3: spec file with @playwright/test ESM import passes', () => {
+  const result = rule.validateFile(
+    'tests/foo.spec.js',
+    `import { test, expect } from '@playwright/test';\ntest('x', () => {});`,
+  );
+  expect(result.ok).toBe(true);
+});
+
+test('#1520 AC3: bare `require("assert")` spec file FAILS', () => {
+  const result = rule.validateFile(
+    'tests/legacy.spec.js',
+    `const assert = require('assert');\nassert.strictEqual(1, 1);`,
+  );
+  expect(result.ok).toBe(false);
+  expect(result.violations[0].rule).toBe('test-not-playwright-discoverable');
+  expect(result.violations[0].filePath).toBe('tests/legacy.spec.js');
+});
+
+test('#1520 AC3: opt-out comment suppresses violation', () => {
+  const result = rule.validateFile(
+    'tests/cli-script.spec.js',
+    `// @megalint:test-discoverability:opt-out — intentional CLI script\nconst assert = require('assert');`,
+  );
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('opt-out-comment-present');
+});
+
+test('#1520 AC3: non-spec files are ignored', () => {
+  expect(rule.validateFile('src/index.js', 'no playwright').ok).toBe(true);
+  expect(rule.validateFile('tests/helpers/util.js', 'no playwright').ok).toBe(true);
+  expect(rule.validateFile('scripts/foo.js', 'no playwright').ok).toBe(true);
+});
+
+test('#1520 AC3: .ts spec files are evaluated too', () => {
+  const ok = rule.validateFile(
+    'tests/foo.spec.ts',
+    `import { test } from '@playwright/test';\ntest('x', () => {});`,
+  );
+  const bad = rule.validateFile('tests/foo.spec.ts', `import 'assert';`);
+  expect(ok.ok).toBe(true);
+  expect(bad.ok).toBe(false);
+});
+
+test('#1520 AC3: shouldEvaluate recognizes tests/*.spec.js pattern', () => {
+  expect(rule.shouldEvaluate('tests/foo.spec.js')).toBe(true);
+  expect(rule.shouldEvaluate('tests/foo.spec.ts')).toBe(true);
+  expect(rule.shouldEvaluate('/some/path/tests/foo.spec.js')).toBe(true);
+  expect(rule.shouldEvaluate('tests/helpers/util.js')).toBe(false);
+  expect(rule.shouldEvaluate('src/foo.spec.js')).toBe(false);
+  expect(rule.shouldEvaluate('')).toBe(false);
+});
+
+test('#1520 AC3: batch validate scans all files in input', () => {
+  const files = [
+    { path: 'tests/a.spec.js', content: `require('@playwright/test')` },
+    { path: 'tests/b.spec.js', content: `require('assert')` },
+    { path: 'tests/c.spec.js', content: `require('assert')` },
+    { path: 'src/d.js', content: 'whatever' },
+  ];
+  const result = rule.validate({ testFiles: files });
+  expect(result.ok).toBe(false);
+  expect(result.violations).toHaveLength(2);
+  expect(result.scanned).toBe(4);
+});
+
+test('#1520 AC3: empty input is safe', () => {
+  expect(rule.validate({}).ok).toBe(true);
+  expect(rule.validate({ testFiles: [] }).ok).toBe(true);
+});
+
+test('#1520 AC4: registered in megalint VALIDATORS map', () => {
+  const megalint = require('../scripts/global/megalint');
+  expect(megalint.VALIDATORS).toHaveProperty('test-discoverability');
+});

--- a/tests/megalint-workflow-sha-pin.spec.js
+++ b/tests/megalint-workflow-sha-pin.spec.js
@@ -1,0 +1,76 @@
+// Tests for scripts/global/megalint/workflow-sha-pin.js (Epic #1510 #1520).
+const { test, expect } = require('@playwright/test');
+const rule = require('../scripts/global/megalint/workflow-sha-pin');
+
+const wf = (uses) => `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n${uses.map((u) => '      - uses: ' + u).join('\n')}\n`;
+
+test('#1520 AC2: parseUseRef recognizes SHA-pinned third-party action as OK', () => {
+  const parsed = rule.parseUseRef('actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5');
+  expect(parsed.ok).toBe(true);
+  expect(parsed.isSha).toBe(true);
+});
+
+test('#1520 AC2: parseUseRef flags @v3 / @v4 tag refs', () => {
+  for (const tag of ['actions/checkout@v3', 'actions/checkout@v4', 'actions/setup-node@v5']) {
+    const parsed = rule.parseUseRef(tag);
+    expect(parsed.ok, tag).toBe(false);
+  }
+});
+
+test('#1520 AC2: parseUseRef flags @main or @latest', () => {
+  for (const ref of ['actions/checkout@main', 'actions/checkout@latest', 'foo/bar@release']) {
+    expect(rule.parseUseRef(ref).ok, ref).toBe(false);
+  }
+});
+
+test('#1520 AC2: repo-owned ./ workflow refs are OK', () => {
+  expect(rule.parseUseRef('./.github/workflows/reusable.yml').kind).toBe('repo-owned');
+  expect(rule.parseUseRef('./.github/workflows/reusable.yml').ok).toBe(true);
+});
+
+test('#1520 AC2: unparseable refs are passed through as OK (no false positive)', () => {
+  // No @ symbol — could be a local file or malformed; let other lints catch.
+  expect(rule.parseUseRef('local-step-no-version').ok).toBe(true);
+});
+
+test('#1520 AC2: validate scans all uses in a workflow', () => {
+  const yaml = wf([
+    'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5',
+    'actions/setup-node@v4',
+    'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b',
+    './.github/workflows/reusable.yml',
+  ]);
+  const result = rule.validate({ workflowContent: yaml });
+  expect(result.ok).toBe(false);
+  expect(result.violations).toHaveLength(1);
+  expect(result.violations[0].action).toBe('actions/setup-node');
+  expect(result.violations[0].version).toBe('v4');
+  expect(result.scanned).toBe(4);
+});
+
+test('#1520 AC2: all-pinned workflow passes', () => {
+  const yaml = wf([
+    'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5',
+    'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b',
+  ]);
+  const result = rule.validate({ workflowContent: yaml });
+  expect(result.ok).toBe(true);
+  expect(result.violations).toHaveLength(0);
+});
+
+test('#1520 AC2: empty / null workflow content is safe', () => {
+  expect(rule.validate({ workflowContent: '' }).ok).toBe(true);
+  expect(rule.validate({}).ok).toBe(true);
+});
+
+test('#1520 AC2: SHA must be exactly 40 hex chars (39 or 41 is not a SHA)', () => {
+  expect(rule.SHA40_RE.test('a'.repeat(40))).toBe(true);
+  expect(rule.SHA40_RE.test('a'.repeat(39))).toBe(false);
+  expect(rule.SHA40_RE.test('a'.repeat(41))).toBe(false);
+  expect(rule.SHA40_RE.test('g'.repeat(40))).toBe(false); // g is not hex
+});
+
+test('#1520 AC4: registered in megalint VALIDATORS map', () => {
+  const megalint = require('../scripts/global/megalint');
+  expect(megalint.VALIDATORS).toHaveProperty('workflow-sha-pin');
+});


### PR DESCRIPTION
## Summary

Phase-1 Bundle 1 of Epic #1510. Three pure-function megalint validators following the established advisory-first pattern. Satisfies Epic AC2 (anti-pattern validator) and AC3 (≥3 new lint rules in one bundle).

## What landed

| Validator | Catches | Resolves |
|---|---|---|
| `lint-as-ac` | ACs that restate enforced lint rules ("all files ≤ N lines", tool restate) | Epic #1510 AC2 + the user-flagged pattern |
| `workflow-sha-pin` | `actions/<name>@<tag>` not pinned to 40-char SHA | Security-baseline gap |
| `test-discoverability` | `tests/*.spec.{js,ts}` missing `@playwright/test` import | **#1489** (longstanding) |

12 megalint validators total now (was 9).

## Test plan

- [x] `npx playwright test tests/megalint-{lint-as-ac,workflow-sha-pin,test-discoverability}.spec.js` — 31/31 passing
- [x] `npm run lint` — green (all files ≤ 100 lines)
- [x] `npm run format:check` — green
- [x] `npm run lint:readability:ci` — green
- [x] All baton artifacts posted BEFORE PR (anneal target holds)

## Eat-own-dogfood

This PR's body and #1520 issue body intentionally do **not** restate enforced lint rules as ACs — the `lint-as-ac` validator passes on this very PR. Phase-1c gate's `Closes #N` requirement is also satisfied (this PR body has `Closes #1520` + `Closes #1489`).

Refs #1520
Closes #1520
Closes #1489
Refs Epic #1510

🤖 Generated with [Claude Code](https://claude.com/claude-code)