### PR TITLE
fix(governance): consultant second-opinion helper #1573

### DIFF
--- a/.changes/unreleased/1573.md
+++ b/.changes/unreleased/1573.md
@@ -1,0 +1,24 @@
+## [Unreleased] — #1573: second-opinion Consultant pass (Epic #1568 AC-4)
+
+### Added
+- `scripts/global/consultant-second-opinion.js` (87 lines): pure helper exporting `parseCloseoutScores` (extracts G1-G9 map from CONSULTANT_CLOSEOUT body), `parseRaterTeamModel`, `providerOf`, `isCrossProviderRater` (string-prefix comparison), `computeDeltas` (signed per-goal + `max_abs_delta`), `shouldEscalateTier3` (returns true when `max_abs_delta > 1.0`), `appendSecondOpinionBlock` (canonical block format), `shouldSkip` (waiver-label check). Exposes `ESCALATE_THRESHOLD=1.0` and `OVERRIDE_LABEL` as module constants.
+- `tests/consultant-second-opinion.spec.js`: 15 unit tests covering parser variants, Team&Model extraction, cross-provider check, delta math, escalation threshold (1.5 fires, 1.0 does not, NaN-safe), block format, waiver path, and an end-to-end integration test.
+- `.github/workflows/consultant-second-opinion-advisory.yml` (56 lines): standalone advisory workflow on PR open/sync. Reads the linked issue's `CONSULTANT_CLOSEOUT`, checks for the `SECOND_OPINION` block, posts a structured advisory comment if missing. **Advisory only — does not block merge during soak.** Waiver via `second-opinion:waived` label.
+
+### Why
+Closes #1573. Implements F5 from #1569 research synthesis: cross-provider rater diversity yields the strongest bias-independence per Star Chamber (Mozilla.AI) and Diverse-LLMs (arXiv 2512.12536) findings. Single-rater self-bias amplifies monotonically when iterated (Panickssery et al. NeurIPS '24/'25). This PR ships the contract; the helper is sufficient for an operator to manually run a cross-family rater (e.g. fleet `gemma3:1b@ollama`) against the rubric and append the result. Tier-3 auto-file wiring into a routine post-merge workflow is documented as Out of scope for follow-on.
+
+### Advisory-first
+Fifth advisory in the megalint family following `cross-checkout-destructive` (#1554), `flaw-emission` (#1555), `model-diversity` (#1572), and `collaborator-self-check` (#1571 / via Copilot Team's #1580 hardening in flight). Promotion to required-blocking is a separate follow-on after 7-day soak with zero false-positives observed (Epic #1486 Path D pattern).
+
+### Verification
+- `npx playwright test tests/consultant-second-opinion.spec.js` → 15/15 pass.
+- `npm test` → 1076 passed (up from 1061), 4 skipped, exit=0. No regressions.
+- `npm run lint` → 100-line cap clean (helper 87 lines, workflow 56 lines).
+- `npm run lint:readability:ci` (cap=420) → exit=0.
+
+### Out of scope (this PR)
+- Live Tier-3 auto-file integration (workflow that calls `gh issue create` when `shouldEscalateTier3` returns true). Helper exposes the boolean; routine wiring is a follow-on.
+- Cross-provider rater invocation orchestration (calling `gemma3:1b@ollama` or similar via HAMR). The helper accepts pre-computed scores; the rater-call layer is a separate Epic-#1568 child.
+- Promotion of the advisory to required-blocking (7-day soak first, parity with #1554/#1555/#1572).
+- Cross-team enforcement coordination (Codex/Copilot adopt independently; helper is provider-neutral by construction).

--- a/.github/workflows/consultant-second-opinion-advisory.yml
+++ b/.github/workflows/consultant-second-opinion-advisory.yml
@@ -1,0 +1,56 @@
+name: consultant-second-opinion-advisory
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  advisory:
+    name: consultant-second-opinion-advisory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const SO = require('./scripts/global/consultant-second-opinion.js');
+            const body = context.payload.pull_request.body || '';
+            const refsMatch = body.match(/Refs\s+#(\d+)/i);
+            if (!refsMatch) { console.log('No Refs #N; skipping.'); return; }
+            const linkedIssue = parseInt(refsMatch[1]);
+            const prLabels = context.payload.pull_request.labels.map(l => l.name);
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: linkedIssue,
+            });
+            const issueLabels = issue.labels.map(l => l.name);
+            if (SO.shouldSkip(prLabels) || SO.shouldSkip(issueLabels)) {
+              console.log('consultant-second-opinion: SKIPPED (waiver label)');
+              return;
+            }
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: linkedIssue, per_page: 100,
+            });
+            const closeout = comments.map(c => c.body || '').find(b => b.includes('CONSULTANT_CLOSEOUT'));
+            if (!closeout) { console.log('No CONSULTANT_CLOSEOUT yet; nothing to compare.'); return; }
+            const hasSecondOpinion = /SECOND_OPINION/.test(closeout);
+            const status = hasSecondOpinion ? 'PASS' : 'ADVISORY-MISSING';
+            console.log(`consultant-second-opinion: ${status}`);
+            await core.summary.addRaw(`### Consultant second-opinion advisory\n\n${status}\n`).write();
+            if (!hasSecondOpinion) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: '<!-- consultant-second-opinion-advisory -->\n' +
+                      '## Consultant second-opinion advisory (Epic #1568 AC-4, #1573)\n\n' +
+                      'CONSULTANT_CLOSEOUT does not include a `SECOND_OPINION` block from a cross-provider rater. ' +
+                      'Run a cross-family rater against the rubric and append the result via ' +
+                      '`scripts/global/consultant-second-opinion.js` `appendSecondOpinionBlock(...)`. ' +
+                      'Waive with label `second-opinion:waived` if intentional. Does not block merge during soak.',
+              });
+            }

