### PR TITLE
feat(governance): worker signature compliance audit #1388

### DIFF
--- a/.changes/unreleased/1388.md
+++ b/.changes/unreleased/1388.md
@@ -1,0 +1,8 @@
+## [Unreleased] — #1388: worker signature governance audit
+
+### Added
+- `scripts/global/worker-signature-governance.js` to validate canonical worker signatures.
+
+### Changed
+- `scripts/global/governance-audit.js` now surfaces worker-signature compliance violations.
+- `tests/governance-audit.spec.js` now covers malformed and canonical worker signature bodies.

--- a/scripts/global/governance-audit.js
+++ b/scripts/global/governance-audit.js
@@ -8,6 +8,7 @@ const REPORT_FILE = '/tmp/governance-audit.json';
 const DEP_HEALTH = require('./dep-graph-health');
 const ANNEAL_SENSOR = require('./anneal-audit-sensor');
 const GIT_STATE_DRIFT = require('./git-state-drift-sensor');
+const WORKER_SIGNATURE = require('./worker-signature-governance');
 const CHECKS = ['governance:drift', 'governance:verify', 'governance:reconcile', 'governance:worktrees'];
 const TIMEOUT_MS = 60_000;
 const RAW_PREVIEW_MAX = 500;
@@ -27,7 +28,7 @@ function runCheck(name) {
 
 function listOpenTickets() {
   try {
-    const cmd = `gh issue list --state open --limit ${TICKET_FETCH_LIMIT} --json number,title,labels --jq ".[] | {number, title, labels: [.labels[].name]}"`;
+    const cmd = `gh issue list --state open --limit ${TICKET_FETCH_LIMIT} --json number,title,labels,body --jq ".[] | {number, title, body, labels: [.labels[].name]}"`;
     const out = execSync(cmd, { encoding: 'utf8', timeout: TIMEOUT_MS });
     return out.trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
   } catch (err) { return []; }
@@ -92,6 +93,14 @@ async function audit(opts = {}) {
   const gitStateDrift = GIT_STATE_DRIFT.compute();
   const tickets = listOpenTickets();
   const violations = detectViolations(tickets);
+  const workerSignatureCompliance = WORKER_SIGNATURE.summarizeTickets(tickets);
+  for (const signatureViolation of workerSignatureCompliance.violations) {
+    violations.push({
+      ticket: signatureViolation.ticket,
+      rule: signatureViolation.rule,
+      detail: signatureViolation.detail,
+    });
+  }
   for (const driftViolation of gitStateDrift.violations || []) {
     violations.push({
       ticket: 'GIT-STATE',
@@ -114,6 +123,7 @@ async function audit(opts = {}) {
     open_tickets: tickets.length, violations, hamr_utilization: hamrSensor,
     git_state_drift: gitStateDrift,
     dependency_health: dependencyHealth, goal_health: goalHealth,
+    worker_signature_compliance: workerSignatureCompliance,
     operator_overrides_active: operatorOverridesActive,
     actuator_state: actuatorState,
     anneal_signals: annealSignals,

--- a/scripts/global/worker-signature-governance.js
+++ b/scripts/global/worker-signature-governance.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const signerFormatCanonical = require('./megalint/signer-format-canonical');
+const signerFidelity = require('./megalint/signer-fidelity');
+
+function inspectBody(body) {
+  const format = signerFormatCanonical.validate({ body });
+  const fidelity = signerFidelity.validate({ body });
+  return {
+    ok: format.ok && fidelity.ok,
+    violations: [...(format.violations || []), ...(fidelity.violations || [])],
+  };
+}
+
+function summarizeTickets(tickets) {
+  const inspected = [];
+  const violations = [];
+  for (const ticket of tickets || []) {
+    const body = ticket && ticket.body;
+    if (!body) continue;
+    const result = inspectBody(body);
+    inspected.push(ticket.number);
+    for (const violation of result.violations) {
+      violations.push({ ticket: ticket.number, ...violation });
+    }
+  }
+  return { inspected, violations, ok: violations.length === 0 };
+}
+
+module.exports = { inspectBody, summarizeTickets };

--- a/tests/governance-audit.spec.js
+++ b/tests/governance-audit.spec.js
@@ -2,6 +2,7 @@
 const { test, expect } = require('@playwright/test');
 const path = require('path');
 const A = require(path.resolve(__dirname, '..', 'scripts', 'global', 'governance-audit.js'));
+const WorkerSignature = require(path.resolve(__dirname, '..', 'scripts', 'global', 'worker-signature-governance.js'));
 
 test('CHECKS list includes the 4 deterministic governance scripts', () => {
   expect(A.CHECKS).toContain('governance:drift');
@@ -52,6 +53,7 @@ test('audit() returns schema_version 4 result with required fields', async () =>
   expect(r).toHaveProperty('git_state_drift');
   expect(r).toHaveProperty('dependency_health');
   expect(r).toHaveProperty('goal_health');
+  expect(r).toHaveProperty('worker_signature_compliance');
   expect(r).toHaveProperty('actuator_state');
   expect(['PASS', 'FAIL']).toContain(r.overall);
 });
@@ -75,4 +77,19 @@ test('dependency cycles become governance audit violations', async () => {
     edges: [{ from: 1, to: 2 }, { from: 2, to: 1 }] }));
   const r = await A.audit({ dependencyHealth: { graph, proposals: graph, decisions: graph } });
   expect(r.violations.some(v => v.rule === 'dependency-cycle')).toBe(true);
+});
+
+test('worker signature governance flags invalid grammar and client identity misuse', () => {
+  const badBody = `Manager: curtisfranks | GitHub Copilot (Claude Sonnet 4.6 @ github-copilot) | 2026-05-14\n\nSigned-by: Curtis Franks\nTeam&Model: copilot:claude-sonnet-4-6@github-copilot\nRole: manager`;
+  const result = WorkerSignature.inspectBody(badBody);
+  expect(result.ok).toBe(false);
+  expect(result.violations.some(v => v.rule === 'role-prefix-as-provenance')).toBe(true);
+  expect(result.violations.some(v => v.rule === 'client-identity-as-signer')).toBe(true);
+});
+
+test('worker signature governance accepts canonical worker blocks', () => {
+  const goodBody = `Signed-by: Quill Mason\nTeam&Model: codex:gpt-5.4@codex-cli\nRole: manager`;
+  const result = WorkerSignature.inspectBody(goodBody);
+  expect(result.ok).toBe(true);
+  expect(result.violations).toHaveLength(0);
 });


### PR DESCRIPTION
## Summary
- Add a worker-signature governance helper that reuses canonical signer validators.
- Surface worker-signature compliance in governance-audit results.
- Add synthetic tests for invalid grammar, client-name misuse, and canonical blocks.
- Add a per-ticket changelog fragment for doc-update-gate.

Refs #1388
Closes #1388

## Validation
- tests/governance-audit.spec.js passed locally
- git diff --check is clean

## Governance
- No runtime-home edits.
- No Claude/Copilot worktrees touched.

Signed-by: Quill Harper
Team&Model: codex:gpt-5.4@openai
Role: collaborator
