### PR TITLE
feat(governance): add claim lease registry #1618

### DIFF
--- a/.changes/unreleased/1618.md
+++ b/.changes/unreleased/1618.md
@@ -1,0 +1,11 @@
+# 1618
+
+- Added a provider-neutral cross-team lease registry contract for active
+  harness work claims.
+- Added a CLI for lease create, refresh, list, expire, close, and GitHub
+  issue marker mirroring.
+- Documented the lease lifecycle in sandbox worktree governance instructions.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/instructions/sandbox-worktree-governance.instructions.md
+++ b/instructions/sandbox-worktree-governance.instructions.md
@@ -20,16 +20,23 @@ Before starting implementation in any sandbox worktree:
 2. Reset launcher branch to `origin/main`
 3. Remove local residue (`git clean -fd`)
 4. Create and switch to ticket-linked task branch
+5. Create or refresh a cross-team lease for the ticket and intended paths
 
 Preferred command:
 
 - `bash scripts/worktree-session-start.sh <copilot|codex|claude-code> feat/<issue#>-<slug>`
+
+Lease command:
+
+- `node scripts/global/cross-team-lease.js create --ticket <N> --team <team> --role collaborator --branch <branch> --paths <paths> --runtime-surfaces <surfaces> --post-comment 1`
 
 ## Forbidden Actions
 
 - Do not commit directly on `sandbox/*` branches.
 - Do not open PRs from `sandbox/*` branches.
 - Do not keep launcher branches behind `origin/main` between sessions.
+- Do not edit files before the ticket has a live `CROSS_TEAM_LEASE_CREATE`
+  comment unless the work is issue-only research.
 
 ## Verification Gates
 
@@ -42,3 +49,16 @@ Preferred command:
 ## Escalation
 
 If any sandbox branch is behind or dirty: stop, run session-start reset flow, then resume on a ticket-linked task branch only.
+
+## Cross-Team Lease Lifecycle
+
+- Live lease state is repo-local runtime state in `.dashboard/cross-team-leases.json`.
+- Schema lives in `inventory/cross-team-lease.schema.json`.
+- Leases record ticket, team, role, branch, worktree, paths, ports, runtime
+  surfaces, timestamps, expiry, and status.
+- `create` claims a ticket/branch before edits.
+- `refresh` heartbeats long-running work.
+- `expire` marks stale claims for cleanup.
+- `close` releases ownership after merge, cancellation, or handoff.
+- Creation and closeout should be mirrored to the GitHub issue with the stable
+  `CROSS_TEAM_LEASE_*` marker block.

--- a/inventory/cross-team-lease.schema.json
+++ b/inventory/cross-team-lease.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://megingjord.local/schemas/cross-team-lease.schema.json",
+  "title": "CrossTeamLeaseRegistry",
+  "type": "object",
+  "required": ["version", "leases"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "const": 1 },
+    "leases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "ticket",
+          "team",
+          "role",
+          "branch",
+          "worktree",
+          "paths",
+          "ports",
+          "runtime_surfaces",
+          "created_at",
+          "last_seen",
+          "expires_at",
+          "status"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "ticket": { "type": "integer", "minimum": 1 },
+          "team": {
+            "enum": ["codex", "copilot", "claude-code", "openclaw", "operator"]
+          },
+          "role": {
+            "enum": ["manager", "collaborator", "admin", "consultant"]
+          },
+          "branch": { "type": "string", "minLength": 1 },
+          "worktree": { "type": "string", "minLength": 1 },
+          "paths": { "type": "array", "items": { "type": "string" } },
+          "ports": { "type": "array", "items": { "type": "integer" } },
+          "runtime_surfaces": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "created_at": { "type": "string", "format": "date-time" },
+          "last_seen": { "type": "string", "format": "date-time" },
+          "expires_at": { "type": "string", "format": "date-time" },
+          "status": { "enum": ["active", "expired", "closed"] }
+        }
+      }
+    }
+  }
+}

