### PR TITLE
feat(governance): add pre-edit conflict gate #1619

### DIFF
--- a/.changes/unreleased/1619.md
+++ b/.changes/unreleased/1619.md
@@ -1,0 +1,9 @@
+# 1619
+
+- Added a provider-neutral pre-edit conflict gate for cross-team lease claims.
+- Added evidence markers for conflict checks and issue-comment mirroring.
+- Documented the conflict-gate command in sandbox worktree governance.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/instructions/sandbox-worktree-governance.instructions.md
+++ b/instructions/sandbox-worktree-governance.instructions.md
@@ -30,6 +30,10 @@ Lease command:
 
 - `node scripts/global/cross-team-lease.js create --ticket <N> --team <team> --role collaborator --branch <branch> --paths <paths> --runtime-surfaces <surfaces> --post-comment 1`
 
+Conflict check:
+
+- `node scripts/global/cross-team-conflict-gate.js --ticket <N> --branch <branch> --paths <paths> --post-comment 1`
+
 ## Forbidden Actions
 
 - Do not commit directly on `sandbox/*` branches.
@@ -62,3 +66,6 @@ If any sandbox branch is behind or dirty: stop, run session-start reset flow, th
 - `close` releases ownership after merge, cancellation, or handoff.
 - Creation and closeout should be mirrored to the GitHub issue with the stable
   `CROSS_TEAM_LEASE_*` marker block.
+- Before edits, run the conflict gate for intended paths. Exact branch and
+  same-ticket path collisions block unless Manager override is present; adjacent
+  governance surfaces warn and should be coordinated in the issue thread.

--- a/scripts/global/cross-team-conflict-gate.js
+++ b/scripts/global/cross-team-conflict-gate.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+'use strict';
+
+const { execFileSync } = require('child_process');
+const leaseRegistry = require('./cross-team-lease-registry');
+
+const SENSITIVE = ['.github/workflows', 'hooks', 'instructions', 'skills', 'scripts/global'];
+
+function parse(args) {
+  const out = { _: [] };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg.startsWith('--')) out[arg.slice(2).replace(/-/g, '_')] = args[++i] || true;
+    else out._.push(arg);
+  }
+  return out;
+}
+
+function csv(value) {
+  return value ? String(value).split(',').map(s => s.trim()).filter(Boolean) : [];
+}
+
+function overlaps(a, b) {
+  return a === b || a.startsWith(`${b}/`) || b.startsWith(`${a}/`);
+}
+
+function surface(path) {
+  return SENSITIVE.find(prefix => overlaps(path, prefix)) || null;
+}
+
+function note(kind, lease, detail, override) {
+  return { kind: override && kind === 'block' ? 'warn' : kind, ticket: lease.ticket,
+    branch: lease.branch, team: lease.team, detail };
+}
+
+function evaluate(registry, input) {
+  const paths = csv(input.paths);
+  const branch = input.branch || '';
+  const ticket = Number(input.ticket || 0);
+  const override = Boolean(input.manager_override);
+  const findings = [];
+  for (const lease of leaseRegistry.active(registry)) {
+    if (lease.ticket === ticket && lease.branch === branch) continue;
+    if (branch && lease.branch === branch) {
+      findings.push(note('block', lease, `branch already claimed: ${branch}`, override));
+    }
+    for (const requestedPath of paths) {
+      const hit = (lease.paths || []).find(existing => overlaps(requestedPath, existing));
+      if (hit && lease.ticket === ticket) {
+        findings.push(note('block', lease, `same-ticket path collision: ${requestedPath} vs ${hit}`, override));
+      } else if (hit && lease.ticket !== ticket) {
+        findings.push(note('warn', lease, `path already claimed by #${lease.ticket}: ${requestedPath} vs ${hit}`));
+      } else {
+        const ours = surface(requestedPath);
+        const theirs = (lease.paths || []).map(surface).find(Boolean);
+        if (ours && theirs && ours !== theirs) {
+          findings.push(note('warn', lease, `adjacent governance surface: ${ours} near ${theirs}`));
+        }
+      }
+    }
+  }
+  return { ok: !findings.some(f => f.kind === 'block'), findings };
+}
+
+function commentBlock(issue, result) {
+  const rows = ['<!-- cross-team-conflict:pull -->', 'CROSS_TEAM_CONFLICT_PULL',
+    `ticket: #${issue}`, `status: ${result.ok ? 'clear' : 'blocked'}`];
+  for (const finding of result.findings) rows.push(`${finding.kind}: #${finding.ticket} ${finding.detail}`);
+  return rows.join('\n');
+}
+
+function post(issue, body) {
+  execFileSync('gh', ['issue', 'comment', String(issue), '--body', body], { stdio: 'inherit' });
+}
+
+function run(argv = process.argv.slice(2)) {
+  const args = parse(argv);
+  const registry = leaseRegistry.read(args.file || leaseRegistry.DEFAULT_PATH);
+  leaseRegistry.expireLeases(registry);
+  const result = evaluate(registry, args);
+  if (args.post_comment) post(args.ticket, commentBlock(args.ticket, result));
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  return result.ok ? 0 : 2;
+}
+
+if (require.main === module) {
+  try { process.exit(run()); } catch (error) { console.error(error.message); process.exit(1); }
+}
+
+module.exports = { evaluate, commentBlock, parse, run };

