### PR TITLE
docs(governance): webhook coordination design #1632

### DIFF
--- a/.changes/unreleased/1632.md
+++ b/.changes/unreleased/1632.md
@@ -1,0 +1,22 @@
+## [Unreleased] — #1632: Webhook coordination plane design (AC1)
+
+### Added
+- `docs/howto/webhook-coordination-design.md` — design doc covering the three delivery surfaces (repository_dispatch, workflow_dispatch, webhook receive), polling-fallback contract, event-type catalog, authentication notes, and composition with #1630 Projects v2.
+
+### Why
+Closes #1632 AC1 (Phase 2 of Epic #1604 / research #1624 F4). Establishes the decision tree for the cross-team event-delivery surface before any implementation child is wired up. Per #1628 G5 contract, recommends GitHub-hosted Actions runner accepting `repository_dispatch` (integral classification) with mandatory polling fallback for air-gapped operators.
+
+### Scope (this ship)
+- AC1: ✅ decision-make on webhook delivery surface; tradeoffs documented.
+- AC2-AC6 deferred to follow-on children.
+
+### Verification
+- `npm run lint` clean.
+- `npm run lint:readability:ci` clean.
+- Cross-references #1628 G5 contract, #1630 Projects v2 board, #1624 F4 research.
+
+### Out of scope
+- Wiring the event listener — covered by AC2 follow-on.
+- Building the Actions-hosted receiver — covered by AC3 follow-on.
+- Building the polling-fallback library — covered by AC4 follow-on.
+- Tests — covered by AC6 follow-on.

--- a/docs/howto/webhook-coordination-design.md
+++ b/docs/howto/webhook-coordination-design.md
@@ -1,0 +1,72 @@
+# Cross-Team Webhook + Polling Coordination Design
+
+Real-time cross-team event delivery via GitHub webhooks +
+`repository_dispatch` + `workflow_dispatch`, with mandatory polling fallback
+for operators without webhook-receive capability.
+
+## Three delivery surfaces
+
+| Surface | Direction | Reach | Latency | Operator requirement |
+|---|---|---|---|---|
+| `repository_dispatch` | push-send | All operators with `repo` scope | Seconds | None beyond GitHub access |
+| `workflow_dispatch` | manual push-send | All operators with `actions:write` | Seconds | None beyond GitHub access |
+| Webhook receive | push-receive | Operators with public endpoint OR Actions-hosted runner | Sub-second | Public URL or Actions runner |
+| Polling | pull | All operators | Configurable (default 60s) | None |
+
+## AC1 decision (this ship)
+
+**Recommended surface**: GitHub-hosted Actions runner accepting
+`repository_dispatch` events. Reasons:
+
+- No external receiver infrastructure required (zero new resources).
+- Operators inherit existing Actions credentials.
+- Per #1628 G5 portability: classified as integral for *push-send + polling-
+  receive*; classified as opt-in for *push-receive via external tunnel*.
+
+Air-gapped operators continue with polling-only coordination at a longer
+interval (default 60s; configurable via `MEGINGJORD_POLL_INTERVAL_SECONDS`).
+
+## Polling-fallback contract (mandatory per G5)
+
+- Default interval: 60s.
+- Backoff on rate-limit signal from GitHub API.
+- Reads the same Projects v2 board state surface (#1630) — claim deltas
+  are visible whether they arrived via webhook or were polled.
+- Opt-in faster intervals via `MEGINGJORD_POLL_INTERVAL_SECONDS=15` (caps at 5s).
+
+## Event types of interest
+
+| Event | Webhook payload | Polling proxy |
+|---|---|---|
+| Issue label change | `issues.labeled` | `gh issue view N --json labels` |
+| Issue closure | `issues.closed` | `state: CLOSED` poll |
+| PR open | `pull_request.opened` | `gh pr list --state open` |
+| PR merge | `pull_request.closed` (merged=true) | `mergedAt` poll |
+| Comment | `issue_comment.created` | `gh issue view N --json comments` |
+| Projects v2 field change | `projects_v2_item.edited` | GraphQL board poll |
+
+## Authentication
+
+- Webhook receiver: HMAC-SHA256 with `MEGINGJORD_WEBHOOK_SECRET`.
+- Polling: standard `GITHUB_TOKEN` (same as `gh` CLI).
+
+## Implementation children
+
+- AC2 (cross-team-event-listener.js helper): follow-on.
+- AC3 (Actions-hosted receiver workflow): follow-on.
+- AC4 (polling-fallback library): follow-on.
+- AC5 (event-to-board write-through): follow-on.
+- AC6 (tests): follow-on.
+
+## Composition with #1630
+
+The polling surface and webhook surface both read/write the same Projects v2
+board state. Webhook arrival just makes the change visible sooner.
+
+## Related
+
+- #1632 — parent (this design)
+- #1630 — Projects v2 board (#1624 F2)
+- #1628 — G5 Portability contract
+- #1624 — research source (F4)
+- `instructions/harness-goals.instructions.md` G5 (opt-in vs fallback)


### PR DESCRIPTION
Refs #1632
Refs #1604
Refs #1624
Refs #1628
Refs #1630
Closes #1632

## Summary

- Adds `docs/howto/webhook-coordination-design.md` (AC1 only): delivery-surface decision tree (repository_dispatch + workflow_dispatch + webhook receive + polling fallback), event-type catalog, HMAC authentication notes, composition with #1630 Projects v2.

## Scope (AC1 only)

AC2-AC6 filed as follow-on children:
- #1662 — AC2 cross-team-event-listener.js
- #1663 — AC3 Actions-hosted receiver workflow
- #1664 — AC4 polling-fallback library
- #1665 — AC5 event-to-board write-through
- #1666 — AC6 tests

## Test plan

- [x] G1 lint clean, G2 readability clean
- [x] 4 baton artifacts before PR (Mason/Harper/Reyes/Vale)
- [x] CONSULTANT_CLOSEOUT rubric_rating 9/10
- [x] AC2-AC6 follow-ons filed before PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)