### PR TITLE
feat(governance): enforce baton signer integrity gates #1728

### DIFF
--- a/.changes/unreleased/1728.md
+++ b/.changes/unreleased/1728.md
@@ -1,0 +1,13 @@
+## [Unreleased] — #1728: Enforce programmatic signer integrity across baton workflow
+
+### Added
+- `scripts/global/baton-artifact-governance.js` — validates baton artifact comments for:
+  - registry-derived `Signed-by` alias fidelity,
+  - artifact-to-role consistency (`MANAGER_HANDOFF` => `Role: manager`, etc.).
+- `tests/baton-artifact-governance.spec.js` — canonical pass + signer injection + role mismatch cases.
+- `tests/baton-signer-stress.spec.js` — sequential (100 transitions) and parallel (20-ticket) signer drift stress checks.
+
+### Changed
+- `scripts/global/consultant-checks.js` adds `gov-007` signer/role consistency check against issue comments.
+- `.github/workflows/baton-gates.yml` admin gate now fails on signer/role governance violations.
+- `instructions/team-model-signing.instructions.md` documents enforcement and recovery workflow.

--- a/.github/workflows/baton-gates.yml
+++ b/.github/workflows/baton-gates.yml
@@ -58,6 +58,8 @@ jobs:
           script: |
             const { checkAdminIndependence } =
               require('./scripts/global/baton-independence.js');
+            const { analyzeComments } =
+              require('./scripts/global/baton-artifact-governance.js');
             const body = context.payload.pull_request.body || '';
             const refsMatch = body.match(/Refs\s+#(\d+)/i);
             if (!refsMatch) { core.setFailed('No Refs #N in PR body.'); return; }
@@ -88,6 +90,17 @@ jobs:
               author: c.user && c.user.login,
             })));
             if (!independence.ok) core.setFailed(independence.message);
+            const signerGov = analyzeComments(comments);
+            if (!signerGov.ok) {
+              const detail = signerGov.violations
+                .map(v => `${v.artifact || 'artifact'}:${v.rule}`)
+                .slice(0, 3)
+                .join(', ');
+              core.setFailed(
+                `Signer/role governance violations in issue #${linkedIssue}: ${detail}. ` +
+                'Rebuild baton artifacts with scripts/global/baton-comment-build.js.'
+              );
+            }
 
   consultant-gate:
     name: consultant-gate

--- a/instructions/team-model-signing.instructions.md
+++ b/instructions/team-model-signing.instructions.md
@@ -47,6 +47,16 @@ applyTo: "**"
 - Current role surnames: Manager=`Mason`, Collaborator=`Harper`, Admin=`Reyes`, Consultant=`Vale`.
 - Use `node scripts/global/agent-signature.js` for raw signatures or `node scripts/global/baton-comment-build.js` for full baton comment templates.
 
+## Enforcement and recovery
+
+- CI enforcement: `.github/workflows/baton-gates.yml` validates baton artifact signer aliases and role consistency against registry rules.
+- Local enforcement: `node scripts/global/consultant-checks.js --issue <N>` includes signer/role consistency checks.
+- Recovery when blocked:
+  1. Rebuild the affected artifact text with `node scripts/global/baton-comment-build.js --artifact ... --role ... --team-model ... --ticket ...`.
+  2. Repost corrected baton artifact comment on the linked issue.
+  3. Re-run consultant checks and re-push.
+- Manual `Signed-by` edits are not allowed for governed baton artifacts.
+
 ## Override rule
 
 - When local rules differ, use the local alias/trailer format and keep canonical `Team&Model` provenance present.

