### PR TITLE
docs(governance): Discussions/Issues split #1633

### DIFF
--- a/.changes/unreleased/1633.md
+++ b/.changes/unreleased/1633.md
@@ -1,0 +1,24 @@
+## [Unreleased] — #1633: Discussions / Issues decisional-actionable split
+
+### Added
+- `docs/howto/discussions-vs-issues.md` — category catalog (Architecture, Cross-team protocol, Tooling research, Operations notes, Q&A), conversion path (Discussion → Issue when scope crystallizes), and what does / does not belong in each surface.
+
+### Changed
+- `instructions/global-standards.instructions.md` — new "Decisional vs. actionable (Discussions vs. Issues)" section codifying the rule + pointer to the howto.
+
+### Why
+Closes #1633 AC2 + AC3 (Phase 2 of Epic #1604 / research #1624 F5). Separates the decisional layer from the actionable layer at the contract level. AC1 (create the Discussion categories on the repo as a Settings op) and AC4+ deferred to follow-on children.
+
+### Scope (this ship)
+- AC1 deferred (one-time Settings op to create the categories): follow-on filed.
+- AC2: ✅ instructions update.
+- AC3: ✅ conversion path documented.
+- AC4+: deferred to follow-on if needed.
+
+### Verification
+- `npm run lint` clean.
+- `npm run lint:readability:ci` clean (no JS changes).
+
+### Out of scope
+- Migrating existing prose-debate Issue comments to Discussions retroactively.
+- Renaming any Discussion category after creation (Settings-level).

--- a/docs/howto/discussions-vs-issues.md
+++ b/docs/howto/discussions-vs-issues.md
@@ -1,0 +1,69 @@
+# Discussions vs. Issues: Decisional / Actionable Split
+
+GitHub Discussions hold the **decisional** layer; Issues hold the
+**actionable** layer. Conflating them in Issue comments creates noise.
+
+## Decision rule
+
+| Question | Where it goes |
+|---|---|
+| Should we adopt X? | Discussion |
+| What's the right way to model Y? | Discussion |
+| Is Z worth shipping? | Discussion |
+| Ship X by Y with AC Z | Issue |
+| Fix bug N | Issue |
+| Update doc M | Issue |
+
+If the question has no concrete deliverable yet, it belongs in a Discussion.
+Once a deliverable + AC crystallizes, convert to an Issue.
+
+## Discussion categories (proposed)
+
+| Category | Purpose | Examples |
+|---|---|---|
+| Architecture | System-level design debate | "Should we split HAMR into multi-region?" |
+| Cross-team protocol | Inter-team coordination | "How should claim conflicts be resolved?" |
+| Tooling research | Tool evaluation | "Compare gh-aw vs Claude-Code agent-teams" |
+| Operations notes | Runbook deltas, op insights | "Pre-push gate hang recovery recipe" |
+| Q&A | Quick questions | "How do I run the lint locally?" |
+
+## Conversion path (Discussion → Issue)
+
+When a Discussion crystallizes into a deliverable:
+
+1. Manager-role agent reads the Discussion to extract scope + AC.
+2. `gh issue create --title "..." --body "Crystallized from Discussion #N. ..."` with full AC.
+3. Comment back on the Discussion: "Crystallized to Issue #M; closing this thread."
+4. Close the Discussion (`gh discussion close N`).
+
+The Discussion link in the Issue body preserves the decisional rationale.
+
+## What stays in Issue comments
+
+- Baton artifacts (MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT).
+- AC-progress updates.
+- Closeout evidence.
+
+## What does NOT go in Issue comments anymore
+
+- Open architectural debates with no deliverable yet → Discussion.
+- "Maybe we should consider X" speculation → Discussion.
+- Tool comparisons not tied to a specific ship → Discussion.
+
+## Portability (per G5 contract, #1628)
+
+- **Resource**: GitHub Discussions GA. Same baseline as Issues.
+- **Opt-out**: not applicable — operators with Issue access have Discussion
+  access by default.
+
+## Implementation children
+
+- AC1 (create the categories on the repo): follow-on filed.
+- AC4+ (validator nudges; convert-helper script): follow-on filed.
+
+## Related
+
+- #1633 — parent ticket
+- #1624 — research source (F5)
+- #1628 — G5 Portability contract
+- `instructions/global-standards.instructions.md` (Decisional vs. actionable section)

--- a/instructions/global-standards.instructions.md
+++ b/instructions/global-standards.instructions.md
@@ -42,3 +42,13 @@ applyTo: "**"
 	or when `MEGINGJORD_MCP_DISABLED=1` is set.
 - See `instructions/github-governance.instructions.md` for the full contract
 	and `docs/howto/mcp-server-adoption.md` for the operator guide.
+
+## Decisional vs. actionable (Discussions vs. Issues)
+
+- **Issues**: actionable work with concrete deliverable + acceptance criteria.
+- **Discussions**: decisional questions, open design exploration, cross-team
+	protocol debates, tooling research — anything without a concrete AC yet.
+- When a Discussion crystallizes into a deliverable, convert it to an Issue
+	via `gh discussion view N --json` + `gh issue create`. Keep the Discussion
+	link in the Issue body so decisional rationale is preserved.
+- See `docs/howto/discussions-vs-issues.md` for category catalog and examples.


### PR DESCRIPTION
Refs #1633
Refs #1604
Refs #1624
Refs #1628
Closes #1633

## Summary

- Adds "Decisional vs. actionable (Discussions vs. Issues)" section to `instructions/global-standards.instructions.md`.
- Adds `docs/howto/discussions-vs-issues.md` with category catalog and Discussion → Issue conversion path.

## Scope (AC2+AC3)

AC1 (one-time Discussion-categories Settings op) filed as follow-on #1668.

## Test plan

- [x] G1 lint clean, G2 readability clean
- [x] 4 baton artifacts before PR (Mason/Harper/Reyes/Vale)
- [x] CONSULTANT_CLOSEOUT rubric_rating 9/10
- [x] AC1 follow-on filed before PR (#1668)

🤖 Generated with [Claude Code](https://claude.com/claude-code)