--- a/scripts/global/cross-team-lease-registry.js
+++ b/scripts/global/cross-team-lease-registry.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_PATH = path.join(process.cwd(), '.dashboard', 'cross-team-leases.json');
+const TTL_HOURS = 24;
+const HOUR_MS = 3600000;
+
+function empty() { return { version: 1, leases: [] }; }
+function now() { return new Date().toISOString(); }
+function expires(hours = TTL_HOURS) {
+  return new Date(Date.now() + Number(hours) * HOUR_MS).toISOString();
+}
+function listArg(value) {
+  if (!value) return [];
+  return String(value).split(',').map(s => s.trim()).filter(Boolean);
+}
+function read(file = DEFAULT_PATH) {
+  if (!fs.existsSync(file)) return empty();
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+function write(registry, file = DEFAULT_PATH) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(registry, null, 2)}\n`);
+}
+function active(registry, at = now()) {
+  return registry.leases.filter(l => l.status === 'active' && l.expires_at > at);
+}
+function ensureFree(registry, lease) {
+  const hit = active(registry).find(l => l.ticket === lease.ticket || l.branch === lease.branch);
+  if (hit) throw new Error(`active lease collision with #${hit.ticket} ${hit.branch}`);
+}
+function createLease(registry, input) {
+  const stamp = now();
+  const lease = {
+    ticket: Number(input.ticket), team: input.team, role: input.role,
+    branch: input.branch, worktree: input.worktree || process.cwd(),
+    paths: listArg(input.paths), ports: listArg(input.ports).map(Number),
+    runtime_surfaces: listArg(input.runtime_surfaces),
+    created_at: stamp, last_seen: stamp, expires_at: expires(input.ttl_hours),
+    status: 'active',
+  };
+  ensureFree(registry, lease);
+  registry.leases.push(lease);
+  return lease;
+}
+function findActive(registry, ticket) {
+  return registry.leases.find(l => l.ticket === Number(ticket) && l.status === 'active');
+}
+function refreshLease(registry, ticket, ttlHours) {
+  const lease = registry.leases.find(l => l.ticket === Number(ticket) && l.status === 'active');
+  if (!lease) throw new Error(`no active lease for #${ticket}`);
+  lease.last_seen = now();
+  lease.expires_at = expires(ttlHours);
+  return lease;
+}
+function expireLeases(registry, at = now()) {
+  const expired = [];
+  for (const lease of registry.leases) {
+    if (lease.status === 'active' && lease.expires_at <= at) {
+      lease.status = 'expired';
+      expired.push(lease);
+    }
+  }
+  return expired;
+}
+function closeLease(registry, ticket) {
+  const lease = findActive(registry, ticket);
+  if (!lease) throw new Error(`no active lease for #${ticket}`);
+  lease.status = 'closed';
+  lease.last_seen = now();
+  return lease;
+}
+function commentBlock(event, lease) {
+  const rows = [
+    `<!-- cross-team-lease:${event} -->`, `CROSS_TEAM_LEASE_${event.toUpperCase()}`,
+    `ticket: #${lease.ticket}`, `team: ${lease.team}`, `role: ${lease.role}`,
+    `branch: ${lease.branch}`, `worktree: ${lease.worktree}`,
+    `paths: ${lease.paths.join(',')}`, `ports: ${lease.ports.join(',')}`,
+    `runtime_surfaces: ${lease.runtime_surfaces.join(',')}`,
+    `expires_at: ${lease.expires_at}`, `status: ${lease.status}`,
+  ];
+  return rows.join('\n');
+}
+module.exports = { read, write, createLease, refreshLease, expireLeases,
+  closeLease, active, commentBlock, DEFAULT_PATH };

