### PR TITLE
docs(governance): Discussion-category API constraint #1668

### DIFF
--- a/.changes/unreleased/1668.md
+++ b/.changes/unreleased/1668.md
@@ -1,0 +1,12 @@
+## [Unreleased] — #1668: Discussion-category Settings constraint documented
+
+### Changed
+- `docs/howto/discussions-vs-issues.md` — adds API-constraint note. Verified that GitHub's GraphQL API does NOT expose a `createDiscussionCategory` mutation; only the 6 default categories (Announcements, General, Ideas, Polls, Q&A, Show and tell) ship by default. The 4 governance-specific categories (Architecture, Cross-team protocol, Tooling research, Operations notes) must be created via the repo Settings UI by an operator with admin access. Documents the title-prefix fallback (`[architecture] ...`) until the Settings op is performed.
+
+### Why
+Closes #1668. AC1 originally proposed programmatic category creation, but GitHub's API does not support it. The honest scope is to document the constraint and provide the fallback pattern. Operators with repo admin access can create the categories any time via Settings; until then, governance discussions can be filed under General with category-tag titles.
+
+### Verification
+- `gh api graphql` schema introspection confirms no `createDiscussionCategory` mutation exists (only Discussion lifecycle mutations: createDiscussion, updateDiscussion, closeDiscussion, etc.).
+- 6 default categories present per `gh api graphql ... discussionCategories ...` query.
+- howto updated; lint clean.

--- a/docs/howto/discussions-vs-issues.md
+++ b/docs/howto/discussions-vs-issues.md
@@ -25,7 +25,17 @@ Once a deliverable + AC crystallizes, convert to an Issue.
 | Cross-team protocol | Inter-team coordination | "How should claim conflicts be resolved?" |
 | Tooling research | Tool evaluation | "Compare gh-aw vs Claude-Code agent-teams" |
 | Operations notes | Runbook deltas, op insights | "Pre-push gate hang recovery recipe" |
-| Q&A | Quick questions | "How do I run the lint locally?" |
+| Q&A (default) | Quick questions | "How do I run the lint locally?" |
+
+**API constraint** (per #1668 verification): GitHub's GraphQL API does **not**
+expose a `createDiscussionCategory` mutation. The 6 default categories
+(Announcements, General, Ideas, Polls, Q&A, Show and tell) ship with every
+Discussions-enabled repo. The 4 governance-specific categories above
+(Architecture, Cross-team protocol, Tooling research, Operations notes) must
+be created via the repo **Settings → Discussions** UI by an operator with
+admin access. Until then, governance discussions can be filed under
+**General** with the category-tag pattern in the title (e.g.,
+`[architecture] should we split HAMR...`).
 
 ## Conversion path (Discussion → Issue)
 


### PR DESCRIPTION
Refs #1668
Refs #1604
Refs #1633
Closes #1668

Documents that GitHub's GraphQL API does not expose createDiscussionCategory; the 4 governance categories must be created via the repo Settings UI. Title-prefix fallback gives a working path until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)