### PR TITLE
feat(instructions): add provider-neutral governance contract #1623

### DIFF
--- a/.changes/unreleased/1623.md
+++ b/.changes/unreleased/1623.md
@@ -1,0 +1,10 @@
+# 1623
+
+- Added a provider-neutral governance instruction with Codex, Copilot, and
+  Claude Code adapter sections.
+- Added research and wiki references for the normalized governance contract.
+- Added regression tests that guard equal runtime adapter coverage.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,8 @@
 
 Every task follows the **role baton sequence**: Manager → Collaborator → Admin → Consultant.
 See `role-baton-routing` for rules. Local repos may override via `.github/copilot-instructions.md`.
+Shared governance is provider-neutral; runtime-specific setup belongs in adapters.
+See `instructions/provider-neutral-governance.instructions.md`.
 
 ## Repo Purpose
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ This repo is the **development workbench** for the DevEnv Ops Harness runtimes:
 - All 3 teams route governed provider calls through HAMR (`https://hamr.chf3198.workers.dev`).
 - Activate per-checkout: `npm run hamr:activate`. Verify: `npm run hamr:sync-verify`.
 - Canonical contract: `instructions/hamr-routing.instructions.md`.
+- Provider-neutral governance contract: `instructions/provider-neutral-governance.instructions.md`.
 
 ## Skill index
 

