### PR TITLE
docs(governance): Projects v2 coordination design #1630

### DIFF
--- a/.changes/unreleased/1630.md
+++ b/.changes/unreleased/1630.md
@@ -1,0 +1,25 @@
+## [Unreleased] — #1630: Projects v2 cross-team coordination design
+
+### Added
+- `docs/howto/projects-v2-coordination.md` — design + GraphQL schema for the cross-team Projects v2 live-state board. Documents custom field shape (`claimed-by`, `locked-paths`, `in-flight-since`, `expected-completion`, `cross-team-stage`), core query + mutation snippets, planned baton-flow integration, and the `MEGINGJORD_PROJECTS_V2_DISABLED=1` opt-out path.
+
+### Why
+Closes #1630 (Phase 1 of Epic #1604 / research #1624 F2 — narrow design-doc scope). The board's GraphQL contract needs to land before any consumer (helper, baton-flow integration, dashboard panel) can be wired up. Per Path D and `[[feedback-epic-ac-wording-vs-shipped-behavior]]`, this ship covers AC3 (docs) only; AC1, AC2, AC4, AC5, AC6 are filed as follow-on children.
+
+### Scope (this ship)
+- AC1 deferred (create the actual board): follow-on #1647.
+- AC2 deferred (pure helper): follow-on #1648.
+- AC3: ✅ design doc + GraphQL schema delivered.
+- AC4 deferred (baton-flow wiring): follow-on #1649.
+- AC5 deferred (test suite): follow-on #1650.
+- AC6 deferred (dashboard panel): follow-on #1651.
+
+### Verification
+- `npm run lint` clean (100-line cap; new doc 92/100 lines).
+- `npm run lint:readability:ci` clean (no JS changes).
+- Cross-references #1628 G5 contract, #1629 MCP-tool equivalents, #1624 F10 (decisions.md) for air-gapped fallback path.
+
+### Out of scope
+- Wiring or implementing any of AC1, AC2, AC4, AC5, AC6 — see follow-on children.
+- Migrating existing in-flight tickets to the new board — separate run-once op.
+- Replacing Issues as the canonical work tracker — Issues stay; Projects v2 is overlay.

--- a/docs/howto/projects-v2-coordination.md
+++ b/docs/howto/projects-v2-coordination.md
@@ -1,0 +1,92 @@
+# Projects v2 Cross-Team Coordination
+
+Projects v2 is the live cross-team state plane. Issues remain the canonical
+work-tracking primary; Projects v2 is the **live-state overlay** showing who
+is working on what right now.
+
+## Board structure
+
+One board per repo, with custom fields:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `claimed-by` | text | Team currently holding the baton (claude-code / copilot / codex) |
+| `locked-paths` | text | Comma-separated file globs the holder has open |
+| `in-flight-since` | date | When current claim started |
+| `expected-completion` | date | Operator estimate; informs cross-team scheduling |
+| `cross-team-stage` | text | `triage`/`in-progress`/`testing`/`review` mirror of issue label |
+
+## Core GraphQL queries
+
+### Query: list in-flight items
+
+```graphql
+query InFlight($projectId: ID!) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          content {
+            ... on Issue { number title state }
+          }
+          fieldValues(first: 10) {
+            nodes {
+              ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2Field { name } } }
+              ... on ProjectV2ItemFieldDateValue { date field { ... on ProjectV2Field { name } } }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Mutation: set claim
+
+```graphql
+mutation SetClaim($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $projectId, itemId: $itemId, fieldId: $fieldId
+    value: { text: $value }
+  }) { projectV2Item { id } }
+}
+```
+
+### Mutation: release claim
+
+Set `claimed-by` to empty string and `in-flight-since` to null via two
+`updateProjectV2ItemFieldValue` calls in sequence.
+
+## Baton-flow integration (planned)
+
+- **Manager handoff**: claim board item, set `claimed-by` + `in-flight-since`.
+- **Collaborator handoff**: set `locked-paths` from staged diff.
+- **Admin handoff**: update `cross-team-stage` to `testing`.
+- **Consultant closeout**: release claim (clear `claimed-by`, set `cross-team-stage` to `done`).
+
+Each step is one GraphQL mutation; failures degrade gracefully to issue-comment-only updates.
+
+## Portability (per G5 contract, #1628)
+
+- **Resource**: Projects v2 requires GitHub org access. Every operator with
+  Issue access has this.
+- **Opt-out**: `MEGINGJORD_PROJECTS_V2_DISABLED=1`. Skills detecting the opt-out
+  fall back to issue-comment-only state.
+- **Air-gapped fallback**: per #1624 F10, decisions.md pattern is the local
+  alternative; see #1636 follow-on.
+
+## Implementation children
+
+- #1630-followup: AC1 (create the board via GraphQL mutation)
+- #1630-followup: AC2 (`scripts/global/projects-v2-state.js` pure helper)
+- #1630-followup: AC4 (wire helper into baton flow)
+- #1630-followup: AC5 (test suite with mock GraphQL responses)
+- #1630-followup: AC6 (dashboard read-only panel)
+
+## Related
+
+- `instructions/github-governance.instructions.md` (MCP-server section — these
+  GraphQL ops are MCP-callable via `mcp__github__update_project_v2_item_field_value`)
+- `docs/howto/mcp-server-adoption.md` (#1629)
+- `instructions/harness-goals.instructions.md` G5 (#1628)


### PR DESCRIPTION
Refs #1630
Refs #1604
Refs #1624
Refs #1628
Refs #1629
Closes #1630

## Summary

- Adds `docs/howto/projects-v2-coordination.md` (92/100 lines): design doc for the cross-team Projects v2 live-state board.
- Documents custom-field shape (`claimed-by`, `locked-paths`, `in-flight-since`, `expected-completion`, `cross-team-stage`), GraphQL query + mutation snippets, planned baton-flow integration, MCP-tool equivalents (via #1629), and the `MEGINGJORD_PROJECTS_V2_DISABLED=1` opt-out path.

## Scope (AC3 only)

This ship lands AC3. The other ACs are filed as follow-on children:

- #1647 — AC1: create the actual board (one-time GraphQL mutation).
- #1648 — AC2: `scripts/global/projects-v2-state.js` pure helper.
- #1649 — AC4: wire helper into baton flow.
- #1650 — AC5: test suite with mock GraphQL responses + air-gapped fallback.
- #1651 — AC6: dashboard read-only panel.

Per `[[feedback-epic-ac-wording-vs-shipped-behavior]]`, closure language for AC1/AC2/AC4/AC5/AC6 is "deferred to follow-on", not "shipped".

## Why

Establishes the GraphQL contract for cross-team coordination before any consumer is implemented. Aligns with #1628 G5 contract via documented opt-out.

## Test plan

- [x] G1 lint clean (`npm run lint`)
- [x] G2 readability clean (`npm run lint:readability:ci`)
- [x] All 4 baton artifacts on #1630 before PR (Mason/Harper/Reyes/Vale)
- [x] CONSULTANT_CLOSEOUT rubric_rating 9/10
- [x] AC1/AC2/AC4/AC5/AC6 follow-ons filed before PR (#1647-#1651)

🤖 Generated with [Claude Code](https://claude.com/claude-code)