### PR TITLE
feat(governance): generation + drift gate pipeline (#1695)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,8 @@ jobs:
         run: npm run lint
       - name: Governance token resolution
         run: npm run governance:tokens
+      - name: Governance sync check
+        run: npm run governance:sync-check
       - name: Readability gate
         run: npm run lint:readability:ci
       - name: Ticket reconciliation

--- a/docs/howto/canonical-governance-adapters.md
+++ b/docs/howto/canonical-governance-adapters.md
@@ -31,6 +31,11 @@ Each generated file includes:
 - `npm run governance:adapters:emit`
 - `npm run governance:adapters:test`
 
+## One-command regeneration
+
+- `npm run governance:generate` — clears and rewrites `generated/governance-adapters/`
+- `npm run governance:sync-check` — compares tracked generated files against a fresh render and fails on drift
+
 ## Output behavior
 
 - Only units whose `targets` include a given runtime are emitted

--- a/docs/howto/canonical-governance-manifest.md
+++ b/docs/howto/canonical-governance-manifest.md
@@ -37,6 +37,10 @@ Example diagnostics:
 2) Validate a custom manifest:
 - `node scripts/global/governance-manifest-validate.js ./path/to/manifest.json`
 
+3) Regenerate canonical adapter previews and sync tracked files:
+- `npm run governance:generate`
+- `npm run governance:sync-check`
+
 ## Adapter mapping readiness
 
 `targets` is explicit per unit, enabling adapter emitters to map units for:

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "governance:manifest:test": "node scripts/global/governance-manifest-validate.spec.js",
     "governance:adapters:emit": "node scripts/global/governance-adapter-emit.js",
     "governance:adapters:test": "node scripts/global/governance-adapter-emit.spec.js",
+    "governance:generate": "node scripts/global/governance-generate.js",
+    "governance:sync-check": "node scripts/global/governance-sync-check.js",
     "governance:no-sync-http": "node scripts/global/no-sync-http-handlers.js",
     "governance:tokens": "node scripts/global/governance-token-lint.js",
     "governance:reconcile": "node scripts/global/ticket-reconcile.js --json",

--- a/scripts/global/governance-adapter-emit.js
+++ b/scripts/global/governance-adapter-emit.js
@@ -7,7 +7,7 @@ const { validate } = require('./governance-manifest-validate');
 
 const root = path.resolve(__dirname, '..', '..');
 const manifestPath = path.join(root, 'inventory', 'governance-manifest.sample.json');
-const outRoot = path.join(root, 'generated', 'governance-adapters');
+const defaultOutRoot = path.join(root, 'generated', 'governance-adapters');
 const targets = ['copilot', 'cline', 'claude-code', 'continue'];
 
 function readJson(file) { return JSON.parse(fs.readFileSync(file, 'utf8')); }
@@ -28,7 +28,7 @@ function provenance(target, unit) {
     '---',
   ].join('\n');
 }
