### PR TITLE
feat: add provider capability registry #1523

### DIFF
--- a/docs/provider-capability-registry.md
+++ b/docs/provider-capability-registry.md
@@ -1,0 +1,29 @@
+# Provider Capability Registry
+
+Generated from `scripts/global/provider-capability-registry.json`.
+Owner boundary: Runtime records describe agent surfaces; provider records describe serving paths.
+
+## Runtimes
+
+| ID | Tools/MCP | Hooks | Agents/Skills | Sandbox/Approval | Cost | Telemetry |
+|---|---|---|---|---|---|---|
+| codex | yes | yes | yes | strong | provider-mediated | mixed |
+| claude-code | yes | yes | yes | strong | anthropic-plan-or-api | mixed |
+| copilot | tools-only | yes | yes | cloud-sandbox | plan-limited | estimated |
+| openclaw-fleet | custom | harness | no | local-fleet | zero-cost-local | derived |
+| hamr | mcp-capable | harness | no | wrapper-mediated | signed-observability | derived |
+
+## Providers
+
+| ID | Tools/MCP | Hooks | Agents/Skills | Sandbox/Approval | Cost | Telemetry |
+|---|---|---|---|---|---|---|
+| openai-compatible | api-tools | no | no | api-key-scoped | provider-usage | mixed |
+| anthropic | api-tools | no | no | api-key-scoped | messages-cache-usage | exact_request |
+| ollama | api-tools | no | no | local-host | zero-cost-local | exact_request |
+| openrouter | api-tools | no | no | api-key-scoped | key-limits-credits | aggregate |
+| litellm | proxy-tools | callbacks | no | proxy-policy | budget-spend-tracking | derived |
+| fleet | local-api | harness | no | tailscale-local | zero-cost-local | derived |
+
+Signed-by: Quill Harper  
+Team&Model: codex:gpt-5.4@local  
+Role: collaborator

--- a/docs/provider-neutral-routing.md
+++ b/docs/provider-neutral-routing.md
@@ -28,6 +28,17 @@ Anthropic, OpenAI-compatible, Ollama, OpenRouter, LiteLLM, and fleet paths.
 Anthropic remains available as a default cloud adapter, but it is no longer the
 visible definition of a paid lane.
 
+## Capability Registry
+
+Provider and runtime capability claims live in
+`scripts/global/provider-capability-registry.json`. The generated operator view
+is `docs/provider-capability-registry.md` and can be refreshed with
+`node scripts/global/provider-capability-registry.js --write-doc`.
+
+Runtime records describe agent surfaces. Provider records describe serving
+paths. Keep those ownership boundaries separate when comparing Codex, Copilot,
+Claude Code, HAMR, OpenClaw, OpenRouter, Ollama, LiteLLM, or vendor APIs.
+
 ## Validation
 
 Routing changes should include:

