### PR TITLE
feat(governance): enforce flaw-recognition anneal discipline

### DIFF
--- a/.github/workflows/closeout-lint.yml
+++ b/.github/workflows/closeout-lint.yml
@@ -53,6 +53,7 @@ jobs:
             const mh = megalint.run('manager-handoff', input);
             const cl = megalint.run('consultant-closeout', input);
             const pg = megalint.run('merge-evidence-pr-gate', input);
+            const fe = megalint.run('flaw-emission', input);
 
             const violations = [];
             const aliasViolations = [];
@@ -85,8 +86,29 @@ jobs:
 
             const summary = `closeout-schema: manager-handoff=${mh.found ? (mh.ok ? 'PASS' : 'FAIL') : 'absent'} `
               + `consultant-closeout=${cl.found ? (cl.ok ? 'PASS' : 'FAIL') : 'absent'} `
-              + `merge-evidence-pr-gate=${pg.skipped ? `SKIP:${pg.skipped}` : (pg.ok ? 'PASS' : 'FAIL')}`;
+              + `merge-evidence-pr-gate=${pg.skipped ? `SKIP:${pg.skipped}` : (pg.ok ? 'PASS' : 'FAIL')} `
+              + `flaw-emission=${fe.skipped ? `SKIP:${fe.skipped}` : (fe.ok ? 'PASS' : 'ADVISORY')}`;
             console.log(summary);
