### PR TITLE
feat(governance): add coordination view

### DIFF
--- a/.changes/unreleased/1622.md
+++ b/.changes/unreleased/1622.md
@@ -1,0 +1,13 @@
+# 1622 Cross-Team Coordination View
+
+- Added `scripts/global/cross-team-coordination-view.js` for read-only active
+  lease, stale lease, conflict, and cleanup-candidate summaries.
+- Added Playwright coverage for empty, active, stale, conflicting, and cleanup
+  report fixtures.
+- Documented the CLI/static report flow for reducing VS Code Source Control
+  clutter without touching parallel team worktrees.
+
+---
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/docs/howto/sandbox-worktree-governance.md
+++ b/docs/howto/sandbox-worktree-governance.md
@@ -34,3 +34,23 @@ node scripts/global/worktree-governance-audit.js --target=codex --json
 
 Valid targets are `copilot`, `codex`, and `claude-code`. The default audit still
 checks every launcher branch and should remain the release-quality signal.
+
+## Coordination View
+
+Use the read-only coordination view before opening VS Code on a multi-team
+workspace:
+
+```bash
+node scripts/global/cross-team-coordination-view.js --json
+```
+
+Write a static report for dashboard ingestion or review packets:
+
+```bash
+node scripts/global/cross-team-coordination-view.js --json --out .dashboard/cross-team-coordination.json
+```
+
+The report separates active leases, stale leases, conflicts, and cleanup
+candidates. Treat active leases as owned by their ticket holder. Treat cleanup
+candidates as plan-only until their owning ticket has merged and its lease is
+closed.