--- a/scripts/global/provider-capability-registry.js
+++ b/scripts/global/provider-capability-registry.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const REGISTRY = path.join(__dirname, 'provider-capability-registry.json');
+const REQUIRED = [
+  'id',
+  'toolsMcp',
+  'hooks',
+  'agentsSkills',
+  'sandboxApproval',
+  'cost',
+  'telemetryConfidence',
+  'citations',
+];
+
+function loadRegistry(file = REGISTRY) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function validateRecord(kind, record, levels) {
+  const errors = [];
+  for (const field of REQUIRED) {
+    if (!record[field] || (Array.isArray(record[field]) && record[field].length === 0)) {
+      errors.push(`${kind}:${record.id || 'unknown'} missing ${field}`);
+    }
+  }
+  if (!levels.includes(record.telemetryConfidence)) {
+    errors.push(`${kind}:${record.id} invalid telemetryConfidence`);
+  }
+  for (const citation of record.citations || []) {
+    if (!/^https?:\/\//.test(citation) && !fs.existsSync(path.join(ROOT, citation))) {
+      errors.push(`${kind}:${record.id} missing citation ${citation}`);
+    }
+  }
+  return errors;
+}
+
+function validateRegistry(registry) {
+  const levels = registry.confidenceLevels || [];
+  const errors = [];
+  for (const kind of ['runtimes', 'providers']) {
+    for (const record of registry[kind] || []) {
+      errors.push(...validateRecord(kind, record, levels));
+    }
+  }
+  const runtimeIds = new Set((registry.runtimes || []).map(r => r.id));
+  for (const provider of registry.providers || []) {
+    if (runtimeIds.has(provider.id)) errors.push(`provider duplicates runtime id ${provider.id}`);
+  }
+  return errors;
+}
+
+function renderTable(title, records) {
+  const rows = records.map(r =>
+    `| ${r.id} | ${r.toolsMcp} | ${r.hooks} | ${r.agentsSkills} | ${r.sandboxApproval} | ${r.cost} | ${r.telemetryConfidence} |`
+  );
+  return [
+    `## ${title}`,
+    '',
+    '| ID | Tools/MCP | Hooks | Agents/Skills | Sandbox/Approval | Cost | Telemetry |',
+    '|---|---|---|---|---|---|---|',
+    ...rows,
+    '',
+  ].join('\n');
+}
+
+function renderMarkdown(registry) {
+  return [
+    '# Provider Capability Registry',
+    '',
+    'Generated from `scripts/global/provider-capability-registry.json`.',
+    `Owner boundary: ${registry.ownerBoundary}`,
+    '',
+    renderTable('Runtimes', registry.runtimes),
+    renderTable('Providers', registry.providers),
+    'Signed-by: Quill Harper  ',
+    'Team&Model: codex:gpt-5.4@local  ',
+    'Role: collaborator', ''].join('\n');
+}
+
+function main() {
+  const registry = loadRegistry();
+  const errors = validateRegistry(registry);
+  if (errors.length) {
+    console.error(errors.join('\n'));
+    process.exit(1);
+  }
+  if (process.argv.includes('--write-doc')) {
+    fs.writeFileSync(path.join(ROOT, registry.generatedDoc), renderMarkdown(registry));
+  } else {
+    console.log(JSON.stringify({ ok: true, runtimes: registry.runtimes.length, providers: registry.providers.length }));
+  }
+}
+
+if (require.main === module) main();
+module.exports = { loadRegistry, validateRegistry, renderMarkdown };

--- a/scripts/global/provider-capability-registry.json
+++ b/scripts/global/provider-capability-registry.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0",
+  "generatedDoc": "docs/provider-capability-registry.md",
+  "confidenceLevels": ["exact_request", "aggregate", "derived", "estimated", "unavailable", "mixed"],
+  "ownerBoundary": "Runtime records describe agent surfaces; provider records describe serving paths.",
+  "runtimes": [
+    { "id": "codex", "toolsMcp": "yes", "hooks": "yes", "agentsSkills": "yes", "sandboxApproval": "strong", "cost": "provider-mediated", "telemetryConfidence": "mixed", "citations": ["https://developers.openai.com/codex/config-reference", "https://developers.openai.com/codex/agent-approvals-security"] },
+    { "id": "claude-code", "toolsMcp": "yes", "hooks": "yes", "agentsSkills": "yes", "sandboxApproval": "strong", "cost": "anthropic-plan-or-api", "telemetryConfidence": "mixed", "citations": ["https://docs.anthropic.com/en/docs/claude-code/hooks", "https://docs.anthropic.com/en/docs/claude-code/settings"] },
+    { "id": "copilot", "toolsMcp": "tools-only", "hooks": "yes", "agentsSkills": "yes", "sandboxApproval": "cloud-sandbox", "cost": "plan-limited", "telemetryConfidence": "estimated", "citations": ["https://docs.github.com/en/copilot/concepts/coding-agent/mcp-and-coding-agent", "https://docs.github.com/en/copilot/using-github-copilot/coding-agent/about-assigning-tasks-to-copilot"] },
+    { "id": "openclaw-fleet", "toolsMcp": "custom", "hooks": "harness", "agentsSkills": "no", "sandboxApproval": "local-fleet", "cost": "zero-cost-local", "telemetryConfidence": "derived", "citations": ["scripts/global/openclaw-chat.js", "scripts/global/fleet-via-hamr.js"] },
+    { "id": "hamr", "toolsMcp": "mcp-capable", "hooks": "harness", "agentsSkills": "no", "sandboxApproval": "wrapper-mediated", "cost": "signed-observability", "telemetryConfidence": "derived", "citations": ["instructions/hamr-routing.instructions.md", "scripts/global/hamr-provider-wrapper.js"] }
+  ],
+  "providers": [
+    { "id": "openai-compatible", "toolsMcp": "api-tools", "hooks": "no", "agentsSkills": "no", "sandboxApproval": "api-key-scoped", "cost": "provider-usage", "telemetryConfidence": "mixed", "citations": ["https://platform.openai.com/docs/guides/rate-limits", "instructions/hamr-routing.instructions.md"] },
+    { "id": "anthropic", "toolsMcp": "api-tools", "hooks": "no", "agentsSkills": "no", "sandboxApproval": "api-key-scoped", "cost": "messages-cache-usage", "telemetryConfidence": "exact_request", "citations": ["https://docs.anthropic.com/en/api/messages-examples", "https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching"] },
+    { "id": "ollama", "toolsMcp": "api-tools", "hooks": "no", "agentsSkills": "no", "sandboxApproval": "local-host", "cost": "zero-cost-local", "telemetryConfidence": "exact_request", "citations": ["https://docs.ollama.com/openai", "scripts/global/ollama-direct.js"] },
+    { "id": "openrouter", "toolsMcp": "api-tools", "hooks": "no", "agentsSkills": "no", "sandboxApproval": "api-key-scoped", "cost": "key-limits-credits", "telemetryConfidence": "aggregate", "citations": ["https://openrouter.ai/docs/api-reference/api-reference/limits", "scripts/global/token-provider-adapters.js"] },
+    { "id": "litellm", "toolsMcp": "proxy-tools", "hooks": "callbacks", "agentsSkills": "no", "sandboxApproval": "proxy-policy", "cost": "budget-spend-tracking", "telemetryConfidence": "derived", "citations": ["https://docs.litellm.ai/", "config/litellm-config.yaml"] },
+    { "id": "fleet", "toolsMcp": "local-api", "hooks": "harness", "agentsSkills": "no", "sandboxApproval": "tailscale-local", "cost": "zero-cost-local", "telemetryConfidence": "derived", "citations": ["inventory/devices.json", "scripts/global/fleet-via-hamr.js"] }
+  ]
+}