--- a/instructions/provider-neutral-governance.instructions.md
+++ b/instructions/provider-neutral-governance.instructions.md
@@ -1,0 +1,63 @@
+---
+name: Provider-Neutral Governance
+description: Shared governance contract for Codex, Copilot, Claude Code, and future agent runtimes.
+applyTo: "**"
+---
+
+# Provider-Neutral Governance
+
+## Shared Contract
+
+Governance rules bind the work, not the vendor runtime. Every orchestrating
+surface follows the same issue baton, lease, signing, branch, PR, test, closeout,
+and cleanup rules before any runtime-specific adapter behavior applies.
+
+- Treat the GitHub issue as the baton and keep one active role per ticket.
+- Use one branch, one ticket, and one active PR for delivery work.
+- Create or refresh a cross-team lease before editing shared files.
+- Run the conflict gate before edits when paths overlap active work.
+- Keep launcher/sandbox branches as entry points only, never delivery branches.
+- Sign governed comments, PRs, docs, and commits with `Team&Model`.
+- Prefer HAMR/fleet/free routing for governed provider calls before paid paths.
+- Preserve dirty or unpushed work with rescue branches or draft PRs before cleanup.
+- Close tickets only after merge, lease closeout, Consultant critique, and AC
+  reconciliation.
+
+## Adapter Boundaries
+
+Runtime-specific wording belongs in adapter sections only. Shared governance
+must say "agent runtime" or "orchestrating team" unless it is naming an adapter.
+
+### Codex Adapter
+
+- Codex project assets live under `.codex/` and repo-root `AGENTS.md`.
+- Use official OpenAI/Codex docs when Codex behavior is uncertain.
+- Do not infer Codex compatibility from Claude Code or Copilot behavior.
+
+### Copilot Adapter
+
+- Copilot project context lives in `.github/copilot-instructions.md`.
+- Copilot runtime deployment targets include `~/.copilot/` via repo-mediated
+  deploy commands only.
+- Copilot-specific skills or agents stay in adapter-owned files.
+
+### Claude Code Adapter
+
+- Claude Code launcher worktrees use `sandbox/claude-code` or governed
+  ticket-linked branches.
+- Claude-specific IDE proxy, vision, and MCP low-resource guidance stays in
+  adapter-owned instruction or skill files.
+- Anthropic-specific provider assumptions must not be promoted into shared
+  governance language.
+
+## Compatibility Checklist
+
+- Shared sections name all three adapters or none of them.
+- Adapter sections may name one runtime and its setup files.
+- Runtime homes (`~/.codex/`, `~/.copilot/`, `~/.agents/skills/`) are deploy
+  targets, not direct edit targets.
+- Tests must fail if Codex is omitted from shared coordination coverage.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/research/issue-1623-provider-neutral-governance-2026-05-16.md
+++ b/research/issue-1623-provider-neutral-governance-2026-05-16.md
@@ -1,0 +1,36 @@
+# Issue #1623 Provider-Neutral Governance Inventory
+
+## Scope
+
+This inventory covers repo-local instructions, global skills, hooks, bootstrap
+scripts, runtime adapters, and wiki references that shape cross-team work.
+
+## Findings
+
+- Shared contract already exists across `role-baton-routing`,
+  `sandbox-worktree-governance`, `team-model-signing`, `global-task-router`, and
+  `hamr-routing`.
+- Provider-specific setup is spread across `AGENTS.md`,
+  `.github/copilot-instructions.md`, `.codex/AGENTS.md`, adapter skills, and hook
+  runtime helpers.
+- The main compatibility risk is not missing Codex support; it is shared prose
+  drifting toward one runtime's vocabulary.
+- A compact provider-neutral instruction is safer than rewriting every runtime
+  file in one pass while other teams are active.
+
+## Contract
+
+`instructions/provider-neutral-governance.instructions.md` is the normalized
+contract. It keeps shared rules in one section and runtime setup in Codex,
+Copilot, and Claude Code adapters.
+
+## Validation
+
+- `tests/provider-neutral-governance.spec.js` verifies Codex, Copilot, and
+  Claude Code adapter coverage.
+- The test also verifies that the shared section does not name a single runtime
+  more than the others.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/tests/provider-neutral-governance.spec.js
+++ b/tests/provider-neutral-governance.spec.js
@@ -1,0 +1,30 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+
+const DOC = 'instructions/provider-neutral-governance.instructions.md';
+
+function section(text, heading) {
+  const start = text.indexOf(`## ${heading}`);
+  const next = text.indexOf('\n## ', start + 1);
+  return text.slice(start, next === -1 ? text.length : next);
+}
+
+test('provider-neutral governance names every runtime adapter', () => {
+  const text = fs.readFileSync(DOC, 'utf8');
+  for (const runtime of ['Codex', 'Copilot', 'Claude Code']) {
+    expect(text).toContain(`### ${runtime} Adapter`);
+  }
+});
+
+test('shared contract avoids single-runtime governance ownership', () => {
+  const shared = section(fs.readFileSync(DOC, 'utf8'), 'Shared Contract');
+  const counts = ['Codex', 'Copilot', 'Claude Code'].map(name =>
+    (shared.match(new RegExp(name, 'g')) || []).length);
+  expect(new Set(counts).size).toBe(1);
+});
+
+test('compatibility checklist keeps Codex in shared coordination coverage', () => {
+  const text = fs.readFileSync(DOC, 'utf8');
+  expect(section(text, 'Compatibility Checklist')).toContain('Codex');
+  expect(text).toContain('Do not infer Codex compatibility');
+});

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -50,6 +50,7 @@ The LLM updates this on every ingest operation.
 
 - [[codex-compatibility-audit-2026-05-13]] — Codex compatibility audit for harness goals/features/functionality
 - [[provider-adapter-matrix-2026-05-14]] — Provider adapter matrix for Codex, Copilot, Claude Code, HAMR, and provider paths
+- [[provider-neutral-governance-2026-05-16]] — Provider-neutral governance contract for Codex, Copilot, and Claude Code
 - [[epic-1271-codex-fdpr-2026-05-10]] — Codex final development plan recommendation for Epic #1271
 - [[epic-1271-cx-rd-plan-2026-05-09]] — Epic #1271 Codex R&D plan for state truthfulness
 - [[epic-1271-cp-rd-plan-2026-05-09]] — Epic #1271 Copilot R&D plan for state truthfulness
@@ -111,6 +112,7 @@ The LLM updates this on every ingest operation.
 
 - [[codex-compatibility-audit-2026-05-13]] — Codex compatibility audit (2026-05-13)
 - [[provider-adapter-matrix-2026-05-14]] — Provider adapter matrix (2026-05-14)
