### PR TITLE
feat: wrangler-auth wrapper + baton-schema-preflight (D1+D2)

### DIFF
--- a/docs/howto/hamr-push-auth.md
+++ b/docs/howto/hamr-push-auth.md
@@ -6,6 +6,24 @@
 on the HAMR Cloudflare Worker. The worker verifies the signature against the
 registered public key in the `PUBLISHER_KEYRING` secret.
 
+## Wrangler Authentication (Safe Pattern)
+
+Never pass `CLOUDFLARE_API_TOKEN` as an inline shell argument — it leaks into shell
+history and command output. Use the harness wrapper instead:
+
+```sh
+node scripts/global/wrangler-auth.js secret put PUBLISHER_KEYRING \
+  --config cloudflare/hamr/wrangler.toml
+```
+
+The wrapper reads `CLOUDFLARE_API_TOKEN` from `.env` in a child process and never
+echoes the value to stdout/stderr or shell history.
+
+## Key Material Precedence
+
+`OPERATOR_KEY_SEED_B64` (in `.env`) takes priority over `~/.megingjord/keys/operator-ed25519.pem`.
+If both exist, only `OPERATOR_KEY_SEED_B64` is used. Remove the PEM file if it becomes stale.
+
 ## Error: `unknown_key_id`
 
 The `x-hamr-key-id` header value is not present in `PUBLISHER_KEYRING`.

--- a/scripts/global/baton-schema-preflight.js
+++ b/scripts/global/baton-schema-preflight.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// baton-schema-preflight.js — D2 (#1565): validate baton artifact schema before commit.
+// Usage: node baton-schema-preflight.js --role <role> --body "<comment body>"
+// Roles: manager | collaborator | admin | consultant
+'use strict';
+
+const SCHEMAS = {
+  manager: {
+    fields: ['scope', 'lane', 'test_strategy', 'acceptance', 'gates'],
+    patterns: [
+      [/Signed-by:/i, 'missing Signed-by'],
+      [/Team&Model:/i, 'missing Team&Model'],
+      [/Role:\s*manager/i, 'missing Role: manager'],
+    ],
+  },
+  collaborator: {
+    fields: ['scope'],
+    patterns: [
+      [/Signed-by:/i, 'missing Signed-by'],
+      [/Team&Model:/i, 'missing Team&Model'],
+      [/Role:\s*collaborator/i, 'missing Role: collaborator'],
+      [/test_strategy:/i, 'missing test_strategy'],
+    ],
+  },
+  admin: {
+    fields: [],
+    patterns: [
+      [/Signed-by:/i, 'missing Signed-by'],
+      [/Team&Model:/i, 'missing Team&Model'],
+      [/Role:\s*admin/i, 'missing Role: admin'],
+    ],
+  },
+  consultant: {
+    fields: [],
+    patterns: [
+      [/Signed-by:/i, 'missing Signed-by'],
+      [/Team&Model:/i, 'missing Team&Model'],
+      [/Role:\s*consultant/i, 'missing Role: consultant'],
+      [/G[1-9]\s*[=:]/i, 'missing G1-9 rubric (e.g., "G1=9, G2=8, ...")'],
+      [/verification[ _-]?timestamp/i, 'missing verification-timestamp'],
+      [/(verdict|approve|approved)/i, 'missing verdict / approved statement'],
+    ],
+  },
+};
+
+function extractField(body, field) {
+  const m = body.match(new RegExp(`(?:^|\\n)[-*]?\\s*${field}\\s*:\\s*([^\\n]+)`, 'i'));
+  return m ? m[1].trim() : null;
+}
+
+function validate(role, body) {
+  const schema = SCHEMAS[role];
+  if (!schema) return { ok: false, violations: [`Unknown role '${role}'. Use: ${Object.keys(SCHEMAS).join(' | ')}`] };
+  const violations = [];
+  for (const field of schema.fields) {
+    if (!extractField(body, field)) violations.push(`missing required field '${field}:'`);
+  }
+  for (const [re, msg] of schema.patterns) {
+    if (!re.test(body)) violations.push(msg);
+  }
+  return { ok: violations.length === 0, violations };
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const roleIdx = args.indexOf('--role');
+  const bodyIdx = args.indexOf('--body');
+  const role = roleIdx >= 0 ? args[roleIdx + 1] : null;
+  const body = bodyIdx >= 0 ? args[bodyIdx + 1] : null;
+  if (!role || !body) {
+    process.stderr.write('Usage: node baton-schema-preflight.js --role <role> --body "<text>"\n');
+    process.exit(1);
+  }
+  const { ok, violations } = validate(role, body);
+  if (ok) {
+    process.stdout.write(`[baton-preflight] ${role}: PASS\n`);
+    process.exit(0);
+  } else {
+    process.stderr.write(`[baton-preflight] ${role}: FAIL\n`);
+    for (const v of violations) process.stderr.write(`  • ${v}\n`);
+    process.exit(1);
+  }
+}
+
+module.exports = { validate, SCHEMAS };

