### PR TITLE
refactor(scripts): clear readability warnings #1549

### DIFF
--- a/.changes/unreleased/1549.md
+++ b/.changes/unreleased/1549.md
@@ -1,0 +1,20 @@
+## [Unreleased] — #1549: readability cleanup, restore lint cap 430 → 420
+
+### Changed
+- `scripts/quota-probes.js` — extracted 5 named constants (`HTTP_OK`, `HTTP_BAD_GATEWAY`, `HTTP_GATEWAY_TIMEOUT`, `DEFAULT_TIMEOUT_MS`, `GROQ_TIMEOUT_MS`); renamed single-letter vars (`h`/`r`/`c`) to descriptive (`headers`/`response`/`chunk`); extracted `parseGroqHeaders(headers)` helper to bring `probeGroq` from 39 lines under the 30-line cap.
+- `scripts/wiki/anneal.js` — renamed single-letter vars (`t`→`normTarget`, `s`→`slug`, `p`→`page`, inner `s`→`input`, destructured `l`→`link`). Behavior unchanged.
+- `package.json` — `lint:readability:ci` cap restored: `--max-warnings=430` → `--max-warnings=420`.
+- `README.md` — script-table mirror updated by package-scripts sync.
+
+### Why
+Closes #1549. PR #1550 (the self-symlink cascade fix) raised the readability cap from 420 → 430 to unblock — a tactical workaround, not the fix. This PR retires the workaround by clearing the actual warnings (421 → 408, Δ −13) and restoring the cap to 420. Both files (`quota-probes.js`, `wiki/anneal.js`) called out in #1549 are now zero-warning.
+
+### Verification
+- `npm run lint:readability` total: **421 → 408** (Δ −13).
+- `npm run lint:readability:ci` with cap=420: exit=0 ✓.
+- `npm test`: 993 passed, 1 flaky (pre-existing `docs-anchors`), 4 skipped, exit=0.
+- Smoke test on refactored quota-probes module exports: all 4 functions load.
+
+### Out of scope (this PR)
+- Other files with residual warnings (`scripts/global/anneal-*`, `scripts/sse-handler.js`, `scripts/wiki/{ingest,lint,retrieval,search,wiki-io}.js`, `scripts/wiki-pages-api.js`, `scripts/validate-plugin-compat.js`, etc.) — leave for future P3 follow-ups when cap can drop further.
+- Tightening cap below 420 — current headroom of 12 absorbs near-term drift; further tightening risks flakiness.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ npm run deploy:both:apply
 | `lint:md` | `markdownlint-cli2 '**/*.md' '!node_modules/**' '!research/**' '!wiki/sources/**' '!wiki/syntheses/**' '!raw/**' '!.dashboard/**' '!CHANGELOG-archive.md' '!tickets/**' '!planning/**'` |
 | `lint:py` | `ruff check --config lint-configs/ruff.devenv.toml hooks/scripts/` |
 | `lint:readability` | `node scripts/lint-readability.js` |
-| `lint:readability:ci` | `node scripts/lint-readability.js --max-warnings=430` |
+| `lint:readability:ci` | `node scripts/lint-readability.js --max-warnings=420` |
 | `lint:router` | `node scripts/lint-router.js` |
 | `lint:sh` | `find scripts -name '*.sh' -exec shellcheck {} +` |
 | `mailbox:flush` | `node scripts/global/mailbox-outbox.js flush` |

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules/**' '!research/**' '!wiki/sources/**' '!wiki/syntheses/**' '!raw/**' '!.dashboard/**' '!CHANGELOG-archive.md' '!tickets/**' '!planning/**'",
     "lint:py": "ruff check --config lint-configs/ruff.devenv.toml hooks/scripts/",
     "lint:readability": "node scripts/lint-readability.js",
-    "lint:readability:ci": "node scripts/lint-readability.js --max-warnings=430",
+    "lint:readability:ci": "node scripts/lint-readability.js --max-warnings=420",
     "lint:router": "node scripts/lint-router.js",
     "lint:sh": "find scripts -name '*.sh' -exec shellcheck {} +",
     "mailbox:flush": "node scripts/global/mailbox-outbox.js flush",

--- a/scripts/quota-probes.js
+++ b/scripts/quota-probes.js
@@ -3,18 +3,39 @@
 
 const https = require('https');
 
-function probeWithHeaders(url, headers, timeout = 5000) {
+const HTTP_OK = 200;
+const HTTP_BAD_GATEWAY = 502;
+const HTTP_GATEWAY_TIMEOUT = 504;
+const DEFAULT_TIMEOUT_MS = 5000;
+const GROQ_TIMEOUT_MS = 8000;
+
+function probeWithHeaders(url, headers, timeout = DEFAULT_TIMEOUT_MS) {
   return new Promise(resolve => {
-    const req = https.get(url, { headers, timeout }, r => {
+    const req = https.get(url, { headers, timeout }, response => {
       let body = '';
-      r.on('data', c => body += c);
-      r.on('end', () => resolve({
-        status: r.statusCode, body, headers: r.headers
+      response.on('data', chunk => body += chunk);
+      response.on('end', () => resolve({
+        status: response.statusCode, body, headers: response.headers
       }));
     });
-    req.on('error', () => resolve({ status: 502, body: '{}', headers: {} }));
-    req.on('timeout', () => { req.destroy(); resolve({ status: 504, body: '{}', headers: {} }); });
+    req.on('error', () => resolve({ status: HTTP_BAD_GATEWAY, body: '{}', headers: {} }));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({ status: HTTP_GATEWAY_TIMEOUT, body: '{}', headers: {} });
+    });
   });
+}
+
+function parseGroqHeaders(headers) {
+  return {
+    id: 'groq',
+    limitReqs: +(headers['x-ratelimit-limit-requests'] || 0),
+    remainReqs: +(headers['x-ratelimit-remaining-requests'] || 0),
+    limitTokens: +(headers['x-ratelimit-limit-tokens'] || 0),
+    remainTokens: +(headers['x-ratelimit-remaining-tokens'] || 0),
+    resetReqs: headers['x-ratelimit-reset-requests'] || '',
+    resetTokens: headers['x-ratelimit-reset-tokens'] || '',
+  };
 }
 
 /** Groq: make tiny completion to read rate-limit headers */