--- a/scripts/global/cross-team-coordination-view.js
+++ b/scripts/global/cross-team-coordination-view.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const leaseRegistry = require('./cross-team-lease-registry');
+const cleanup = require('./worktree-cleanup-plan');
+const HOUR_MS = 60 * 60 * 1000;
+
+function hoursBetween(start, end) {
+  return Math.max(0, Math.round((new Date(end) - new Date(start)) / HOUR_MS));
+}
+
+const github = (repo, kind, value) => value ? `https://github.com/${repo}/${kind}/${value}` : null;
+const issueLink = (ticket, repo = 'chf3198/megingjord-harness') => github(repo, 'issues', ticket);
+const prLink = (pr, repo = 'chf3198/megingjord-harness') => github(repo, 'pull', pr);
+const branchLink = (branch, repo = 'chf3198/megingjord-harness') =>
+  github(repo, 'tree', branch && encodeURIComponent(branch));
+
+function conflictKey(lease) {
+  return [lease.paths || [], lease.ports || []].flat().join('|');
+}
+
+function conflictTickets(lease, leases) {
+  return leases.filter(other => other.ticket !== lease.ticket &&
+    conflictKey(other) && conflictKey(lease) && conflictKey(other) === conflictKey(lease))
+    .map(other => other.ticket);
+}
+
+function leaseRows(registry, at, repo) {
+  const active = leaseRegistry.active(registry, at);
+  return active.map(lease => ({
+    team: lease.team, ticket: lease.ticket, branch: lease.branch,
+    paths: lease.paths || [], ports: lease.ports || [],
+    age_hours: hoursBetween(lease.created_at, at),
+    expires_hours: hoursBetween(at, lease.expires_at),
+    conflicts: conflictTickets(lease, active),
+    links: { issue: issueLink(lease.ticket, repo), branch: branchLink(lease.branch, repo),
+      worktree: lease.worktree || null },
+  }));
+}
+
+function cleanupRows(plan, repo) {
+  return plan.worktrees.filter(w => w.cleanupState !== 'active-lease')
+    .filter(w => ['merged-clean', 'prune-metadata', 'preserve-dirty', 'stale-open-pr'].includes(w.cleanupState))
+    .map(w => ({
+      state: w.cleanupState, ticket: w.ticket, branch: w.branch || null,
+      path: w.path, commands: w.commands || [],
+      links: { issue: issueLink(w.ticket, repo), branch: branchLink(w.branch, repo),
+        pr: prLink(w.openPr, repo), worktree: w.path },
+    }));
+}
+
+function summarize(input = {}) {
+  const at = input.at || new Date().toISOString();
+  const repo = input.repo || 'chf3198/megingjord-harness';
+  const registry = input.registry || leaseRegistry.read(input.leaseFile);
+  const plan = input.plan || cleanup.plan({
+    inventory: input.inventory, registry, leaseFile: input.leaseFile,
+  });
+  const active = leaseRows(registry, at, repo);
+  return {
+    generatedAt: at,
+    mode: 'read-only',
+    active,
+    byTeam: active.reduce((out, row) => {
+      out[row.team] = [...(out[row.team] || []), row];
+      return out;
+    }, {}),
+    stale: active.filter(row => row.expires_hours <= 2),
+    conflicts: active.filter(row => row.conflicts.length > 0),
+    cleanup: cleanupRows(plan, repo),
+  };
+}
+
+function text(report) {
+  const lines = [`active leases: ${report.active.length}`,
+    `conflicts: ${report.conflicts.length}`, `cleanup candidates: ${report.cleanup.length}`];
+  for (const row of report.active) {
+    lines.push(`${row.team.padEnd(10)} #${row.ticket} ${row.branch} age=${row.age_hours}h`);
+  }
+  for (const row of report.cleanup) lines.push(`cleanup ${row.state} ${row.branch || row.path}`);
+  return `${lines.join('\n')}\n`;
+}
+
+function run(argv = process.argv.slice(2)) {
+  const outIndex = argv.indexOf('--out');
+  const report = summarize();
+  if (outIndex >= 0) fs.writeFileSync(argv[outIndex + 1], `${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write(argv.includes('--json') ? `${JSON.stringify(report, null, 2)}\n` : text(report));
+  return report;
+}
+
+if (require.main === module) run();
+
+module.exports = { branchLink, cleanupRows, conflictTickets, summarize, text };

--- a/tests/cross-team-coordination-view.spec.js
+++ b/tests/cross-team-coordination-view.spec.js
@@ -1,0 +1,62 @@
+const { test, expect } = require('@playwright/test');
+const view = require('../scripts/global/cross-team-coordination-view');
+
+const FUTURE = '2999-01-01T02:00:00.000Z';
+const NOW = '2999-01-01T00:00:00.000Z';
+
+function lease(overrides = {}) {
+  return {
+    ticket: 1801,
+    team: 'codex',
+    branch: 'feat/1801-demo',
+    worktree: '/tmp/demo',
+    paths: ['scripts/global'],
+    ports: [],
+    created_at: '2998-12-31T22:00:00.000Z',
+    expires_at: FUTURE,
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function plan(worktrees = []) {
+  return { worktrees };
+}
+
+test('reports an empty registry', () => {
+  const report = view.summarize({ at: NOW, registry: { version: 1, leases: [] }, plan: plan() });
+  expect(report.active).toEqual([]);
+  expect(report.cleanup).toEqual([]);
+});
+
+test('groups active leases by team with links and age', () => {
+  const report = view.summarize({ at: NOW, registry: { version: 1, leases: [lease()] }, plan: plan() });
+  expect(report.byTeam.codex[0].ticket).toBe(1801);
+  expect(report.active[0].age_hours).toBe(2);
+  expect(report.active[0].links.issue).toContain('/issues/1801');
+});
+
+test('flags stale leases that expire soon', () => {
+  const report = view.summarize({ at: NOW, registry: { version: 1, leases: [lease()] }, plan: plan() });
+  expect(report.stale[0].ticket).toBe(1801);
+});
+
+test('detects conflicting active leases by shared path', () => {
+  const registry = { version: 1, leases: [
+    lease({ ticket: 1801, branch: 'feat/1801-a' }),
+    lease({ ticket: 1802, team: 'copilot', branch: 'feat/1802-b' }),
+  ] };
+  const report = view.summarize({ at: NOW, registry, plan: plan() });
+  expect(report.conflicts.map(row => row.ticket)).toEqual([1801, 1802]);
+});
+
+test('separates cleanup candidates from active work', () => {
+  const report = view.summarize({
+    at: NOW,
+    registry: { version: 1, leases: [] },
+    plan: plan([{ cleanupState: 'merged-clean', ticket: 1803, branch: 'feat/1803-done',
+      path: '/tmp/done', commands: ['git worktree remove /tmp/done'] }]),
+  });
+  expect(report.cleanup[0].state).toBe('merged-clean');
+  expect(view.text(report)).toContain('cleanup candidates: 1');
+});


### PR DESCRIPTION
## Summary

Adds a read-only cross-team coordination CLI/static report that summarizes active leases, stale leases, conflicts, cleanup candidates, and links back to issue, branch, PR, and worktree references where available.

## Issue Linkage

Closes #1622
Refs #1622
Refs #1604
Refs #1616

## Test Strategy

test_strategy: tdd-pyramid

- `node scripts/global/cross-team-conflict-gate.js --ticket 1622 --branch feat/1622-coordination-view --paths scripts/global,tests,docs/howto,.changes/unreleased --post-comment 1`
- `npx playwright test tests/cross-team-coordination-view.spec.js tests/worktree-cleanup-plan.spec.js`
- `node scripts/global/cross-team-coordination-view.js --json --out /tmp/cross-team-coordination.json`
- `npm run lint`
- `npm run lint:readability:ci`
- `npm run lint:js -- --quiet`
- `npm run lint:md -- docs/howto/sandbox-worktree-governance.md .changes/unreleased/1622.md`

---
Signed-by: Quill Reyes
Team&Model: codex:gpt-5.4@openai
Role: admin