### PR TITLE
research(knowledge): define unified wiki health contract

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -41,6 +41,7 @@ ADRs that change governance must follow Manager → Consultant baton.
 | 016 | log4brains as the ADR Pipeline | [`016-log4brains-adr-pipeline.md`](../research/adr/016-log4brains-adr-pipeline.md) |
 | 017 | package-lock.json — Commit vs. Gitignore Decision | [`017-package-lock-decision.md`](../research/adr/017-package-lock-decision.md) |
 | 018 | Enable GitHub Actions to create and approve pull requests | [`018-actions-pr-permission.md`](../research/adr/018-actions-pr-permission.md) |
+| 019 | Unified Wiki Health Contract | [`019-unified-wiki-health-contract.md`](../research/adr/019-unified-wiki-health-contract.md) |
 
 ## Resolved issues
 

--- a/research/adr/019-unified-wiki-health-contract.md
+++ b/research/adr/019-unified-wiki-health-contract.md
@@ -1,0 +1,61 @@
+# ADR-019: Unified Wiki Health Contract
+
+**Status:** Accepted
+**Date:** 2026-05-16
+**Refs:** #1673, #1625, #1626
+
+## Context
+
+The wiki surface has three health tools:
+
+| Tool | Source | What it measures |
+|---|---|---|
+| `scripts/wiki/lint.js` | Repo wiki (all 4 category dirs) | broken links, orphans, frontmatter, indexSync |
+| `scripts/wiki/hygiene.js` | Repo wiki | stale, duplicate, orphan, weak-link, frontmatter |
+| `dashboard-api.js /api/wiki-health` | `~/.copilot/wiki/entities/` only | entity file count only |
+
+This caused operators to see contradictory signals: "31 orphans" from the dashboard vs "17 orphans" from lint; "4 frontmatter issues" from the dashboard vs "18" from lint.
+
+## Root Cause Analysis
+
+**Orphan count divergence (31 vs 17):**
+
+- The dashboard does not compute orphans. Its "31" is the **entity file count** from the deployed runtime (`~/.copilot/wiki/entities/`), not an orphan count.
+- `health-contract.js` computes true orphans via link-graph traversal across all four category dirs (`entities`, `concepts`, `sources`, `syntheses`) in the repo wiki.
+- These are incommensurable metrics from different directories.
+
+**Frontmatter count divergence (4 vs 18):**
+
+- The dashboard returns `entities` (file count), which has no relationship to frontmatter violations.
+- `health-contract.js` emits one `"slug: missing 'field'"` string per missing field per page. With 4 REQUIRED_FIELDS, a single page can contribute up to 4 violations. 18 violations across N pages is a per-field count, not a per-page count.
+
+## Decision
+
+`scripts/wiki/health-contract.js` is the **single source of truth** for wiki health metrics.
+
+Its `computeWikiHealth(pages?)` function and return schema are canonical:
+
+```js
+{
+  loaded: boolean,
+  pages: number,
+  dirs: number,
+  issues: number,          // total violation count
+  broken: string[],        // "slug→target" per broken wikilink
+  orphans: string[],       // slugs with no inbound links
+  frontmatter: string[],   // "slug: missing 'field'" per violation
+  indexSync: string[],     // slugs missing from index.md
+  lastCheck: ISO8601,
+}
+```
+
+All callers must import and call `computeWikiHealth()`. Custom ad-hoc counting is prohibited.
+
+**`dashboard-api.js` fix:** The `/api/wiki-health` endpoint must call `computeWikiHealth()` (passing the deployed wiki path) instead of counting entity files directly. This is tracked in #1674.
+
+## Consequences
+
+- Lint, hygiene, and dashboard will report identical orphan and frontmatter counts.
+- Dashboard endpoint gains richer health signal (broken links, orphans, frontmatter, indexSync).
+- `hygiene.js` already routes through `computeWikiHealth()` for orphan data; no change needed there.
+- `dashboard-api.js` requires a one-line import change and a path parameter.


### PR DESCRIPTION
## Summary
Research findings for #1673. Documents the root cause of wiki health metric divergence and establishes `health-contract.js` as the canonical SSoT.

## Root Causes Found

**Orphan count divergence (31 vs 17):**
- `dashboard-api.js /api/wiki-health` reads from `~/.copilot/wiki/entities/` (deployed runtime, one subdirectory) and returns an **entity file count** — not an orphan count
- `health-contract.js` computes true orphans via link-graph traversal across all 4 category dirs in the **repo** wiki
- These are incommensurable metrics from different directories

**Frontmatter count divergence (4 vs 18):**
- Dashboard returns `entities` file count (4 files), unrelated to frontmatter
- health-contract emits one `"slug: missing 'field'"` string per missing field per page — 18 is a per-field count (up to 4 violations per page), not a per-page count

## Deliverables
- `research/adr/019-unified-wiki-health-contract.md` — ADR formalizing canonical interface
- `docs/DECISIONS.md` — ADR-019 row added

## Decision
`computeWikiHealth()` from `health-contract.js` is SSoT. `dashboard-api.js` must consume it (tracked in #1674).

Closes #1673
Refs #1626, #1625, #1674

Signed-by: Quill Mason
Team&Model: GitHub Copilot:Claude Sonnet 4.6
Role: collaborator