--- a/scripts/global/consultant-second-opinion.js
+++ b/scripts/global/consultant-second-opinion.js
@@ -1,0 +1,87 @@
+'use strict';
+// consultant-second-opinion — Epic #1568 AC-4 (#1573). Pure helper that parses
+// a CONSULTANT_CLOSEOUT body, compares its per-goal scores against a second
+// rater's scores, and decides whether a Tier-3 escalation should fire. Caller
+// supplies the second rater's output; helper does no LLM calls itself (pure +
+// testable). Defeats single-rater self-bias amplification per Mozilla.AI
+// Star Chamber finding F5 from #1569 research.
+
+const ESCALATE_THRESHOLD = 1.0;
+const SCORE_LINE_RE = /\b(G[1-9])\s*[=:]\s*(\d+(?:\.\d+)?)/gi;
+const RATER_RE = /Team&Model:\s*([^\n]+)/i;
+const OVERRIDE_LABEL = 'second-opinion:waived';
+
+function parseCloseoutScores(body) {
+  const out = {};
+  const text = body || '';
+  for (const match of text.matchAll(SCORE_LINE_RE)) {
+    const goal = match[1].toUpperCase();
+    const score = Number(match[2]);
+    if (Number.isFinite(score) && !(goal in out)) out[goal] = score;
+  }
+  return out;
+}
+
+function parseRaterTeamModel(body) {
+  const match = (body || '').match(RATER_RE);
+  return match ? match[1].trim() : null;
+}
+
+function providerOf(teamModel) {
+  if (!teamModel) return null;
+  return String(teamModel).split(':')[0].toLowerCase();
+}
+
+function isCrossProviderRater(firstRater, secondRater) {
+  const a = providerOf(firstRater);
+  const b = providerOf(secondRater);
+  if (!a || !b) return false;
+  return a !== b;
+}
+
+function computeDeltas(firstScores, secondScores) {
+  const deltas = {};
+  let maxAbs = 0;
+  const goals = new Set([...Object.keys(firstScores || {}), ...Object.keys(secondScores || {})]);
+  for (const goal of goals) {
+    const a = (firstScores || {})[goal];
+    const b = (secondScores || {})[goal];
+    if (a == null || b == null) continue;
+    const delta = b - a;
+    if (Number.isFinite(delta)) {
+      deltas[goal] = delta;
+      if (Math.abs(delta) > maxAbs) maxAbs = Math.abs(delta);
+    }
+  }
+  return { deltas, max_abs_delta: maxAbs };
+}
+
+function shouldEscalateTier3(maxAbsDelta) {
+  return Number.isFinite(maxAbsDelta) && maxAbsDelta > ESCALATE_THRESHOLD;
+}
+
+function appendSecondOpinionBlock(input) {
+  const scores = input.second_scores || {};
+  const deltas = input.deltas || {};
+  const scoreLine = Object.keys(scores).sort().map(g => `${g}=${scores[g]}`).join(',');
+  const deltaLine = Object.keys(deltas).sort().map(g => `${g}=${deltas[g]}`).join(',');
+  const verdict = input.escalate ? 'ESCALATE_TIER_3' : 'NO_ESCALATION';
+  return [
+    'SECOND_OPINION',
+    `rater_team_model: ${input.rater_team_model || 'unknown'}`,
+    `scores: ${scoreLine}`,
+    `deltas: ${deltaLine}`,
+    `max_abs_delta: ${input.max_abs_delta || 0}`,
+    `verdict: ${verdict}`,
+  ].join('\n');
+}
+
+function shouldSkip(labels) {
+  return (labels || []).includes(OVERRIDE_LABEL) ? 'override-waived' : null;
+}
+
+module.exports = {
+  parseCloseoutScores, parseRaterTeamModel, providerOf, isCrossProviderRater,
+  computeDeltas, shouldEscalateTier3, appendSecondOpinionBlock,
+  shouldSkip, ESCALATE_THRESHOLD, OVERRIDE_LABEL,
+};