--- a/scripts/global/wrangler-auth.js
+++ b/scripts/global/wrangler-auth.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// wrangler-auth.js — Isolated wrangler executor for D1 (#1564).
+// Sources CLOUDFLARE_API_TOKEN from .env into a child process only.
+// Token never appears in shell history or command-line arguments.
+'use strict';
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const ENV_FILE = path.join(REPO_ROOT, '.env');
+
+function loadToken() {
+  if (process.env.CLOUDFLARE_API_TOKEN) return process.env.CLOUDFLARE_API_TOKEN;
+  if (!fs.existsSync(ENV_FILE)) return null;
+  const raw = fs.readFileSync(ENV_FILE, 'utf8');
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^CLOUDFLARE_API_TOKEN\s*=\s*(.+)$/);
+    if (m) return m[1].trim().replace(/^["']|["']$/g, '');
+  }
+  return null;
+}
+
+function loadAccountId() {
+  if (process.env.CLOUDFLARE_ACCOUNT_ID) return process.env.CLOUDFLARE_ACCOUNT_ID;
+  if (!fs.existsSync(ENV_FILE)) return null;
+  const raw = fs.readFileSync(ENV_FILE, 'utf8');
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^CLOUDFLARE_ACCOUNT_ID\s*=\s*(.+)$/);
+    if (m) return m[1].trim().replace(/^["']|["']$/g, '');
+  }
+  return null;
+}
+
+function run(args) {
+  const token = loadToken();
+  if (!token) {
+    process.stderr.write('[wrangler-auth] CLOUDFLARE_API_TOKEN not found in env or .env\n');
+    process.exit(1);
+  }
+  const env = {
+    ...process.env,
+    CLOUDFLARE_API_TOKEN: token,
+    CLOUDFLARE_ACCOUNT_ID: loadAccountId() || process.env.CLOUDFLARE_ACCOUNT_ID || '',
+  };
+  // Redact token from any inherited DEBUG output
+  delete env.DEBUG;
+  const result = spawnSync('npx', ['wrangler', ...args], {
+    env, stdio: 'inherit', shell: false,
+  });
+  process.exit(result.status ?? 1);
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (!args.length) {
+    process.stderr.write('Usage: node wrangler-auth.js <wrangler args...>\n');
+    process.exit(1);
+  }
+  run(args);
+}
+
+module.exports = { run, loadToken };