--- a/scripts/global/cross-team-lease.js
+++ b/scripts/global/cross-team-lease.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+'use strict';
+
+const { execFileSync } = require('child_process');
+const leaseRegistry = require('./cross-team-lease-registry');
+
+function parse(args) {
+  const out = { _: [] };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg.startsWith('--')) out[arg.slice(2).replace(/-/g, '_')] = args[++i] || true;
+    else out._.push(arg);
+  }
+  return out;
+}
+
+function post(issue, body) {
+  execFileSync('gh', ['issue', 'comment', String(issue), '--body', body], {
+    stdio: 'inherit',
+  });
+}
+
+function run(argv = process.argv.slice(2)) {
+  const args = parse(argv);
+  const cmd = args._[0];
+  const registry = leaseRegistry.read(args.file || leaseRegistry.DEFAULT_PATH);
+  const commands = {
+    create: () => leaseRegistry.createLease(registry, args),
+    refresh: () => leaseRegistry.refreshLease(registry, args.ticket, args.ttl_hours),
+    expire: () => leaseRegistry.expireLeases(registry),
+    close: () => leaseRegistry.closeLease(registry, args.ticket),
+    list: () => leaseRegistry.active(registry),
+  };
+  if (!commands[cmd]) throw new Error('usage: create|refresh|expire|close|list');
+  const result = commands[cmd]();
+  if (cmd !== 'list') leaseRegistry.write(registry, args.file || leaseRegistry.DEFAULT_PATH);
+  if (args.post_comment && result && !Array.isArray(result)) {
+    post(result.ticket, leaseRegistry.commentBlock(cmd, result));
+  }
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  return result;
+}
+
+if (require.main === module) {
+  try { run(); } catch (error) { console.error(error.message); process.exit(1); }
+}
+
+module.exports = { run, parse };

--- a/tests/cross-team-lease-registry.spec.js
+++ b/tests/cross-team-lease-registry.spec.js
@@ -1,0 +1,106 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const L = require('../scripts/global/cross-team-lease-registry');
+
+function baseInput(overrides = {}) {
+  return {
+    ticket: 1618,
+    team: 'codex',
+    role: 'collaborator',
+    branch: 'feat/1618-claim-lease-registry',
+    worktree: '/tmp/devenv-ops-codex-1618',
+    paths: 'scripts/global,tests',
+    ports: '8090,8787',
+    runtime_surfaces: 'codex,github',
+    ...overrides,
+  };
+}
+
+test('createLease stores the required cross-team fields', () => {
+  const registry = { version: 1, leases: [] };
+  const lease = L.createLease(registry, baseInput());
+  expect(lease.ticket).toBe(1618);
+  expect(lease.team).toBe('codex');
+  expect(lease.role).toBe('collaborator');
+  expect(lease.paths).toEqual(['scripts/global', 'tests']);
+  expect(lease.ports).toEqual([8090, 8787]);
+  expect(lease.runtime_surfaces).toEqual(['codex', 'github']);
+  expect(lease.status).toBe('active');
+  expect(registry.leases).toHaveLength(1);
+});
+
+test('createLease rejects duplicate active ticket claims', () => {
+  const registry = { version: 1, leases: [] };
+  L.createLease(registry, baseInput());
+  expect(() => L.createLease(registry, baseInput({ branch: 'feat/999-other' })))
+    .toThrow(/active lease collision/);
+});
+
+test('createLease rejects duplicate active branches', () => {
+  const registry = { version: 1, leases: [] };
+  L.createLease(registry, baseInput());
+  expect(() => L.createLease(registry, baseInput({ ticket: 999 })))
+    .toThrow(/active lease collision/);
+});
+
+test('refreshLease updates heartbeat and expiration', () => {
+  const registry = { version: 1, leases: [] };
+  const lease = L.createLease(registry, baseInput({ ttl_hours: 1 }));
+  const before = lease.expires_at;
+  const refreshed = L.refreshLease(registry, 1618, 48);
+  expect(refreshed.expires_at > before).toBe(true);
+  expect(refreshed.status).toBe('active');
+});
+
+test('expireLeases marks stale active leases expired', () => {
+  const registry = { version: 1, leases: [] };
+  const lease = L.createLease(registry, baseInput());
+  lease.expires_at = '2026-01-01T00:00:00.000Z';
+  const expired = L.expireLeases(registry, '2026-01-02T00:00:00.000Z');
+  expect(expired).toHaveLength(1);
+  expect(lease.status).toBe('expired');
+});
+
+test('closeLease marks an active lease closed', () => {
+  const registry = { version: 1, leases: [] };
+  L.createLease(registry, baseInput());
+  const closed = L.closeLease(registry, 1618);
+  expect(closed.status).toBe('closed');
+  expect(L.active(registry)).toEqual([]);
+});
+
+test('read returns empty registry when file is absent and write persists JSON', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lease-test-'));
+  const file = path.join(dir, 'leases.json');
+  expect(L.read(file)).toEqual({ version: 1, leases: [] });
+  const registry = { version: 1, leases: [] };
+  L.createLease(registry, baseInput());
+  L.write(registry, file);
+  expect(L.read(file).leases[0].ticket).toBe(1618);
+});
+
+test('commentBlock renders stable machine-readable markers', () => {
+  const registry = { version: 1, leases: [] };
+  const block = L.commentBlock('create', L.createLease(registry, baseInput()));
+  expect(block).toContain('<!-- cross-team-lease:create -->');
+  expect(block).toContain('CROSS_TEAM_LEASE_CREATE');
+  expect(block).toContain('ticket: #1618');
+  expect(block).toContain('branch: feat/1618-claim-lease-registry');
+});
+
+test('CLI create and list operate on an explicit repo-local file', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lease-cli-'));
+  const file = path.join(dir, 'leases.json');
+  const cli = path.resolve(__dirname, '..', 'scripts', 'global', 'cross-team-lease.js');
+  execFileSync('node', [cli, 'create', '--file', file, '--ticket', '1618',
+    '--team', 'codex', '--role', 'collaborator',
+    '--branch', 'feat/1618-claim-lease-registry', '--paths', 'scripts/global']);
+  const listed = JSON.parse(execFileSync('node', [cli, 'list', '--file', file], {
+    encoding: 'utf8',
+  }));
+  expect(listed[0].ticket).toBe(1618);
+  expect(listed[0].paths).toEqual(['scripts/global']);
+});