--- a/tests/consultant-second-opinion.spec.js
+++ b/tests/consultant-second-opinion.spec.js
@@ -1,0 +1,119 @@
+// Unit tests for scripts/global/consultant-second-opinion.js (Epic #1568 AC-4, #1573).
+// Helper pins the second-opinion contract: parse a CONSULTANT_CLOSEOUT body into
+// a G1-G9 score map, compare against a second rater's map, decide on Tier-3
+// escalation when any goal's |delta| > 1.0, and format a SECOND_OPINION block.
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const SO = require(path.resolve(__dirname, '..', 'scripts', 'global', 'consultant-second-opinion.js'));
+
+test('parseCloseoutScores extracts the standard "G1=10, G2=9, ..." inline form', () => {
+  const body = 'G1=10, G2=9, G3=10, G4=10, G5=10, G6=8, G7=9, G8=9, G9=10. Mean=9.4.';
+  expect(SO.parseCloseoutScores(body)).toEqual({
+    G1: 10, G2: 9, G3: 10, G4: 10, G5: 10, G6: 8, G7: 9, G8: 9, G9: 10,
+  });
+});
+
+test('parseCloseoutScores tolerates colon-separated scores (G1: 10) and decimals', () => {
+  expect(SO.parseCloseoutScores('G1: 9.4 G2: 8 G3: 7.5')).toEqual({ G1: 9.4, G2: 8, G3: 7.5 });
+});
+
+test('parseCloseoutScores returns empty object on null, empty, or no-score body', () => {
+  expect(SO.parseCloseoutScores('')).toEqual({});
+  expect(SO.parseCloseoutScores(null)).toEqual({});
+  expect(SO.parseCloseoutScores('this body has no per-goal scores at all')).toEqual({});
+});
+
+test('parseRaterTeamModel extracts the Team&Model literal from a rater output body', () => {
+  expect(SO.parseRaterTeamModel('Signed-by: Gemma Vale\nTeam&Model: fleet:gemma3:1b@ollama\nRole: consultant'))
+    .toBe('fleet:gemma3:1b@ollama');
+});
+
+test('parseRaterTeamModel returns null when Team&Model field absent', () => {
+  expect(SO.parseRaterTeamModel('rater output without team-model field')).toBeNull();
+  expect(SO.parseRaterTeamModel(null)).toBeNull();
+});
+
+test('isCrossProviderRater true when provider prefixes differ; false on identical provider', () => {
+  expect(SO.isCrossProviderRater('claude-code:opus-4-7@anthropic', 'fleet:gemma3:1b@ollama')).toBe(true);
+  expect(SO.isCrossProviderRater('claude-code:opus-4-7@anthropic', 'claude-code:sonnet-4-6@anthropic')).toBe(false);
+  expect(SO.isCrossProviderRater('copilot:gpt-5.3-codex@github', 'codex:gpt-5.3-codex@openai')).toBe(true);
+});
+
+test('isCrossProviderRater false when either side is null or empty', () => {
+  expect(SO.isCrossProviderRater(null, 'fleet:gemma3:1b@ollama')).toBe(false);
+  expect(SO.isCrossProviderRater('claude-code:opus-4-7@anthropic', '')).toBe(false);
+});
+
+test('computeDeltas yields signed per-goal deltas and max-abs across the union of goals', () => {
+  const first = { G1: 10, G2: 8, G5: 6 };
+  const second = { G1: 9, G2: 9, G5: 8 };
+  const result = SO.computeDeltas(first, second);
+  expect(result.deltas).toEqual({ G1: -1, G2: 1, G5: 2 });
+  expect(result.max_abs_delta).toBe(2);
+});
+
+test('computeDeltas skips goals where either rater lacks a score', () => {
+  const first = { G1: 10, G2: 8 };
+  const second = { G2: 9, G5: 7 };
+  const result = SO.computeDeltas(first, second);
+  expect(result.deltas).toEqual({ G2: 1 });
+  expect(result.max_abs_delta).toBe(1);
+});
+
+test('computeDeltas tolerates empty inputs', () => {
+  expect(SO.computeDeltas({}, {})).toEqual({ deltas: {}, max_abs_delta: 0 });
+  expect(SO.computeDeltas(null, null)).toEqual({ deltas: {}, max_abs_delta: 0 });
+});
+
+test('shouldEscalateTier3 fires when max_abs_delta > 1.0; not at exactly 1.0', () => {
+  expect(SO.shouldEscalateTier3(1.5)).toBe(true);
+  expect(SO.shouldEscalateTier3(1.0)).toBe(false);
+  expect(SO.shouldEscalateTier3(0.5)).toBe(false);
+  expect(SO.shouldEscalateTier3(NaN)).toBe(false);
+});
+
+test('appendSecondOpinionBlock formats the canonical SECOND_OPINION block', () => {
+  const block = SO.appendSecondOpinionBlock({
+    rater_team_model: 'fleet:gemma3:1b@ollama',
+    second_scores: { G1: 9, G2: 8 },
+    deltas: { G1: -1, G2: 0 },
+    max_abs_delta: 1,
+    escalate: false,
+  });
+  expect(block).toContain('SECOND_OPINION');
+  expect(block).toContain('rater_team_model: fleet:gemma3:1b@ollama');
+  expect(block).toContain('scores: G1=9,G2=8');
+  expect(block).toContain('deltas: G1=-1,G2=0');
+  expect(block).toContain('verdict: NO_ESCALATION');
+});
+
+test('appendSecondOpinionBlock emits ESCALATE_TIER_3 verdict when escalate flag set', () => {
+  const block = SO.appendSecondOpinionBlock({
+    rater_team_model: 'fleet:gemma3:1b@ollama',
+    second_scores: { G5: 4 }, deltas: { G5: -2 }, max_abs_delta: 2, escalate: true,
+  });
+  expect(block).toContain('verdict: ESCALATE_TIER_3');
+});
+
+test('shouldSkip returns the waiver-reason when override label present, null otherwise', () => {
+  expect(SO.shouldSkip(['second-opinion:waived'])).toBe('override-waived');
+  expect(SO.shouldSkip([])).toBeNull();
+  expect(SO.shouldSkip(null)).toBeNull();
+});
+
+test('end-to-end: parse, cross-provider check, compute, escalate, format', () => {
+  const firstBody = 'G1=10 G2=8 G3=9\nSigned-by: Orla Vale\nTeam&Model: claude-code:opus-4-7@anthropic';
+  const secondBody = 'G1=8 G2=9 G3=4\nSigned-by: Gemma Vale\nTeam&Model: fleet:gemma3:1b@ollama';
+  const first = SO.parseCloseoutScores(firstBody);
+  const second = SO.parseCloseoutScores(secondBody);
+  const firstRater = SO.parseRaterTeamModel(firstBody);
+  const secondRater = SO.parseRaterTeamModel(secondBody);
+  expect(SO.isCrossProviderRater(firstRater, secondRater)).toBe(true);
+  const { deltas, max_abs_delta } = SO.computeDeltas(first, second);
+  expect(max_abs_delta).toBe(5);
+  expect(SO.shouldEscalateTier3(max_abs_delta)).toBe(true);
+  const block = SO.appendSecondOpinionBlock({
+    rater_team_model: secondRater, second_scores: second, deltas, max_abs_delta, escalate: true,
+  });
+  expect(block).toContain('verdict: ESCALATE_TIER_3');
+});


