### PR TITLE
feat(infra): add worktree cleanup planner #1620

### DIFF
--- a/.changes/unreleased/1620.md
+++ b/.changes/unreleased/1620.md
@@ -1,0 +1,9 @@
+# 1620
+
+- Added a plan-only worktree cleanup script for safe VS Code clutter control.
+- Added VS Code active-worktree workspace generation from live lease state.
+- Documented cleanup-plan use in sandbox worktree governance.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/instructions/sandbox-worktree-governance.instructions.md
+++ b/instructions/sandbox-worktree-governance.instructions.md
@@ -49,10 +49,16 @@ Conflict check:
 - Audit command: `npm run governance:worktrees`.
 - Targeted audit: `node scripts/global/worktree-governance-audit.js --target=codex --json`.
 - Default audits must still check all Copilot, Claude Code, and Codex launchers.
+- Cleanup plan: `node scripts/global/worktree-cleanup-plan.js --json`.
+- VS Code active workspace: `node scripts/global/worktree-cleanup-plan.js --workspace .dashboard/active-worktrees.code-workspace`.
 
 ## Escalation
 
 If any sandbox branch is behind or dirty: stop, run session-start reset flow, then resume on a ticket-linked task branch only.
+
+If Source Control is cluttered: generate the cleanup plan, remove only
+`merged-clean` worktrees, and preserve dirty or unpushed work through rescue
+branches or draft PRs before any deletion.
 
 ## Cross-Team Lease Lifecycle
 

--- a/scripts/global/worktree-cleanup-plan.js
+++ b/scripts/global/worktree-cleanup-plan.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const leaseRegistry = require('./cross-team-lease-registry');
+const worktreeInventory = require('./worktree-inventory');
+
+function ticketFrom(branch = '') {
+  const hit = branch.match(/(?:feat|fix|chore|docs|refactor|hotfix)\/(\d+)-/);
+  return hit ? Number(hit[1]) : null;
+}
+
+function leaseFor(entry, leases) {
+  const ticket = ticketFrom(entry.branch);
+  return leases.find(lease => lease.branch === entry.branch || lease.ticket === ticket) || null;
+}
+
+function classify(entry, lease) {
+  if (lease) return 'active-lease';
+  if (entry.locked) return 'keep-locked';
+  if ((entry.branch || '').startsWith('sandbox/')) return 'keep-launcher';
+  if (entry.dirtyCount > 0 || entry.ahead > 0) return 'preserve-dirty';
+  if (entry.openPr) return 'stale-open-pr';
+  if (entry.mergedToMain) return 'merged-clean';
+  if (entry.prunable) return 'prune-metadata';
+  return 'keep-review';
+}
+
+function commands(entry, state) {
+  if (state === 'merged-clean') return [`git worktree remove ${entry.path}`, `git branch -d ${entry.branch}`];
+  if (state === 'prune-metadata') return ['git worktree prune'];
+  if (state === 'preserve-dirty') return [
+    `git switch -c rescue/${ticketFrom(entry.branch) || 'unknown'}-preserve`,
+    'gh pr create --draft --fill',
+  ];
+  if (state === 'stale-open-pr') return [`gh pr view ${entry.openPr}`, `gh pr comment ${entry.openPr} --body "cleanup review requested"`];
+  return [];
+}
+
+function plan(input = {}) {
+  const inventory = input.inventory || worktreeInventory.inventory();
+  const registry = input.registry || leaseRegistry.read(input.leaseFile || leaseRegistry.DEFAULT_PATH);
+  const leases = leaseRegistry.active(registry);
+  const worktrees = inventory.worktrees.map(entry => {
+    const lease = leaseFor(entry, leases);
+    const state = classify(entry, lease);
+    return { ...entry, ticket: ticketFrom(entry.branch), lease: lease?.ticket || null,
+      cleanupState: state, commands: commands(entry, state) };
+  });
+  return { generatedAt: new Date().toISOString(), mode: 'plan-only', worktrees };
+}
+
+function workspace(report) {
+  return {
+    folders: report.worktrees.filter(w => w.cleanupState === 'active-lease')
+      .map(w => ({ name: w.branch || w.path, path: w.path })),
+    settings: { 'git.autoRepositoryDetection': 'subFolders' },
+  };
+}
+
+function run(argv = process.argv.slice(2)) {
+  const json = argv.includes('--json');
+  const workspaceIndex = argv.indexOf('--workspace');
+  const workspacePath = workspaceIndex >= 0 ? argv[workspaceIndex + 1] : null;
+  const report = plan();
+  if (workspacePath) fs.writeFileSync(workspacePath, `${JSON.stringify(workspace(report), null, 2)}\n`);
+  if (json || workspacePath) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  else for (const worktree of report.worktrees) {
+    console.log(`${worktree.cleanupState.padEnd(15)} ${worktree.branch || 'DETACHED'} ${worktree.path}`);
+  }
+  return report;
+}
+
+if (require.main === module) run();
+
+module.exports = { classify, commands, plan, ticketFrom, workspace };

