### PR TITLE
feat(governance): add cross-team comment artifacts

### DIFF
--- a/.changes/unreleased/1621.md
+++ b/.changes/unreleased/1621.md
@@ -1,0 +1,10 @@
+# 1621
+
+- Added structured cross-team communication artifact templates and validation.
+- Added tests for malformed comments, ticket refs, signatures, and duplicates.
+- Documented artifact names and Manager adjudication in the shared governance
+  contract.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/instructions/provider-neutral-governance.instructions.md
+++ b/instructions/provider-neutral-governance.instructions.md
@@ -58,6 +58,18 @@ must say "agent runtime" or "orchestrating team" unless it is naming an adapter.
   targets, not direct edit targets.
 - Tests must fail if Codex is omitted from shared coordination coverage.
 
+## Cross-Team Comment Artifacts
+
+Use these machine-readable GitHub comment blocks for coordination:
+`CLAIM_LEASE`, `CONFLICT_PULL`, `TEAM_QUESTION`, `TEAM_RESPONSE`, and
+`LEASE_CLOSE`.
+
+- Validate artifacts with `scripts/global/cross-team-comment-artifacts.js`.
+- Manager adjudicates `CONFLICT_PULL` when the owning team does not respond
+  before the requested deadline.
+- Manager escalates unanswered `TEAM_QUESTION` comments after `reply_by`.
+- `CLAIM_LEASE` duplicates by ticket or branch are invalid.
+
 Signed-by: Quill Harper
 Team&Model: codex:gpt-5.4@openai
 Role: collaborator

--- a/scripts/global/cross-team-comment-artifacts.js
+++ b/scripts/global/cross-team-comment-artifacts.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+'use strict';
+
+const REQUIRED = {
+  CLAIM_LEASE: ['ticket', 'team', 'role', 'branch', 'paths', 'expires_at'],
+  CONFLICT_PULL: ['ticket', 'from_team', 'to_team', 'paths', 'requested_action'],
+  TEAM_QUESTION: ['ticket', 'from_team', 'to_team', 'question', 'reply_by'],
+  TEAM_RESPONSE: ['ticket', 'from_team', 'to_team', 'response_to', 'answer'],
+  LEASE_CLOSE: ['ticket', 'team', 'branch', 'status'],
+};
+
+function parse(body = '') {
+  const lines = body.split(/\r?\n/);
+  const type = (lines.find(line => /^CROSS_TEAM_[A-Z_]+$/.test(line)) || '')
+    .replace(/^CROSS_TEAM_/, '');
+  const fields = {};
+  for (const line of lines) {
+    const match = line.match(/^([a-z_]+):\s*(.+)$/i);
+    if (match) fields[match[1].toLowerCase()] = match[2].trim();
+  }
+  const signedBy = body.match(/^Signed-by:\s*(.+)$/im)?.[1];
+  const teamModel = body.match(/^Team&Model:\s*(.+)$/im)?.[1];
+  const role = body.match(/^Role:\s*(.+)$/im)?.[1];
+  return { type, fields, signedBy, teamModel, role };
+}
+
+function validate(body, activeClaims = []) {
+  const artifact = parse(body);
+  const errors = [];
+  if (!REQUIRED[artifact.type]) errors.push('unknown artifact type');
+  for (const field of REQUIRED[artifact.type] || []) {
+    if (!artifact.fields[field]) errors.push(`missing ${field}`);
+  }
+  if (!/^#\d+$/.test(artifact.fields.ticket || '')) errors.push('missing ticket ref');
+  if (!artifact.signedBy || !artifact.teamModel || !artifact.role) errors.push('missing signature');
+  const duplicate = activeClaims.find(claim => claim.ticket === artifact.fields.ticket
+    || (artifact.fields.branch && claim.branch === artifact.fields.branch));
+  if (artifact.type === 'CLAIM_LEASE' && duplicate) errors.push('duplicate active claim');
+  return { ok: errors.length === 0, errors, artifact };
+}
+
+function block(type, fields) {
+  const rows = [`<!-- cross-team:${type.toLowerCase()} -->`, `CROSS_TEAM_${type}`];
+  for (const [key, value] of Object.entries(fields)) rows.push(`${key}: ${value}`);
+  rows.push('Signed-by: Quill Harper', 'Team&Model: codex:gpt-5.4@openai',
+    'Role: collaborator');
+  return rows.join('\n');
+}
+
+module.exports = { block, parse, validate, REQUIRED };

--- a/tests/cross-team-comment-artifacts.spec.js
+++ b/tests/cross-team-comment-artifacts.spec.js
@@ -1,0 +1,42 @@
+const { test, expect } = require('@playwright/test');
+const A = require('../scripts/global/cross-team-comment-artifacts');
+
+function claim(overrides = {}) {
+  return A.block('CLAIM_LEASE', {
+    ticket: '#1621',
+    team: 'codex',
+    role: 'collaborator',
+    branch: 'feat/1621-cross-team-artifacts',
+    paths: 'scripts/global,tests',
+    expires_at: '2026-05-17T00:00:00.000Z',
+    ...overrides,
+  });
+}
+
+test('renders all required artifact types', () => {
+  for (const type of Object.keys(A.REQUIRED)) {
+    expect(A.block(type, { ticket: '#1' })).toContain(`CROSS_TEAM_${type}`);
+  }
+});
+
+test('validates a signed claim lease comment', () => {
+  const result = A.validate(claim());
+  expect(result.ok).toBe(true);
+  expect(result.artifact.fields.ticket).toBe('#1621');
+});
+
+test('rejects malformed comments and missing ticket refs', () => {
+  const result = A.validate('CROSS_TEAM_TEAM_QUESTION\nquestion: hi');
+  expect(result.ok).toBe(false);
+  expect(result.errors).toContain('missing ticket ref');
+});
+
+test('rejects missing signatures', () => {
+  const unsigned = claim().replace(/Signed-by:[\s\S]+$/, '');
+  expect(A.validate(unsigned).errors).toContain('missing signature');
+});
+
+test('rejects duplicate active claims by ticket or branch', () => {
+  const active = [{ ticket: '#1621', branch: 'feat/other' }];
+  expect(A.validate(claim(), active).errors).toContain('duplicate active claim');
+});


### PR DESCRIPTION
## Summary

Adds structured GitHub comment artifacts for cross-team coordination so Claude Code Team, Copilot Team, and Codex Team can claim leases, request conflict pulls, ask/answer team questions, and close leases with a shared signed format.

## Issue Linkage

Closes #1621
Refs #1621
Refs #1604
Refs #1616

## Test Strategy

test_strategy: tdd-pyramid

- `node scripts/global/cross-team-conflict-gate.js --ticket 1621 --branch feat/1621-cross-team-artifacts --paths scripts/global,tests,instructions,.changes/unreleased --post-comment 1`
- `npx playwright test tests/cross-team-comment-artifacts.spec.js tests/cross-team-lease-registry.spec.js`
- `npm run lint`
- `npm run lint:readability:ci`
- `npm run lint:js -- --quiet`
- `npm run lint:md -- instructions/provider-neutral-governance.instructions.md .changes/unreleased/1621.md`

---
Signed-by: Quill Reyes
Team&Model: codex:gpt-5.4@openai
Role: admin