### PR TITLE
docs(tests): test-discoverability convention #1489

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,35 @@
+# Tests directory conventions
+
+## Discoverability
+
+Every spec file under `tests/` must register tests via `@playwright/test` so they are collected by the project's test runner (`npm test` → `npx playwright test`):
+
+```js
+const { test, expect } = require('@playwright/test');
+// or
+import { test, expect } from '@playwright/test';
+```
+
+A spec file that uses bare `require('assert')` or its own IIFE sits in the test directory but Playwright registers zero tests from it. CI thinks the file is covered when nothing actually runs.
+
+**Enforced by:** `scripts/global/megalint/test-discoverability.js` (Epic #1510, PR #1522). The validator flags any `tests/*.spec.{js,ts}` file that does not import `@playwright/test`.
+
+## Opt-out (rare)
+
+If a `.spec.js` file is intentionally a CLI script and not meant to be Playwright-discovered, include this magic comment at the top:
+
+```js
+// @megalint:test-discoverability:opt-out — <reason>
+```
+
+Use sparingly. Prefer placing CLI scripts under `scripts/tools/` instead.
+
+## Fixtures + golden files
+
+Fixtures live under `tests/fixtures/`. Golden-file outputs from load tests (e.g., `sse-load-test-1000x5.json` from #1374) are committed for reproducibility — regenerate them via the corresponding npm script when intentional changes are made.
+
+## Related conventions
+
+- File-size cap (≤ 100 lines) does **not** apply to files under `tests/` (per `scripts/lint.js` IGNORE_PATHS).
+- Readability gate (`npm run lint:readability:ci`) does apply.
+- See `inventory/coding-practice-coverage.json` for the full lint coverage map.


### PR DESCRIPTION
## Summary

Closes #1489 honestly. Responds to Copilot Team review (2026-05-14) that flagged the premature `Closes #1489` trailer in PR #1522 — only AC3 (lint rule) was shipped there, ACs 1/2/4/5 were not.

## Current state of the 18-files finding

A recursive sweep of `tests/**` shows **0 of 136** spec files use bare `assert`. The original audit's "18 of 120" either was an overestimate at the time OR was resolved organically when Copilot Team's #1526 merge avoided shipping the would-be violators (e.g., `tests/cross-team-edit-warn.spec.js` from `feat/1298-crypto-signatures` never landed). Either way, current state has zero violations.

## What landed

| File | Lines | Role |
|---|---|---|
| `tests/README.md` | 35 | Convention doc (AC4) |

## Final AC state

- AC1: 0 violations (recursive grep verified)
- AC2: N/A — no files to convert
- AC3: `scripts/global/megalint/test-discoverability.js` ✓ (PR #1522)
- AC4: `tests/README.md` ✓ (this PR)
- AC5: 136/136 specs Playwright-discoverable (verified)

## Test plan

- [x] `npm run lint` — 339 files within 100-line limit
- [x] Recursive sweep confirms 0 bare-assert spec files

Refs #1489
Closes #1489

🤖 Generated with [Claude Code](https://claude.com/claude-code)