### PR TITLE
feat(governance): circuit-breaker primitive #1279

### DIFF
--- a/.changes/unreleased/1279.md
+++ b/.changes/unreleased/1279.md
@@ -1,0 +1,26 @@
+## [Unreleased] — #1279: circuit-breaker primitive for rate-limit handling
+
+### Added
+- `scripts/global/circuit-breaker.js` — pure-state circuit breaker complementing the existing `scripts/global/backoff.js`. Tracks `closed`/`open`/`half-open` state with configurable failure threshold and cool-off window. No timers, no I/O — caller supplies `Date.now` for deterministic testing. Exports `create`, `canPass`, `recordSuccess`, `recordFailure`, `status`, plus `STATES`, `DEFAULT_THRESHOLD` (5), `DEFAULT_COOL_OFF_MS` (30s).
+- `tests/circuit-breaker.spec.js` — 14 Playwright tests covering every state transition, both threshold paths (immediate `threshold:1` and burst), half-open success → closed, half-open failure → open with cool-off restart, success resets the consecutive-failure counter, non-consecutive failures DON'T accumulate, telemetry `status()` snapshot, frozen STATES constants, and an integration scenario that exercises a full burst-fail-recover cycle.
+
+### Why
+Closes #1279 (governance-audit `rate-limit-event-frequency` finding). `backoff.js` already handles "retry on rate-limit"; circuit-breaker is the orthogonal primitive that says "stop trying after N consecutive failures and let the upstream recover." Both primitives are needed for production-grade dispatcher reliability:
+
+```
++--------------------+----------------------+----------------------+
+| Primitive          | Existing             | New (this PR)        |
++--------------------+----------------------+----------------------+
+| Recognize 429/503  | isRateLimitError()   | (used downstream)    |
+| Wait between tries | backoff(attempt,opts)| —                    |
+| Stop on N failures | —                    | recordFailure        |
+| Fast-fail open     | —                    | canPass → false      |
+| Probe with one trial | —                  | half-open state      |
+| Recover on success | —                    | recordSuccess        |
++--------------------+----------------------+----------------------+
+```
+
+### Out of scope (this PR)
+- Wiring the breaker into specific dispatchers (`cascade-dispatch.js`, `fleet-via-hamr.js`, etc.) — opt-in adoption per dispatcher's needs. Module is callable now.
+- Refining `consultant-checks.js` fleet-001 regex (currently SKIPs when telemetry file absent; rule itself works as-designed when the file exists).
+- Persisting breaker state across process boundaries (future enhancement; in-memory state is correct for single-process dispatchers).

--- a/scripts/global/circuit-breaker.js
+++ b/scripts/global/circuit-breaker.js
@@ -1,0 +1,74 @@
+'use strict';
+// circuit-breaker — Epic-companion to backoff.js (#1279). A pure-state
+// circuit breaker for rate-limit / failure handling in fleet dispatchers.
+//
+// States:
+//   closed:    requests flow through. Consecutive failures increment counter.
+//              On threshold breach → open.
+//   open:      requests fail fast (call site decides what to do). After
+//              cool-off elapses → half-open.
+//   half-open: allow exactly one trial. Success → closed (counter reset).
+//              Failure → open (counter unchanged; cool-off restarts).
+//
+// Pure functions only — the breaker is a plain object the caller mutates
+// via record* helpers. No timers, no I/O. Caller supplies Date.now via opts
+// when deterministic timing is needed for tests.
+
+const DEFAULT_THRESHOLD = 5;
+const DEFAULT_COOL_OFF_MS = 30 * 1000;
+const STATES = Object.freeze({ closed: 'closed', open: 'open', halfOpen: 'half-open' });
+
+function create(opts = {}) {
+  return {
+    state: STATES.closed,
+    consecutiveFailures: 0,
+    openedAt: 0,
+    threshold: opts.threshold || DEFAULT_THRESHOLD,
+    coolOffMs: opts.coolOffMs || DEFAULT_COOL_OFF_MS,
+  };
+}
+
+function canPass(breaker, nowMs) {
+  if (breaker.state === STATES.closed) return true;
+  if (breaker.state === STATES.halfOpen) return true;
+  if (breaker.state === STATES.open) {
+    if (nowMs - breaker.openedAt >= breaker.coolOffMs) {
+      breaker.state = STATES.halfOpen;
+      return true;
+    }
+    return false;
+  }
+  return false;
+}
+
+function recordSuccess(breaker) {
+  breaker.consecutiveFailures = 0;
+  breaker.state = STATES.closed;
+  breaker.openedAt = 0;
+}
+
+function recordFailure(breaker, nowMs) {
+  if (breaker.state === STATES.halfOpen) {
+    breaker.state = STATES.open;
+    breaker.openedAt = nowMs;
+    return;
+  }
+  breaker.consecutiveFailures++;
+  if (breaker.consecutiveFailures >= breaker.threshold) {
+    breaker.state = STATES.open;
+    breaker.openedAt = nowMs;
+  }
+}
+
+function status(breaker) {
+  return {
+    state: breaker.state,
+    consecutiveFailures: breaker.consecutiveFailures,
+    openedAt: breaker.openedAt,
+  };
+}
+
+module.exports = {
+  create, canPass, recordSuccess, recordFailure, status,
+  STATES, DEFAULT_THRESHOLD, DEFAULT_COOL_OFF_MS,
+};

