### PR TITLE
docs: add provider adapter matrix #1485

### DIFF
--- a/research/provider-adapter-matrix-2026-05-14.md
+++ b/research/provider-adapter-matrix-2026-05-14.md
@@ -1,0 +1,79 @@
+# Provider Adapter Matrix
+
+**Ticket**: #1485  
+**Parent**: #1480  
+**Date**: 2026-05-14  
+**Scope**: Research/docs only; no implementation files changed.
+
+## Visual Summary
+
+```mermaid
+flowchart LR
+  R[Runtime: Codex/Copilot/Claude/OpenClaw] --> H[HAMR lane + policy]
+  H --> A[Provider adapter]
+  A --> P[Provider: OpenAI/Anthropic/Ollama/OpenRouter/LiteLLM]
+  P --> T[Telemetry: exact, aggregate, estimated, or unavailable]
+```
+
+## Decision
+
+Keep runtimes and providers separate. A runtime owns instructions, tools,
+hooks, approvals, and worktree behavior. A provider owns model IDs, wire API,
+usage fields, caching, budgets, and rate limits. HAMR should remain the bridge
+that maps a lane to a provider adapter without making any runtime canonical.
+
+## Capability Matrix
+
+| Surface | Role | Tools/MCP | Hooks | Agents/skills | Cost/telemetry | Evidence |
+|---|---|---:|---:|---:|---|---|
+| Codex | runtime | yes | yes | yes | OTel + provider usage | OpenAI docs |
+| Claude Code | runtime | yes | yes | yes | Anthropic + hooks | Anthropic docs |
+| Copilot coding agent | runtime | tools only | yes | yes | plan-limited | GitHub docs |
+| OpenClaw/fleet | runtime/provider | custom | harness | no | local logs | local scripts |
+| HAMR | policy bridge | MCP-capable | harness | no | signed JSONL/KV | local docs |
+| OpenAI-compatible | provider | API tools | no | no | usage when exposed | OpenAI/HAMR |
+| Anthropic | provider | API tools | no | no | messages/cache usage | Anthropic docs |
+| Ollama | provider | API tools | no | no | local usage objects | Ollama docs |
+| OpenRouter | provider | API tools | no | no | key limits/usage | OpenRouter docs |
+| LiteLLM | proxy | proxy tools | callbacks | no | budget/spend tracking | LiteLLM docs |
+
+## Adapter Gaps
+
+1. **Registry gap**: `routing-provider-adapters.json` covers lanes, but not the
+   full runtime/provider capability matrix or citation-backed feature flags.
+2. **Telemetry confidence gap**: exact per-call usage, aggregate usage, local
+   session metadata, and estimates need an enforced confidence label.
+3. **Copilot MCP gap**: Copilot coding agent supports MCP tools, but not MCP
+   resources/prompts, so wiki adapters must expose retrieval as tools.
+4. **OpenRouter quota gap**: free-model limits require runtime-visible backoff
+   before OpenRouter can be a dependable free default.
+5. **LiteLLM proxy gap**: spend tracking is strong, but harness policy still
+   needs generated docs/tests before using it as the primary adapter registry.
+
+## Follow-Up
+
+Created #1523 to turn this matrix into a generated, linted provider capability
+registry. Existing telemetry work (#1484/#1375) covers the confidence-label
+path; do not duplicate it here.
+
+## Sources
+
+- OpenAI Codex config, subagents, and sandbox docs:
+  <https://developers.openai.com/codex/config-reference>
+- Claude Code hooks, MCP, settings, and subagents:
+  <https://docs.anthropic.com/en/docs/claude-code/hooks>
+- GitHub Copilot coding agent MCP and customization:
+  <https://docs.github.com/en/copilot/concepts/coding-agent/mcp-and-coding-agent>
+- Anthropic Messages and prompt caching:
+  <https://docs.anthropic.com/en/api/messages-examples>
+- LiteLLM proxy docs: <https://docs.litellm.ai/>
+- OpenRouter limits: <https://openrouter.ai/docs/api-reference/api-reference/limits>
+- Ollama OpenAI compatibility: <https://docs.ollama.com/openai>
+- Local: `docs/provider-neutral-routing.md`,
+  `scripts/global/routing-provider-adapters.json`,
+  `scripts/global/hamr-provider-wrapper.js`, `config/litellm-config.yaml`,
+  `scripts/global/ollama-direct.js`, `instructions/hamr-routing.instructions.md`.
+
+Signed-by: Quill Harper  
+Team&Model: codex:gpt-5.4@local  
+Role: collaborator

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -49,6 +49,7 @@ The LLM updates this on every ingest operation.
 ## Source Summaries
 
 - [[codex-compatibility-audit-2026-05-13]] — Codex compatibility audit for harness goals/features/functionality
+- [[provider-adapter-matrix-2026-05-14]] — Provider adapter matrix for Codex, Copilot, Claude Code, HAMR, and provider paths
 - [[epic-1271-codex-fdpr-2026-05-10]] — Codex final development plan recommendation for Epic #1271
 - [[epic-1271-cx-rd-plan-2026-05-09]] — Epic #1271 Codex R&D plan for state truthfulness
 - [[epic-1271-cp-rd-plan-2026-05-09]] — Epic #1271 Copilot R&D plan for state truthfulness
@@ -109,6 +110,7 @@ The LLM updates this on every ingest operation.
 ## Recent Additions
 
 - [[codex-compatibility-audit-2026-05-13]] — Codex compatibility audit (2026-05-13)
+- [[provider-adapter-matrix-2026-05-14]] — Provider adapter matrix (2026-05-14)
 - [[distributed-self-anneal]] — Three-tier distributed self-anneal (2026-05-10)
 - [[andon-pull-protocol]] — Any-role pull protocol (2026-05-10)
 - [[epic-1271-codex-fdpr-2026-05-10]] — Codex FDPR for Epic #1271 (2026-05-10)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -51,6 +51,12 @@ and OpenAI/Codex telemetry. New source page:
 `wiki/sources/codex-compatibility-audit-2026-05-13.md`. Source:
 `research/codex-compatibility-audit-2026-05-13.md`.
 
+## [2026-05-14] research | Provider adapter matrix (#1485, EPIC #1480)
+Added runtime-vs-provider matrix for Codex, Claude Code, Copilot, OpenClaw,
+fleet, HAMR, OpenAI-compatible, Anthropic, Ollama, OpenRouter, and LiteLLM.
+New source page: `wiki/sources/provider-adapter-matrix-2026-05-14.md`.
+Source: `research/provider-adapter-matrix-2026-05-14.md`.
+
 **Tip**: `grep "^## \[" log.md | tail -5` shows last 5 entries.
 
 ---

--- a/wiki/sources/provider-adapter-matrix-2026-05-14.md
+++ b/wiki/sources/provider-adapter-matrix-2026-05-14.md
@@ -1,0 +1,65 @@
+---
+title: "Provider Adapter Matrix 2026-05-14"
+type: source
+created: 2026-05-14
+updated: 2026-05-14
+tags: [providers, routing, codex, hamr]
+sources: ["/home/curtisfranks/devenv-ops/research/provider-adapter-matrix-2026-05-14.md"]
+related: ["[[codex-compatibility-audit-2026-05-13]]", "[[token-provider-adapters]]"]
+status: active
+confidence: high
+last_verified: 2026-05-14
+---
+
+# Provider Adapter Matrix 2026-05-14
+
+## Summary
+
+Ticket #1485 maps runtime capabilities separately from provider capabilities so
+the harness can support Codex, Copilot, Claude Code, OpenClaw, fleet, and
+provider paths without hard-coding one vendor's assumptions.
+
+## Details
+
+Runtime surfaces own interaction mechanics: instructions, MCP/tool access,
+hooks, subagents, sandboxing, approvals, and worktree behavior. Provider
+surfaces own model IDs, wire APIs, usage fields, caching, budgets, rate limits,
+and quota behavior.
+
+Key conclusions:
+
+- Codex has first-class config, MCP, hooks, skills, subagents, sandbox,
+  approvals, and OpenTelemetry controls.
+- Claude Code remains richest in hook/plugin/subagent patterns, but should be
+  treated as one runtime adapter rather than the shared policy baseline.
+- Copilot coding agent supports MCP tools, custom instructions, custom agents,
+  hooks, and a sandboxed cloud environment, but MCP resources/prompts are not a
+  portable assumption.
+- HAMR should expose capability lanes and telemetry confidence, while provider
+  adapters handle OpenAI-compatible, Anthropic, Ollama, OpenRouter, LiteLLM,
+  and fleet-specific details.
+
+## Related
+
+- [[codex-compatibility-audit-2026-05-13]]
+- [[token-provider-adapters]]
+- [[model-routing]]
+- [[harness-goals]]
+
+## Sources
+
+- Research artifact:
+  `research/provider-adapter-matrix-2026-05-14.md`
+- OpenAI Codex docs: <https://developers.openai.com/codex/config-reference>
+- Claude Code hooks: <https://docs.anthropic.com/en/docs/claude-code/hooks>
+- GitHub Copilot MCP:
+  <https://docs.github.com/en/copilot/concepts/coding-agent/mcp-and-coding-agent>
+- Anthropic Messages: <https://docs.anthropic.com/en/api/messages-examples>
+- LiteLLM: <https://docs.litellm.ai/>
+- OpenRouter limits:
+  <https://openrouter.ai/docs/api-reference/api-reference/limits>
+- Ollama OpenAI compatibility: <https://docs.ollama.com/openai>
+
+Signed-by: Quill Harper  
+Team&Model: codex:gpt-5.4@local  
+Role: collaborator


### PR DESCRIPTION
## Summary
- Adds the #1485 runtime-vs-provider adapter matrix for Codex, Claude Code, Copilot, OpenClaw/fleet, HAMR, OpenAI-compatible paths, Anthropic, Ollama, OpenRouter, and LiteLLM.
- Adds a Karpathy LLM Wiki source page and indexes/logs it.
- Creates follow-up #1523 for the generated provider capability registry implementation gap.

## Validation
- npm run lint: PASS
- npm run lint:md: PASS
- npm run docs:lint: PASS
- npm run docs:anchors: PASS
- git diff --check: PASS
- npm run wiki:lint: FAILS on pre-existing wiki drift; new provider-adapter page is indexed and is not listed in the failures.

## Cross-Team Safety
- Research/wiki-only changes.
- Avoided active #1510/#1520/#1521 megalint and instruction-channel files owned by other teams.

Refs #1485
Refs Epic #1480
Refs #1523
Closes #1485

Signed-by: Quill Reyes
Team&Model: codex:gpt-5.4@local
Role: admin