### PR TITLE
feat(wiki): team append write safety #1111

### DIFF
--- a/.changes/unreleased/1111.md
+++ b/.changes/unreleased/1111.md
@@ -1,0 +1,9 @@
+# 1111
+
+- Added team-scoped wiki append locks for parallel cross-team R&D notes.
+- Added team-append provenance fields: `thread_id` and `append_position`.
+- Added read-only thread status aggregation for `status.md` style views.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/dashboard/js/tier-c-banner.js
+++ b/dashboard/js/tier-c-banner.js
@@ -8,9 +8,9 @@ function getTierCAgents(sessions) {
 }
 
 function renderTierCBanner(sessions) {
-  var tierC = getTierCAgents(sessions);
+  const tierC = getTierCAgents(sessions);
   if (!tierC.length) return '';
-  var names = tierC.map(function(s) { return s.vendor + ':' + s.agentId; }).join(', ');
+  const names = tierC.map(function(s) { return s.vendor + ':' + s.agentId; }).join(', ');
   return '<div class="tier-c-banner" role="alert" aria-live="polite">'
     + '<span class="tier-c-icon">⚠️</span>'
     + '<span>' + TIER_C_MSG + TIER_C_MSG2 + '</span>'
@@ -21,7 +21,7 @@ function renderTierCBanner(sessions) {
 }
 
 function groupBy(sessions, key) {
-  var groups = {};
+  const groups = {};
   sessions.forEach(function(s) {
     if (s[key]) {
       if (!groups[s[key]]) groups[s[key]] = [];
@@ -32,7 +32,7 @@ function groupBy(sessions, key) {
 }
 
 function conflictsFromGroup(groups, type, prefix) {
-  var out = [];
+  const out = [];
   Object.keys(groups).forEach(function(k) {
     if (groups[k].length > 1) {
       out.push({ type: type, key: prefix + k,
@@ -44,17 +44,17 @@ function conflictsFromGroup(groups, type, prefix) {
 
 function detectConflicts(sessions) {
   if (!sessions || sessions.length < 2) return [];
-  var byTicket = groupBy(sessions, 'ticket');
-  var byBranch = groupBy(sessions, 'branch');
+  const byTicket = groupBy(sessions, 'ticket');
+  const byBranch = groupBy(sessions, 'branch');
   return conflictsFromGroup(byTicket, 'ticket', '#')
     .concat(conflictsFromGroup(byBranch, 'branch', ''));
 }
 
 function renderConflictAlerts(sessions) {
-  var conflicts = detectConflicts(sessions);
+  const conflicts = detectConflicts(sessions);
   if (!conflicts.length) return '';
   return conflicts.map(function(c) {
-    var label = c.type === 'ticket' ? 'Ticket conflict' : 'Branch conflict';
+    const label = c.type === 'ticket' ? 'Ticket conflict' : 'Branch conflict';
     return '<div class="conflict-alert" role="alert">'
       + '<strong>🚨 ' + label + ':</strong> <code>' + c.key + '</code>'
       + ' claimed by: ' + c.agents.join(', ')

--- a/scripts/wiki/write-safety.js
+++ b/scripts/wiki/write-safety.js
@@ -10,13 +10,16 @@ const crypto = require('node:crypto');
 const LOCK_DIR = path.resolve(__dirname, '..', '..', '.megingjord', 'wiki-locks');
 const LOCK_TTL_MS = 5 * 60 * 1000;
 const PROVENANCE_FIELDS = ['author', 'team', 'model', 'agent_role', 'commit'];
+const TEAM_APPEND_FIELDS = ['thread_id', 'append_position'];
 
 function ensureLockDir() {
   fs.mkdirSync(LOCK_DIR, { recursive: true });
 }
 
-function lockKey(slug) {
-  return crypto.createHash('sha256').update(slug).digest('hex').slice(0, 16);
+function lockKey(slug, provenance = {}, options = {}) {
+  const scope = options.scope || provenance.scope;
+  const key = scope === 'team-append' ? `${slug}:${provenance.team}` : slug;
+  return crypto.createHash('sha256').update(key).digest('hex').slice(0, 16);
 }
 
 /** Acquire a local advisory lock for a wiki page slug.
@@ -24,9 +27,11 @@ function lockKey(slug) {
  * @param {object} provenance - Writer identity (author, team, model, agent_role, commit).
  * @returns {{ok, lockPath, reason?}}
  */
-function acquireLock(slug, provenance) {
+function acquireLock(slug, provenance, options = {}) {
+  const validation = validateProvenance(provenance, options);
+  if (!validation.ok) return { ok: false, reason: 'invalid-provenance', missing: validation.missing };
   ensureLockDir();
-  const lockPath = path.join(LOCK_DIR, `${lockKey(slug)}.lock`);
+  const lockPath = path.join(LOCK_DIR, `${lockKey(slug, provenance, options)}.lock`);
   if (fs.existsSync(lockPath)) {
     const stat = fs.statSync(lockPath);
     if (Date.now() - stat.mtimeMs < LOCK_TTL_MS) {
@@ -39,23 +44,38 @@ function acquireLock(slug, provenance) {
   return { ok: true, lockPath, envelope: env };
 }
 
-function releaseLock(slug) {
-  const lockPath = path.join(LOCK_DIR, `${lockKey(slug)}.lock`);
+function releaseLock(slug, provenance = {}, options = {}) {
+  const lockPath = path.join(LOCK_DIR, `${lockKey(slug, provenance, options)}.lock`);
   if (fs.existsSync(lockPath)) fs.unlinkSync(lockPath);
 }
 
 /** Validate that a write provenance object has required fields. */
-function validateProvenance(prov) {
-  const missing = PROVENANCE_FIELDS.filter(f => !prov || !prov[f]);
+function validateProvenance(prov, options = {}) {
+  const required = options.scope === 'team-append' ? PROVENANCE_FIELDS.concat(TEAM_APPEND_FIELDS) : PROVENANCE_FIELDS;
+  const missing = required.filter(f => !prov || prov[f] === undefined || prov[f] === null || prov[f] === '');
   return { ok: missing.length === 0, missing };
 }
 
 /** Stamp a wiki page body with provenance frontmatter (additive). */
-function stampProvenance(body, provenance) {
-  const validation = validateProvenance(provenance);
+function stampProvenance(body, provenance, options = {}) {
+  const validation = validateProvenance(provenance, options);
   if (!validation.ok) return { ok: false, missing: validation.missing };
   const stamp = `<!-- provenance: ${JSON.stringify(provenance)} -->`;
   return { ok: true, stamped: `${stamp}\n${body}` };
+}
+
+function readThreadStatus(threadDir) {
+  const files = fs.readdirSync(threadDir).filter(f => f.endsWith('.md')).sort();
+  const appends = files.map(file => {
+    const body = fs.readFileSync(path.join(threadDir, file), 'utf8');
+    const match = body.match(/<!-- provenance: (.+?) -->/);
+    const provenance = match ? JSON.parse(match[1]) : {};
+    return { file, team: provenance.team, thread_id: provenance.thread_id,
+      append_position: provenance.append_position };
+  });
+  const lines = ['# Thread Status', '', ...appends.map(item =>
+    `- ${item.team}: ${item.file} @ ${item.append_position}`)];
+  return { ok: true, appends, status_md: `${lines.join('\n')}\n` };
 }
 
 if (require.main === module) {
@@ -70,4 +90,4 @@ if (require.main === module) {
 }
 
 module.exports = { acquireLock, releaseLock, validateProvenance, stampProvenance,
-  lockKey, LOCK_TTL_MS, PROVENANCE_FIELDS, LOCK_DIR };
+  readThreadStatus, lockKey, LOCK_TTL_MS, PROVENANCE_FIELDS, TEAM_APPEND_FIELDS, LOCK_DIR };

--- a/tests/wiki-safety-answers.spec.js
+++ b/tests/wiki-safety-answers.spec.js
@@ -8,11 +8,13 @@ const A = require(path.resolve(__dirname, '..', 'scripts', 'wiki', 'answer.js'))
 
 const PROV = { author: 'test', team: 'claude-code', model: 'opus-4-7',
   agent_role: 'collaborator', commit: 'abc123' };
+const TEAM_PROV = { ...PROV, thread_id: 'thread-1', append_position: 1 };
 
 test('write-safety constants documented', () => {
   expect(W.LOCK_TTL_MS).toBe(5 * 60 * 1000);
   expect(W.PROVENANCE_FIELDS).toContain('author');
   expect(W.PROVENANCE_FIELDS).toContain('team');
+  expect(W.TEAM_APPEND_FIELDS).toContain('thread_id');
 });
 
 test('validateProvenance rejects missing fields', () => {
@@ -24,9 +26,19 @@ test('validateProvenance accepts complete fields', () => {
   expect(W.validateProvenance(PROV).ok).toBe(true);
 });
 
+test('validateProvenance requires append fields in team-append mode', () => {
+  expect(W.validateProvenance(PROV, { scope: 'team-append' }).ok).toBe(false);
+  expect(W.validateProvenance(TEAM_PROV, { scope: 'team-append' }).ok).toBe(true);
+});
+
 test('lockKey is deterministic 16-char hash', () => {
   expect(W.lockKey('test-slug').length).toBe(16);
   expect(W.lockKey('test-slug')).toBe(W.lockKey('test-slug'));
+});
+
+test('lockKey scopes team-append locks by team', () => {
+  expect(W.lockKey('test-slug', { team: 'claude-code' }, { scope: 'team-append' }))
+    .not.toBe(W.lockKey('test-slug', { team: 'codex' }, { scope: 'team-append' }));
 });
 
 test('acquireLock + releaseLock work for unique slug', () => {
@@ -48,11 +60,31 @@ test('acquireLock blocks second-acquire within TTL', () => {
   W.releaseLock(slug);
 });
 
+test('team-append writes can coexist in the same thread dir', () => {
+  const threadDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wiki-thread-'));
+  const cases = [
+    ['claude.md', { ...TEAM_PROV, team: 'claude-code' }],
+    ['copilot.md', { ...TEAM_PROV, team: 'copilot-team' }],
+    ['codex.md', { ...TEAM_PROV, team: 'codex-team' }],
+  ];
+  const results = cases.map(([file, provenance]) => W.acquireLock(path.join(threadDir, file), provenance,
+    { scope: 'team-append' }));
+  expect(results.every(result => result.ok)).toBe(true);
+  cases.forEach(([file, provenance]) => W.releaseLock(path.join(threadDir, file), provenance, { scope: 'team-append' }));
+  fs.rmSync(threadDir, { recursive: true, force: true });
+});
+
 test('stampProvenance prepends provenance comment', () => {
   const result = W.stampProvenance('# Hello', PROV);
   expect(result.ok).toBe(true);
   expect(result.stamped).toContain('provenance');
   expect(result.stamped).toContain('# Hello');
+});
+
+test('stampProvenance accepts team-append provenance fields', () => {
+  const result = W.stampProvenance('# Thread note', TEAM_PROV, { scope: 'team-append' });
+  expect(result.ok).toBe(true);
+  expect(result.stamped).toContain('thread_id');
 });
 
 test('answer slugify produces clean slug', () => {

--- a/tests/wiki-safety-team-append.spec.js
+++ b/tests/wiki-safety-team-append.spec.js
@@ -1,0 +1,30 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const W = require(path.resolve(__dirname, '..', 'scripts', 'wiki', 'write-safety.js'));
+
+const BASE = { author: 'test', model: 'local', agent_role: 'collaborator', commit: 'abc123',
+  thread_id: 'thread-1' };
+
+test('#1111 readThreadStatus derives status.md without a lock', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wiki-thread-status-'));
+  const items = [
+    ['claude.md', { ...BASE, team: 'claude-code', append_position: 1 }],
+    ['copilot.md', { ...BASE, team: 'copilot-team', append_position: 2 }],
+    ['codex.md', { ...BASE, team: 'codex-team', append_position: 3 }],
+  ];
+  for (const [file, provenance] of items) {
+    const stamped = W.stampProvenance(`# ${file}`, provenance, { scope: 'team-append' });
+    fs.writeFileSync(path.join(dir, file), stamped.stamped);
+  }
+  const status = W.readThreadStatus(dir);
+  expect(status.ok).toBe(true);
+  expect(status.appends.map(item => item.team).sort()).toEqual([
+    'claude-code', 'codex-team', 'copilot-team',
+  ]);
+  expect(status.status_md).toContain('# Thread Status');
+  const locks = fs.existsSync(W.LOCK_DIR) ? fs.readdirSync(W.LOCK_DIR) : [];
+  expect(locks.filter(file => file.endsWith('.lock')).length).toBe(0);
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- Scope team-append wiki write locks by `{slug}:{team}` while preserving default exclusive locking.
- Require and stamp `thread_id` / `append_position` only for `team-append` provenance.
- Add lock-free `readThreadStatus()` aggregation for team append markdown files.
- Clear a pre-existing repo-wide lint blocker in `dashboard/js/tier-c-banner.js` by replacing `var` with `const`.

Refs #1111
Closes #1111

## Test strategy
`test_strategy: tdd-pyramid`

## Validation
- `npx playwright test tests/wiki-safety-answers.spec.js tests/wiki-safety-team-append.spec.js` -> 14 passed
- `npm run lint -- --max-warnings=9999` -> passed line-cap scan
- `npx eslint -c lint-configs/eslint.config.devenv.js --quiet dashboard/js scripts/global scripts/wiki` -> passed with 0 errors
- `npm run docs:anchors` -> passed
- `git diff --check` -> passed
- `node scripts/global/closeout-preflight.js` -> passed
- `git push -u origin feat/1111-team-append-write-safety` -> pre-push passed; branch published

## Governance
- MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, and CONSULTANT_CLOSEOUT are on #1111.
- No runtime-home edits; no Claude/Copilot worktrees touched.

Signed-by: Quill Harper
Team&Model: codex:gpt-5.4@openai
Role: collaborator