### PR TITLE
fix(hamr): repair push auth + quota freshness (#1415)

### DIFF
--- a/cloudflare/hamr/routes/cache-stats.ts
+++ b/cloudflare/hamr/routes/cache-stats.ts
@@ -4,6 +4,8 @@
 import type { Env } from '../worker';
 
 const HIT_RATE_KEY = 'cache-stats:hit-rate-7d';
+const STALE_KEY = 'cache-stats:hit-rate-7d:stale';
+const LAST_UPDATE_KEY = 'cache-stats:last-update-ms';
 const MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function unauthorized(reason: string): Response {
@@ -61,6 +63,9 @@ export async function cacheStats(request: Request, env: Env): Promise<Response> 
   });
   await env.HAMR_KV.put(HIT_RATE_KEY, String(payload.hit_rate));
   await env.HAMR_KV.put(`${HIT_RATE_KEY}:meta`, record);
+    const now = Date.now();
+    await env.HAMR_KV.put(LAST_UPDATE_KEY, String(now));
+    await env.HAMR_KV.put(STALE_KEY, 'false');
   return new Response(JSON.stringify({ ok: true, written: HIT_RATE_KEY, hit_rate: payload.hit_rate }), {
     status: 200, headers: { 'content-type': 'application/json' },
   });

--- a/docs/howto/hamr-push-auth.md
+++ b/docs/howto/hamr-push-auth.md
@@ -1,0 +1,48 @@
+# HAMR Cache-Stats Push Auth — Runbook
+
+## Overview
+
+`cache-stats-push.js` posts a signed Ed25519 payload to `POST /cache-stats`
+on the HAMR Cloudflare Worker. The worker verifies the signature against the
+registered public key in the `PUBLISHER_KEYRING` secret.
+
+## Error: `unknown_key_id`
+
+The `x-hamr-key-id` header value is not present in `PUBLISHER_KEYRING`.
+
+**Fix:**
+1. Derive the SPKI from the operator key that will sign requests:
+   ```sh
+   node -e "
+   const crypto = require('node:crypto');
+   const seed = Buffer.from(process.env.OPERATOR_KEY_SEED_B64, 'base64');
+   const der = Buffer.concat([Buffer.from('302e020100300506032b657004220420','hex'),seed]);
+   const priv = crypto.createPrivateKey({key:der,format:'der',type:'pkcs8'});
+   const spki = crypto.createPublicKey(priv).export({type:'spki',format:'der'}).toString('base64');
+   console.log(JSON.stringify({'operator-default':spki}));
+   "
+   ```
+2. Pipe the output to `wrangler secret put`:
+   ```sh
+   echo '<json-from-step-1>' | \
+     CLOUDFLARE_API_TOKEN=<token> npx wrangler secret put PUBLISHER_KEYRING \
+     --config cloudflare/hamr/wrangler.toml
+   ```
+3. Retry `node scripts/global/cache-stats-push.js`.
+
+## Error: `no_publisher_keyring_configured`
+
+The `PUBLISHER_KEYRING` secret is not set on the Worker at all.
+Run step 2 above to create it.
+
+## Error: `bad_signature`
+
+The key in `PUBLISHER_KEYRING` does not match the key signing the request.
+Ensure `OPERATOR_KEY_SEED_B64` in `.env` corresponds to the registered SPKI.
+
+## Verifying Quota Freshness
+
+After a successful push, `/quota` should show `stale: false`:
+```sh
+curl -s https://hamr.chf3198.workers.dev/quota | jq '{hit_rate_7d,stale,last_update_ms}'
+```

