### PR TITLE
docs(governance): adopt GitHub MCP server cross-team #1629

### DIFF
--- a/.changes/unreleased/1629.md
+++ b/.changes/unreleased/1629.md
@@ -1,0 +1,32 @@
+## [Unreleased] — #1629: Adopt GitHub MCP server as the standard cross-team tool surface
+
+### Added
+- `docs/howto/mcp-server-adoption.md` — operator guide covering MCP server install, per-runtime config paths, opt-out mechanism, example baton flow via MCP tool names, and G5 portability notes.
+
+### Changed
+- `instructions/github-governance.instructions.md` — added "MCP server as standard tool surface" section codifying MCP as the preferred GitHub tool surface across Claude Code / Copilot / Codex teams. Documents `GITHUB_TOKEN` reuse, `MEGINGJORD_MCP_DISABLED=1` opt-out (parity with HAMR), and the gh CLI fallback.
+- `instructions/global-standards.instructions.md` — added "Cross-team GitHub tool surface" section pointing at the MCP contract and howto guide.
+
+### Why
+Closes #1629 (Phase 1 of Epic #1604 / research #1624 F1). Standardizes the GitHub agent tool surface across three teams (Claude Code / Copilot / Codex) so cross-team baton flows use uniform tool calls instead of per-team REST/CLI adapters.
+
+The G5 Portability backing #1628 already classified MCP server adoption as **integral to harness goals** with `MEGINGJORD_MCP_DISABLED=1` as the opt-out gate; this ticket lands the corresponding instruction text.
+
+### Scope (this ship)
+- AC1: ✅ Documented in `global-standards.instructions.md` and `github-governance.instructions.md`.
+- AC2: ✅ Adoption guide added at `docs/howto/mcp-server-adoption.md`.
+- AC3-AC5: deferred to follow-on children (audit of existing gh-CLI helpers; collaborator-self-check MCP-load check; MCP test suite).
+
+### Verification
+- `npm run lint` clean (100-line cap; modified files 84/44/58 lines).
+- `npm run lint:readability:ci` clean (no JS changes).
+- Three teams inherit the new tool-surface contract symmetrically via the standard instruction-load path (CLAUDE.md, .github/copilot-instructions.md, ~/.codex/AGENTS.md).
+
+### Cross-team note
+Provider-neutral and runtime-neutral; MCP server is the official GitHub project, not a team-specific tool. Codex Team's Epic #1605 and Copilot Team's Epic #1601 do not overlap with this ticket.
+
+### Out of scope
+- Wholesale migration of existing `scripts/global/*.js` `gh` CLI calls to MCP — see follow-on AC3 child.
+- Collaborator-self-check helper extension — see follow-on AC4 child.
+- MCP integration test suite — see follow-on AC5 child.
+- Adding net-new functionality not already covered by `gh` CLI — this is a standardization ticket only.

