### PR TITLE
feat(scripts): Sub-issues migration batch #1655 #1656 #1657 #1658 #1659

### DIFF
--- a/.changes/unreleased/1655-1659.md
+++ b/.changes/unreleased/1655-1659.md
@@ -1,0 +1,26 @@
+## [Unreleased] — #1655 #1656 #1657 #1658 #1659: Sub-issues migration batch
+
+### Added
+- `scripts/global/sub-issue-link.js` — pure helper (`addSubIssue`, `removeSubIssue`, `listSubIssues`) wrapping the GraphQL Sub-issue mutations/queries (#1656).
+- `scripts/global/sub-issue-migrate.js` — one-time migration planner + executor for closed Epics with prose `Refs Epic #N` (#1657). Dry-run by default.
+- `scripts/global/megalint/sub-issue-preference.js` — closeout-schema helper that prefers `<!-- sub-issue-linked: parent=N -->` marker over prose `Refs Epic #N` scanning (#1658). Falls back to prose for backward compat.
+- `tests/sub-issue-link.spec.js` — 8 unit tests covering helper + migration planner.
+- `tests/sub-issue-preference.spec.js` — 6 unit tests covering the preference helper.
+
+### Verified (#1655)
+
+GraphQL query confirms:
+- `repository.issue.subIssues` field is queryable on this repo — **Sub-issues is enabled** (no Settings action required).
+- `repository.issueTypes` returns `null` — **Issue Types is org-only**, not available for the user-account repo `chf3198/megingjord-harness`. Documented as a known portability constraint.
+
+### Why
+Closes #1655 (Sub-issues enabled; Issue Types is org-only), #1656 (helper), #1657 (migration planner), #1658 (closeout-schema preference helper), #1659 (test suite covers the above).
+
+### Verification
+- 14/14 unit tests pass.
+- `npm run lint` clean.
+
+### Out of scope
+- Org migration to enable Issue Types — out of scope for a user-account repo.
+- Running the migration script against historical closed Epics — script is dry-run-default; operator runs when ready.
+- Wiring `sub-issue-preference.js` into the actual `consultant-closeout.js` validator — current prose-scan path remains canonical until migration script populates the new markers.

--- a/scripts/global/megalint/sub-issue-preference.js
+++ b/scripts/global/megalint/sub-issue-preference.js
@@ -1,0 +1,26 @@
+'use strict';
+// sub-issue-preference (#1658) — closeout-schema helper preferring Sub-issue
+// link evidence over prose `Refs #N` scanning. Pure function; no network.
+
+const SUB_ISSUE_MARKER_RE = /<!--\s*sub-issue-linked:\s*parent=(\d+)\s*-->/i;
+const PROSE_REFS_RE = /\bRefs(?:\s+Epic)?\s+#(\d+)\b/i;
+
+function detectParentByMarker(body) {
+  const match = (body || '').match(SUB_ISSUE_MARKER_RE);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+function detectParentByProse(body) {
+  const match = (body || '').match(PROSE_REFS_RE);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+function detectParent(body) {
+  const markerParent = detectParentByMarker(body);
+  if (markerParent !== null) return { parent: markerParent, source: 'sub-issue-marker' };
+  const proseParent = detectParentByProse(body);
+  if (proseParent !== null) return { parent: proseParent, source: 'prose-refs' };
+  return { parent: null, source: 'none' };
+}
+
+module.exports = { detectParent, detectParentByMarker, detectParentByProse, SUB_ISSUE_MARKER_RE };

--- a/scripts/global/sub-issue-link.js
+++ b/scripts/global/sub-issue-link.js
@@ -1,0 +1,46 @@
+'use strict';
+// sub-issue-link (#1656) — pure helper exporting addSubIssue, removeSubIssue, listSubIssues.
+// Uses GitHub GraphQL via injected client (testable).
+
+const ADD_QUERY = `
+mutation AddSubIssue($issueId: ID!, $subId: ID!) {
+  addSubIssue(input: { issueId: $issueId, subIssueId: $subId }) {
+    subIssue { id number title }
+  }
+}`;
+
+const REMOVE_QUERY = `
+mutation RemoveSubIssue($issueId: ID!, $subId: ID!) {
+  removeSubIssue(input: { issueId: $issueId, subIssueId: $subId }) {
+    issue { id number }
+  }
+}`;
+
+const LIST_QUERY = `
+query ListSubIssues($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      subIssues(first: 100) {
+        nodes { id number title state }
+      }
+    }
+  }
+}`;
+
+async function addSubIssue(client, parentNodeId, childNodeId) {
+  if (!parentNodeId || !childNodeId) throw new Error('parent and child node IDs required');
+  return client.graphql(ADD_QUERY, { issueId: parentNodeId, subId: childNodeId });
+}
+
+async function removeSubIssue(client, parentNodeId, childNodeId) {
+  if (!parentNodeId || !childNodeId) throw new Error('parent and child node IDs required');
+  return client.graphql(REMOVE_QUERY, { issueId: parentNodeId, subId: childNodeId });
+}
+
+async function listSubIssues(client, owner, repo, parentNumber) {
+  if (!owner || !repo || !parentNumber) throw new Error('owner, repo, parentNumber required');
+  const result = await client.graphql(LIST_QUERY, { owner, repo, number: parentNumber });
+  return (result?.repository?.issue?.subIssues?.nodes) || [];
+}
+
+module.exports = { addSubIssue, removeSubIssue, listSubIssues, ADD_QUERY, REMOVE_QUERY, LIST_QUERY };

--- a/scripts/global/sub-issue-migrate.js
+++ b/scripts/global/sub-issue-migrate.js
@@ -1,0 +1,55 @@
+'use strict';
+// sub-issue-migrate (#1657) — one-time migration. Walks closed Epics with
+// "Refs Epic #N" prose and emits Sub-issue links. Dry-run by default.
+
+const REFS_EPIC_RE = /^Refs\s+Epic\s+#(\d+)\s*$/im;
+
+function extractRefsEpic(body) {
+  const match = (body || '').match(REFS_EPIC_RE);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+function plan(closedChildren) {
+  const proposals = [];
+  for (const child of (closedChildren || [])) {
+    const parentNumber = extractRefsEpic(child.body);
+    if (parentNumber) {
+      proposals.push({
+        action: 'addSubIssue',
+        parent: parentNumber,
+        child: child.number,
+        parentNodeId: null,
+        childNodeId: child.id,
+      });
+    }
+  }
+  return proposals;
+}
+
+async function execute(client, owner, repo, proposals, { dryRun = true } = {}) {
+  const results = [];
+  for (const proposal of proposals) {
+    if (dryRun) {
+      results.push({ ...proposal, status: 'dry-run' });
+      continue;
+    }
+    const parentLookup = await client.graphql(
+      'query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){issue(number:$number){id}}}',
+      { owner, repo, number: proposal.parent }
+    );
+    const parentNodeId = parentLookup?.repository?.issue?.id;
+    if (!parentNodeId) { results.push({ ...proposal, status: 'parent-not-found' }); continue; }
+    try {
+      await client.graphql(
+        'mutation($issueId:ID!,$subId:ID!){addSubIssue(input:{issueId:$issueId,subIssueId:$subId}){subIssue{number}}}',
+        { issueId: parentNodeId, subId: proposal.childNodeId }
+      );
+      results.push({ ...proposal, status: 'linked' });
+    } catch (error) {
+      results.push({ ...proposal, status: 'error', error: error.message });
+    }
+  }
+  return results;
+}
+
+module.exports = { extractRefsEpic, plan, execute, REFS_EPIC_RE };

--- a/tests/sub-issue-link.spec.js
+++ b/tests/sub-issue-link.spec.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const link = require('../scripts/global/sub-issue-link.js');
+const { extractRefsEpic, plan } = require('../scripts/global/sub-issue-migrate.js');
+
+function fakeClient(handler) { return { graphql: handler }; }
+
+test('addSubIssue requires both parent and child node IDs', async () => {
+  await expect(link.addSubIssue(fakeClient(() => ({})), null, 'child')).rejects.toThrow();
+  await expect(link.addSubIssue(fakeClient(() => ({})), 'parent', null)).rejects.toThrow();
+});
+
+test('addSubIssue invokes the addSubIssue mutation with both IDs', async () => {
+  let captured = null;
+  const client = fakeClient((query, vars) => { captured = { query, vars }; return { subIssue: { number: 5 } }; });
+  await link.addSubIssue(client, 'P_ID', 'C_ID');
+  expect(captured.query).toContain('addSubIssue');
+  expect(captured.vars).toEqual({ issueId: 'P_ID', subId: 'C_ID' });
+});
+
+test('removeSubIssue invokes the removeSubIssue mutation', async () => {
+  let captured = null;
+  const client = fakeClient((query) => { captured = query; return {}; });
+  await link.removeSubIssue(client, 'P_ID', 'C_ID');
+  expect(captured).toContain('removeSubIssue');
+});
+
+test('listSubIssues returns nodes array', async () => {
+  const client = fakeClient(() => ({
+    repository: { issue: { subIssues: { nodes: [{ number: 5 }, { number: 7 }] } } },
+  }));
+  const result = await link.listSubIssues(client, 'chf3198', 'megingjord-harness', 1604);
+  expect(result).toEqual([{ number: 5 }, { number: 7 }]);
+});
+
+test('listSubIssues returns empty array when no sub-issues exist', async () => {
+  const client = fakeClient(() => ({ repository: { issue: { subIssues: { nodes: [] } } } }));
+  expect(await link.listSubIssues(client, 'chf3198', 'repo', 1)).toEqual([]);
+});
+
+test('extractRefsEpic extracts the epic number from prose Refs Epic #N', () => {
+  expect(extractRefsEpic('Body text\nRefs Epic #1604\nMore body')).toBe(1604);
+  expect(extractRefsEpic('No epic reference here')).toBe(null);
+});
+
+test('plan returns proposals for closed children with Refs Epic prose', () => {
+  const children = [
+    { number: 100, id: 'C100', body: 'Refs Epic #1604' },
+    { number: 101, id: 'C101', body: 'No reference' },
+    { number: 102, id: 'C102', body: 'Refs Epic #2000' },
+  ];
+  const proposals = plan(children);
+  expect(proposals).toHaveLength(2);
+  expect(proposals[0]).toMatchObject({ parent: 1604, child: 100 });
+  expect(proposals[1]).toMatchObject({ parent: 2000, child: 102 });
+});
+
+test('plan returns empty list for empty input', () => {
+  expect(plan([])).toEqual([]);
+  expect(plan(null)).toEqual([]);
+});

--- a/tests/sub-issue-preference.spec.js
+++ b/tests/sub-issue-preference.spec.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { detectParent, detectParentByMarker, detectParentByProse } =
+  require('../scripts/global/megalint/sub-issue-preference.js');
+
+test('detectParent prefers sub-issue marker over prose refs', () => {
+  const body = '<!-- sub-issue-linked: parent=1604 -->\nRefs Epic #9999\nrest of body';
+  const result = detectParent(body);
+  expect(result.parent).toBe(1604);
+  expect(result.source).toBe('sub-issue-marker');
+});
+
+test('detectParent falls back to prose Refs when no marker present', () => {
+  const result = detectParent('No marker. Refs Epic #1604 in body.');
+  expect(result.parent).toBe(1604);
+  expect(result.source).toBe('prose-refs');
+});
+
+test('detectParent returns none when no parent reference at all', () => {
+  const result = detectParent('Plain body without any parent reference.');
+  expect(result.parent).toBe(null);
+  expect(result.source).toBe('none');
+});
+
+test('detectParentByMarker extracts parent from sentinel marker', () => {
+  expect(detectParentByMarker('<!-- sub-issue-linked: parent=42 -->')).toBe(42);
+  expect(detectParentByMarker('plain text')).toBe(null);
+});
+
+test('detectParentByProse extracts parent from Refs Epic #N', () => {
+  expect(detectParentByProse('Refs Epic #100')).toBe(100);
+  expect(detectParentByProse('Refs #200')).toBe(200);
+  expect(detectParentByProse('no refs')).toBe(null);
+});
+
+test('detectParent handles null and empty body gracefully', () => {
+  expect(detectParent(null).parent).toBe(null);
+  expect(detectParent('').parent).toBe(null);
+  expect(detectParent('').source).toBe('none');
+});


### PR DESCRIPTION
Refs #1655
Refs #1656
Refs #1657
Refs #1658
Refs #1659
Refs #1604
Refs #1631
Closes #1655
Closes #1656
Closes #1657
Closes #1658
Closes #1659

Helper + migrate planner + closeout preference + 14 unit tests. Sub-issues confirmed enabled; Issue Types is org-only and N/A for the user-account repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)