--- a/scripts/global/cache-stats-push.js
+++ b/scripts/global/cache-stats-push.js
@@ -53,8 +53,19 @@ async function pushHitRate(opts = {}) {
 if (require.main === module) {
   pushHitRate().then((result) => {
     console.log(JSON.stringify(result, null, 2));
+      if (!result.ok && result.status === 401) emitAuthError(result);
     process.exit(result.ok ? 0 : 1);
   }).catch((err) => { console.error(err.message); process.exit(1); });
 }
+
+  function emitAuthError(result) {
+    const reason = result.response?.reason ?? 'unknown';
+    const hint = reason === 'unknown_key_id'
+      ? 'Register SPKI in PUBLISHER_KEYRING: see docs/howto/hamr-push-auth.md'
+      : reason === 'no_publisher_keyring_configured'
+        ? 'Set PUBLISHER_KEYRING wrangler secret: see docs/howto/hamr-push-auth.md'
+        : `Check KEY_ID + key material. Reason: ${reason}`;
+    process.stderr.write(`[cache-stats-push] 401 auth failure — ${hint}\n`);
+  }
 
 module.exports = { pushHitRate, canonicalize, loadEd25519Key };

--- a/tests/hamr-push-auth-1415.spec.js
+++ b/tests/hamr-push-auth-1415.spec.js
@@ -1,0 +1,68 @@
+// cache-stats-push auth regression (#1415): PUBLISHER_KEYRING + stale/last_update fix.
+const { test, expect } = require('@playwright/test');
+const crypto = require('node:crypto');
+const path = require('path');
+
+const PUSH = require(path.resolve(__dirname, '..', 'scripts', 'global', 'cache-stats-push.js'));
+const BASE = 'https://hamr.chf3198.workers.dev';
+
+function makeSeed32() { return Buffer.alloc(32, 0xab); }
+function deriveKeyPair(seed) {
+  const der = Buffer.concat([
+    Buffer.from('302e020100300506032b657004220420', 'hex'), seed,
+  ]);
+  const priv = crypto.createPrivateKey({ key: der, format: 'der', type: 'pkcs8' });
+  const pub = crypto.createPublicKey(priv);
+  return { priv, spkiB64: pub.export({ type: 'spki', format: 'der' }).toString('base64') };
+}
+
+test('emitAuthError helper: exports present', () => {
+  expect(typeof PUSH.canonicalize).toBe('function');
+  expect(typeof PUSH.loadEd25519Key).toBe('function');
+  expect(typeof PUSH.pushHitRate).toBe('function');
+});
+
+test('signature is verifiable by webcrypto (cross-runtime)', async () => {
+  const { webcrypto } = crypto;
+  const { priv, spkiB64 } = deriveKeyPair(makeSeed32());
+  const msg = PUSH.canonicalize({ hit_rate: 0.5, sample_count: 8, ts: 9000 });
+  const sigB64 = crypto.sign(null, Buffer.from(msg), priv).toString('base64');
+  const spki = Uint8Array.from(atob(spkiB64), (c) => c.charCodeAt(0));
+  const sigBytes = Uint8Array.from(atob(sigB64), (c) => c.charCodeAt(0));
+  const key = await webcrypto.subtle.importKey(
+    'spki', spki, { name: 'Ed25519' }, false, ['verify'],
+  );
+  const ok = await webcrypto.subtle.verify('Ed25519', key, sigBytes, new TextEncoder().encode(msg));
+  expect(ok).toBe(true);
+});
+
+test.describe('live /cache-stats — registered key (#1415)', () => {
+  test('/cache-stats returns 401 unknown_key_id for unregistered key_id', async ({ request }) => {
+    const seed = Buffer.alloc(32, 0xff);
+    const { priv, spkiB64: _ } = deriveKeyPair(seed);
+    const payload = { hit_rate: 0.5, sample_count: 4, ts: Date.now() };
+    const canonical = PUSH.canonicalize(payload);
+    const sig = crypto.sign(null, Buffer.from(canonical), priv).toString('base64');
+    const r = await request.post(`${BASE}/cache-stats`, {
+      data: payload,
+      headers: {
+        authorization: 'DPoP cache-stats-push',
+        'x-hamr-key-id': 'unregistered-key-1415',
+        'x-hamr-signature': sig,
+        'x-hamr-canonical': canonical,
+      },
+    });
+    expect(r.status()).toBe(401);
+    const body = await r.json();
+    expect(body.reason).toBe('unknown_key_id');
+  });
+
+  test('/quota reflects fresh hit_rate_7d after successful push', async ({ request }) => {
+    const r = await request.get(`${BASE}/quota`);
+    expect(r.status()).toBe(200);
+    const body = await r.json();
+    expect(typeof body.hit_rate_7d).toBe('number');
+    expect(body.stale).toBe(false);
+    expect(typeof body.last_update_ms).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes HAMR telemetry push auth (401 unknown_key_id) and quota stale state.

### Root Cause
`PUBLISHER_KEYRING` Cloudflare secret was never populated — worker had no authorized key registered.

### Changes
- `cloudflare/hamr/routes/cache-stats.ts`: write `STALE_KEY=false` + `LAST_UPDATE_KEY` after successful push so `/quota` reports `stale:false`
- `scripts/global/cache-stats-push.js`: add `emitAuthError()` for actionable stderr messages on 401
- `docs/howto/hamr-push-auth.md`: new runbook for PUBLISHER_KEYRING setup and auth failure recovery
- `tests/hamr-push-auth-1415.spec.js`: 4 new tests; all pass

### Evidence
```json
{"hit_rate_7d":0.7549668874172185,"stale":false,"last_update_ms":1778799482665,"slo_breach":false}
```

Refs #1415
Closes #1415