### PR TITLE
docs(governance): Sub-issues migration design #1631

### DIFF
--- a/.changes/unreleased/1631.md
+++ b/.changes/unreleased/1631.md
@@ -1,0 +1,31 @@
+## [Unreleased] — #1631: Sub-issues primitive migration design
+
+### Added
+- `docs/howto/sub-issues-migration.md` — migration plan, new-Epic recipe, backward-compat notes, and the GraphQL mutation pattern for `addSubIssue`.
+
+### Changed
+- `instructions/role-baton-routing.instructions.md` — new "Parent/child relationships (Sub-issues primitive)" section codifying Sub-issues as the canonical relationship for new tickets; prose `Refs Epic #N` deprecated for new use but retained for backward compatibility.
+- `instructions/epic-governance.instructions.md` — new "Epic-child linkage (Sub-issues primitive)" section pointing at the migration guide and listing the trap-class motivation.
+
+### Why
+Closes #1631 (Phase 1 of Epic #1604 / research #1624 F3). Eliminates the prose-collision trap class at the relationship layer (Codex Team #1614 hardens the parser; this ticket reduces dependence on the regex path).
+
+Per Path D and `[[feedback-epic-ac-wording-vs-shipped-behavior]]`, this ship covers AC3 (instructions update + migration doc) only; AC1/AC2/AC4/AC5/AC6 are filed as follow-on children.
+
+### Scope (this ship)
+- AC1 deferred (org/repo Settings enable): follow-on filed.
+- AC2 deferred (sub-issue-link.js helper): follow-on filed.
+- AC3: ✅ instruction updates + migration design doc delivered.
+- AC4 deferred (closed-Epic migration script): follow-on filed.
+- AC5 deferred (closeout-schema validator prefers Sub-issue): follow-on filed.
+- AC6 deferred (test suite): follow-on filed.
+
+### Verification
+- `npm run lint` clean (instructions/ and docs/howto/ are excluded from the 100-line cap by design — both files added are well within reasonable size).
+- `npm run lint:readability:ci` clean (no JS changes).
+- Composes with Codex Team #1614 (parser-level hardening of legacy regex path).
+
+### Out of scope
+- Backfilling Sub-issue links on already-closed Epics (covered by AC4 follow-on as a one-time migration script).
+- Changing Epic close conditions.
+- Removing the prose `Refs Epic #N` regex path — kept for backward compatibility.