--- a/docs/howto/mcp-server-adoption.md
+++ b/docs/howto/mcp-server-adoption.md
@@ -1,0 +1,58 @@
+# GitHub MCP Server Adoption
+
+The official GitHub MCP server (`github/github-mcp-server`) is the standard
+GitHub tool surface across Claude Code, Copilot, and Codex teams.
+
+## Why MCP over `gh` CLI
+
+- **Uniform surface**: Issues, PRs, Discussions, Projects v2, Sub-issues, Actions,
+  and Repositories all exposed as MCP tools — no per-team adapter drift.
+- **Tool-call observability**: MCP tool calls are visible to harness telemetry
+  in the same shape across runtimes.
+- **Schema-validated arguments**: MCP servers enforce typed inputs; `gh` CLI
+  string args bypass type-checking.
+
+## Activation
+
+1. Install the GitHub MCP server (per https://github.com/github/github-mcp-server).
+2. Set `GITHUB_TOKEN` (or `GITHUB_PERSONAL_ACCESS_TOKEN`). Every operator with
+   `gh auth status` already has one.
+3. Register the server in the team's MCP config:
+   - Claude Code: `.claude/mcp-servers.json` (per-project) or user-level.
+   - Copilot: `.github/copilot-mcp.json` (per-project).
+   - Codex: `~/.codex/mcp-servers.json`.
+4. Restart the runtime so the new server registers.
+
+## Opt-out
+
+Set `MEGINGJORD_MCP_DISABLED=1` for air-gapped or restricted operators. Skills
+detect the env var and fall back to `gh` CLI without behavior change.
+
+## Example baton flow via MCP
+
+Replace each step with MCP tool calls (canonical tool names):
+
+| Step | `gh` CLI | MCP tool |
+|---|---|---|
+| Open issue | `gh issue create --title X --body Y` | `mcp__github__create_issue` |
+| Add comment | `gh issue comment N --body Y` | `mcp__github__create_issue_comment` |
+| Edit labels | `gh issue edit N --add-label X` | `mcp__github__update_issue` |
+| Open PR | `gh pr create --title X --body Y` | `mcp__github__create_pull_request` |
+| List checks | `gh pr checks N` | `mcp__github__list_workflow_runs` |
+| Merge PR | `gh pr merge N --merge` | `mcp__github__merge_pull_request` |
+
+## Portability notes (per G5 contract)
+
+- GitHub MCP server requires network access to `api.github.com`. Air-gapped
+  operators have no GitHub access at baseline; MCP server's absence is consistent
+  with their existing constraints — no fallback required for the network gap.
+- Operators on plan tiers without Projects v2 access continue with their existing
+  Issue-driven flows; MCP server's `mcp__github__projects_*` tools silently
+  return permission errors that skills gracefully degrade past.
+
+## Related
+
+- `instructions/global-standards.instructions.md` (cross-team tool surface)
+- `instructions/github-governance.instructions.md` (MCP-server section)
+- `instructions/harness-goals.instructions.md` G5 Portability contract (#1628)
+- `docs/howto/baton-workflow.md` (the baton steps the MCP tools support)

--- a/instructions/github-governance.instructions.md
+++ b/instructions/github-governance.instructions.md
@@ -65,3 +65,20 @@ applyTo: "**"
 - Before recommending rulesets or plan-sensitive features, run `github-capability-resolver` to verify availability.
 - Route workflow governance requests through `github-ops-tree-router`; invoke `github-ruleset-architecture` for ruleset design.
 - For workflow automation that compares actors, apply Team&Model-first identity resolution per `instructions/team-model-in-workflows.instructions.md`.
+
+## MCP server as standard tool surface
+
+The official GitHub MCP server (`github/github-mcp-server`) is the preferred
+GitHub tool surface across Claude Code / Copilot / Codex teams. MCP tools cover
+Issues, Pull Requests, Discussions, Projects v2, Sub-issues, Actions, and
+Repositories. Standardizing on MCP eliminates per-team REST/CLI adapter drift.
+
+- **Activation**: each team's skill MAY load the MCP server before composing
+  baton artifacts. `gh` CLI remains the supported fallback.
+- **Credentials**: MCP server requires a `GITHUB_TOKEN`. Every operator using
+  `gh` CLI already has one; no new credential surface.
+- **G5 portability**: integral to harness goals; air-gapped operators have no
+  GitHub access at baseline (consistent constraint, not an MCP gap).
+- **Opt-out**: `MEGINGJORD_MCP_DISABLED=1` (parity with `MEGINGJORD_HAMR_DISABLED`).
+  Skills detecting the opt-out fall back to `gh` CLI without behavior change.
+- **Adoption guide**: `docs/howto/mcp-server-adoption.md`.

--- a/instructions/global-standards.instructions.md
+++ b/instructions/global-standards.instructions.md
@@ -34,3 +34,11 @@ applyTo: "**"
 	`G1 Governance > G2 Quality > G3 Zero Cost > G4 Privacy > G5 Portability > G6 Resilience > G7 Throughput > G8 Observability > G9 Interoperability`.
 - When tradeoffs occur, explicitly justify why a lower-priority goal overrides a higher one.
 - Keep the justification short and evidence-based in ticket comments, PR body, or closeout notes.
+
+## Cross-team GitHub tool surface
+
+- Default to the official GitHub MCP server (`github/github-mcp-server`) for
+	cross-team GitHub interactions. Falls back to `gh` CLI when MCP unavailable
+	or when `MEGINGJORD_MCP_DISABLED=1` is set.
+- See `instructions/github-governance.instructions.md` for the full contract
+	and `docs/howto/mcp-server-adoption.md` for the operator guide.


### PR DESCRIPTION
Refs #1629
Refs #1604
Refs #1624
Refs #1628
Closes #1629

## Summary

- Adds MCP server adoption section to `instructions/github-governance.instructions.md` codifying the official `github/github-mcp-server` as the preferred cross-team GitHub tool surface.
- Adds cross-team tool surface pointer in `instructions/global-standards.instructions.md`.
- Adds `docs/howto/mcp-server-adoption.md` operator guide (install steps, per-runtime config paths, opt-out via `MEGINGJORD_MCP_DISABLED=1`, example baton flow via MCP tool names, G5 portability notes).

## Scope

This ship lands AC1 + AC2 of the parent acceptance criteria. AC3, AC4, AC5 are filed as follow-on children:

- #1641 — audit existing `scripts/global/*.js` `gh` CLI calls for MCP migration value.
- #1642 — extend collaborator pre-handoff helper with `mcp-load-check` (advisory-first per Path D).
- #1643 — MCP integration test suite with mock MCP server.

Per `[[feedback-epic-ac-wording-vs-shipped-behavior]]`, closure language for AC3-AC5 is "deferred to follow-on", not "shipped".

## Why

Standardizes the GitHub agent tool surface across Claude Code / Copilot / Codex teams. Eliminates per-team REST/CLI adapter drift; aligns with #1628 G5 Portability contract (opt-in classification with `MEGINGJORD_MCP_DISABLED=1` opt-out, parity with the HAMR pattern).

## Test plan

- [x] G1 lint clean (`npm run lint`)
- [x] G2 readability clean (`npm run lint:readability:ci`)
- [x] All 4 baton artifacts posted on #1629 before PR opened (Mason / Harper / Reyes / Vale)
- [x] CONSULTANT_CLOSEOUT rubric_rating 9/10 (peer-review threshold >=7)
- [x] AC3-AC5 follow-on children #1641 #1642 #1643 filed BEFORE PR (preserves Epic close-language honesty)
- [x] Cross-team neutrality: MCP server is GitHub's official project; no per-team adaptation

🤖 Generated with [Claude Code](https://claude.com/claude-code)