--- a/tests/provider-capability-registry.spec.js
+++ b/tests/provider-capability-registry.spec.js
@@ -1,0 +1,34 @@
+const { test, expect } = require('@playwright/test');
+const registryTools = require('../scripts/global/provider-capability-registry');
+
+test('provider capability registry validates cleanly', () => {
+  const registry = registryTools.loadRegistry();
+  expect(registryTools.validateRegistry(registry)).toEqual([]);
+});
+
+test('runtime and provider records stay separate', () => {
+  const registry = registryTools.loadRegistry();
+  const runtimeIds = new Set(registry.runtimes.map(r => r.id));
+  for (const provider of registry.providers) {
+    expect(runtimeIds.has(provider.id)).toBe(false);
+  }
+});
+
+test('validator rejects missing telemetry confidence and citations', () => {
+  const registry = registryTools.loadRegistry();
+  const broken = {
+    ...registry,
+    providers: [{ ...registry.providers[0], telemetryConfidence: '', citations: [] }],
+  };
+  const errors = registryTools.validateRegistry(broken).join('\n');
+  expect(errors).toContain('missing telemetryConfidence');
+  expect(errors).toContain('missing citations');
+});
+
+test('generated markdown names output source and owner boundary', () => {
+  const registry = registryTools.loadRegistry();
+  const markdown = registryTools.renderMarkdown(registry);
+  expect(markdown).toContain('provider-capability-registry.json');
+  expect(markdown).toContain('Owner boundary:');
+  expect(markdown).toContain('| openai-compatible |');
+});


### PR DESCRIPTION
Refs #1523
Closes #1523

## Summary
- Adds a structured provider capability registry with separate runtime/provider records.
- Adds validation for required capability fields, confidence labels, citations, and runtime/provider ID separation.
- Generates the operator-facing provider capability registry doc and links the refresh path from provider-neutral routing docs.

## Validation
- PASS `node scripts/global/provider-capability-registry.js --write-doc && node scripts/global/provider-capability-registry.js`
- PASS `npx playwright test tests/provider-capability-registry.spec.js`
- PASS `npx eslint -c lint-configs/eslint.config.devenv.js --max-warnings 9999 scripts/global/provider-capability-registry.js`
- PASS `npm run lint:md`
- PASS `npm run docs:anchors`
- PASS `git diff --check`
- PASS `git push` pre-push format/readability checks
- BLOCKED `npm run lint:js` by pre-existing unrelated JS errors outside this ticket
- BLOCKED/TERMINATED `npm test` due local missing Playwright Chromium, `better-sqlite3`, and unrelated HAMR config

## Conflict Avoidance
- Dedicated worktree and one-ticket branch.
- Avoided #1510/#1520/#1521 active megalint/instruction-channel surfaces.
- Did not touch active Claude Code or Copilot team files.

Signed-by: Quill Harper  
Team&Model: codex:gpt-5.4@local  
Role: collaborator
