### PR TITLE
fix(governance): G5 operator-env variance backing #1628

### DIFF
--- a/.changes/unreleased/1628.md
+++ b/.changes/unreleased/1628.md
@@ -1,0 +1,37 @@
+## [Unreleased] — #1628: G5 Portability backing extension (operator-environment variance + opt-in/fallback contract)
+
+### Changed
+- `instructions/harness-goals.instructions.md` G5 definition extended to explicitly cover:
+  1. Operator-environment variance as a first-class portability dimension (each operator has a unique baseline of local/fleet/remote resources).
+  2. Opt-in classification (env-var or label gate, parity with `MEGINGJORD_HAMR_DISABLED` and IDE-proxy opt-in patterns) for features requiring resources beyond the GitHub-access baseline.
+  3. Minimal-resource fallback as the alternative to opt-in.
+  4. Clear distinction from G6: G6 covers temporary outages of normally-available resources; G5 covers baseline-absent resources for a given operator.
+- Decision Lens question 5 reworded from "Is it portable?" to "Is it portable across operator baselines (will it work for an operator without resource X)?" — makes the dimension actionable at decision time.
+
+### Why
+Closes #1628. The previous G5 wording (`avoid user-specific coupling; settings-driven behavior preferred`) covered code portability but not operator-environment variance. Surfaced during adoption planning for #1624's GitHub-primitives research, where multiple primitives (gh-aw Agentic Workflows preview, Codespaces, Claude-Code agent-teams, webhook receivers) have differential availability per operator. Without an explicit G5 extension, the downstream Epic #1604 implementation children risked shipping features assuming baseline resources not every operator has.
+
+### Audit of 5 existing features against the extended G5 contract
+
+| Feature | Resource dependency | Current state | New-contract verdict |
+|---|---|---|---|
+| HAMR routing | Cloudflare worker + telemetry KV | Opt-in via `MEGINGJORD_HAMR_DISABLED=1`; documented in `instructions/hamr-routing.instructions.md` | **Compliant** — perfect precedent for the new contract |
+| IDE proxy | LiteLLM endpoint + local proxy port | "Opt-in only; default behavior is unchanged" per `instructions/ide-proxy.instructions.md` | **Compliant** — perfect precedent |
+| Playwright MCP / browser automation | Chromium binary + system resources | Required at-test-time but workflow degrades to deterministic DOM/code inspection per `instructions/playwright-mcp-low-resource.instructions.md` | **Compliant** — explicit fallback documented |
+| Fleet dispatch (Ollama / local models) | Local GPU/fleet binary | Default-on for fleet-capable operators; Haiku fallback for cloud-only | **Compliant** — fallback documented in `instructions/global-task-router.instructions.md` |
+| Dashboard server (`dashboard-server.js` :8090) | Local node process + port 8090 | Required for visual QA tests; no documented "what if port is taken" or "headless operator" fallback | **Gap** — needs minimal-resource fallback for headless operators |
+
+The 4-of-5 compliance rate confirms the new G5 contract reflects already-established practice in the harness. The 1 gap (dashboard server) is a known limitation that surfaces during visual QA work; flagging for a follow-on if it becomes blocking.
+
+### Verification
+- `npm run lint` → 100-line cap clean (`harness-goals.instructions.md` is 45 lines after the extension).
+- `npm run lint:readability:ci` → exit=0 (no JS changes).
+- The extension cites existing opt-in precedents (`MEGINGJORD_HAMR_DISABLED`, IDE-proxy) so cross-team operators have a concrete template to follow.
+
+### Cross-team note
+This contract change is provider-neutral. Every team (Claude Code / Copilot / Codex) inherits the extended G5 wording and the audit pattern.
+
+### Out of scope
+- Renaming any existing goals or changing priority order.
+- Implementing fallback paths for the 1 gap identified (dashboard server) — flagged for follow-on if operationally blocking.
+- Mandating retroactive audits of every existing feature — the 5-feature audit demonstrates the contract; ongoing audits attach to per-feature tickets going forward.