### PR DESCRIPTION
## Summary

- New `scripts/global/consultant-second-opinion.js` (87 lines): pure helper for parsing CONSULTANT_CLOSEOUT rubric scores, parsing rater Team&Model, checking cross-provider independence, computing per-goal deltas, deciding Tier-3 escalation when `max_abs_delta > 1.0`, formatting the canonical `SECOND_OPINION` block.
- New 15-test spec covers parser variants, Team&Model extraction, cross-provider check, delta math, escalation threshold (1.5 fires, 1.0 does not), block format, waiver path, end-to-end integration.
- New standalone advisory workflow `.github/workflows/consultant-second-opinion-advisory.yml` (56 lines): runs on PR events; if linked-issue CONSULTANT_CLOSEOUT lacks SECOND_OPINION block, posts a structured advisory comment. **Advisory only — does not block merge.**

Closes #1573
Refs #1573
Refs Epic #1568
Refs #1569

## Why

Implements F5 from #1569 research synthesis: cross-provider rater diversity yields the strongest bias-independence per Star Chamber (Mozilla.AI) and Diverse-LLMs (arXiv 2512.12536). Single-rater self-bias amplifies monotonically when iterated (Panickssery et al. NeurIPS '24/'25). Helper accepts pre-computed scores from any cross-family rater (default suggestion: fleet `gemma3:1b@ollama`).

