### PR TITLE
feat(governance): canonical manifest schema + validator (#1693)

### DIFF
--- a/docs/howto/canonical-governance-manifest.md
+++ b/docs/howto/canonical-governance-manifest.md
@@ -1,0 +1,58 @@
+# Canonical Governance Manifest — How-To
+
+Date: 2026-05-16  
+Last-updated: 2026-05-16
+
+## Summary
+
+| Item | Value |
+|---|---|
+| Schema file | `inventory/governance-manifest.schema.json` |
+| Sample manifest | `inventory/governance-manifest.sample.json` |
+| Validator | `scripts/global/governance-manifest-validate.js` |
+| Command | `npm run governance:manifest:validate` |
+
+## What this defines
+
+A runtime-agnostic governance unit format with required metadata:
+- `id`, `title`, `priority`, `appliesTo`, `targets`, `tags`, `bodyRef`
+- `targets` supports Copilot, Cline, Claude Code, Continue
+- `bodyRef` points to source markdown/instruction files in this repo
+
+## Validation behavior
+
+- Exit `0`: manifest valid
+- Exit `1`: manifest invalid (diagnostics printed)
+- Exit `2`: runtime/read error
+
+Example diagnostics:
+- `units[0].priority invalid`
+- `units[1].bodyRef not found: instructions/missing.md`
+
+## Usage
+
+1) Validate sample:
+- `npm run governance:manifest:validate`
+
+2) Validate a custom manifest:
+- `node scripts/global/governance-manifest-validate.js ./path/to/manifest.json`
+
+## Adapter mapping readiness
+
+`targets` is explicit per unit, enabling adapter emitters to map units for:
+- `copilot`
+- `cline`
+- `claude-code`
+- `continue`
+
+## Source links
+
+- Issue scope: #1693
+- Research input: #1692
+- Epic parent: #1701
+
+## Actionable next steps
+
+1. Implement adapter emitters (#1694) using `targets` and `bodyRef`.
+2. Add generate/sync commands and CI drift gates (#1695).
+3. Add matrix/golden parity tests across outputs (#1696).

--- a/inventory/governance-manifest.sample.json
+++ b/inventory/governance-manifest.sample.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "units": [
+    {
+      "id": "operator-identity-context",
+      "title": "Operator Identity Context",
+      "priority": "P1",
+      "appliesTo": ["**"],
+      "targets": ["copilot", "cline", "claude-code", "continue"],
+      "tags": ["governance", "baton", "operator"],
+      "bodyRef": "instructions/operator-identity-context.instructions.md"
+    },
+    {
+      "id": "team-model-signing",
+      "title": "Team Model Signing",
+      "priority": "P1",
+      "appliesTo": ["instructions/**", "scripts/global/**"],
+      "targets": ["copilot", "claude-code", "continue"],
+      "tags": ["governance", "signing", "traceability"],
+      "bodyRef": "instructions/team-model-signing.instructions.md"
+    }
+  ]
+}

--- a/inventory/governance-manifest.schema.json
+++ b/inventory/governance-manifest.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://megingjord.local/schemas/governance-manifest.schema.json",
+  "title": "CanonicalGovernanceManifest",
+  "type": "object",
+  "required": ["version", "units"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "const": 1 },
+    "units": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "priority", "appliesTo", "targets", "tags", "bodyRef"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]{2,63}$"
+          },
+          "title": { "type": "string", "minLength": 3 },
+          "priority": { "enum": ["P0", "P1", "P2", "P3"] },
+          "appliesTo": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "targets": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": ["copilot", "cline", "claude-code", "continue"]
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "bodyRef": {
+            "type": "string",
+            "pattern": "^(instructions|skills|hooks|scripts|docs)/.+\\.(md|instructions\\.md)$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "governance:drift": "node scripts/global/governance-drift-classifier.js --json",
     "governance:epic": "node scripts/global/epic-evidence.js",
     "governance:epics": "node scripts/global/epic-close-validator.js",
+    "governance:manifest:validate": "node scripts/global/governance-manifest-validate.js",
+    "governance:manifest:test": "node scripts/global/governance-manifest-validate.spec.js",
     "governance:no-sync-http": "node scripts/global/no-sync-http-handlers.js",
     "governance:tokens": "node scripts/global/governance-token-lint.js",
     "governance:reconcile": "node scripts/global/ticket-reconcile.js --json",

--- a/scripts/global/governance-manifest-validate.js
+++ b/scripts/global/governance-manifest-validate.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..', '..');
+const schemaPath = path.join(root, 'inventory', 'governance-manifest.schema.json');
+const defaultManifestPath = path.join(root, 'inventory', 'governance-manifest.sample.json');
+const allowedTargets = new Set(['copilot', 'cline', 'claude-code', 'continue']);
+const allowedPriority = new Set(['P0', 'P1', 'P2', 'P3']);
+
+function fail(msg) { process.stderr.write(`manifest-validate: ${msg}\n`); }
+function readJson(file) { return JSON.parse(fs.readFileSync(file, 'utf8')); }
+function uniq(arr) { return new Set(arr).size === arr.length; }
+
+function validateUnit(u, i, errors) {
+  const req = ['id', 'title', 'priority', 'appliesTo', 'targets', 'tags', 'bodyRef'];
+  for (const k of req) if (u[k] === undefined) errors.push(`units[${i}] missing ${k}`);
+  if (!/^[a-z][a-z0-9-]{2,63}$/.test(String(u.id || ''))) errors.push(`units[${i}].id invalid`);
+  if (!allowedPriority.has(u.priority)) errors.push(`units[${i}].priority invalid`);
+  if (!Array.isArray(u.appliesTo) || u.appliesTo.length < 1) errors.push(`units[${i}].appliesTo invalid`);
+  if (!Array.isArray(u.targets) || u.targets.length < 1) errors.push(`units[${i}].targets invalid`);
+  if (Array.isArray(u.targets) && !uniq(u.targets)) errors.push(`units[${i}].targets has duplicates`);
+  if (Array.isArray(u.targets)) {
+    for (const t of u.targets) if (!allowedTargets.has(t)) errors.push(`units[${i}].targets contains ${t}`);
+  }
+  if (!Array.isArray(u.tags)) errors.push(`units[${i}].tags invalid`);
+  const rx = /^(instructions|skills|hooks|scripts|docs)\/.+\.(md|instructions\.md)$/;
+  if (!rx.test(String(u.bodyRef || ''))) errors.push(`units[${i}].bodyRef invalid`);
+  const abs = path.join(root, String(u.bodyRef || ''));
+  if (!fs.existsSync(abs)) errors.push(`units[${i}].bodyRef not found: ${u.bodyRef}`);
+}
+
+function validate(manifest) {
+  const errors = [];
+  if (!manifest || typeof manifest !== 'object') errors.push('manifest must be object');
+  if (manifest.version !== 1) errors.push('version must be 1');
+  if (!Array.isArray(manifest.units) || manifest.units.length < 1) errors.push('units must be non-empty array');
+  if (Array.isArray(manifest.units)) manifest.units.forEach((u, i) => validateUnit(u, i, errors));
+  const ids = Array.isArray(manifest.units) ? manifest.units.map(u => u.id).filter(Boolean) : [];
+  if (!uniq(ids)) errors.push('unit ids must be unique');
+  return errors;
+}
+
+function main() {
+  const file = process.argv[2] ? path.resolve(process.argv[2]) : defaultManifestPath;
+  try {
+    readJson(schemaPath);
+    const manifest = readJson(file);
+    const errors = validate(manifest);
+    if (errors.length) {
+      errors.forEach(e => fail(e));
+      process.exit(1);
+    }
+    process.stdout.write(`manifest-validate: OK (${path.relative(root, file)})\n`);
+  } catch (e) {
+    fail(e.message);
+    process.exit(2);
+  }
+}
+
+module.exports = { validate };
+if (require.main === module) main();

--- a/scripts/global/governance-manifest-validate.spec.js
+++ b/scripts/global/governance-manifest-validate.spec.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const cp = require('child_process');
+
+const root = path.resolve(__dirname, '..', '..');
+const cli = path.join(root, 'scripts', 'global', 'governance-manifest-validate.js');
+const sample = path.join(root, 'inventory', 'governance-manifest.sample.json');
+let pass = 0; let fail = 0;
+function test(n, f) { try { f(); pass++; console.log(`✓ ${n}`); } catch (e) { fail++; console.error(`✗ ${n}: ${e.message}`); } }
+function run(file) { return cp.spawnSync('node', [cli, file], { encoding: 'utf8' }); }
+
+test('valid sample manifest passes', () => {
+  const r = run(sample);
+  assert.strictEqual(r.status, 0);
+  assert.ok(/OK/.test(r.stdout));
+});
+
+test('invalid manifest fails with diagnostics', () => {
+  const f = path.join(os.tmpdir(), `manifest-bad-${Date.now()}.json`);
+  fs.writeFileSync(f, JSON.stringify({ version: 1, units: [{ id: 'x', priority: 'PX' }] }));
+  const r = run(f);
+  assert.strictEqual(r.status, 1);
+  assert.ok(/missing title|priority invalid/.test(r.stderr));
+  fs.unlinkSync(f);
+});
+
+test('unknown target fails clearly', () => {
+  const f = path.join(os.tmpdir(), `manifest-target-${Date.now()}.json`);
+  const m = JSON.parse(fs.readFileSync(sample, 'utf8'));
+  m.units[0].targets = ['copilot', 'bogus'];
+  fs.writeFileSync(f, JSON.stringify(m));
+  const r = run(f);
+  assert.strictEqual(r.status, 1);
+  assert.ok(/targets contains bogus/.test(r.stderr));
+  fs.unlinkSync(f);
+});
+
+console.log(`Results: ${pass} passed, ${fail} failed`);
+if (fail) process.exit(1);


### PR DESCRIPTION
Implements #1693 by introducing a canonical governance manifest schema, validator, sample, and docs.

## Delivered
- inventory/governance-manifest.schema.json
  - required unit fields: id, title, priority, appliesTo, targets, tags, bodyRef
  - target adapter support: copilot, cline, claude-code, continue
- inventory/governance-manifest.sample.json
- scripts/global/governance-manifest-validate.js
  - clear diagnostics
  - exit code 1 for invalid manifest, 2 for runtime/read errors
- scripts/global/governance-manifest-validate.spec.js
- docs/howto/canonical-governance-manifest.md
- package.json
  - governance:manifest:validate
  - governance:manifest:test

## Validation
- npm run governance:manifest:validate ✅
- npm run governance:manifest:test ✅ (3 passed)

Closes #1693
Team&Model: GitHub Copilot:GPT-5.3-Codex