+
+            const advisoryMarker = '<!-- flaw-emission-advisory -->';
+            if (!fe.ok) {
+              const advisory = `${advisoryMarker}\n## ⚠️ Mid-flight flaw accounting advisory\n\n`
+                + `Detected ${fe.mentions} flaw mention(s) in baton artifacts with missing artifact citation nearby.\n`
+                + `For each flaw mention, include one of: issue ref (#N), incidents.jsonl pattern_id, memory note path, or anneal_tickets_filed entry.\n\n`
+                + fe.violations.map(v => `- ${v.detail}`).join('\n');
+              const existing = comments.find(c => (c.body || '').includes(advisoryMarker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: existing.id, body: advisory,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: linkedIssue, body: advisory,
+                });
+              }
+            }
 
             if (violations.length) {
               core.setFailed(

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -36,7 +36,7 @@ deferred       role:manager        Epic-only: blocked, no ETA (Rule E5)
 - `ready → in-progress`: Collaborator picks up; applies `role:collaborator`.
 - `in-progress → testing`: COLLABORATOR_HANDOFF; all ACs ✅; swap to `role:admin`.
 - `testing → review`: ADMIN_HANDOFF; all gates pass; swap to `role:consultant`.
-- `review → done`: CONSULTANT_CLOSEOUT; remove `role:consultant`; close issue (atomic). Must declare `anneal_tickets_filed: [#N,...] | none`.
+- `review → done`: CONSULTANT_CLOSEOUT; remove `role:consultant`; close issue (atomic). Must declare `anneal_tickets_filed: [#N,...] | none` and `mid_flight_flaws:` accounting.
 - `any → cancelled`: Manager authority — remove current `role:*`; post `CANCELLATION: <reason>`; close as "not planned".
 - `in-progress ↔ dormant` (Epic-only): Manager pauses; carries `role:manager` per Rule E2.
 - `in-progress ↔ deferred` (Epic-only): Manager flags external blocker; carries `role:manager`.
@@ -69,6 +69,17 @@ on issues closed >30 days. Archived tickets are excluded from all dashboard and 
 - `ADMIN_HANDOFF` signer identity must differ from `COLLABORATOR_HANDOFF`.
 - All governed work requires a GitHub issue and `Refs #N` in the PR body; workflow identity resolution follows `instructions/team-model-in-workflows.instructions.md`.
 - Skip baton only for: single Q&A, read-only lookup, no file edits, no state-changing tool calls.
+
+## Flaw-recognition anneal decision (required)
+
+When any active role recognizes a flaw/error during execution, it must record one explicit decision:
+- `file-ticket` — structural/repeatable gap; include `#N`
+- `log-incident-only` — one-off operational event; include `incidents.jsonl`/`pattern_id`
+- `memory-note-only` — judgment/process note with no immediate code/process delta; include memory path
+- `no-action-justified` — include a short rationale
+
+This decision must be cited in baton artifacts and summarized in `CONSULTANT_CLOSEOUT` under:
+- `mid_flight_flaws: [<flaw>, decision=<...>, artifact=<...>]`
 
 ## Enforcement Points
 

--- a/scripts/global/megalint/flaw-emission.js
+++ b/scripts/global/megalint/flaw-emission.js
@@ -1,0 +1,51 @@
+'use strict';
+// flaw-emission — detects mid-flight flaw mentions lacking anneal artifact citations.
+
+const MARKERS = [/\bI had to\b/i, /\bworked around\b/i, /\bside-?effect\b/i, /\bflaw\b/i, /\bbug\b/i, /\bfailure\b/i, /\bincident\b/i];
+const CITE = /#\d+|incidents\.jsonl|pattern_id\s*:|anneal_tickets_filed\s*:|memory\//i;
+
+function findArtifacts(comments) {
+  const out = [];
+  for (const c of comments || []) {
+    const body = c.body || '';
+    if (/(COLLABORATOR_HANDOFF|CONSULTANT_CLOSEOUT|ADMIN_HANDOFF)/.test(body)) out.push(body);
+  }
+  return out;
+}
+
+function detectMentions(text) {
+  const lines = String(text || '').split('\n');
+  const hits = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (MARKERS.some(r => r.test(lines[i]))) hits.push({ line: i, text: lines[i].trim() });
+  }
+  return { lines, hits };
+}
+
+function citedNear(lines, line) {
+  const start = Math.max(0, line - 2);
+  const end = Math.min(lines.length - 1, line + 2);
+  for (let i = start; i <= end; i++) if (CITE.test(lines[i])) return true;
+  return false;
+}
+
+function validate(input) {
+  const artifacts = findArtifacts(input.comments || []);
+  const violations = [];
+  let mentions = 0;
+  for (const body of artifacts) {
+    const { lines, hits } = detectMentions(body);
+    mentions += hits.length;
+    for (const hit of hits) {
+      if (!citedNear(lines, hit.line)) {
+        violations.push({
+          rule: 'flaw-mention-missing-anneal-artifact',
+          detail: `Flaw mention lacks ticket/incident/memory citation near: "${hit.text}"`,
+        });
+      }
+    }
+  }
+  return { ok: violations.length === 0, violations, mentions, skipped: mentions === 0 ? 'no-flaw-mentions' : undefined };
+}
+
+module.exports = { validate, detectMentions, citedNear, findArtifacts };

--- a/scripts/global/megalint/index.js
+++ b/scripts/global/megalint/index.js
@@ -17,6 +17,7 @@ const lintAsAc = require('./lint-as-ac.js');
 const workflowShaPin = require('./workflow-sha-pin.js');
 const testDiscoverability = require('./test-discoverability.js');
 const signerFormatCanonical = require('./signer-format-canonical.js');
+const flawEmission = require('./flaw-emission.js');
 
 const VALIDATORS = {
   'manager-handoff': manager,
@@ -32,6 +33,7 @@ const VALIDATORS = {
   'workflow-sha-pin': workflowShaPin,
   'test-discoverability': testDiscoverability,
   'signer-format-canonical': signerFormatCanonical,
+  'flaw-emission': flawEmission,
 };
 
 function runAll(input) {

--- a/tests/megalint-flaw-emission.spec.js
+++ b/tests/megalint-flaw-emission.spec.js
@@ -1,0 +1,31 @@
+const { test, expect } = require('@playwright/test');
+const rule = require('../scripts/global/megalint/flaw-emission');
+
+const c = body => ({ body });
+
+test('#1555: skip when no flaw mentions', () => {
+  const result = rule.validate({ comments: [c('## COLLABORATOR_HANDOFF\nAll good.')] });
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('no-flaw-mentions');
+});
+
+test('#1555 AC2: passes when flaw mention includes nearby artifact citation', () => {
+  const body = '## CONSULTANT_CLOSEOUT\nI had to work around a side-effect\nartifact: #1554';
+  const result = rule.validate({ comments: [c(body)] });
+  expect(result.ok).toBe(true);
+  expect(result.mentions).toBeGreaterThan(0);
+});
+
+test('#1555 AC2: fails when flaw mention lacks citation', () => {
+  const body = '## COLLABORATOR_HANDOFF\nI had to patch around a bug in workflow';
+  const result = rule.validate({ comments: [c(body)] });
+  expect(result.ok).toBe(false);
+  expect(result.violations[0].rule).toBe('flaw-mention-missing-anneal-artifact');
+});
+
+test('#1555: registered in megalint VALIDATORS map', () => {
+  const megalint = require('../scripts/global/megalint');
+  expect(megalint.VALIDATORS).toHaveProperty('flaw-emission');
+  const result = megalint.run('flaw-emission', { comments: [c('## CONSULTANT_CLOSEOUT\nflaw fixed\n#1')] });
+  expect(result.ok).toBe(true);
+});


### PR DESCRIPTION
## Summary\n- add megalint validator  to detect mid-flight flaw mentions lacking artifact citations\n- wire advisory-first reporting into closeout-lint with issue comment marker\n- add explicit flaw-recognition decision protocol to role baton routing instructions\n- add tests covering skip/pass/fail and megalint registration\n\n## Validation\n- runTests: tests/megalint-flaw-emission.spec.js + tests/megalint-merge-evidence-pr-gate.spec.js (17 passed)\n- npm run lint (pass)\n\nRefs #1555\n\nSigned-by: Coda Mason\nTeam&Model: copilot:gpt-5.3-codex@github-copilot\nRole: collaborator