### PR TITLE
fix(governance): anneal stopping rules #1574

### DIFF
--- a/.changes/unreleased/1574.md
+++ b/.changes/unreleased/1574.md
@@ -1,0 +1,25 @@
+## [Unreleased] — #1574: anneal stopping rules (Epic #1568 AC-5)
+
+### Added
+- `scripts/global/anneal-stop.js` (45 lines): pure helper exporting `shouldStop({ iterations, prev_rubric_mean, current_rubric_mean, deterministic_gates_ok, telemetrySink })`. Returns `{ stop, reason, ... }` where `reason` is one of `gates`, `iter-cap`, `delta-cap`, `no-prev`, `continue`. Precedence: gates-green wins, then iter-cap, then delta-cap. Exposes `MAX_ITERATIONS=3` and `DELTA_CAP=0.5` as module constants for testability + future override.
+- `tests/anneal-stop.spec.js`: 13 unit tests — precedence checks, first-iter null-prev path, malformed input safety (missing iterations, non-numeric rubric means), telemetry-sink invocation, telemetry-sink-that-throws safety, null prev with gates-green still stops on gates.
+
+### Changed
+- `skills/workflow-self-anneal/SKILL.md`: added stop-condition reference directing iterative anneal loops to call `shouldStop(...)` after every iteration. Continuation past a stop requires `ANNEAL_OVERRIDE_CONTINUE: rationale` and emits `event:kill-switch-bypass`.
+
+### Why
+Closes #1574. Self-Refine (arXiv 2303.17651) shows refinement gain tapers after iter 2; MAR (arXiv 2512.20845) plateaus at iter 5 with majority of gain by iter 3. Without an explicit delta-cap, repeated same-model self-critique inflates rubric scores monotonically while quality stagnates or worsens (Panickssery et al., NeurIPS '24/'25). The 3-iteration cap captures the gain curve; the 0.5-point delta cap is half a point on a 10-point rubric — below the noise floor of subjective scoring. Together they compose with the existing rate-limit kill-switches in `workflow-resilience.instructions.md` (max 1 active pivot per session, max 3 pivots per 24h, max 5 anneal tickets per 7d pattern_id, step counter aborts >50 tool calls) — those bound *how often* the loop fires; this PR bounds *how long* each invocation runs.
+
+### Verification
+- `npx playwright test tests/anneal-stop.spec.js` → 13/13 pass.
+- `npm test` → 1061 passed, 4 skipped, exit=0. No regressions.
+- `npm run lint` → 100-line cap clean (helper 45 lines).
+- `npm run lint:readability:ci` (cap=420) → exit=0.
+
+### Out of scope (this PR)
+- Wiring the helper into a live anneal loop runner. The helper is the contract; the orchestrator integration is its own follow-on (covered by future Epic #1568 children).
+- Persisting the bypass event to `incidents.jsonl`. Helper provides a `telemetrySink` hook; caller wires the actual JSONL append (keeps the helper pure + testable).
+- Promotion of the soft-gate behavior to a CI-required check. The stopping rule lives in the agent-side skill at this stage; wiring to a closeout-schema advisory is a future Epic child once enough anneal loops have run with the cap in place to validate the thresholds empirically.
+
+### Self-application
+This very PR is composed by a solo Opus session. Manager → Collaborator → Admin → Consultant baton runs on the same model; `model-diversity:waived` label applied with rationale (Epic #1568 AC-3 / #1572 advisory).

--- a/scripts/global/anneal-stop.js
+++ b/scripts/global/anneal-stop.js
@@ -1,0 +1,45 @@
+'use strict';
+// anneal-stop — Epic #1568 AC-5 (#1574). Explicit stopping rules for the
+// workflow-self-anneal loop. Self-Refine (arXiv 2303.17651) shows refinement
+// gain tapers after iter 2; MAR (arXiv 2512.20845) plateaus at iter 5 with
+// majority of gain by iter 3. Self-bias amplifies monotonically when the same
+// model rates itself across iterations (Panickssery et al. NeurIPS '24/'25),
+// so the loop must cap on score-delta too, not just iteration count.
+//
+// Pure function: no file I/O. Caller wires telemetry via input.telemetrySink.
+
+const MAX_ITERATIONS = 3;
+const DELTA_CAP = 0.5;
+
+function shouldStop(input) {
+  const i = input || {};
+  const iterations = Number.isFinite(i.iterations) ? i.iterations : 0;
+  const prev = i.prev_rubric_mean;
+  const current = i.current_rubric_mean;
+  const gatesOk = Boolean(i.deterministic_gates_ok);
+
+  if (gatesOk) {
+    return emit(i, { stop: true, reason: 'gates' });
+  }
+  if (iterations >= MAX_ITERATIONS) {
+    return emit(i, { stop: true, reason: 'iter-cap', iterations });
+  }
+  if (prev == null || current == null) {
+    return emit(i, { stop: false, reason: 'no-prev' });
+  }
+  const delta = Math.abs(Number(current) - Number(prev));
+  if (Number.isFinite(delta) && delta <= DELTA_CAP) {
+    return emit(i, { stop: true, reason: 'delta-cap', delta });
+  }
+  return emit(i, { stop: false, reason: 'continue', delta });
+}
+
+function emit(input, decision) {
+  const sink = input && input.telemetrySink;
+  if (typeof sink === 'function') {
+    try { sink({ ...decision, ts: new Date().toISOString() }); } catch (_) { /* ignore */ }
+  }
+  return decision;
+}
+
+module.exports = { shouldStop, MAX_ITERATIONS, DELTA_CAP };

--- a/skills/workflow-self-anneal/SKILL.md
+++ b/skills/workflow-self-anneal/SKILL.md
@@ -87,6 +87,8 @@ Prioritize: project runbooks/checklists, workflow docs, system-stability docs, l
 
 Return `NO_CHANGE` if: change cannot be validated objectively, evidence is missing, change expands permissions, or same fix was already applied.
 
+For iterative anneal loops (refinement passes), call `shouldStop(...)` from `scripts/global/anneal-stop.js` after every iteration (Epic #1568 AC-5, #1574). Stop when: deterministic gates green, OR `iterations >= 3`, OR `|rubric_mean_delta| <= 0.5`. Continuation past a stop requires `ANNEAL_OVERRIDE_CONTINUE: rationale` comment from the operator and is logged as `event:kill-switch-bypass`.
+
 ## Quality bar
 
 Good anneal output is: **specific** (concrete artifacts), **minimal** (smallest viable delta), **testable** (pass/fail checks), **traceable** (rationale + risk), **trend-aware** (drift reducing).

--- a/tests/anneal-stop.spec.js
+++ b/tests/anneal-stop.spec.js
@@ -1,0 +1,136 @@
+// Unit tests for scripts/global/anneal-stop.js (Epic #1568 AC-5, #1574).
+// Pins the stopping rules: max 3 iterations, |delta| <= 0.5, or gates-green.
+// Precedence: gates > iter-cap > delta-cap.
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const A = require(path.resolve(__dirname, '..', 'scripts', 'global', 'anneal-stop.js'));
+
+test('exposes MAX_ITERATIONS=3 and DELTA_CAP=0.5 as module constants', () => {
+  expect(A.MAX_ITERATIONS).toBe(3);
+  expect(A.DELTA_CAP).toBe(0.5);
+});
+
+test('first iteration (no prev_rubric_mean) returns stop=false reason=no-prev', () => {
+  const result = A.shouldStop({ iterations: 1, current_rubric_mean: 7.0 });
+  expect(result.stop).toBe(false);
+  expect(result.reason).toBe('no-prev');
+});
+
+test('gates-green wins over every other condition (highest precedence)', () => {
+  const result = A.shouldStop({
+    iterations: 99,
+    prev_rubric_mean: 7.0,
+    current_rubric_mean: 9.9,
+    deterministic_gates_ok: true,
+  });
+  expect(result.stop).toBe(true);
+  expect(result.reason).toBe('gates');
+});
+
+test('iter-cap fires at iterations === MAX_ITERATIONS when gates not green', () => {
+  const result = A.shouldStop({
+    iterations: 3,
+    prev_rubric_mean: 7.0,
+    current_rubric_mean: 7.4,
+    deterministic_gates_ok: false,
+  });
+  expect(result.stop).toBe(true);
+  expect(result.reason).toBe('iter-cap');
+});
+
+test('iter just below cap (iterations=2) continues when no other trip', () => {
+  const result = A.shouldStop({
+    iterations: 2,
+    prev_rubric_mean: 7.0,
+    current_rubric_mean: 8.0,
+    deterministic_gates_ok: false,
+  });
+  expect(result.stop).toBe(false);
+  expect(result.reason).toBe('continue');
+});
+
+test('delta-cap fires when |delta| <= DELTA_CAP', () => {
+  const result = A.shouldStop({
+    iterations: 2,
+    prev_rubric_mean: 8.0,
+    current_rubric_mean: 8.4,
+    deterministic_gates_ok: false,
+  });
+  expect(result.stop).toBe(true);
+  expect(result.reason).toBe('delta-cap');
+});
+
+test('delta just above cap (|delta| = 0.51) continues', () => {
+  const result = A.shouldStop({
+    iterations: 2,
+    prev_rubric_mean: 8.0,
+    current_rubric_mean: 8.51,
+    deterministic_gates_ok: false,
+  });
+  expect(result.stop).toBe(false);
+  expect(result.reason).toBe('continue');
+});
+
+test('precedence: iter-cap wins over delta-cap when both fire', () => {
+  const result = A.shouldStop({
+    iterations: 3,
+    prev_rubric_mean: 8.0,
+    current_rubric_mean: 8.4,
+    deterministic_gates_ok: false,
+  });
+  expect(result.stop).toBe(true);
+  expect(result.reason).toBe('iter-cap');
+});
+
+test('malformed input: missing iterations field defaults to 0 (treated as first iter)', () => {
+  const result = A.shouldStop({});
+  expect(result.stop).toBe(false);
+  expect(result.reason).toBe('no-prev');
+});
+
+test('malformed input: non-numeric rubric means yield NaN delta and trigger continue', () => {
+  const result = A.shouldStop({
+    iterations: 2,
+    prev_rubric_mean: 'not a number',
+    current_rubric_mean: 'also not',
+    deterministic_gates_ok: false,
+  });
+  expect(result.stop).toBe(false);
+  expect(result.reason).toBe('continue');
+});
+
+test('telemetrySink is invoked with the decision payload when provided', () => {
+  const events = [];
+  const sink = payload => events.push(payload);
+  A.shouldStop({
+    iterations: 3,
+    prev_rubric_mean: 7.0,
+    current_rubric_mean: 7.4,
+    telemetrySink: sink,
+  });
+  expect(events).toHaveLength(1);
+  expect(events[0].reason).toBe('iter-cap');
+  expect(events[0].ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+});
+
+test('telemetrySink that throws does not affect the returned decision', () => {
+  const result = A.shouldStop({
+    iterations: 3,
+    prev_rubric_mean: 7.0,
+    current_rubric_mean: 7.4,
+    telemetrySink: () => { throw new Error('disk full'); },
+  });
+  expect(result.stop).toBe(true);
+  expect(result.reason).toBe('iter-cap');
+});
+
+test('null prev with gates-green still stops on gates (gates precedence beats no-prev)', () => {
+  const result = A.shouldStop({
+    iterations: 0,
+    prev_rubric_mean: null,
+    current_rubric_mean: null,
+    deterministic_gates_ok: true,
+  });
+  expect(result.stop).toBe(true);
+  expect(result.reason).toBe('gates');
+});


### PR DESCRIPTION
Closes #1574
Refs #1574
Refs #1568

## Summary

Implements explicit stopping rules for the `workflow-self-anneal` loop to prevent self-bias score inflation via repeated same-model critique.

## Changes

- `scripts/global/anneal-stop.js` — pure function `shouldStop()` with three stopping conditions:
  1. `deterministic_gates_ok` (highest precedence)
  2. `iterations >= 3` (per Self-Refine literature)
  3. `|rubric_mean_delta| <= 0.5` (below noise floor per Panickssery et al.)
- `tests/anneal-stop.spec.js` — 13 unit tests covering all decision paths
- `skills/workflow-self-anneal/SKILL.md` — documented stopping function and ANNEAL_OVERRIDE_CONTINUE override path

## Test Strategy

`tdd-pyramid` — pure-function helper with comprehensive negative/positive fixtures.