@@ -26,31 +47,20 @@ async function probeGroq() {
     messages: [{ role: 'user', content: 'ping' }],
     max_tokens: 1
   });
+  const opts = {
+    hostname: 'api.groq.com', path: '/openai/v1/chat/completions',
+    method: 'POST', timeout: GROQ_TIMEOUT_MS,
+    headers: {
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(payload)
+    }
+  };
   return new Promise(resolve => {
-    const opts = {
-      hostname: 'api.groq.com', path: '/openai/v1/chat/completions',
-      method: 'POST', timeout: 8000,
-      headers: {
-        Authorization: `Bearer ${key}`,
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(payload)
-      }
-    };
-    const req = https.request(opts, r => {
+    const req = https.request(opts, response => {
       let body = '';
-      r.on('data', c => body += c);
-      r.on('end', () => {
-        const h = r.headers;
-        resolve({
-          id: 'groq',
-          limitReqs: +(h['x-ratelimit-limit-requests'] || 0),
-          remainReqs: +(h['x-ratelimit-remaining-requests'] || 0),
-          limitTokens: +(h['x-ratelimit-limit-tokens'] || 0),
-          remainTokens: +(h['x-ratelimit-remaining-tokens'] || 0),
-          resetReqs: h['x-ratelimit-reset-requests'] || '',
-          resetTokens: h['x-ratelimit-reset-tokens'] || '',
-        });
-      });
+      response.on('data', chunk => body += chunk);
+      response.on('end', () => resolve(parseGroqHeaders(response.headers)));
     });
     req.on('error', () => resolve({ id: 'groq', error: 'unreachable' }));
     req.on('timeout', () => { req.destroy(); resolve({ id: 'groq', error: 'timeout' }); });
@@ -63,10 +73,10 @@ async function probeGoogle() {
   const key = process.env.GOOGLE_AI_STUDIO_API_KEY;
   if (!key) return { id: 'google-ai', error: 'no key' };
   const url = `https://generativelanguage.googleapis.com/v1beta/models?key=${key}`;
-  const r = await probeWithHeaders(url, {});
-  if (r.status !== 200) return { id: 'google-ai', error: `HTTP ${r.status}` };
+  const response = await probeWithHeaders(url, {});
+  if (response.status !== HTTP_OK) return { id: 'google-ai', error: `HTTP ${response.status}` };
   try {
-    const data = JSON.parse(r.body);
+    const data = JSON.parse(response.body);
     return {
       id: 'google-ai', status: 'active',
       models: (data.models || []).length,
@@ -79,10 +89,10 @@ async function probeCerebras() {
   const key = process.env.CEREBRAS_API_KEY;
   if (!key) return { id: 'cerebras', error: 'no key' };
   const url = 'https://api.cerebras.ai/v1/models';
-  const r = await probeWithHeaders(url, { Authorization: `Bearer ${key}` });
-  if (r.status !== 200) return { id: 'cerebras', error: `HTTP ${r.status}` };
+  const response = await probeWithHeaders(url, { Authorization: `Bearer ${key}` });
+  if (response.status !== HTTP_OK) return { id: 'cerebras', error: `HTTP ${response.status}` };
   try {
-    const data = JSON.parse(r.body);
+    const data = JSON.parse(response.body);
     return { id: 'cerebras', status: 'active', models: (data.data || []).length };
   } catch (e) { return { id: 'cerebras', error: 'parse error' }; }
 }

--- a/scripts/wiki/anneal.js
+++ b/scripts/wiki/anneal.js
@@ -9,10 +9,10 @@ const APPLY = process.argv.includes('--apply');
 const fixes = { broken: [], orphans: [], frontmatter: [] };
 
 function fuzzyMatch(target, slugs) {
-  const norm = (s) => s.replace(/[-_]/g, '').toLowerCase();
-  const t = norm(target);
-  for (const s of slugs) {
-    if (norm(s).includes(t) || t.includes(norm(s))) return s;
+  const norm = (input) => input.replace(/[-_]/g, '').toLowerCase();
+  const normTarget = norm(target);
+  for (const slug of slugs) {
+    if (norm(slug).includes(normTarget) || normTarget.includes(norm(slug))) return slug;
   }
   return null;
 }
@@ -35,9 +35,9 @@ function fixBrokenLinks(pages, allSlugs) {
 
 function fixOrphans(pages, allSlugs) {
   const inbound = new Set();
-  for (const p of pages) {
-    const content = fs.readFileSync(p.path, 'utf-8');
-    for (const [, l] of content.matchAll(/\[\[([^\]]+)\]\]/g)) inbound.add(l);
+  for (const page of pages) {
+    const content = fs.readFileSync(page.path, 'utf-8');
+    for (const [, link] of content.matchAll(/\[\[([^\]]+)\]\]/g)) inbound.add(link);
   }
   const indexPath = path.join(WIKI_DIR, 'index.md');
   let idx = fs.readFileSync(indexPath, 'utf-8');


### PR DESCRIPTION
## Summary

- Clears residual readability warnings in `scripts/quota-probes.js` (constants extracted, single-letter vars renamed, `probeGroq` decomposed) and `scripts/wiki/anneal.js` (single-letter vars renamed).
- Restores `lint:readability:ci` cap from 430 back to 420 — retires the tactical bump from PR #1550 now that the actual count is below 420.
- Net: 421 → 408 readability warnings (Δ −13), both target files zero-warning, `npm test` 993 passed.

Closes #1549
Refs #1549

## Baton artifacts (all 4 posted on issue before PR open)

### MANAGER_HANDOFF

Scoped readability cleanup of `quota-probes.js` + `wiki/anneal.js`; `test_strategy: tdd-pyramid`; lane `code-change`; cap restoration as final AC.
Full: https://github.com/chf3198/megingjord-harness/issues/1549#issuecomment-4454918424
Signed-by: Orla Mason · Team&Model: claude-code:opus-4-7@anthropic · Role: manager

### COLLABORATOR_HANDOFF

Implemented: 5 named constants in quota-probes.js, renamed h/r→headers/response, extracted `parseGroqHeaders` to fit 30-line cap; renamed t/s/p/l in anneal.js. All 5 ACs ticked.
Full: https://github.com/chf3198/megingjord-harness/issues/1549#issuecomment-4454989464
Signed-by: Orla Harper · Team&Model: claude-code:opus-4-7@anthropic · Role: collaborator

### ADMIN_HANDOFF

Branch `refactor/1549-readability-cleanup` off `b4ab8fd`; commit `4682106`; pre-push hooks green; `lint:readability:ci` cap=420 passes; sync-verification N/A (no runtime artifact); `.changes/unreleased/1549.md` created.
Full: https://github.com/chf3198/megingjord-harness/issues/1549#issuecomment-4455008780
Signed-by: Orla Reyes · Team&Model: claude-code:opus-4-7@anthropic · Role: admin

### CONSULTANT_CLOSEOUT

Rubric 9/10 (G1=10, G2=9, G3=10, G4=10, G5=10, G6=9, G7=10, G8=8, G9=10; mean 9.6). Verdict APPROVED / SHIP. `anneal_tickets_filed: none`; `mid_flight_flaws: none`.
Full: https://github.com/chf3198/megingjord-harness/issues/1549#issuecomment-4455010896
Signed-by: Orla Vale · Team&Model: claude-code:opus-4-7@anthropic · Role: consultant

## Test plan

- [x] `npm run lint:readability` baseline = 421, post = 408
- [x] `npm run lint:readability:ci` (cap=420) exit=0
- [x] `npm test` 993 passed, 1 pre-existing flaky (`docs-anchors`), 4 skipped, exit=0
- [x] `node -e "const p=require('./scripts/quota-probes'); ..."` — all 4 exports load
- [x] `grep` confirms both target files are now zero-warning
- [x] pre-push hook gate passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)