-function targetPath(target, unit) {
+function targetPath(target, unit, outRoot = defaultOutRoot) {
   const base = path.join(outRoot, target);
   if (target === 'copilot') return path.join(base, '.github', 'instructions', `${unit.id}.instructions.md`);
   if (target === 'cline') return path.join(base, '.clinerules', `${unit.id}.md`);
@@ -63,7 +63,7 @@ function body(target, unit) {
     `This is a generated adapter preview for ${target}.`,
   ].join('\n');
 }
-function emit(manifestFile = manifestPath) {
+function emit(manifestFile = manifestPath, outRoot = defaultOutRoot) {
   const manifest = readJson(manifestFile);
   const errors = validate(manifest);
   if (errors.length) throw new Error(errors.join('; '));
@@ -71,7 +71,7 @@ function emit(manifestFile = manifestPath) {
   for (const target of targets) {
     for (const unit of manifest.units) {
       if (!unit.targets.includes(target)) continue;
-      const file = targetPath(target, unit);
+      const file = targetPath(target, unit, outRoot);
       const content = body(target, unit);
       write(file, content);
       outputs.push(file);

--- a/scripts/global/governance-generate.js
+++ b/scripts/global/governance-generate.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { readFileSync, mkdirSync, rmSync } = require('fs');
+const { validate } = require('./governance-manifest-validate');
+const { emit } = require('./governance-adapter-emit');
+
+const root = path.resolve(__dirname, '..', '..');
+const manifestPath = path.join(root, 'inventory', 'governance-manifest.sample.json');
+const outRoot = path.join(root, 'generated', 'governance-adapters');
+
+function main() {
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    const errors = validate(manifest);
+    if (errors.length) throw new Error(errors.join('; '));
+    rmSync(outRoot, { recursive: true, force: true });
+    mkdirSync(outRoot, { recursive: true });
+    const outputs = emit(manifestPath, outRoot);
+    process.stdout.write(`governance-generate: wrote ${outputs.length} files\n`);
+  } catch (e) {
+    process.stderr.write(`governance-generate: ${e.message}\n`);
+    process.exit(2);
+  }
+}
+
+if (require.main === module) main();

--- a/scripts/global/governance-generate.spec.js
+++ b/scripts/global/governance-generate.spec.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+
+const root = path.resolve(__dirname, '..', '..');
+const generate = path.join(root, 'scripts', 'global', 'governance-generate.js');
+const syncCheck = path.join(root, 'scripts', 'global', 'governance-sync-check.js');
+const trackedRoot = path.join(root, 'generated', 'governance-adapters');
+let pass = 0; let fail = 0;
+function test(name, fn) { try { fn(); pass++; console.log(`✓ ${name}`); } catch (e) { fail++; console.error(`✗ ${name}: ${e.message}`); } }
+function run(script) { return cp.spawnSync('node', [script], { cwd: root, encoding: 'utf8' }); }
+
+function firstFile(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = firstFile(full);
+      if (nested) return nested;
+    } else return full;
+  }
+  return null;
+}
+
+function snapshot(dir) {
+  const out = [];
+  const walk = current => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else out.push([path.relative(dir, full), fs.readFileSync(full, 'utf8')]);
+    }
+  };
+  walk(dir);
+  return out.sort((a, b) => a[0].localeCompare(b[0]));
+}
+
+test('governance generate succeeds', () => {
+  const r = run(generate);
+  assert.strictEqual(r.status, 0);
+  assert.ok(/wrote/.test(r.stdout));
+});
+
+test('sync-check succeeds after generate', () => {
+  run(generate);
+  const r = run(syncCheck);
+  assert.strictEqual(r.status, 0);
+  assert.ok(/clean/.test(r.stdout));
+});
+
+test('sync-check fails when tracked generated files drift', () => {
+  run(generate);
+  const driftFile = firstFile(trackedRoot);
+  const original = fs.readFileSync(driftFile, 'utf8');
+  fs.writeFileSync(driftFile, `${original}\nDRIFT\n`);
+  const r = run(syncCheck);
+  fs.writeFileSync(driftFile, original);
+  assert.strictEqual(r.status, 1);
+  assert.ok(/stale generated artifacts/.test(r.stderr));
+});
+
+test('generate is idempotent', () => {
+  run(generate);
+  const before = snapshot(trackedRoot);
+  run(generate);
+  const after = snapshot(trackedRoot);
+  assert.deepStrictEqual(after, before);
+});
+
+console.log(`Results: ${pass} passed, ${fail} failed`);
+if (fail) process.exit(1);

--- a/scripts/global/governance-sync-check.js
+++ b/scripts/global/governance-sync-check.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { emit } = require('./governance-adapter-emit');
+
+const root = path.resolve(__dirname, '..', '..');
+const manifestPath = path.join(root, 'inventory', 'governance-manifest.sample.json');
+const trackedRoot = path.join(root, 'generated', 'governance-adapters');
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'governance-sync-'));
+
+function relFiles(dir) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+  const walk = current => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else results.push(path.relative(dir, full));
+    }
+  };
+  walk(dir);
+  return results.sort();
+}
+
+function read(file) { return fs.readFileSync(file, 'utf8'); }
+
+function main() {
+  try {
+    emit(manifestPath, tempRoot);
+    const generated = relFiles(path.join(tempRoot));
+    const tracked = relFiles(trackedRoot);
+    const all = new Set([...generated, ...tracked]);
+    const diffs = [];
+    for (const rel of [...all].sort()) {
+      const a = path.join(tempRoot, rel);
+      const b = path.join(trackedRoot, rel);
+      if (!fs.existsSync(a)) diffs.push(`missing generated: ${rel}`);
+      else if (!fs.existsSync(b)) diffs.push(`missing tracked: ${rel}`);
+      else if (read(a) !== read(b)) diffs.push(`out of date: ${rel}`);
+    }
+    if (diffs.length) {
+      process.stderr.write(`governance-sync-check: stale generated artifacts\n`);
+      for (const diff of diffs) process.stderr.write(`- ${diff}\n`);
+      process.exit(1);
+    }
+    process.stdout.write('governance-sync-check: clean\n');
+  } catch (e) {
+    process.stderr.write(`governance-sync-check: ${e.message}\n`);
+    process.exit(2);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+if (require.main === module) main();


### PR DESCRIPTION
Implements #1695 by adding an idempotent governance generation pipeline and a drift gate.

## Delivered
- scripts/global/governance-generate.js
  - clears and regenerates tracked adapter previews from the canonical manifest
  - one-command regeneration for developers
- scripts/global/governance-sync-check.js
  - renders to a temp tree and compares against tracked generated files
  - exits `1` on stale artifacts, `2` on runtime/read errors
- scripts/global/governance-generate.spec.js
  - verifies generation succeeds
  - verifies sync-check passes after generate
  - verifies sync-check fails on drift
  - verifies generate is idempotent
- .github/workflows/lint.yml
  - runs `npm run governance:sync-check` in CI
- docs/howto/canonical-governance-manifest.md
  - documents `governance:generate` and `governance:sync-check`
- docs/howto/canonical-governance-adapters.md
  - documents the regeneration workflow too
- package.json scripts
  - governance:generate
  - governance:sync-check

## Validation
- npm run governance:generate ✅
- npm run governance:sync-check ✅
- node scripts/global/governance-generate.spec.js ✅ (4 passed)

Closes #1695
Team&Model: GitHub Copilot:GPT-5.3-Codex
