### PR TITLE
feat(governance): canonical adapter emitters (#1694)

### DIFF
--- a/docs/howto/canonical-governance-adapters.md
+++ b/docs/howto/canonical-governance-adapters.md
@@ -1,0 +1,44 @@
+# Canonical Governance Adapters
+
+Date: 2026-05-16  
+Last-updated: 2026-05-16
+
+## Summary
+
+| Item | Value |
+|---|---|
+| Canonical manifest | `inventory/governance-manifest.sample.json` |
+| Schema | `inventory/governance-manifest.schema.json` |
+| Adapter emitter | `scripts/global/governance-adapter-emit.js` |
+| Output root | `generated/governance-adapters/` |
+
+## What the emitter does
+
+The adapter emitter converts the canonical manifest into deterministic, target-native previews for:
+- Copilot → `.github/instructions/*.instructions.md`
+- Cline → `.clinerules/*.md`
+- Claude Code → `CLAUDE.md`
+- Continue → `.continue/rules/*.md`
+
+Each generated file includes:
+- provenance header
+- target metadata
+- frontmatter with `applyTo`/`paths`
+- canonical source reference via `bodyRef`
+
+## Validation
+
+- `npm run governance:adapters:emit`
+- `npm run governance:adapters:test`
+
+## Output behavior
+
+- Only units whose `targets` include a given runtime are emitted
+- Emission is deterministic for the same manifest
+- Generated previews are written under `generated/governance-adapters/<target>/...`
+
+## Next steps
+
+1. Add sync-check generation in CI (#1695).
+2. Add parity matrix/golden tests across target outputs (#1696).
+3. Use these previews as the reference for migration (#1698).

--- a/generated/governance-adapters/claude-code/CLAUDE.md
+++ b/generated/governance-adapters/claude-code/CLAUDE.md
@@ -1,0 +1,26 @@
+---
+target: claude-code
+id: team-model-signing
+title: Team Model Signing
+priority: P1
+bodyRef: instructions/team-model-signing.instructions.md
+appliesTo:
+  - "instructions/**"
+  - "scripts/global/**"
+targets:
+  - "copilot"
+  - "claude-code"
+  - "continue"
+---
+---
+description: Governance unit team-model-signing
+applyTo: "instructions/**"
+priority: P1
+targets: "copilot,claude-code,continue"
+---
+# Team Model Signing
+
+Source: instructions/team-model-signing.instructions.md
+Targets: copilot, claude-code, continue
+
+This is a generated adapter preview for claude-code.

--- a/generated/governance-adapters/cline/.clinerules/operator-identity-context.md
+++ b/generated/governance-adapters/cline/.clinerules/operator-identity-context.md
@@ -1,0 +1,27 @@
+---
+target: cline
+id: operator-identity-context
+title: Operator Identity Context
+priority: P1
+bodyRef: instructions/operator-identity-context.instructions.md
+appliesTo:
+  - "**"
+targets:
+  - "copilot"
+  - "cline"
+  - "claude-code"
+  - "continue"
+---
+---
+applyTo: "**"
+paths:
+  - "**"
+priority: P1
+targets: "copilot,cline,claude-code,continue"
+---
+# Operator Identity Context
+
+Source: instructions/operator-identity-context.instructions.md
+Targets: copilot, cline, claude-code, continue
+
+This is a generated adapter preview for cline.

--- a/generated/governance-adapters/continue/.continue/rules/operator-identity-context.md
+++ b/generated/governance-adapters/continue/.continue/rules/operator-identity-context.md
@@ -1,0 +1,27 @@
+---
+target: continue
+id: operator-identity-context
+title: Operator Identity Context
+priority: P1
+bodyRef: instructions/operator-identity-context.instructions.md
+appliesTo:
+  - "**"
+targets:
+  - "copilot"
+  - "cline"
+  - "claude-code"
+  - "continue"
+---
+---
+applyTo: "**"
+paths:
+  - "**"
+priority: P1
+targets: "copilot,cline,claude-code,continue"
+---
+# Operator Identity Context
+
+Source: instructions/operator-identity-context.instructions.md
+Targets: copilot, cline, claude-code, continue
+
+This is a generated adapter preview for continue.

--- a/generated/governance-adapters/continue/.continue/rules/team-model-signing.md
+++ b/generated/governance-adapters/continue/.continue/rules/team-model-signing.md
@@ -1,0 +1,28 @@
+---
+target: continue
+id: team-model-signing
+title: Team Model Signing
+priority: P1
+bodyRef: instructions/team-model-signing.instructions.md
+appliesTo:
+  - "instructions/**"
+  - "scripts/global/**"
+targets:
+  - "copilot"
+  - "claude-code"
+  - "continue"
+---
+---
+applyTo: "instructions/**"
+paths:
+  - "instructions/**"
+  - "scripts/global/**"
+priority: P1
+targets: "copilot,claude-code,continue"
+---
+# Team Model Signing
+
+Source: instructions/team-model-signing.instructions.md
+Targets: copilot, claude-code, continue
+
+This is a generated adapter preview for continue.

--- a/generated/governance-adapters/copilot/.github/instructions/operator-identity-context.instructions.md
+++ b/generated/governance-adapters/copilot/.github/instructions/operator-identity-context.instructions.md
@@ -1,0 +1,27 @@
+---
+target: copilot
+id: operator-identity-context
+title: Operator Identity Context
+priority: P1
+bodyRef: instructions/operator-identity-context.instructions.md
+appliesTo:
+  - "**"
+targets:
+  - "copilot"
+  - "cline"
+  - "claude-code"
+  - "continue"
+---
+---
+applyTo: "**"
+paths:
+  - "**"
+priority: P1
+targets: "copilot,cline,claude-code,continue"
+---
+# Operator Identity Context
+
+Source: instructions/operator-identity-context.instructions.md
+Targets: copilot, cline, claude-code, continue
+
+This is a generated adapter preview for copilot.

--- a/generated/governance-adapters/copilot/.github/instructions/team-model-signing.instructions.md
+++ b/generated/governance-adapters/copilot/.github/instructions/team-model-signing.instructions.md
@@ -1,0 +1,28 @@
+---
+target: copilot
+id: team-model-signing
+title: Team Model Signing
+priority: P1
+bodyRef: instructions/team-model-signing.instructions.md
+appliesTo:
+  - "instructions/**"
+  - "scripts/global/**"
+targets:
+  - "copilot"
+  - "claude-code"
+  - "continue"
+---
+---
+applyTo: "instructions/**"
+paths:
+  - "instructions/**"
+  - "scripts/global/**"
+priority: P1
+targets: "copilot,claude-code,continue"
+---
+# Team Model Signing
+
+Source: instructions/team-model-signing.instructions.md
+Targets: copilot, claude-code, continue
+
+This is a generated adapter preview for copilot.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "governance:epics": "node scripts/global/epic-close-validator.js",
     "governance:manifest:validate": "node scripts/global/governance-manifest-validate.js",
     "governance:manifest:test": "node scripts/global/governance-manifest-validate.spec.js",
+    "governance:adapters:emit": "node scripts/global/governance-adapter-emit.js",
+    "governance:adapters:test": "node scripts/global/governance-adapter-emit.spec.js",
     "governance:no-sync-http": "node scripts/global/no-sync-http-handlers.js",
     "governance:tokens": "node scripts/global/governance-token-lint.js",
     "governance:reconcile": "node scripts/global/ticket-reconcile.js --json",

--- a/scripts/global/governance-adapter-emit.js
+++ b/scripts/global/governance-adapter-emit.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { validate } = require('./governance-manifest-validate');
+
+const root = path.resolve(__dirname, '..', '..');
+const manifestPath = path.join(root, 'inventory', 'governance-manifest.sample.json');
+const outRoot = path.join(root, 'generated', 'governance-adapters');
+const targets = ['copilot', 'cline', 'claude-code', 'continue'];
+
+function readJson(file) { return JSON.parse(fs.readFileSync(file, 'utf8')); }
+function write(file, content) { fs.mkdirSync(path.dirname(file), { recursive: true }); fs.writeFileSync(file, `${content}\n`); }
+function yamlList(items) { return items.map(item => `  - ${JSON.stringify(item)}`).join('\n'); }
+function provenance(target, unit) {
+  return [
+    '---',
+    `target: ${target}`,
+    `id: ${unit.id}`,
+    `title: ${unit.title}`,
+    `priority: ${unit.priority}`,
+    `bodyRef: ${unit.bodyRef}`,
+    `appliesTo:`,
+    yamlList(unit.appliesTo),
+    `targets:`,
+    yamlList(unit.targets),
+    '---',
+  ].join('\n');
+}
+function targetPath(target, unit) {
+  const base = path.join(outRoot, target);
+  if (target === 'copilot') return path.join(base, '.github', 'instructions', `${unit.id}.instructions.md`);
+  if (target === 'cline') return path.join(base, '.clinerules', `${unit.id}.md`);
+  if (target === 'claude-code') return path.join(base, 'CLAUDE.md');
+  if (target === 'continue') return path.join(base, '.continue', 'rules', `${unit.id}.md`);
+  throw new Error(`unsupported target: ${target}`);
+}
+function frontmatter(target, unit) {
+  const lines = ['---'];
+  if (target === 'claude-code') {
+    lines.push(`description: Governance unit ${unit.id}`);
+    lines.push(`applyTo: ${JSON.stringify(unit.appliesTo[0] || '**')}`);
+  } else {
+    lines.push(`applyTo: ${JSON.stringify(unit.appliesTo[0] || '**')}`);
+    lines.push(`paths:`);
+    lines.push(yamlList(unit.appliesTo));
+  }
+  lines.push(`priority: ${unit.priority}`);
+  lines.push(`targets: ${JSON.stringify(unit.targets.join(','))}`);
+  lines.push('---');
+  return lines.join('\n');
+}
+function body(target, unit) {
+  return [
+    provenance(target, unit),
+    frontmatter(target, unit),
+    `# ${unit.title}`,
+    '',
+    `Source: ${unit.bodyRef}`,
+    `Targets: ${unit.targets.join(', ')}`,
+    '',
+    `This is a generated adapter preview for ${target}.`,
+  ].join('\n');
+}
+function emit(manifestFile = manifestPath) {
+  const manifest = readJson(manifestFile);
+  const errors = validate(manifest);
+  if (errors.length) throw new Error(errors.join('; '));
+  const outputs = [];
+  for (const target of targets) {
+    for (const unit of manifest.units) {
+      if (!unit.targets.includes(target)) continue;
+      const file = targetPath(target, unit);
+      const content = body(target, unit);
+      write(file, content);
+      outputs.push(file);
+    }
+  }
+  return outputs;
+}
+function main() {
+  try {
+    const outputs = emit();
+    process.stdout.write(outputs.map(o => path.relative(root, o)).join('\n') + '\n');
+  } catch (e) {
+    process.stderr.write(`governance-adapter-emit: ${e.message}\n`);
+    process.exit(2);
+  }
+}
+module.exports = { emit, targetPath, provenance, frontmatter, body };
+if (require.main === module) main();

--- a/scripts/global/governance-adapter-emit.spec.js
+++ b/scripts/global/governance-adapter-emit.spec.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { emit, targetPath, provenance, frontmatter } = require('./governance-adapter-emit');
+
+let pass = 0; let fail = 0;
+function test(name, fn) {
+  try { fn(); pass++; console.log(`✓ ${name}`); }
+  catch (e) { fail++; console.error(`✗ ${name}: ${e.message}`); }
+}
+
+const manifest = path.join(__dirname, '..', '..', 'inventory', 'governance-manifest.sample.json');
+
+test('target paths are deterministic', () => {
+  const unit = { id: 'operator-identity-context', title: 'Operator Identity Context', priority: 'P1', appliesTo: ['**'], targets: ['copilot', 'cline', 'claude-code', 'continue'], bodyRef: 'instructions/operator-identity-context.instructions.md' };
+  assert.ok(targetPath('copilot', unit).includes('.github/instructions/operator-identity-context.instructions.md'));
+  assert.ok(targetPath('cline', unit).includes('.clinerules/operator-identity-context.md'));
+  assert.ok(targetPath('claude-code', unit).endsWith('CLAUDE.md'));
+  assert.ok(targetPath('continue', unit).includes('.continue/rules/operator-identity-context.md'));
+});
+
+test('frontmatter maps appliesTo into paths', () => {
+  const unit = { id: 'x', title: 'X', priority: 'P1', appliesTo: ['scripts/**', 'instructions/**'], targets: ['copilot'], bodyRef: 'instructions/x.instructions.md' };
+  const fm = frontmatter('copilot', unit);
+  assert.ok(fm.includes('paths:'));
+  assert.ok(fm.includes('scripts/**'));
+  assert.ok(fm.includes('instructions/**'));
+});
+
+test('emit writes deterministic adapter previews', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gov-adapt-'));
+  const orig = process.cwd();
+  process.chdir(path.join(__dirname, '..', '..'));
+  const outputs = emit(manifest);
+  process.chdir(orig);
+  assert.ok(outputs.length >= 3);
+  for (const file of outputs.slice(0, 3)) {
+    assert.ok(fs.existsSync(file), `missing ${file}`);
+    const txt = fs.readFileSync(file, 'utf8');
+    assert.ok(txt.includes('---'));
+    assert.ok(txt.includes('Source:'));
+  }
+});
+
+console.log(`Results: ${pass} passed, ${fail} failed`);
+if (fail) process.exit(1);


### PR DESCRIPTION
Implements #1694 by adding canonical adapter emitters that render governance units into target-native preview layouts.

## Delivered
- scripts/global/governance-adapter-emit.js
  - emits deterministic previews from inventory/governance-manifest.sample.json
  - target mapping for Copilot, Cline, Claude Code, and Continue
  - provenance header + frontmatter with applyTo/paths
- scripts/global/governance-adapter-emit.spec.js
  - verifies deterministic target paths
  - verifies frontmatter mapping
  - verifies generated previews exist and contain provenance/source headers
- docs/howto/canonical-governance-adapters.md
- generated/governance-adapters/
  - copilot/.github/instructions/*.instructions.md
  - cline/.clinerules/*.md
  - claude-code/CLAUDE.md
  - continue/.continue/rules/*.md
- package.json scripts
  - governance:adapters:emit
  - governance:adapters:test

## Validation
- npm run governance:adapters:emit ✅
- npm run governance:adapters:test ✅ (3 passed)

Closes #1694
Team&Model: GitHub Copilot:GPT-5.3-Codex