--- a/docs/howto/sub-issues-migration.md
+++ b/docs/howto/sub-issues-migration.md
@@ -1,0 +1,77 @@
+# Sub-issues Migration
+
+GitHub's native **Sub-issues** primitive replaces the prose-level
+`Refs Epic #N` convention for parent/child relationships.
+
+## Why move off `Refs Epic #N` prose
+
+- **Trap class**: prose `Refs Epic #N` collides with closeout-schema regex
+  scans (per `[[feedback-team-model-prose-collision]]`, `[[feedback-role-colon-prose-collision]]`).
+  Codex Team #1614 hardens the parser; this migration sidesteps prose entirely.
+- **No automatic rollup**: prose `Refs` gives no parent-completion percentage.
+- **No native UI**: GitHub UI doesn't surface prose `Refs` as a tree.
+
+## Sub-issues capabilities (per #1624 F3 research)
+
+- Up to 100 children per parent.
+- 8 levels of nesting.
+- Native REST + GraphQL APIs.
+- Issue Types (Bug / Task / Feature / Epic) attach independently of relationships.
+- Progress rollup automatic.
+
+## Migration plan (children of #1631)
+
+| Phase | Ticket | Scope |
+|---|---|---|
+| 1 (this ship, AC3) | #1631 | Update instructions to reference Sub-issues |
+| 2 | #1631 AC1 follow-on | Enable Sub-issues + Issue Types on org/repo (Settings op) |
+| 3 | #1631 AC2 follow-on | `scripts/global/sub-issue-link.js` pure helper |
+| 4 | #1631 AC4 follow-on | Migration script for closed Epics (run-once) |
+| 5 | #1631 AC5 follow-on | Update `closeout-schema` to prefer Sub-issue link |
+| 6 | #1631 AC6 follow-on | Test suite |
+
+## New-Epic recipe (post-migration)
+
+1. Create the Epic issue with `type:epic` label.
+2. Create child issues normally.
+3. For each child, link via GraphQL mutation:
+
+```graphql
+mutation AddSubIssue($issueId: ID!, $parentId: ID!) {
+  addSubIssue(input: { issueId: $issueId, parentIssueId: $parentId }) {
+    subIssue { id number title }
+  }
+}
+```
+
+Or via the `sub-issue-link.js` helper (follow-on #1631 AC2):
+
+```bash
+node scripts/global/sub-issue-link.js --parent 1604 --child 1655
+```
+
+4. The native UI now shows the child under the Epic's sub-issue list.
+5. Closeout-schema (after AC5) reads the native relationship; prose-scan
+   fallback retained for legacy Epics.
+
+## Backward-compatibility note
+
+- Pre-existing Epics with `Refs Epic #N` children continue to work via the
+  closeout-schema prose-scan path; no migration is mandatory.
+- The one-time migration script (AC4 follow-on) walks closed Epics and
+  emits Sub-issue links so historical data is queryable in the native UI.
+
+## Portability (per G5 contract, #1628)
+
+- **Resource**: GitHub API (same baseline as Issues). No new credential.
+- **Opt-out**: not needed — air-gapped operators have no GitHub access at
+  baseline, so neither prose `Refs` nor Sub-issues work for them.
+
+## Related
+
+- #1631 — parent ticket (this migration)
+- #1614 — Codex Team parser-level prose-collision hardening (composes with this)
+- #1628 — G5 Portability contract
+- #1624 — research source (F3)
+- `instructions/role-baton-routing.instructions.md` (parent/child section)
+- `instructions/epic-governance.instructions.md` (Epic-child linkage section)

--- a/instructions/epic-governance.instructions.md
+++ b/instructions/epic-governance.instructions.md
@@ -77,6 +77,22 @@ An epic may close **only when ALL of these are true**:
 - If original epic ACs cannot be completed, Manager must publish an explicit re-scope artifact (deferred scope + follow-on child tickets) before review/close.
 - Post-hoc scope normalization at Consultant closeout is forbidden.
 
+## Epic-child linkage (Sub-issues primitive)
+
+New Epics SHOULD use GitHub's native **Sub-issues** primitive to link children
+to the parent Epic. The legacy `Refs Epic #N` prose convention remains valid
+for backward compatibility but is deprecated for new Epics. Sub-issues
+provides:
+
+- Native parent/child API (REST + GraphQL) and progress rollup.
+- Eliminates prose-collision trap class at the relationship layer (see #1614
+  for the legacy-regex hardening path and #1631 for the migration plan).
+- Up to 100 children per parent, 8 levels of nesting.
+
+Migration guide: `docs/howto/sub-issues-migration.md`. Validator behavior
+follows #1631 AC5 follow-on (closeout-schema prefers Sub-issue link over
+prose-scan; prose-scan fallback retained).
+
 ## Branch Naming
 
 Branches are created for child tickets only: `<type>/<child-issue-number>-<slug>`

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -100,6 +100,15 @@ Required fields on every `MANAGER_HANDOFF` comment:
 
 `test_strategy` selected per `instructions/test-methodology-matrix.instructions.md`; missing on legacy tickets defaults to `none` (advisory). New tickets with `none` on non-permitted lane fail `test-evidence`.
 
+## Parent/child relationships (Sub-issues primitive)
+
+The canonical parent/child relationship uses GitHub's native **Sub-issues**
+primitive (up to 100 children per parent, 8 levels deep). The legacy prose
+`Refs Epic #N` convention remains supported for backward compatibility but
+is deprecated for new tickets. See `docs/howto/sub-issues-migration.md` for
+the migration plan and #1631 follow-on children for the helper, validator,
+and test-suite implementation.
+
 ## Local Override
 
 A repo may override via `.github/copilot-instructions.md`; local wins on conflict.


### PR DESCRIPTION
Refs #1631
Refs #1604
Refs #1624
Refs #1628
Refs #1614
Closes #1631

## Summary

- Updates `instructions/role-baton-routing.instructions.md` and `instructions/epic-governance.instructions.md` to codify GitHub's native **Sub-issues** primitive as the canonical parent/child relationship for new tickets.
- Adds `docs/howto/sub-issues-migration.md` with migration plan, GraphQL `addSubIssue` mutation, new-Epic recipe, and backward-compat notes.
- Prose `Refs Epic #N` remains supported for backward compatibility but is deprecated for new use.

## Scope (AC3 only)

This ship lands AC3. Other ACs filed as follow-on children:

- #1655 — AC1: enable Sub-issues + Issue Types on org/repo (Settings op).
- #1656 — AC2: `scripts/global/sub-issue-link.js` pure helper.
- #1657 — AC4: one-time migration script for closed Epics.
- #1658 — AC5: closeout-schema validator prefers Sub-issue link over prose scan.
- #1659 — AC6: test suite.

## Why

Eliminates the prose-collision trap class at the relationship layer (see `[[feedback-team-model-prose-collision]]`, `[[feedback-role-colon-prose-collision]]`). Composes with Codex Team #1614 (legacy regex hardening).

## Test plan

- [x] G1 lint clean (`npm run lint`)
- [x] G2 readability clean (`npm run lint:readability:ci`)
- [x] All 4 baton artifacts on #1631 before PR (Mason/Harper/Reyes/Vale)
- [x] CONSULTANT_CLOSEOUT rubric_rating 9/10
- [x] AC1/AC2/AC4/AC5/AC6 follow-ons filed before PR (#1655-#1659)
- [x] Backward compat retained (prose Refs Epic still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)