--- a/tests/cross-team-conflict-gate.spec.js
+++ b/tests/cross-team-conflict-gate.spec.js
@@ -1,0 +1,88 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const leaseRegistry = require('../scripts/global/cross-team-lease-registry');
+const gate = require('../scripts/global/cross-team-conflict-gate');
+
+function registryWith(input = {}) {
+  const registry = { version: 1, leases: [] };
+  leaseRegistry.createLease(registry, {
+    ticket: 1700, team: 'copilot', role: 'collaborator',
+    branch: 'feat/1700-shared-work', paths: 'scripts/global',
+    runtime_surfaces: 'github', ...input,
+  });
+  return registry;
+}
+
+test('allows non-conflicting paths and branches', () => {
+  const result = gate.evaluate(registryWith(), {
+    ticket: 1619, branch: 'feat/1619-pre-edit-conflict-gate', paths: 'docs',
+  });
+  expect(result.ok).toBe(true);
+  expect(result.findings).toEqual([]);
+});
+
+test('ignores the caller lease when ticket and branch match', () => {
+  const result = gate.evaluate(registryWith({
+    ticket: 1619, branch: 'feat/1619-pre-edit-conflict-gate',
+  }), {
+    ticket: 1619, branch: 'feat/1619-pre-edit-conflict-gate',
+    paths: 'scripts/global',
+  });
+  expect(result.ok).toBe(true);
+});
+
+test('blocks duplicate active branch claims', () => {
+  const result = gate.evaluate(registryWith(), {
+    ticket: 1619, branch: 'feat/1700-shared-work', paths: 'docs',
+  });
+  expect(result.ok).toBe(false);
+  expect(result.findings[0].detail).toContain('branch already claimed');
+});
+
+test('blocks same-ticket path collisions', () => {
+  const result = gate.evaluate(registryWith({ ticket: 1619 }), {
+    ticket: 1619, branch: 'feat/1619-other', paths: 'scripts/global/hooks.js',
+  });
+  expect(result.ok).toBe(false);
+  expect(result.findings[0].detail).toContain('same-ticket path collision');
+});
+
+test('warns on adjacent governance surfaces', () => {
+  const result = gate.evaluate(registryWith({ paths: 'instructions' }), {
+    ticket: 1619, branch: 'feat/1619-other', paths: '.github/workflows',
+  });
+  expect(result.ok).toBe(true);
+  expect(result.findings[0].kind).toBe('warn');
+});
+
+test('ignores expired leases', () => {
+  const registry = registryWith();
+  registry.leases[0].expires_at = '2026-01-01T00:00:00.000Z';
+  registry.leases[0].status = 'expired';
+  expect(gate.evaluate(registry, {
+    ticket: 1700, branch: 'feat/1700-shared-work', paths: 'scripts/global',
+  }).ok).toBe(true);
+});
+
+test('manager override downgrades blocks to warnings', () => {
+  const result = gate.evaluate(registryWith(), {
+    ticket: 1619, branch: 'feat/1700-shared-work', paths: 'docs',
+    manager_override: '#1619',
+  });
+  expect(result.ok).toBe(true);
+  expect(result.findings[0].kind).toBe('warn');
+});
+
+test('CLI exits with 2 when blocked and prints evidence JSON', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'conflict-gate-'));
+  const file = path.join(dir, 'leases.json');
+  leaseRegistry.write(registryWith(), file);
+  const cli = path.resolve(__dirname, '..', 'scripts', 'global', 'cross-team-conflict-gate.js');
+  const run = spawnSync('node', [cli, '--file', file, '--ticket', '1619',
+    '--branch', 'feat/1700-shared-work', '--paths', 'docs'], { encoding: 'utf8' });
+  expect(run.status).toBe(2);
+  expect(JSON.parse(run.stdout).ok).toBe(false);
+});


### PR DESCRIPTION
Closes #1619
Refs #1619
Refs #1604

## Summary

Adds a provider-neutral pre-edit conflict gate that reads the #1618 cross-team lease registry before an agent edits claimed paths, branches, or governance-adjacent surfaces.

## Changes

- Add `scripts/global/cross-team-conflict-gate.js` evaluator and CLI.
- Add `tests/cross-team-conflict-gate.spec.js` coverage for clear, blocked, warning, expired, override, and CLI cases.
- Update sandbox worktree governance instructions with conflict-gate usage.
- Add `.changes/unreleased/1619.md` for docs-drift evidence.

## Validation

- `npx playwright test tests/cross-team-conflict-gate.spec.js tests/cross-team-lease-registry.spec.js` -> 17/17 passed.
- `npm run lint` -> all files within 100-line cap.
- `npm run lint:readability:ci` -> 420 warnings, within cap.
- `npm run lint:js -- --quiet` -> exit 0.
- `npm run lint:md -- instructions/sandbox-worktree-governance.instructions.md .changes/unreleased/1619.md` -> 0 errors.
- Live `CROSS_TEAM_CONFLICT_PULL` marker posted on #1619 with `ok: true`.

## Governance

- Manager handoff posted before edits on #1619.
- Live `CROSS_TEAM_LEASE_CREATE` marker posted on #1619.
- Collaborator handoff posted on #1619.
- One branch, one ticket, one PR.

Signed-by: Quill Reyes
Team&Model: codex:gpt-5.4@openai
Role: admin