Fifth megalint advisory in the family following `cross-checkout-destructive` (#1554), `flaw-emission` (#1555), `model-diversity` (#1572), and `collaborator-self-check` (#1571 via Copilot Team's #1580 hardening). Promotion to required-blocking is a separate follow-on after 7-day soak (Epic #1486 Path D pattern).

## Race-aware sequencing applied

Per the #1574 lesson, all 4 baton artifacts were posted on the issue BEFORE this PR opened. Each artifact predates PR creation by ≥60s, so `evidence-completeness` should pass naturally.

## Baton artifacts (all on issue before PR)

### MANAGER_HANDOFF
Scoped helper + spec + advisory workflow + fragment; lane code-change; test_strategy tdd-pyramid.
Full: https://github.com/chf3198/megingjord-harness/issues/1573#issuecomment-4457160695

### COLLABORATOR_HANDOFF
15/15 spec pass; 1076 full suite pass; lint clean; pre_handoff_checks 10/10 ticked.
Full: https://github.com/chf3198/megingjord-harness/issues/1573#issuecomment-4457188658

### ADMIN_HANDOFF
Branch fix/1573-second-opinion-consultant off 1bee2f5; sync N/A (governance tooling); race-aware sequencing applied; waiver-label rationale.
Full: https://github.com/chf3198/megingjord-harness/issues/1573#issuecomment-4457196631

### CONSULTANT_CLOSEOUT
Rubric 9.4 mean (G1=10, G2=10, G3=10, G4=10, G5=10, G6=8, G7=9, G8=8, G9=10). Verdict APPROVED. anneal_tickets_filed: none. mid_flight_flaws: none — race-aware sequencing prevented the patterns seen on #1574.
Full: https://github.com/chf3198/megingjord-harness/issues/1573#issuecomment-4457199802

## Test plan

- [x] \`npx playwright test tests/consultant-second-opinion.spec.js\` → 15/15 pass
- [x] \`npm test\` → 1076 passed, 4 skipped, exit=0
- [x] \`npm run lint\` → 100-line cap clean
- [x] \`npm run lint:readability:ci\` (cap=420) → exit=0
- [x] flaw-emission dry-run on issue comments → ok=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)