### PR TITLE
feat(scripts): MCP follow-ons batch #1641 #1642 #1643

### DIFF
--- a/.changes/unreleased/1641-1642-1643.md
+++ b/.changes/unreleased/1641-1642-1643.md
@@ -1,0 +1,20 @@
+## [Unreleased] — #1641 #1642 #1643: MCP follow-ons batch
+
+### Added
+- `research/scripts-gh-cli-mcp-audit-2026-05-15.md` — full audit of 8 gh-CLI callers in `scripts/global/`, MCP-tool equivalents, and migration value scoring (#1641).
+- `scripts/global/collaborator-self-check-rules.js` `mcpLoadCheck` rule — detects MCP-tool usage in handoff body or honors `MEGINGJORD_MCP_DISABLED=1` opt-out with cited rationale (#1642).
+- `scripts/global/github-dispatcher.js` — MCP-vs-gh-CLI dispatcher; `provider()`, `toolName()`, `dispatch()` (#1643).
+- `tests/collaborator-self-check.spec.js` — 5 new tests covering the mcpLoadCheck rule (#1642).
+- `tests/mcp-integration.spec.js` — 10 unit tests covering MCP/gh-CLI fallback dispatch (#1643).
+
+### Why
+Closes #1641 (audit), #1642 (collab-self-check MCP-load rule with advisory-first per Path D), #1643 (test suite with mock).
+
+### Verification
+- 20/20 `collaborator-self-check.spec.js` tests pass.
+- 10/10 `mcp-integration.spec.js` tests pass.
+- `npm run lint` clean.
+
+### Out of scope
+- Wholesale migration of audited gh-CLI helpers — covered by per-helper tickets that emerge when an owner team chooses to migrate.
+- Live MCP server e2e tests — mock-based only per AC scope.

--- a/research/scripts-gh-cli-mcp-audit-2026-05-15.md
+++ b/research/scripts-gh-cli-mcp-audit-2026-05-15.md
@@ -1,0 +1,67 @@
+# scripts/global/*.js gh-CLI → MCP migration audit (#1641)
+
+Inventory of direct `gh` CLI / REST calls in `scripts/global/*.js` and
+MCP-tool equivalents. Per #1641 AC1-AC4. Sourced from #1629 contract.
+
+## Callers found (8 files)
+
+| File | Calls | MCP-tool equivalent | Migration value |
+|---|---|---|---|
+| `anneal-tier2-autofile.js` | `gh issue create`, `gh issue comment` | `mcp__github__create_issue`, `mcp__github__create_issue_comment` | **High** — frequent path; benefits from schema validation |
+| `closeout-preflight.js` | `gh issue view --json`, `gh pr view --json` | `mcp__github__get_issue`, `mcp__github__get_pull_request` | **High** — runs on every push; performance + schema |
+| `cross-team-conflict-gate.js` | `gh pr list --json` | `mcp__github__list_pull_requests` | Medium — runs on PR open only |
+| `dep-graph-aggregate.js` | `gh issue list --json` | `mcp__github__list_issues` | Medium — runs on schedule |
+| `epic-evidence.js` | `gh issue view --json`, `gh issue comment` | `mcp__github__get_issue`, `mcp__github__create_issue_comment` | Medium — runs at Epic close |
+| `issue-transition.js` | `gh issue edit --add-label`, `gh issue edit --remove-label`, `gh issue close` | `mcp__github__update_issue` | **High** — runs on every baton transition |
+| `anneal-schedule-health.js` | `gh issue list --json` | `mcp__github__list_issues` | Low — daily cron |
+| `cross-team-lease.js` | `gh issue comment`, `gh issue view --json` | `mcp__github__create_issue_comment`, `mcp__github__get_issue` | **High** — claim flow |
+
+## Categorization (AC2)
+
+| MCP capability | Callers |
+|---|---|
+| Issues (read) | closeout-preflight, dep-graph-aggregate, epic-evidence, anneal-schedule-health, cross-team-lease |
+| Issues (write — create) | anneal-tier2-autofile |
+| Issue comments (write) | anneal-tier2-autofile, epic-evidence, cross-team-lease |
+| Issue labels (write) | issue-transition |
+| Pull requests (read) | closeout-preflight, cross-team-conflict-gate |
+| Projects v2 | (none yet — surface untouched; future per #1630) |
+| Sub-issues | (none yet — future per #1631) |
+| Discussions | (none yet — future per #1633) |
+
+## Migration value scoring (AC3)
+
+Sorted by recommended migration order:
+
+1. **`issue-transition.js`** — runs on every baton transition (dozens of calls per session). Schema-validation prevents typos like `lable` vs `label`. **High value**.
+2. **`closeout-preflight.js`** — runs on every push. Schema-validation prevents the lane-hardcoded class of bugs caught by #1639. **High value**.
+3. **`anneal-tier2-autofile.js`** — emits new issues; schema validation guards against malformed bodies. **High value**.
+4. **`cross-team-lease.js`** — claim flow correctness matters. **High value**.
+5. **`epic-evidence.js`** — Epic-close gate; lower frequency but high stakes. **Medium**.
+6. **`cross-team-conflict-gate.js`** — runs on PR open only. **Medium**.
+7. **`dep-graph-aggregate.js`** — scheduled cron. **Medium**.
+8. **`anneal-schedule-health.js`** — daily cron, low stakes. **Low**.
+
+## Output (AC4)
+
+This file is the AC4 deliverable.
+
+## Next steps (separate follow-ons, not in #1641 scope)
+
+Per-helper migration tickets are NOT filed by this audit. Migration is opt-in
+and incremental — each helper's owner team can prioritize. The audit gives
+the prioritization framework; per-helper work tickets emerge when an owner
+team chooses to migrate.
+
+## Portability (per #1628 G5)
+
+Migration is **opt-in via `MEGINGJORD_MCP_DISABLED=1`** per #1629 contract.
+Each migrated helper must retain the `gh` CLI fallback path so air-gapped
+operators or operators with the opt-out env var see no behavior change.
+
+## Related
+
+- #1641 — parent (this audit)
+- #1629 — MCP server adoption (contract)
+- #1628 — G5 Portability backing
+- `docs/howto/mcp-server-adoption.md` — operator guide

--- a/scripts/global/collaborator-self-check-rules.js
+++ b/scripts/global/collaborator-self-check-rules.js
@@ -91,9 +91,20 @@ const modelDiversityProspectiveAdmin = (own, admin) => {
     : fail('model-diversity-prospective-admin', `both on ${own}`);
 };
 
+const mcpLoadCheck = (handoffBody, env) => {
+  if ((env || process.env).MEGINGJORD_MCP_DISABLED === '1') {
+    return /MEGINGJORD_MCP_DISABLED=1/.test(handoffBody || '')
+      ? ok('mcp-load-check', 'opt-out cited')
+      : fail('mcp-load-check', 'opt-out env set but rationale missing in handoff');
+  }
+  return /mcp__github__|MCP/i.test(handoffBody || '')
+    ? ok('mcp-load-check', 'mcp usage detected')
+    : ok('mcp-load-check', 'no mcp marker (advisory; gh CLI fallback assumed)');
+};
+
 module.exports = {
   branchNamePrefix, refsThisTicketFirst, closesAndRefsBothPresent,
   tddSpecInDiffWhenRequired, noProseColonCollision, noMarkdownBoldOnTestStrategy,
   flawMarkerCitations, readabilityNoNewWarnings, allAcceptanceCriteriaTicked,
-  modelDiversityProspectiveAdmin,
+  modelDiversityProspectiveAdmin, mcpLoadCheck,
 };

--- a/scripts/global/github-dispatcher.js
+++ b/scripts/global/github-dispatcher.js
@@ -1,0 +1,34 @@
+'use strict';
+// github-dispatcher (#1643) — MCP-vs-gh-CLI dispatcher contract.
+// Returns which provider should handle a given operation given the env state.
+
+function provider(env = process.env) {
+  if (env.MEGINGJORD_MCP_DISABLED === '1') return 'gh-cli';
+  if (env.MEGINGJORD_MCP_FORCE_AVAILABLE === '1') return 'mcp';
+  // Default detection: if MCP server registered (caller injects mcpAvailable), use it.
+  return env.MEGINGJORD_MCP_AVAILABLE === '1' ? 'mcp' : 'gh-cli';
+}
+
+function toolName(operation, prov) {
+  const MAP = {
+    'create-issue': { mcp: 'mcp__github__create_issue', cli: 'gh issue create' },
+    'add-comment': { mcp: 'mcp__github__create_issue_comment', cli: 'gh issue comment' },
+    'get-issue': { mcp: 'mcp__github__get_issue', cli: 'gh issue view' },
+    'list-issues': { mcp: 'mcp__github__list_issues', cli: 'gh issue list' },
+    'update-issue': { mcp: 'mcp__github__update_issue', cli: 'gh issue edit' },
+    'update-project-v2-item-field': {
+      mcp: 'mcp__github__update_project_v2_item_field_value',
+      cli: 'gh api graphql -f query=...',
+    },
+  };
+  if (!MAP[operation]) return null;
+  return prov === 'mcp' ? MAP[operation].mcp : MAP[operation].cli;
+}
+
+function dispatch(operation, env = process.env) {
+  const prov = provider(env);
+  const tool = toolName(operation, prov);
+  return { provider: prov, tool, ok: tool !== null };
+}
+
+module.exports = { provider, toolName, dispatch };

--- a/tests/collaborator-self-check.spec.js
+++ b/tests/collaborator-self-check.spec.js
@@ -129,3 +129,35 @@ test('formatChecks renders the skip reason when override label is present', () =
   expect(C.formatChecks({ ok: true, checks: [], skipped: 'override-waived' }))
     .toBe('Pre-handoff verification: SKIPPED (override-waived)');
 });
+
+test('mcpLoadCheck passes when MCP marker present in handoff body', () => {
+  const { mcpLoadCheck } = require('../scripts/global/collaborator-self-check-rules.js');
+  const result = mcpLoadCheck('Used mcp__github__create_issue for the ship', {});
+  expect(result.ok).toBe(true);
+});
+
+test('mcpLoadCheck passes when opt-out env set and cited in body', () => {
+  const { mcpLoadCheck } = require('../scripts/global/collaborator-self-check-rules.js');
+  const result = mcpLoadCheck('Skipped MCP because MEGINGJORD_MCP_DISABLED=1; air-gapped operator', { MEGINGJORD_MCP_DISABLED: '1' });
+  expect(result.ok).toBe(true);
+});
+
+test('mcpLoadCheck fails when opt-out env set but rationale missing', () => {
+  const { mcpLoadCheck } = require('../scripts/global/collaborator-self-check-rules.js');
+  const result = mcpLoadCheck('Plain body without any opt-out citation here', { MEGINGJORD_MCP_DISABLED: '1' });
+  expect(result.ok).toBe(false);
+});
+
+test('mcpLoadCheck advisory-passes when no MCP marker and no opt-out set', () => {
+  const { mcpLoadCheck } = require('../scripts/global/collaborator-self-check-rules.js');
+  const result = mcpLoadCheck('Plain body no markers', {});
+  expect(result.ok).toBe(true);
+  expect(result.evidence).toContain('advisory');
+});
+
+test('mcpLoadCheck detects MCP via plain MCP marker', () => {
+  const { mcpLoadCheck } = require('../scripts/global/collaborator-self-check-rules.js');
+  const result = mcpLoadCheck('Used MCP server tools', {});
+  expect(result.ok).toBe(true);
+});
+

--- a/tests/mcp-integration.spec.js
+++ b/tests/mcp-integration.spec.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { provider, toolName, dispatch } = require('../scripts/global/github-dispatcher.js');
+
+test('provider falls back to gh-cli when MEGINGJORD_MCP_DISABLED=1', () => {
+  expect(provider({ MEGINGJORD_MCP_DISABLED: '1' })).toBe('gh-cli');
+});
+
+test('provider uses mcp when MEGINGJORD_MCP_FORCE_AVAILABLE=1', () => {
+  expect(provider({ MEGINGJORD_MCP_FORCE_AVAILABLE: '1' })).toBe('mcp');
+});
+
+test('provider defaults to gh-cli when no MCP signals set', () => {
+  expect(provider({})).toBe('gh-cli');
+});
+
+test('toolName maps create-issue to MCP tool when provider=mcp', () => {
+  expect(toolName('create-issue', 'mcp')).toBe('mcp__github__create_issue');
+});
+
+test('toolName maps create-issue to gh CLI when provider=gh-cli', () => {
+  expect(toolName('create-issue', 'gh-cli')).toBe('gh issue create');
+});
+
+test('toolName maps update-project-v2-item-field to GraphQL CLI fallback', () => {
+  expect(toolName('update-project-v2-item-field', 'gh-cli')).toContain('gh api graphql');
+});
+
+test('dispatch returns provider + tool for known operation', () => {
+  const result = dispatch('add-comment', { MEGINGJORD_MCP_FORCE_AVAILABLE: '1' });
+  expect(result.ok).toBe(true);
+  expect(result.provider).toBe('mcp');
+  expect(result.tool).toBe('mcp__github__create_issue_comment');
+});
+
+test('dispatch returns ok=false for unknown operation', () => {
+  const result = dispatch('not-a-real-op', {});
+  expect(result.ok).toBe(false);
+  expect(result.tool).toBe(null);
+});
+
+test('dispatch with MCP-disabled chooses gh-cli regardless of force flag', () => {
+  const result = dispatch('get-issue', {
+    MEGINGJORD_MCP_DISABLED: '1',
+    MEGINGJORD_MCP_FORCE_AVAILABLE: '1',
+  });
+  expect(result.provider).toBe('gh-cli');
+});
+
+test('dispatch list-issues works on both providers', () => {
+  expect(dispatch('list-issues', { MEGINGJORD_MCP_FORCE_AVAILABLE: '1' }).tool)
+    .toBe('mcp__github__list_issues');
+  expect(dispatch('list-issues', { MEGINGJORD_MCP_DISABLED: '1' }).tool)
+    .toBe('gh issue list');
+});


### PR DESCRIPTION
Refs #1641
Refs #1642
Refs #1643
Refs #1604
Refs #1629
Closes #1641
Closes #1642
Closes #1643

Audit doc + mcpLoadCheck rule + github-dispatcher + 15 new unit tests covering MCP/gh-CLI fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)