--- a/instructions/harness-goals.instructions.md
+++ b/instructions/harness-goals.instructions.md
@@ -20,6 +20,14 @@ G10 Maintainability.
   secrets never in git, env vars, or logs; least-privilege tokens enforced; supply-chain
   dependencies pinned; agent-consumed inputs sanitised against injection.
 - G5 Portability: avoid user-specific coupling; settings-driven behavior preferred.
+  Each operator has a unique baseline of local, fleet, and remote resources;
+  features that require resources beyond the GitHub-access baseline (keys, secrets,
+  remote services, paid plans, specific fleet hardware, preview-tier features) must
+  either be classified as opt-in via env-var or label gate (parity with the existing
+  MEGINGJORD_HAMR_DISABLED and IDE proxy opt-in patterns) OR ship with a documented
+  minimal-resource fallback. Operator-environment variance is a first-class
+  portability dimension distinct from G6: G6 covers temporary outages of normally-
+  available resources, G5 covers baseline-absent resources for a given operator.
 - G6 Resilience: graceful degradation and fallback paths for partial outages.
 - G7 Throughput: acceptable speed after higher-priority goals are satisfied.
 - G8 Observability: decisions and outcomes are visible, auditable, and attributable.
@@ -32,5 +40,6 @@ G10 Maintainability.
 For any design/routing/tooling decision, briefly verify in this order:
 1) Is it governance-compliant? 2) Does it improve or preserve quality?
 3) Can it run at zero cost first? 4) Is privacy and security preserved by default?
-5) Is it portable? 6) Is degradation safe? 7) Is it fast enough?
+5) Is it portable across operator baselines (will it work for an operator without
+   resource X)? 6) Is degradation safe? 7) Is it fast enough?
 8) Is it observable? 9) Does it remain interoperable? 10) Is it maintainable?


### PR DESCRIPTION
Refs #1628
Refs #1604
Refs #1624
Closes #1628

## Summary

- Extend the G5 Portability definition in instructions/harness-goals.instructions.md to cover operator-environment variance as a first-class portability dimension.
- Codify the opt-in classification clause (env-var/label gate parity with the MEGINGJORD_HAMR_DISABLED + IDE proxy precedents) as one of two contract options.
- Codify the minimal-resource fallback clause as the alternative.
- Add explicit G5-vs-G6 distinction: G6 covers temporary outages of normally-available resources; G5 covers baseline-absent resources for a given operator.
- Reword Decision Lens question 5 from "Is it portable?" to "Is it portable across operator baselines (will it work for an operator without resource X)?" so the dimension is actionable at decision time.

## Why

Surfaced during adoption planning for #1624's GitHub-primitives research. Multiple primitives (gh-aw Agentic Workflows preview, Codespaces, Claude-Code agent-teams, webhook receivers) have differential availability per operator. The previous G5 wording covered code portability but not operator-environment variance — without the extension, the downstream Epic #1604 implementation children would risk shipping features assuming baseline resources not every operator has.

## Verification

- npm run lint clean (100-line cap; harness-goals.instructions.md 45/100 lines after the extension).
- npm run lint:readability:ci clean (no JS changes).
- The 4-of-5 audit (HAMR, IDE proxy, Playwright MCP, Fleet dispatch all compliant; dashboard server flagged as 1 gap) confirms the new contract reflects already-established practice.

## Test plan

- [x] G1 lint clean (`npm run lint`)
- [x] G2 readability clean (`npm run lint:readability:ci`)
- [x] All 4 baton artifacts posted on #1628 before PR opened
- [x] CONSULTANT_CLOSEOUT rubric mean 9.2/10 (peer-review threshold >=7)
- [x] Cross-team neutrality: provider-neutral; no per-team adaptation needed
- [x] Out-of-scope items declared in the closeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)