### PR TITLE
feat(scripts): baton-team-model-v2 rotation rules #1723

### DIFF
--- a/.changes/unreleased/1723.md
+++ b/.changes/unreleased/1723.md
@@ -1,0 +1,19 @@
+## [Unreleased] — #1723: Phase 3.1 — baton-team-model-v2 helper
+
+### Added
+- `scripts/global/baton-team-model-v2.js` — extends #1572 critical-path-only check with the 3 rotation rules per Epic #1716 contract v2 (#1719). New: `extractTeam` (parses `team:model@substrate`); `enforceRotationV2` (returns pass/fail per rule); `extractRecordsFromComments` (handles 5 record types incl. `COLLABORATOR_SELF_CHECK`); 3 rule-check functions.
+- `tests/baton-team-model-v2.spec.js` — 11 unit tests covering each rule pass/fail; mode skipping; legacy v1 + new v2 waiver labels; end-to-end 4-team scenario.
+
+### Why
+Closes #1723 (Phase 3.1 of Epic #1716). Schema source for Phase 3.2-3.4: the HAMR-side validator (#1724), crypto-signing default-on (#1725), and integration tests (#1726) all consume this helper's API.
+
+### Verification
+- 11/11 unit tests pass.
+- `npm run lint` clean.
+- Helper is 86 lines (≤100 cap).
+- Honors both v1 (`model-diversity:waived`) and v2 (`rotation-required-waived`) waiver labels for backward compatibility with #1572.
+- `single-model-fleet` mode short-circuits all rules per #1722 G5 fallback spec.
+
+### Out of scope
+- Wiring into the actual baton skill / closeout-schema validator — Phase 3.2 (#1724) does HAMR-side; subsequent CI workflow integration is a separate follow-on.
+- Crypto-signing requirement — Phase 3.3 (#1725).

--- a/scripts/global/baton-team-model-v2.js
+++ b/scripts/global/baton-team-model-v2.js
@@ -1,0 +1,86 @@
+'use strict';
+// baton-team-model-v2 — Epic #1716 rotation contract v2 (#1719 schema).
+// Extends #1572 critical-path-only with: Rule 1 (Collaborator self-review),
+// Rule 2 (Admin not in any earlier step), Rule 3 (Consultant not in ANY prior step).
+// Family = `team` portion of `team:model@substrate` Team&Model string.
+
+const OVERRIDE_LABEL_V1 = 'model-diversity:waived';
+const OVERRIDE_LABEL_V2 = 'rotation-required-waived';
+const TEAM_MODEL_RE = /^Team&Model:\s*([^\n]+)$/m;
+
+function extractTeam(teamModel) {
+  if (typeof teamModel !== 'string') return null;
+  const colonIdx = teamModel.indexOf(':');
+  return colonIdx > 0 ? teamModel.slice(0, colonIdx).trim() : null;
+}
+
+function parseTeamModel(body) {
+  if (typeof body !== 'string' || !body) return null;
+  const match = body.match(TEAM_MODEL_RE);
+  return match ? match[1].trim() : null;
+}
+
+function shouldSkip(labels, mode) {
+  if (mode === 'single-model-fleet') return 'single-model-fleet';
+  const set = new Set(labels || []);
+  if (set.has(OVERRIDE_LABEL_V1)) return 'v1-waived';
+  if (set.has(OVERRIDE_LABEL_V2)) return 'v2-waived';
+  return null;
+}
+
+function checkRule1(records) {
+  if (!records.collaborator_self_check || !records.implementation) return null;
+  const implTeam = extractTeam(records.implementation);
+  const checkTeam = extractTeam(records.collaborator_self_check);
+  return implTeam === checkTeam
+    ? { rule: 'rule_1_collab_self_review', detail: `self-review team '${checkTeam}' matches implementation team '${implTeam}'` }
+    : null;
+}
+
+function checkRule2(records) {
+  if (!records.admin) return null;
+  const adminTeam = extractTeam(records.admin);
+  const priorTeams = [records.manager, records.collaborator].map(extractTeam).filter(Boolean);
+  return priorTeams.includes(adminTeam)
+    ? { rule: 'rule_2_admin_diversity', detail: `admin team '${adminTeam}' appears in earlier role (manager or collaborator)` }
+    : null;
+}
+
+function checkRule3(records) {
+  if (!records.consultant) return null;
+  const consultantTeam = extractTeam(records.consultant);
+  const priorTeams = [records.manager, records.collaborator, records.admin].map(extractTeam).filter(Boolean);
+  return priorTeams.includes(consultantTeam)
+    ? { rule: 'rule_3_consultant_independent', detail: `consultant team '${consultantTeam}' appears in earlier role` }
+    : null;
+}
+
+function enforceRotationV2(input) {
+  const mode = input.operator_mode || 'strict-rotation';
+  const skipReason = shouldSkip(input.labels, mode);
+  if (skipReason) return { ok: true, violations: [], skipped: skipReason, mode };
+  const records = input.roles_observed || {};
+  const violations = [checkRule1(records), checkRule2(records), checkRule3(records)].filter(Boolean);
+  return { ok: violations.length === 0, violations, mode };
+}
+
+function extractRecordsFromComments(comments) {
+  const out = { manager: null, collaborator: null, collaborator_self_check: null, admin: null, consultant: null, implementation: null };
+  for (const c of comments || []) {
+    const body = (c && c.body) || '';
+    const tm = parseTeamModel(body);
+    if (!tm) continue;
+    if (body.includes('MANAGER_HANDOFF')) out.manager = tm;
+    else if (body.includes('COLLABORATOR_SELF_CHECK')) out.collaborator_self_check = tm;
+    else if (body.includes('COLLABORATOR_HANDOFF')) { out.collaborator = tm; out.implementation = tm; }
+    else if (body.includes('ADMIN_HANDOFF')) out.admin = tm;
+    else if (body.includes('CONSULTANT_CLOSEOUT')) out.consultant = tm;
+  }
+  return out;
+}
+
+module.exports = {
+  parseTeamModel, extractTeam, enforceRotationV2, extractRecordsFromComments,
+  shouldSkip, checkRule1, checkRule2, checkRule3,
+  OVERRIDE_LABEL_V1, OVERRIDE_LABEL_V2,
+};

--- a/tests/baton-team-model-v2.spec.js
+++ b/tests/baton-team-model-v2.spec.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const v2 = require('../scripts/global/baton-team-model-v2.js');
+
+test('extractTeam returns team portion of team:model@substrate', () => {
+  expect(v2.extractTeam('claude-code:opus-4-7@anthropic')).toBe('claude-code');
+  expect(v2.extractTeam('codex:gpt-5@openai')).toBe('codex');
+  expect(v2.extractTeam('no-colon')).toBe(null);
+  expect(v2.extractTeam(null)).toBe(null);
+});
+
+test('Rule 1 passes when self-review team differs from implementation', () => {
+  const result = v2.enforceRotationV2({
+    roles_observed: {
+      implementation: 'claude-code:opus-4-7@anthropic',
+      collaborator_self_check: 'codex:gpt-5@openai',
+    },
+  });
+  expect(result.ok).toBe(true);
+});
+
+test('Rule 1 fails when self-review uses same team as implementation', () => {
+  const result = v2.enforceRotationV2({
+    roles_observed: {
+      implementation: 'claude-code:opus-4-7@anthropic',
+      collaborator_self_check: 'claude-code:sonnet@anthropic',
+    },
+  });
+  expect(result.ok).toBe(false);
+  expect(result.violations[0].rule).toBe('rule_1_collab_self_review');
+});
+
+test('Rule 2 fails when admin team matches earlier role', () => {
+  const result = v2.enforceRotationV2({
+    roles_observed: {
+      manager: 'claude-code:opus-4-7@anthropic',
+      collaborator: 'codex:gpt-5@openai',
+      admin: 'claude-code:opus-4-7@anthropic',
+    },
+  });
+  expect(result.ok).toBe(false);
+  expect(result.violations[0].rule).toBe('rule_2_admin_diversity');
+});
+
+test('Rule 3 fails when consultant team matches earlier role', () => {
+  const result = v2.enforceRotationV2({
+    roles_observed: {
+      manager: 'claude-code:opus@anthropic',
+      collaborator: 'codex:gpt-5@openai',
+      admin: 'copilot:opus@github-copilot',
+      consultant: 'codex:gpt-5@openai',
+    },
+  });
+  expect(result.ok).toBe(false);
+  expect(result.violations[0].rule).toBe('rule_3_consultant_independent');
+});
+
+test('All 3 rules pass with 4 distinct teams', () => {
+  const result = v2.enforceRotationV2({
+    roles_observed: {
+      manager: 'claude-code:opus@anthropic',
+      collaborator: 'codex:gpt-5@openai',
+      admin: 'copilot:opus@github-copilot',
+      consultant: 'openclaw:qwen2.5@ollama',
+    },
+  });
+  expect(result.ok).toBe(true);
+});
+
+test('single-model-fleet operator mode skips enforcement', () => {
+  const result = v2.enforceRotationV2({
+    operator_mode: 'single-model-fleet',
+    roles_observed: {
+      manager: 'claude-code:opus@anthropic',
+      collaborator: 'claude-code:opus@anthropic',
+      admin: 'claude-code:opus@anthropic',
+      consultant: 'claude-code:opus@anthropic',
+    },
+  });
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('single-model-fleet');
+});
+
+test('rotation-required-waived label v2 honored', () => {
+  const result = v2.enforceRotationV2({
+    labels: ['rotation-required-waived'],
+    roles_observed: {
+      manager: 'claude-code:opus@anthropic',
+      collaborator: 'claude-code:opus@anthropic',
+      admin: 'claude-code:opus@anthropic',
+    },
+  });
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('v2-waived');
+});
+
+test('legacy model-diversity:waived v1 label still honored', () => {
+  const result = v2.enforceRotationV2({
+    labels: ['model-diversity:waived'],
+    roles_observed: { manager: 'a:x@y', collaborator: 'a:x@y', admin: 'a:x@y' },
+  });
+  expect(result.ok).toBe(true);
+  expect(result.skipped).toBe('v1-waived');
+});
+
+test('extractRecordsFromComments captures all 5 role records', () => {
+  const comments = [
+    { body: 'MANAGER_HANDOFF\nTeam&Model: claude-code:opus@anthropic\nRole: manager' },
+    { body: 'COLLABORATOR_HANDOFF\nTeam&Model: codex:gpt-5@openai\nRole: collaborator' },
+    { body: 'COLLABORATOR_SELF_CHECK\nTeam&Model: openclaw:qwen@ollama\nRole: collaborator' },
+    { body: 'ADMIN_HANDOFF\nTeam&Model: copilot:opus@github-copilot\nRole: admin' },
+    { body: 'CONSULTANT_CLOSEOUT\nTeam&Model: openclaw:mistral@ollama\nRole: consultant' },
+  ];
+  const out = v2.extractRecordsFromComments(comments);
+  expect(out.manager).toBe('claude-code:opus@anthropic');
+  expect(out.collaborator).toBe('codex:gpt-5@openai');
+  expect(out.collaborator_self_check).toBe('openclaw:qwen@ollama');
+  expect(out.admin).toBe('copilot:opus@github-copilot');
+  expect(out.consultant).toBe('openclaw:mistral@ollama');
+});
+
+test('end-to-end: 4 distinct teams + self-check from 5th = all rules pass', () => {
+  const comments = [
+    { body: 'MANAGER_HANDOFF\nTeam&Model: claude-code:opus@anthropic\nRole: manager' },
+    { body: 'COLLABORATOR_HANDOFF\nTeam&Model: codex:gpt-5@openai\nRole: collaborator' },
+    { body: 'COLLABORATOR_SELF_CHECK\nTeam&Model: openclaw:qwen@ollama\nRole: collaborator' },
+    { body: 'ADMIN_HANDOFF\nTeam&Model: copilot:opus@github-copilot\nRole: admin' },
+    { body: 'CONSULTANT_CLOSEOUT\nTeam&Model: openclaw:mistral@ollama\nRole: consultant' },
+  ];
+  const records = v2.extractRecordsFromComments(comments);
+  const result = v2.enforceRotationV2({ roles_observed: records });
+  expect(result.ok).toBe(true);
+  expect(result.violations).toHaveLength(0);
+});


### PR DESCRIPTION
Refs #1723
Refs #1716
Refs #1719
Closes #1723

Phase 3.1 of Epic #1716. New helper extends #1572 critical-path-only with the 3 rotation rules: Collaborator self-review, Admin diversity, Consultant fully independent. 11 unit tests. Cross-family Gemma3:1b code review: LOGIC_CORRECT=yes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)