+- [[provider-neutral-governance-2026-05-16]] — Provider-neutral governance contract (2026-05-16)
 - [[distributed-self-anneal]] — Three-tier distributed self-anneal (2026-05-10)
 - [[andon-pull-protocol]] — Any-role pull protocol (2026-05-10)
 - [[epic-1271-codex-fdpr-2026-05-10]] — Codex FDPR for Epic #1271 (2026-05-10)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -57,6 +57,11 @@ fleet, HAMR, OpenAI-compatible, Anthropic, Ollama, OpenRouter, and LiteLLM.
 New source page: `wiki/sources/provider-adapter-matrix-2026-05-14.md`.
 Source: `research/provider-adapter-matrix-2026-05-14.md`.
 
+## [2026-05-16] governance | Provider-neutral governance contract (#1623, EPIC #1604)
+Added shared governance contract with Codex, Copilot, and Claude Code adapter
+sections. Source: `research/issue-1623-provider-neutral-governance-2026-05-16.md`.
+Wiki page: `wiki/sources/provider-neutral-governance-2026-05-16.md`.
+
 **Tip**: `grep "^## \[" log.md | tail -5` shows last 5 entries.
 
 ---

--- a/wiki/sources/provider-neutral-governance-2026-05-16.md
+++ b/wiki/sources/provider-neutral-governance-2026-05-16.md
@@ -1,0 +1,24 @@
+# Provider-Neutral Governance
+
+Source: `research/issue-1623-provider-neutral-governance-2026-05-16.md`.
+
+The normalized governance contract separates shared rules from runtime adapters.
+Shared rules bind every orchestrating team: issue baton, one branch/ticket/PR,
+cross-team lease, conflict gate, Team&Model signing, HAMR/fleet/free routing,
+preservation before cleanup, and Consultant closeout.
+
+Runtime-specific details stay in adapter sections:
+
+- Codex: `.codex/`, `AGENTS.md`, and official OpenAI/Codex docs for uncertainty.
+- Copilot: `.github/copilot-instructions.md`, `~/.copilot/` deploy targets, and
+  Copilot-specific skills or agents.
+- Claude Code: `sandbox/claude-code`, IDE proxy, vision, and MCP low-resource
+  guidance.
+
+The compatibility invariant is simple: shared coordination coverage must include
+Codex, Copilot, and Claude Code equally, while provider assumptions remain
+adapter-local.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator


### PR DESCRIPTION
## Summary

Closes #1623
Refs #1623
Refs #1604
Refs #1616
Refs #1476
Refs #1485

- Adds a provider-neutral governance instruction with shared rules and Codex, Copilot, and Claude Code adapter sections.
- Adds research and wiki references for the normalized contract.
- Adds compatibility tests that guard equal adapter coverage and Codex inclusion.
- Adds references from repo-level AGENTS/Copilot instructions to the shared contract.

## Validation

- `node scripts/global/cross-team-conflict-gate.js --ticket 1623 --branch feat/1623-provider-neutral-governance --paths instructions,research,wiki,tests,.changes/unreleased --post-comment 1`
- `npx playwright test tests/provider-neutral-governance.spec.js`
- `npm run lint`
- `npm run lint:readability:ci`
- `npm run lint:js -- --quiet`
- `npm run lint:md -- instructions/provider-neutral-governance.instructions.md research/issue-1623-provider-neutral-governance-2026-05-16.md wiki/sources/provider-neutral-governance-2026-05-16.md .changes/unreleased/1623.md`

## Governance

- Manager handoff posted before edits.
- Cross-team lease active before edits.
- Conflict gate was run late but clean; recorded in #1623 collaborator handoff as `mid_flight_flaws`.
- test_strategy: tdd-pyramid

Signed-by: Quill Harper
Team&Model: codex:gpt-5.4@openai
Role: collaborator