### PR TITLE
docs(governance): per-runtime hook event matrix #1804

### DIFF
--- a/.changes/unreleased/1804.md
+++ b/.changes/unreleased/1804.md
@@ -1,0 +1,13 @@
+### Added
+
+- **Per-runtime hook event registration matrix** in `instructions/canonical-governance-anti-duplication.instructions.md` (#1804). Documents the intentional asymmetry between Copilot and Codex adapters surfaced by the Epic #1798 stress test: Codex CLI natively emits 6 lifecycle events (SessionStart, PreToolUse, PermissionRequest, PostToolUse, UserPromptSubmit, Stop) per `https://developers.openai.com/codex/hooks`; Copilot (Auto-routing on Claude family) and Claude Code additionally emit `PreCompact` and `SubagentStart`. Adapters wire only events their native runtime fires.
+
+### Changed
+
+- `governance/README.md` adapter-onboarding checklist extended with step 6 (wire only natively-emitted lifecycle events) referencing the new matrix.
+
+### Closed AC1 reference
+
+Codex `PreCompact` feature request `openai/codex#12208` is closed as duplicate of `#2109` (still pending). When Codex CLI ships these events, revisit the matrix.
+
+Closes #1804

--- a/governance/README.md
+++ b/governance/README.md
@@ -65,6 +65,7 @@ npm run governance:cross-team-check     # verify 4 invariants present
 3. Add the corresponding entry-point file at the root (referencing this contract).
 4. Update `cross-team-contract-check.js` `ENTRY_POINTS` constant.
 5. Add tests covering the new adapter path.
+6. Wire only the lifecycle events the runtime natively emits — see the per-runtime event matrix in `instructions/canonical-governance-anti-duplication.instructions.md`.
 
 ## Related research
 

--- a/instructions/canonical-governance-anti-duplication.instructions.md
+++ b/instructions/canonical-governance-anti-duplication.instructions.md
@@ -106,6 +106,25 @@ The trade-off favored: **G5 (portability) + G9 (interoperability)** over **G7 (t
 
 Cross-team contract entry point: `governance/README.md`. Operators should consult that file as the canonical reference rather than relying on hook-driven warnings as a checklist.
 
+## Per-runtime hook event registration matrix (#1804 decision)
+
+Each adapter wires only the lifecycle events its native runtime emits. Wiring an event the runtime never fires would be dead code; omitting one it does fire would lose enforcement coverage. The matrix below documents the intentional asymmetry surfaced by the Epic #1798 stress test (Codex Step 8).
+
+| Event | Codex CLI | Copilot (Auto: Claude family) | Claude Code | Notes |
+|---|:---:|:---:|:---:|---|
+| `SessionStart` | ✓ | ✓ | n/a (skill) | All three fire; Claude Code handles via skill |
+| `UserPromptSubmit` | ✓ | ✓ | n/a (skill) | |
+| `PreToolUse` | ✓ | ✓ | n/a (skill) | |
+| `PostToolUse` | ✓ | ✓ | n/a (skill) | |
+| `Stop` | ✓ | ✓ | n/a (skill) | |
+| `PermissionRequest` | ✓ (Codex-only) | — | — | Codex-specific permission-mode event |
+| `PreCompact` | ✗ not emitted | ✓ | ✓ | Codex feature request `openai/codex#12208` closed as duplicate of `#2109` (still pending) |
+| `SubagentStart` | ✗ not emitted | ✓ | ✓ | Anthropic-runtime-native (Claude Code's `Agent` tool spawn); Copilot Auto-routing on Claude family inherits |
+
+Source: `https://developers.openai.com/codex/hooks` (Codex native event list = SessionStart + PreToolUse + PermissionRequest + PostToolUse + UserPromptSubmit + Stop, 2026).
+
+Operators should NOT attempt to add `PreCompact` or `SubagentStart` registration to `~/.codex/hooks.json` — Codex CLI will never fire them and the entries are inert. When Codex CLI gains these events (track `openai/codex#2109`), revisit this matrix.
+
 ## Enforcement
 
 Mandatory checks for governance changes:


### PR DESCRIPTION
## Summary

Closes #1804. Answers AC1 via research: Codex CLI natively emits 6 lifecycle events (SessionStart, PreToolUse, PermissionRequest, PostToolUse, UserPromptSubmit, Stop) per `developers.openai.com/codex/hooks`. PreCompact + SubagentStart are NOT in the native event set (`openai/codex#12208` closed as duplicate of `#2109`, still pending).

Refs #1804

## Decision (Option 3: Document asymmetry)

Each adapter wires only events its native runtime fires:
- **Codex** `~/.codex/hooks.json` — 5 of 6 (we don't use PermissionRequest)
- **Copilot** `~/.copilot/hooks/global-standards.json` — 7 (5 shared + PreCompact + SubagentStart from Claude family via Auto-routing)
- **Claude Code** `~/.claude/settings.json` — 0 (intentional exemption per #1798 F5)

Wiring inert events on Codex would be dead code; the apparent "drift" is correct per-runtime adaptation.

## Files

- `instructions/canonical-governance-anti-duplication.instructions.md` — added §"Per-runtime hook event registration matrix (#1804 decision)" with full 8-row matrix + source citation
- `governance/README.md` — adapter-onboarding step 6 added (cross-reference)
- `.changes/unreleased/1804.md` — fragment

## Test plan

- [x] `npm run lint` — 444 files ≤100
- [x] `npm run governance:cross-team-check` — pass
- [x] `npm run governance:hooks:test` — 11/11 regression-clean

## Baton artifacts

All 4 posted on #1804. Cross-family verdict via Qwen 7B (Alibaba): approve.

Closes #1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)