### PR TITLE
fix(scripts): closeout-preflight derives lane from labels #1639

### DIFF
--- a/.changes/unreleased/1639.md
+++ b/.changes/unreleased/1639.md
@@ -1,0 +1,14 @@
+## [Unreleased] — #1639: closeout-preflight derives lane from labels
+
+### Fixed
+- `scripts/global/closeout-preflight.js` `toValidatorInput()` no longer hardcodes `lane: 'lane:code-change'`. New `deriveLaneFromLabels()` helper extracts the first `lane:*` label from the issue's label set; falls back to `lane:code-change` if no lane label present.
+
+### Added
+- `tests/closeout-preflight.spec.js` new test "closeout-preflight derives lane from labels when handoff is docs-only" — asserts that an issue labelled `lane:docs-only` with a matching MANAGER_HANDOFF passes preflight (previously failed with `lane-mismatch`).
+
+### Why
+Closes #1639. Surfaced during #1628 push and recurred on every docs-only push in the 2026-05-15 session (#1633, #1636). The hardcoded `lane:code-change` forced every non-code-change ticket to bypass preflight via `SKIP_CLOSEOUT_PREFLIGHT=1`. Now the validator honors the actual lane label.
+
+### Verification
+- `npm run lint` clean.
+- `npx playwright test tests/closeout-preflight.spec.js` → 5 passed.

--- a/scripts/global/closeout-preflight.js
+++ b/scripts/global/closeout-preflight.js
@@ -25,13 +25,19 @@ function normalizeLabels(labels) {
   return (labels || []).map(label => (typeof label === 'string' ? label : label.name)).filter(Boolean);
 }
 
+function deriveLaneFromLabels(labels) {
+  const laneLabel = (labels || []).find(l => typeof l === 'string' && l.startsWith('lane:'));
+  return laneLabel || 'lane:code-change';
+}
+
 function toValidatorInput(issue, issueNum, branch) {
   const body = issue.body || '';
+  const labels = normalizeLabels(issue.labels);
   return {
     body,
     comments: normalizeComments(issue.comments),
-    labels: normalizeLabels(issue.labels),
-    lane: 'lane:code-change',
+    labels,
+    lane: deriveLaneFromLabels(labels),
     prBody: '',
     state: issue.state || 'open',
     ticketRef: issueNum,

--- a/tests/closeout-preflight.spec.js
+++ b/tests/closeout-preflight.spec.js
@@ -50,6 +50,21 @@ test('closeout-preflight skips branches without ticket numbers', () => {
   expect(result.stdout).toContain('skip');
 });
 
+test('closeout-preflight derives lane from labels when handoff is docs-only', () => {
+  const result = runWith({
+    title: 'D Test',
+    body: '',
+    comments: [
+      { body: 'MANAGER_HANDOFF\nscope: docs\nlane: lane:docs-only\ntest_strategy: peer-review\nacceptance: ok\ngates: peer\nSigned-by: Orla Mason\nTeam&Model: claude-code:opus@anthropic\nRole: manager' },
+      { body: '## CONSULTANT_CLOSEOUT\nG1=9\nverification-timestamp: 2026-05-15T00:00:00Z\nverdict: approved\nSigned-by: Orla Vale\nTeam&Model: claude-code:opus@anthropic\nRole: consultant\nrubric_rating: 9/10' },
+    ],
+    labels: ['lane:docs-only', 'type:doc'],
+    state: 'open',
+  }, 'fix/1639-derives-lane');
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('PASS #1639');
+});
+
 test('closeout-preflight skips when SKIP_CLOSEOUT_PREFLIGHT=1', () => {
   const result = spawnSync(process.execPath, [SCRIPT], {
     env: {


### PR DESCRIPTION
Refs #1639
Refs #1604
Closes #1639

## Summary

- `scripts/global/closeout-preflight.js`: `toValidatorInput()` no longer hardcodes `lane: 'lane:code-change'`. New `deriveLaneFromLabels()` reads the first `lane:*` label from the issue.
- `tests/closeout-preflight.spec.js`: new test asserting docs-only ships pass preflight.

## Why

Surfaced during the 2026-05-15 Phase 1+2 ship sequence — every docs-only ticket (#1628 #1633 #1636) required `SKIP_CLOSEOUT_PREFLIGHT=1` bypass. Now preflight matches the actual lane.

## Test plan

- [x] G1 lint clean
- [x] 5/5 unit tests pass (4 existing + 1 new lane-derivation case)
- [x] G2 readability clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)