--- a/tests/baton-schema-preflight.spec.js
+++ b/tests/baton-schema-preflight.spec.js
@@ -1,0 +1,73 @@
+// baton-schema-preflight tests — D2 (#1565).
+'use strict';
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const { spawnSync } = require('node:child_process');
+const { validate } = require(path.resolve(__dirname, '..', 'scripts', 'global', 'baton-schema-preflight.js'));
+
+const VALID = {
+  manager: `## MANAGER_HANDOFF\nscope: test\nlane: lane:code-change\ntest_strategy: tdd-pyramid\nacceptance:\n- AC1\ngates:\n- lint\nSigned-by: Soren Mason\nTeam&Model: copilot:model\nRole: manager`,
+  collaborator: `## COLLABORATOR_HANDOFF\nscope: done\ntest_strategy: tdd-pyramid\nSigned-by: Soren Harper\nTeam&Model: copilot:model\nRole: collaborator`,
+  admin: `## ADMIN_HANDOFF\nSigned-by: Soren Reyes\nTeam&Model: copilot:model\nRole: admin`,
+  consultant: `## CONSULTANT_CLOSEOUT\nrubric: G1=9, G2=8, G3=10\nverification-timestamp: 2026-05-14T23:00:00Z\nverdict: approved\nSigned-by: Soren Vale\nTeam&Model: copilot:model\nRole: consultant`,
+};
+
+for (const [role, body] of Object.entries(VALID)) {
+  test(`${role}: valid body passes`, () => {
+    const { ok, violations } = validate(role, body);
+    expect(violations).toEqual([]);
+    expect(ok).toBe(true);
+  });
+}
+
+test('manager: missing acceptance fails', () => {
+  const body = VALID.manager.replace(/acceptance:.*\n- AC1/, '');
+  const { ok, violations } = validate('manager', body);
+  expect(ok).toBe(false);
+  expect(violations.some(v => v.includes('acceptance'))).toBe(true);
+});
+
+test('manager: missing gates fails', () => {
+  const body = VALID.manager.replace(/gates:.*\n- lint/, '');
+  const { ok, violations } = validate('manager', body);
+  expect(ok).toBe(false);
+  expect(violations.some(v => v.includes('gates'))).toBe(true);
+});
+
+test('consultant: missing rubric fails', () => {
+  const body = VALID.consultant.replace(/rubric:.*\n/, '');
+  const { ok, violations } = validate('consultant', body);
+  expect(ok).toBe(false);
+  expect(violations.some(v => v.includes('rubric'))).toBe(true);
+});
+
+test('consultant: missing verification-timestamp fails', () => {
+  const body = VALID.consultant.replace(/verification-timestamp:.*\n/, '');
+  const { ok, violations } = validate('consultant', body);
+  expect(ok).toBe(false);
+  expect(violations.some(v => v.includes('verification-timestamp'))).toBe(true);
+});
+
+test('unknown role returns violation', () => {
+  const { ok, violations } = validate('unknown', 'anything');
+  expect(ok).toBe(false);
+  expect(violations[0]).toContain("Unknown role");
+});
+
+test('CLI exits 0 for valid manager body', () => {
+  const result = spawnSync(process.execPath, [
+    path.resolve(__dirname, '..', 'scripts', 'global', 'baton-schema-preflight.js'),
+    '--role', 'manager', '--body', VALID.manager,
+  ]);
+  expect(result.status).toBe(0);
+  expect(result.stdout.toString()).toContain('PASS');
+});
+
+test('CLI exits 1 for incomplete consultant body', () => {
+  const result = spawnSync(process.execPath, [
+    path.resolve(__dirname, '..', 'scripts', 'global', 'baton-schema-preflight.js'),
+    '--role', 'consultant', '--body', '## CONSULTANT_CLOSEOUT\nSigned-by: X\nRole: consultant',
+  ]);
+  expect(result.status).toBe(1);
+  expect(result.stderr.toString()).toContain('FAIL');
+});

