### PR TITLE
fix(workflows): post-merge race defensive skip #1541

### DIFF
--- a/.changes/unreleased/1541.md
+++ b/.changes/unreleased/1541.md
@@ -1,0 +1,36 @@
+## [Unreleased] — #1541: post-merge race fix (consultant-activation skips when terminal)
+
+### Added
+- `scripts/global/consultant-activation-decision.js` — pure decision function for the `consultant-activation` job in post-merge-automation. Returns `{action, reason, removeLabelsMatching, addLabels}` given `{state, labels, comments}`. Exports `decide`, `hasCloseoutComment`, `TERMINAL_LABELS`, `CLOSEOUT_HEADER_RE`.
+- `tests/consultant-activation-decision.spec.js` — 14 Playwright tests covering all four skip paths (closed-state, terminal-label, closeout-in-trail, not-at-testing) + standard-activation path + regex coverage + closeout-header variants (`##`, `**`, EPIC_CLOSEOUT) + malformed-input safety + priority-order tie-breakers.
+
+### Changed
+- `.github/workflows/post-merge-automation.yml` — `consultant-activation` job now:
+  1. Checks out the repo (needed to require the new module).
+  2. Fetches issue comments alongside labels.
+  3. Delegates the skip-vs-activate decision to the pure function.
+  4. Logs `decision=<action> reason=<reason>` per merge so the workflow run history shows which path was taken.
+
+### Why
+
+`consultant-activation` was racing with `label-lint`'s auto-transition (added in #1515). Sequence pre-fix:
+
+```
+T+0    PR merges → GitHub auto-closes issue
+T+0    label-lint fires on issues.closed → auto-transitions
+       status:testing → status:done + resolution:completed
+T+5s   post-merge-automation fires on pr.closed → fetches
+       labels (still status:testing from a stale snapshot in
+       the event payload) → overwrites status:done with
+       status:review + role:consultant
+T+10s  human notices messy labels, manually cleans up
+```
+
+Observed on **6 consecutive merges this session** (#1279, #1374, #1521, #1536, #1489, #1540). Each cost ~30s of manual cleanup.
+
+Path B from the Phase-0 design (this ticket's body §"Proposed fixes"): defensive skip rather than coordinated races. If issue is already at a terminal state OR a `CONSULTANT_CLOSEOUT` is in the trail, the consultant has already done their job — no activation needed.
+
+### Out of scope (this PR)
+- Coordinating two workflows via shared lock (#1541 Path A). The defensive-skip approach is simpler and equally effective.
+- Moving auto-transition into post-merge-automation entirely (#1541 Path C). Would centralize logic but increase blast radius.
+- Backfill of already-affected merges — that's operational cleanup (manual `gh issue edit` calls already done per-ticket).

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -19,9 +19,11 @@ jobs:
     permissions:
       issues: write
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
+            const decision = require('./scripts/global/consultant-activation-decision.js');
             const body = context.payload.pull_request.body || '';
             const refsMatch = body.match(/Refs\s+#(\d+)/i);
             if (!refsMatch) return;
@@ -31,9 +33,18 @@ jobs:
               owner: context.repo.owner, repo: context.repo.repo, issue_number: linkedNum,
             });
             const labels = issue.labels.map(l => l.name);
-            if (!labels.includes('status:testing')) return; // not at testing → skip
+            // #1541: fetch comments + apply pure decision to avoid racing
+            // label-lint's auto-transition. Skip when issue is already
+            // terminal OR CONSULTANT_CLOSEOUT exists in trail.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: linkedNum, per_page: 100,
+            });
+            const result = decision.decide({ state: issue.state, labels, comments });
+            console.log(`#${linkedNum}: consultant-activation decision=${result.action} reason=${result.reason}`);
+            if (result.action !== 'activate') return;
 
-            const remove = labels.filter(l => /^(status:|role:admin)/.test(l));
+            const remove = labels.filter(l => result.removeLabelsMatching.test(l));
             for (const l of remove) {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner, repo: context.repo.repo,
@@ -42,7 +53,7 @@ jobs:
             }
             await github.rest.issues.addLabels({
               owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: linkedNum, labels: ['status:review', 'role:consultant'],
+              issue_number: linkedNum, labels: result.addLabels,
             });
             const sha = context.payload.pull_request.merge_commit_sha?.slice(0, 7);
             const prUrl = context.payload.pull_request.html_url;

--- a/scripts/global/consultant-activation-decision.js
+++ b/scripts/global/consultant-activation-decision.js
@@ -1,0 +1,49 @@
+'use strict';
+// consultant-activation-decision — Epic-companion to #1515. Pure decision
+// function for the post-merge-automation `consultant-activation` job.
+// Without this guard, the workflow races with label-lint's auto-transition
+// (added in #1515): label-lint completes status:testing→status:done, then
+// consultant-activation reads pre-race labels and overrides back to
+// status:review + role:consultant. Pattern recurred on #1279, #1374,
+// #1521, #1536, #1489, #1540 before this fix.
+//
+// Decision rules:
+//   1. Issue is already terminal (status:done / status:cancelled OR state:
+//      closed) → skip; the lifecycle is complete.
+//   2. CONSULTANT_CLOSEOUT exists in the comment trail → skip; the
+//      consultant has already signed off, no activation needed.
+//   3. Issue not at status:testing → skip (existing behavior).
+//   4. Otherwise → activate (flip status:testing→status:review +
+//      role:consultant).
+
+const TERMINAL_LABELS = ['status:done', 'status:cancelled'];
+const CLOSEOUT_HEADER_RE = /(^|\n)\s*(?:\*\*|##\s+)?CONSULTANT_CLOSEOUT(?:_EPIC_CLOSEOUT)?\b/;
+
+function hasCloseoutComment(comments) {
+  return (comments || []).some((c) => CLOSEOUT_HEADER_RE.test((c && c.body) || ''));
+}
+
+function decide({ state, labels = [], comments = [] }) {
+  if (state === 'closed') {
+    return { action: 'skip', reason: 'issue-closed-terminal' };
+  }
+  if (labels.some((l) => TERMINAL_LABELS.includes(l))) {
+    return { action: 'skip', reason: 'already-terminal-label' };
+  }
+  if (hasCloseoutComment(comments)) {
+    return { action: 'skip', reason: 'closeout-already-posted' };
+  }
+  if (!labels.includes('status:testing')) {
+    return { action: 'skip', reason: 'not-at-status-testing' };
+  }
+  return {
+    action: 'activate',
+    removeLabelsMatching: /^(status:|role:admin)/,
+    addLabels: ['status:review', 'role:consultant'],
+    reason: 'standard-activation',
+  };
+}
+
+module.exports = {
+  decide, hasCloseoutComment, TERMINAL_LABELS, CLOSEOUT_HEADER_RE,
+};

--- a/tests/consultant-activation-decision.spec.js
+++ b/tests/consultant-activation-decision.spec.js
@@ -1,0 +1,112 @@
+// Tests for scripts/global/consultant-activation-decision.js (#1541).
+const { test, expect } = require('@playwright/test');
+const dec = require('../scripts/global/consultant-activation-decision');
+
+const closeoutComment = () => ({ body: '## CONSULTANT_CLOSEOUT\n\nrubric_rating: 9/10\n\nVerdict: APPROVED.' });
+const someOtherComment = () => ({ body: '## MANAGER_HANDOFF\n\n- scope: ...' });
+
+test('#1541 AC1: closed issue skips (already terminal)', () => {
+  const result = dec.decide({
+    state: 'closed', labels: ['status:testing', 'role:admin'], comments: [],
+  });
+  expect(result.action).toBe('skip');
+  expect(result.reason).toBe('issue-closed-terminal');
+});
+
+test('#1541 AC1: status:done label skips (label-lint already auto-transitioned)', () => {
+  const result = dec.decide({
+    state: 'open', labels: ['status:done', 'resolution:completed'], comments: [],
+  });
+  expect(result.action).toBe('skip');
+  expect(result.reason).toBe('already-terminal-label');
+});
+
+test('#1541 AC1: status:cancelled label skips', () => {
+  const result = dec.decide({
+    state: 'open', labels: ['status:cancelled'], comments: [],
+  });
+  expect(result.action).toBe('skip');
+  expect(result.reason).toBe('already-terminal-label');
+});
+
+test('#1541 AC1: closeout in trail skips (the core race-fix path)', () => {
+  // This is the exact race scenario: label-lint auto-transitioned to
+  // status:done, then post-merge-automation fetched stale labels showing
+  // status:testing. The closeout-in-trail check catches it.
+  const result = dec.decide({
+    state: 'open', labels: ['status:testing', 'role:admin'],
+    comments: [closeoutComment()],
+  });
+  expect(result.action).toBe('skip');
+  expect(result.reason).toBe('closeout-already-posted');
+});
+
+test('#1541 AC1: status not testing skips (existing behavior preserved)', () => {
+  const result = dec.decide({
+    state: 'open', labels: ['status:in-progress', 'role:collaborator'], comments: [],
+  });
+  expect(result.action).toBe('skip');
+  expect(result.reason).toBe('not-at-status-testing');
+});
+
+test('#1541 AC1: standard activation path still works', () => {
+  const result = dec.decide({
+    state: 'open', labels: ['status:testing', 'role:admin'], comments: [someOtherComment()],
+  });
+  expect(result.action).toBe('activate');
+  expect(result.addLabels).toEqual(['status:review', 'role:consultant']);
+  expect(result.removeLabelsMatching).toBeInstanceOf(RegExp);
+});
+
+test('#1541 AC1: removeLabelsMatching regex captures status:* and role:admin', () => {
+  const result = dec.decide({
+    state: 'open', labels: ['status:testing', 'role:admin'], comments: [],
+  });
+  const re = result.removeLabelsMatching;
+  expect(re.test('status:testing')).toBe(true);
+  expect(re.test('status:in-progress')).toBe(true);
+  expect(re.test('role:admin')).toBe(true);
+  expect(re.test('role:collaborator')).toBe(false);
+  expect(re.test('priority:P1')).toBe(false);
+  expect(re.test('area:scripts')).toBe(false);
+});
+
+test('#1541: hasCloseoutComment recognizes ## CONSULTANT_CLOSEOUT header', () => {
+  expect(dec.hasCloseoutComment([{ body: '## CONSULTANT_CLOSEOUT\n\nx' }])).toBe(true);
+});
+
+test('#1541: hasCloseoutComment recognizes **CONSULTANT_CLOSEOUT** bold form', () => {
+  expect(dec.hasCloseoutComment([{ body: '**CONSULTANT_CLOSEOUT** inline\n\nx' }])).toBe(true);
+});
+
+test('#1541: hasCloseoutComment recognizes EPIC variant', () => {
+  expect(dec.hasCloseoutComment([{ body: '## CONSULTANT_CLOSEOUT_EPIC_CLOSEOUT\n\nx' }])).toBe(true);
+});
+
+test('#1541: hasCloseoutComment ignores non-closeout comments', () => {
+  expect(dec.hasCloseoutComment([
+    { body: '## MANAGER_HANDOFF\n\n- scope: ...' },
+    { body: 'A discussion comment mentioning CONSULTANT_CLOSEOUT in prose' },
+  ])).toBe(false);
+});
+
+test('#1541: malformed comment entries handled safely', () => {
+  expect(dec.hasCloseoutComment([null, {}, { body: null }, closeoutComment()])).toBe(true);
+  expect(dec.hasCloseoutComment([])).toBe(false);
+  expect(dec.hasCloseoutComment(null)).toBe(false);
+});
+
+test('#1541 AC1: priority order — closed state wins over closeout-in-trail', () => {
+  // Both conditions hold; closed-state check runs first.
+  const result = dec.decide({
+    state: 'closed', labels: ['status:testing'], comments: [closeoutComment()],
+  });
+  expect(result.reason).toBe('issue-closed-terminal');
+});
+
+test('#1541 AC1: priority order — terminal-label wins over closeout-in-trail', () => {
+  const result = dec.decide({
+    state: 'open', labels: ['status:done'], comments: [closeoutComment()],
+  });
+  expect(result.reason).toBe('already-terminal-label');
+});


### PR DESCRIPTION
## Summary

Eliminates the recurring post-merge race that overwrote `status:done` with `status:review + role:consultant` on 6 consecutive merges this session (#1279, #1374, #1521, #1536, #1489, #1540).

## The race

```
T+0    PR merges → GitHub auto-closes issue
T+0    label-lint fires → my #1515 fix auto-transitions
       status:testing → status:done + resolution:completed
T+5s   post-merge-automation fires with stale-snapshot labels
       (still status:testing) → overwrites status:done with
       status:review + role:consultant   ✗
T+30s  human cleans up labels manually
```

## Fix (Path B — defensive skip)

Pure decision function skips activation when:
- Issue state is `closed`
- `status:done` or `status:cancelled` label present
- `CONSULTANT_CLOSEOUT` in comment trail
- Status not `status:testing` (pre-existing behavior)

## What landed

| File | Lines | Role |
|---|---|---|
| `scripts/global/consultant-activation-decision.js` | 49 | Pure decision function |
| `tests/consultant-activation-decision.spec.js` | 112 | 14 Playwright tests |
| `.github/workflows/post-merge-automation.yml` | 94 | + checkout, + comments fetch, + decision delegate |
| `.changes/unreleased/1541.md` | 33 | Changelog |

## Eat-own-dogfood

This PR's own merge IS the integration test. If the race-fix works, #1541 lands at `status:done` automatically.

## Test plan

- [x] 14/14 unit tests passing
- [x] lint / format / readability all green
- [x] All 4 baton artifacts BEFORE PR

Refs #1541
Closes #1541
Refs #1515

🤖 Generated with [Claude Code](https://claude.com/claude-code)