--- a/tests/circuit-breaker.spec.js
+++ b/tests/circuit-breaker.spec.js
@@ -1,0 +1,129 @@
+// Tests for scripts/global/circuit-breaker.js (#1279).
+const { test, expect } = require('@playwright/test');
+const cb = require('../scripts/global/circuit-breaker');
+
+test('#1279 AC1: create() returns closed breaker with defaults', () => {
+  const b = cb.create();
+  expect(b.state).toBe(cb.STATES.closed);
+  expect(b.consecutiveFailures).toBe(0);
+  expect(b.threshold).toBe(cb.DEFAULT_THRESHOLD);
+  expect(b.coolOffMs).toBe(cb.DEFAULT_COOL_OFF_MS);
+});
+
+test('#1279 AC1: create() honors custom threshold and coolOffMs', () => {
+  const b = cb.create({ threshold: 3, coolOffMs: 1000 });
+  expect(b.threshold).toBe(3);
+  expect(b.coolOffMs).toBe(1000);
+});
+
+test('#1279 AC1: closed state lets requests pass through', () => {
+  const b = cb.create();
+  expect(cb.canPass(b, 0)).toBe(true);
+});
+
+test('#1279 AC1: consecutive failures below threshold keep state closed', () => {
+  const b = cb.create({ threshold: 3 });
+  cb.recordFailure(b, 100);
+  cb.recordFailure(b, 200);
+  expect(b.state).toBe(cb.STATES.closed);
+  expect(b.consecutiveFailures).toBe(2);
+});
+
+test('#1279 AC1: hitting threshold opens the breaker', () => {
+  const b = cb.create({ threshold: 3 });
+  cb.recordFailure(b, 100);
+  cb.recordFailure(b, 200);
+  cb.recordFailure(b, 300);
+  expect(b.state).toBe(cb.STATES.open);
+  expect(b.openedAt).toBe(300);
+});
+
+test('#1279 AC1: open state rejects requests before cool-off', () => {
+  const b = cb.create({ threshold: 1, coolOffMs: 1000 });
+  cb.recordFailure(b, 100);
+  expect(b.state).toBe(cb.STATES.open);
+  expect(cb.canPass(b, 500)).toBe(false);
+  expect(cb.canPass(b, 999)).toBe(false);
+});
+
+test('#1279 AC1: open → half-open transition after cool-off elapses', () => {
+  const b = cb.create({ threshold: 1, coolOffMs: 1000 });
+  cb.recordFailure(b, 100);
+  expect(cb.canPass(b, 1100)).toBe(true);
+  expect(b.state).toBe(cb.STATES.halfOpen);
+});
+
+test('#1279 AC1: half-open + success → closed (counter reset)', () => {
+  const b = cb.create({ threshold: 1, coolOffMs: 1000 });
+  cb.recordFailure(b, 100);
+  cb.canPass(b, 1100); // transitions to half-open
+  cb.recordSuccess(b);
+  expect(b.state).toBe(cb.STATES.closed);
+  expect(b.consecutiveFailures).toBe(0);
+});
+
+test('#1279 AC1: half-open + failure → open (cool-off restarts)', () => {
+  const b = cb.create({ threshold: 1, coolOffMs: 1000 });
+  cb.recordFailure(b, 100);
+  cb.canPass(b, 1100); // half-open
+  cb.recordFailure(b, 1200);
+  expect(b.state).toBe(cb.STATES.open);
+  expect(b.openedAt).toBe(1200);
+});
+
+test('#1279 AC1: success in closed state resets consecutiveFailures', () => {
+  const b = cb.create({ threshold: 3 });
+  cb.recordFailure(b, 100);
+  cb.recordFailure(b, 200);
+  expect(b.consecutiveFailures).toBe(2);
+  cb.recordSuccess(b);
+  expect(b.consecutiveFailures).toBe(0);
+  expect(b.state).toBe(cb.STATES.closed);
+});
+
+test('#1279 AC1: non-consecutive failures restart accumulation toward threshold', () => {
+  const b = cb.create({ threshold: 3 });
+  cb.recordFailure(b, 100);
+  cb.recordFailure(b, 200);
+  cb.recordSuccess(b);
+  cb.recordFailure(b, 300);
+  expect(b.state).toBe(cb.STATES.closed);
+  expect(b.consecutiveFailures).toBe(1);
+});
+
+test('#1279 AC1: status() emits state snapshot for telemetry', () => {
+  const b = cb.create({ threshold: 2, coolOffMs: 500 });
+  cb.recordFailure(b, 100);
+  const s = cb.status(b);
+  expect(s.state).toBe(cb.STATES.closed);
+  expect(s.consecutiveFailures).toBe(1);
+  expect(s.openedAt).toBe(0);
+  cb.recordFailure(b, 200);
+  expect(cb.status(b).state).toBe(cb.STATES.open);
+  expect(cb.status(b).openedAt).toBe(200);
+});
+
+test('#1279 AC2: integration — recovers cleanly from a burst then partial-fail then full-recover', () => {
+  const b = cb.create({ threshold: 3, coolOffMs: 1000 });
+  // burst of failures opens it
+  for (let i = 0; i < 3; i++) cb.recordFailure(b, 100 + i * 10);
+  expect(b.state).toBe(cb.STATES.open);
+  // wait → half-open
+  expect(cb.canPass(b, 1500)).toBe(true);
+  // partial fail
+  cb.recordFailure(b, 1500);
+  expect(b.state).toBe(cb.STATES.open);
+  expect(b.openedAt).toBe(1500);
+  // wait again → half-open → success → closed
+  expect(cb.canPass(b, 2700)).toBe(true);
+  cb.recordSuccess(b);
+  expect(b.state).toBe(cb.STATES.closed);
+  expect(b.consecutiveFailures).toBe(0);
+});
+
+test('#1279: STATES constants exported and frozen', () => {
+  expect(cb.STATES.closed).toBe('closed');
+  expect(cb.STATES.open).toBe('open');
+  expect(cb.STATES.halfOpen).toBe('half-open');
+  expect(() => { cb.STATES.foo = 'bar'; }).toThrow();
+});