### PR DESCRIPTION
Closes #1618
Refs #1618
Refs #1604

## Summary

Adds the first cross-team coordination primitive for Epic #1604: a provider-neutral claim/lease registry and CLI that Claude Code Team, Copilot Team, and Codex Team can use before editing shared harness surfaces.

## Changes

- Add `inventory/cross-team-lease.schema.json` for the active lease contract.
- Add `scripts/global/cross-team-lease-registry.js` pure helper for create, refresh, expire, close, active list, duplicate ticket/branch detection, persistence, and issue-comment marker rendering.
- Add `scripts/global/cross-team-lease.js` CLI for `create|refresh|expire|close|list`, with optional `--post-comment` GitHub mirroring.
- Add focused Playwright tests for helper and CLI behavior.
- Update sandbox worktree governance instructions with the lease lifecycle and required command.
- Add unreleased change note for docs-drift evidence.

## Validation

- `npx playwright test tests/cross-team-lease-registry.spec.js` — 9/9 passed.
- `npm run lint` — all files within 100-line limit.
- `npm run lint:readability:ci` — 420 warnings, within cap.
- `npm run lint:js -- --quiet` — exit 0.
- `npm run lint:md -- instructions/sandbox-worktree-governance.instructions.md` — 0 errors.
- Final push: local pre-push hook passed branch name, lint, closeout-preflight, and governance checks. The test-evidence diff warning is a nonblocking existing advisory.

## Governance

- Manager handoff posted before edits on #1618 and updated with explicit gate list after CI schema feedback.
- Collaborator handoff posted on #1618.
- Admin handoff posted on #1618.
- Consultant closeout posted on #1618.
- Live `CROSS_TEAM_LEASE_CREATE` marker posted on #1618 via the new CLI.
- One branch, one ticket, one PR.

Signed-by: Quill Reyes
Team&Model: codex:gpt-5.4@openai
Role: admin