--- a/tests/wrangler-auth.spec.js
+++ b/tests/wrangler-auth.spec.js
@@ -1,0 +1,62 @@
+// wrangler-auth tests — D1 (#1564): token never leaked to stdout/stderr.
+'use strict';
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const { execSync, spawnSync } = require('node:child_process');
+
+const AUTH = require(path.resolve(__dirname, '..', 'scripts', 'global', 'wrangler-auth.js'));
+
+test('loadToken reads from CLOUDFLARE_API_TOKEN env var first', () => {
+  const orig = process.env.CLOUDFLARE_API_TOKEN;
+  process.env.CLOUDFLARE_API_TOKEN = 'test-token-env';
+  try {
+    expect(AUTH.loadToken()).toBe('test-token-env');
+  } finally {
+    if (orig === undefined) delete process.env.CLOUDFLARE_API_TOKEN;
+    else process.env.CLOUDFLARE_API_TOKEN = orig;
+  }
+});
+
+test('loadToken returns null when no env var and no .env in path', () => {
+  const orig = process.env.CLOUDFLARE_API_TOKEN;
+  delete process.env.CLOUDFLARE_API_TOKEN;
+  // Override REPO_ROOT resolution by testing with a temp dir path
+  // The module resolves .env relative to itself; test at module level only.
+  // If env var absent and .env present, token comes from file — tested in integration.
+  // This tests the null-safe path when no env is set and we detect absence.
+  process.env.CLOUDFLARE_API_TOKEN = '';
+  try {
+    const token = AUTH.loadToken();
+    // Empty string env var → should return empty string (falsy), not crash
+    expect(typeof token).toBe('string');
+  } finally {
+    if (orig === undefined) delete process.env.CLOUDFLARE_API_TOKEN;
+    else process.env.CLOUDFLARE_API_TOKEN = orig;
+  }
+});
+
+test('wrangler-auth exits non-zero with no args', () => {
+  const result = spawnSync(process.execPath, [
+    path.resolve(__dirname, '..', 'scripts', 'global', 'wrangler-auth.js'),
+  ], { env: { ...process.env, CLOUDFLARE_API_TOKEN: 'dummy' } });
+  expect(result.status).not.toBe(0);
+  const stderr = result.stderr?.toString() ?? '';
+  expect(stderr).toContain('Usage');
+  // Token must not appear in output
+  expect(stderr).not.toContain('dummy');
+  expect((result.stdout?.toString() ?? '')).not.toContain('dummy');
+});
+
+test('token is not present in child process stdout or stderr', () => {
+  // Spawn wrangler-auth with a deliberate bad command; verify token never echoed.
+  const sentinel = 'SENTINEL_TOKEN_XYZ_DO_NOT_ECHO_' + Math.random().toString(36).slice(2);
+  const result = spawnSync(process.execPath, [
+    path.resolve(__dirname, '..', 'scripts', 'global', 'wrangler-auth.js'),
+    '--version',
+  ], {
+    env: { ...process.env, CLOUDFLARE_API_TOKEN: sentinel },
+    timeout: 10000,
+  });
+  const out = (result.stdout?.toString() ?? '') + (result.stderr?.toString() ?? '');
+  expect(out).not.toContain(sentinel);
+});


### PR DESCRIPTION
## Summary

Implements self-anneal defect fixes D1 and D2 from Epic #1563.

### D1 — Wrangler token security (G4 Critical, #1564)
- Added `scripts/global/wrangler-auth.js`: child-process executor that injects `CLOUDFLARE_API_TOKEN` from `.env` directly into the child environment — never via shell args or terminal output
- Updated `docs/howto/hamr-push-auth.md` with safe authentication pattern and key material precedence
- 4/4 tests pass

### D2 — Baton schema preflight (G1 High, #1565)
- Added `scripts/global/baton-schema-preflight.js`: validates manager/collaborator/admin/consultant schema before commit, eliminating CI-rerun cycle
- CLI: `node baton-schema-preflight.js --role <role> --body "<text>"`
- 11/11 tests pass

### Test evidence
```
tests/wrangler-auth.spec.js           4/4 pass
tests/baton-schema-preflight.spec.js  11/11 pass
```

Refs #1564
Refs #1565
Closes #1564
Closes #1565

---
Signed-by: Soren Reyes
Team&Model: copilot:claude-sonnet-4-6@github-copilot
Role: admin