### PR DESCRIPTION
## Summary

New `scripts/global/circuit-breaker.js` complements existing `backoff.js` to deliver the second primitive needed for production-grade rate-limit handling. Closes governance-audit `rate-limit-event-frequency` finding.

## What landed

| File | Lines | Role |
|---|---|---|
| `scripts/global/circuit-breaker.js` | 74 | Pure-state primitive |
| `tests/circuit-breaker.spec.js` | 129 | 14 Playwright tests |
| `.changes/unreleased/1279.md` | 32 | Changelog fragment |

## Primitive boundary

```
+--------------------+----------------------+----------------------+
| Concern            | backoff.js (exists)  | circuit-breaker.js   |
+--------------------+----------------------+----------------------+
| Recognize 429/503  | isRateLimitError()   | (caller signals)     |
| Wait between tries | backoff(attempt,opts)| -                    |
| Stop on N failures | -                    | recordFailure        |
| Fast-fail open     | -                    | canPass → false      |
| Probe one trial    | -                    | half-open state      |
| Recover on success | -                    | recordSuccess        |
+--------------------+----------------------+----------------------+
```

## State machine

```
closed ───[N failures]──→ open ─[cool-off]─→ half-open ──[success]──→ closed
                            ↑                    │
                            └───[failure]────────┘
```

## Test plan

- [x] `npx playwright test tests/circuit-breaker.spec.js` — 14/14 passing
- [x] `npm run lint` — green
- [x] `npm run format:check` — green
- [x] `npm run lint:readability:ci` — green
- [x] All 4 baton artifacts BEFORE PR

## Out of scope

- Wiring into specific dispatchers (opt-in adoption; module is callable now)
- Persisting state across processes (future enhancement)

Refs #1279
Closes #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)