--- a/scripts/global/baton-artifact-governance.js
+++ b/scripts/global/baton-artifact-governance.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const { validateArtifactAlias } = require('./megalint/signer-registry-check');
+
+const ARTIFACT_ROLE = {
+  MANAGER_HANDOFF: 'manager',
+  COLLABORATOR_HANDOFF: 'collaborator',
+  ADMIN_HANDOFF: 'admin',
+  CONSULTANT_CLOSEOUT: 'consultant',
+};
+
+function roleFromBody(body) {
+  const m = String(body || '').match(/Role\s*:\s*(\w+)/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+function entries(comments) {
+  const out = [];
+  for (const c of comments || []) {
+    const body = String((c && c.body) || c || '');
+    for (const [artifact, role] of Object.entries(ARTIFACT_ROLE)) {
+      if (body.includes(artifact)) out.push({ artifact, role, body });
+    }
+  }
+  return out;
+}
+
+function analyzeComments(comments, opts = {}) {
+  const violations = [];
+  for (const entry of entries(comments)) {
+    const actualRole = roleFromBody(entry.body);
+    if (!actualRole || actualRole !== entry.role) {
+      violations.push({
+        artifact: entry.artifact,
+        rule: 'artifact-role-mismatch',
+        detail: `Expected Role: ${entry.role} for ${entry.artifact}.`,
+      });
+    }
+    const alias = validateArtifactAlias(entry.body, opts);
+    if (alias.ok) continue;
+    if (alias.violation) violations.push({ artifact: entry.artifact, ...alias.violation });
+    else violations.push({ artifact: entry.artifact, rule: 'signer-fields-invalid', detail: alias.skipped || 'invalid signer fields' });
+  }
+  return { ok: violations.length === 0, count: entries(comments).length, violations };
+}
+
+module.exports = { analyzeComments, ARTIFACT_ROLE };

--- a/scripts/global/consultant-checks.js
+++ b/scripts/global/consultant-checks.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
 const lib = require('./consultant-checks-lib');
+const batonGov = require('./baton-artifact-governance');
 
 const args = process.argv.slice(2);
 const asJson = args.includes('--json');
@@ -49,6 +50,20 @@ const checks = [
   [id('gov', 4), 'governance', () => { const gitLog = run("git log --oneline -99"); const matchCount = (gitLog.match(/#\d+/g) || []).length; const total = gitLog ? gitLog.split('\n').length : 0; return ok(id('gov', 4), 'governance', total > 0 && matchCount / total >= 0.8, `${matchCount}/${total} commit refs`, 'commit-issue-linkage', 'reference issue numbers in commits'); }],
   [id('gov', 5), 'governance', () => issue ? ok(id('gov', 5), 'governance', lib.decideGov005(run(`gh issue view ${issue}`)), 'issue body checklist scanned', 'ac-evidence-completeness', 'complete unchecked ACs') : skip(id('gov', 5), 'governance', 'missing --issue')],
   [id('gov', 6), 'governance', () => { const branch = run('git branch --show-current'); return ok(id('gov', 6), 'governance', /^(feat|fix|skill|hook)\//.test(branch), branch || 'unknown-branch', 'branch-naming', 'use approved branch prefix'); }],
+  [id('gov', 7), 'governance', () => {
+    if (!issue) return skip(id('gov', 7), 'governance', 'missing --issue');
+    let comments = [];
+    try { comments = JSON.parse(run(`gh issue view ${issue} --json comments`)).comments || []; }
+    catch {}
+    const result = batonGov.analyzeComments(comments);
+    const first = result.violations[0];
+    return ok(
+      id('gov', 7), 'governance', result.ok,
+      result.ok ? `${result.count} baton artifact comments validated` : `${first?.artifact || 'artifact'} ${first?.rule || 'unknown'}`,
+      'signer-role-consistency',
+      'rebuild artifact via baton-comment-build.js or agent-signature.js and correct role fields'
+    );
+  }],
   [id('tool', 1), 'tools', () => ok(id('tool', 1), 'tools', exists('wiki/index.md') && exists('wiki/log.md'), 'wiki index/log presence', 'wiki-growth-ready', 'maintain wiki index/log updates')],
   [id('tool', 2), 'tools', () => ok(id('tool', 2), 'tools', !/\[\[[^\]]+\]\].*\(not found\)/.test(run('npm run wiki:lint 2>&1 | cat')), 'wiki lint output scanned', 'wiki-orphan-check', 'add backlinks/cross-links')],
   [id('tool', 3), 'tools', () => ok(id('tool', 3), 'tools', /All files within 100-line/.test(run('npm run lint 2>&1 | cat')), 'lint output scanned', 'lint-clean', 'reduce file length or split files')],

--- a/tests/baton-artifact-governance.spec.js
+++ b/tests/baton-artifact-governance.spec.js
@@ -1,0 +1,38 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const G = require(path.resolve(__dirname, '..', 'scripts', 'global', 'baton-artifact-governance.js'));
+const { buildBatonComment } = require(path.resolve(__dirname, '..', 'scripts', 'global', 'baton-comment-build.js'));
+
+function mk(artifact, role, teamModel) {
+  return { body: buildBatonComment({ artifact, role, teamModel, ticket: 1728 }) };
+}
+
+test('passes for canonical baton artifacts', () => {
+  const comments = [
+    mk('MANAGER_HANDOFF', 'manager', 'copilot:gpt-5.3-codex@github-copilot'),
+    mk('COLLABORATOR_HANDOFF', 'collaborator', 'codex:gpt-5.4@codex-cli'),
+    mk('ADMIN_HANDOFF', 'admin', 'claude-code:opus-4-7@claude-code-cli'),
+    mk('CONSULTANT_CLOSEOUT', 'consultant', 'openclaw:qwen2.5-coder:7b@openclaw-gateway/windows-laptop'),
+  ];
+  const r = G.analyzeComments(comments);
+  expect(r.ok).toBe(true);
+  expect(r.count).toBe(4);
+});
+
+test('fails on client-name signer injection', () => {
+  const comments = [{
+    body: '## MANAGER_HANDOFF\nSigned-by: Curtis Franks\nTeam&Model: codex:gpt-5.4@codex-cli\nRole: manager',
+  }];
+  const r = G.analyzeComments(comments);
+  expect(r.ok).toBe(false);
+  expect(r.violations.some(v => v.rule === 'signer-alias-not-registry-derived')).toBe(true);
+});
+
+test('fails on artifact-role mismatch', () => {
+  const comments = [{
+    body: '## MANAGER_HANDOFF\nSigned-by: Quill Mason\nTeam&Model: codex:gpt-5.4@codex-cli\nRole: consultant',
+  }];
+  const r = G.analyzeComments(comments);
+  expect(r.ok).toBe(false);
+  expect(r.violations.some(v => v.rule === 'artifact-role-mismatch')).toBe(true);
+});

--- a/tests/baton-signer-stress.spec.js
+++ b/tests/baton-signer-stress.spec.js
@@ -1,0 +1,38 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const { buildBatonComment } = require(path.resolve(__dirname, '..', 'scripts', 'global', 'baton-comment-build.js'));
+const G = require(path.resolve(__dirname, '..', 'scripts', 'global', 'baton-artifact-governance.js'));
+
+const ROLES = [
+  ['MANAGER_HANDOFF', 'manager', 'copilot:gpt-5.3-codex@github-copilot'],
+  ['COLLABORATOR_HANDOFF', 'collaborator', 'codex:gpt-5.4@codex-cli'],
+  ['ADMIN_HANDOFF', 'admin', 'claude-code:opus-4-7@claude-code-cli'],
+  ['CONSULTANT_CLOSEOUT', 'consultant', 'openclaw:qwen2.5-coder:7b@openclaw-gateway/windows-laptop'],
+];
+
+test('stress: 100 sequential baton transitions have zero signer drift', () => {
+  const comments = [];
+  for (let i = 0; i < 100; i++) {
+    for (const [artifact, role, teamModel] of ROLES) {
+      comments.push({ body: buildBatonComment({ artifact, role, teamModel, ticket: `${2000 + i}` }) });
+    }
+  }
+  const r = G.analyzeComments(comments);
+  expect(r.ok).toBe(true);
+  expect(r.count).toBe(400);
+});
+
+test('stress: 20 parallel synthetic tickets keep signer/role integrity', async () => {
+  const parallel = Array.from({ length: 20 }, (_, idx) => new Promise(resolve => {
+    setTimeout(() => {
+      const comments = ROLES.map(([artifact, role, teamModel]) => ({
+        body: buildBatonComment({ artifact, role, teamModel, ticket: `${3000 + idx}` }),
+      }));
+      resolve(comments);
+    }, Math.floor(Math.random() * 8));
+  }));
+  const allComments = (await Promise.all(parallel)).flat();
+  const r = G.analyzeComments(allComments);
+  expect(r.ok).toBe(true);
+  expect(r.count).toBe(80);
+});


### PR DESCRIPTION
## Summary
- add baton artifact signer/role validator
- enforce signer/role checks in baton admin gate
- add consultant gov-007 signer/role check
- add signer integrity stress + adversarial tests
- document signer enforcement + recovery path

## Validation
- runTests: baton signer/governance suite passed

Refs #1728