--- a/tests/worktree-cleanup-plan.spec.js
+++ b/tests/worktree-cleanup-plan.spec.js
@@ -1,0 +1,69 @@
+const { test, expect } = require('@playwright/test');
+const planner = require('../scripts/global/worktree-cleanup-plan');
+
+function entry(overrides = {}) {
+  return {
+    path: `/tmp/${overrides.branch || 'feat/1700-demo'}`,
+    branch: 'feat/1700-demo',
+    dirtyCount: 0,
+    ahead: 0,
+    mergedToMain: false,
+    prunable: false,
+    ...overrides,
+  };
+}
+
+function registry() {
+  return {
+    version: 1,
+    leases: [{
+      ticket: 1704,
+      branch: 'feat/1704-active',
+      status: 'active',
+      expires_at: '2999-01-01T00:00:00.000Z',
+    }],
+  };
+}
+
+test('classifies merged clean worktrees for removal', () => {
+  const state = planner.classify(entry({ mergedToMain: true }), null);
+  expect(state).toBe('merged-clean');
+  expect(planner.commands(entry({ mergedToMain: true }), state)[0]).toContain('worktree remove');
+});
+
+test('preserves dirty or unpushed work with rescue commands', () => {
+  const state = planner.classify(entry({ dirtyCount: 2, ahead: 1 }), null);
+  expect(state).toBe('preserve-dirty');
+  expect(planner.commands(entry(), state)[0]).toContain('rescue/1700-preserve');
+});
+
+test('keeps active lease worktrees visible', () => {
+  const report = planner.plan({
+    inventory: { worktrees: [entry({ branch: 'feat/1704-active' })] },
+    registry: registry(),
+  });
+  expect(report.worktrees[0].cleanupState).toBe('active-lease');
+  expect(report.worktrees[0].commands).toEqual([]);
+});
+
+test('never removes sandbox launcher worktrees', () => {
+  const state = planner.classify(entry({ branch: 'sandbox/copilot', mergedToMain: true }), null);
+  expect(state).toBe('keep-launcher');
+  expect(planner.commands(entry({ branch: 'sandbox/copilot' }), state)).toEqual([]);
+});
+
+test('flags stale open PRs for review comments', () => {
+  const state = planner.classify(entry({ openPr: 44 }), null);
+  expect(state).toBe('stale-open-pr');
+  expect(planner.commands(entry({ openPr: 44 }), state)[0]).toBe('gh pr view 44');
+});
+
+test('builds VS Code workspace from active leases only', () => {
+  const report = {
+    worktrees: [
+      { cleanupState: 'active-lease', branch: 'feat/1-a', path: '/tmp/a' },
+      { cleanupState: 'merged-clean', branch: 'feat/2-b', path: '/tmp/b' },
+    ],
+  };
+  expect(planner.workspace(report).folders).toEqual([{ name: 'feat/1-a', path: '/tmp/a' }]);
+});


### PR DESCRIPTION
## Summary

Closes #1620
Refs #1620
Refs #1604
Refs #1616

- Adds a plan-only worktree cleanup planner for VS Code Source Control clutter control.
- Preserves active leases, sandbox launcher worktrees, dirty/unpushed work, and stale open PRs through review/rescue commands rather than deletion.
- Adds active-lease-only VS Code workspace generation for focused operator views.
- Documents the cleanup workflow in sandbox worktree governance.

## Validation

- `npx playwright test tests/worktree-cleanup-plan.spec.js tests/worktree-inventory.test.js tests/cross-team-lease-registry.spec.js`
- `npm run lint`
- `npm run lint:readability:ci`
- `npm run lint:js -- --quiet`
- `npm run lint:md -- instructions/sandbox-worktree-governance.instructions.md .changes/unreleased/1620.md`
- `node scripts/global/worktree-cleanup-plan.js --json | head -80`
- `test ! -e ./--json`

## Governance

- Manager handoff posted before edits.
- Collaborator handoff posted with validation evidence.
- One branch / one ticket / one active PR preserved; PR #1640 was closed unmerged because it was created before the 60-second evidence threshold.
- No destructive cleanup is performed by this implementation.
- test_strategy: tdd-pyramid

Signed-by: Quill Harper
Team&Model: codex:gpt-5.4@openai
Role: collaborator