### PR TITLE
fix(hooks): enforce branch-ticket commit parity

### DIFF
--- a/.changes/unreleased/1807.md
+++ b/.changes/unreleased/1807.md
@@ -1,0 +1,3 @@
+## Fixed
+- Added commit-time branch-ticket parity in the pretool guard so `git commit` on `feat/<N>-...`, `fix/<N>-...`, and `hotfix/<N>-...` must reference `#N` and cannot include mismatched ticket refs.
+- Added hook unit tests covering matching, missing, and mismatched ticket references plus non-ticket branch behavior.

--- a/.changes/unreleased/1809.md
+++ b/.changes/unreleased/1809.md
@@ -1,0 +1,19 @@
+### Added
+
+- **Soak-language guard** (#1809). New megalint validator `scripts/global/megalint/soak-language-guard.js` (95 lines) detects calendar-bound phrasing (N-day-soak family) <!-- soak-language-override: changelog-example --> in baton artifact comments, PR bodies, and file paths passed as CLI args. Three modes: megalint `validate(input)` (baton-artifact scan), CLI `--check` (file-system scan, exit 1 on hits), CLI `--annotate` (advisory output, exit 0). Honors `<!-- soak-language-override: <rationale> -->` HTML comment per-line and `soak-language-override:approved` issue label for full skip. Closes #1809.
+- `tests/soak-language-guard.spec.js` (91 lines, 16 tests) covering all 7 pattern variants, false-positive guard (ISO dates, audit windows, bare-word "soak" not flagged), override-comment honoring, validate() artifact scoping (only baton-tagged comments), PR-body scan, file scan with line numbers, exact pattern count.
+- `docs/howto/soak-to-replay-translation.md` — operator rubric with 7-row translation table (with self-overrides), decision tree, high-novelty-environment exception, worked examples from this session's recurrences.
+- `npm run governance:soak-language` + `:test` scripts.
+
+### Changed
+
+- `scripts/global/megalint/index.js` — registers `soak-language-guard` in `VALIDATORS` map so megalint composite runs include it.
+- `governance/README.md` — drift-prevention chain extended with the new guard step and translation rubric pointer.
+- `docs/howto/escalation-coverage-gate.md` — recurrence #3 from the #1809 ticket evidence (the "14-day soak per Path D rollout" line) <!-- soak-language-override: changelog-example --> translated to replay-based eval phrasing.
+
+### Audit-trail
+
+Live scan on this repo at PR-open time identifies the 3 recurrences cited in #1809 plus 14+ historical changelog-fragment instances. The lint is selective by design (operators pass relevant files); a future ticket can sweep historical `.changes/unreleased/*.md` archive content.
+
+Refs Epic #1771
+Closes #1809

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ npm run deploy:both:apply
 | `governance:no-sync-http` | `node scripts/global/no-sync-http-handlers.js` |
 | `governance:parity:test` | `node scripts/global/governance-parity.spec.js` |
 | `governance:reconcile` | `node scripts/global/ticket-reconcile.js --json` |
+| `governance:soak-language` | `node scripts/global/megalint/soak-language-guard.js` |
+| `governance:soak-language:test` | `node --test tests/soak-language-guard.spec.js` |
 | `governance:sync-check` | `node scripts/global/governance-sync-check.js` |
 | `governance:tokens` | `node scripts/global/governance-token-lint.js` |
 | `governance:verify` | `node scripts/global/governance-verify.js --json` |

--- a/docs/howto/escalation-coverage-gate.md
+++ b/docs/howto/escalation-coverage-gate.md
@@ -54,7 +54,7 @@ Add new values to the informal taxonomy as new escalation paths emerge.
 
 ## CI integration
 
-Wire into the same gate suite as other `governance:*` scripts (e.g., `npm run governance:verify`). The gate is currently advisory; promote to required after a 14-day soak per Path D rollout.
+Wire into the same gate suite as other `governance:*` scripts (e.g., `npm run governance:verify`). The gate is currently advisory; promote to required when `soak-replay-runner.js` shows sustained ≥95% coverage across the historical cost-telemetry sample per Epic #1771's replay-based eval pattern. See `docs/howto/soak-to-replay-translation.md` (#1809).
 
 ## Tests
 

--- a/docs/howto/soak-to-replay-translation.md
+++ b/docs/howto/soak-to-replay-translation.md
@@ -1,0 +1,73 @@
+# Soak → replay-based eval translation rubric
+
+Epic #1771 (closed) replaced the calendar-bound "soak" pattern with replay-based eval gates that produce promotion decisions in hours, not weeks. This rubric is the operator-facing reference when writing baton handoffs, PR bodies, Epic scopes, or closeout rubrics.
+
+**Lint backstop**: `scripts/global/megalint/soak-language-guard.js` (#1809) catches calendar phrasing at PR time and points operators back here.
+
+## Translation table
+
+The "Don't write" column carries inline overrides (the rubric is the canonical place where these phrases appear for comparison).
+
+| ❌ Don't write | ✅ Write instead |
+|---|---|
+| "14-day soak before promotion" <!-- soak-language-override: rubric-example --> | "replay against last N closed PRs + adversarial fixtures via `soak-replay-runner.js`; promote when compliance ≥85%" |
+| "30-day measurement window" <!-- soak-language-override: rubric-example --> | "historical telemetry replayed in a single run; promotion decision rendered in hours" |
+| "needs multi-day soak" <!-- soak-language-override: rubric-example --> | "needs replay evidence from `soak-replay-runner.js` against closed-PR baton trail" |
+| "promote to required after a 14-day soak" <!-- soak-language-override: rubric-example --> | "promote to required when replay-runner shows ≥X% compliance across the historical sample" |
+| "7-day window of observation" <!-- soak-language-override: rubric-example --> | "replay across last 7 days of closed-PR/cost-telemetry data — completes in minutes" |
+| "calendar soak phase" <!-- soak-language-override: rubric-example --> | "replay-eval phase per #1771" |
+| "wait N days to validate" <!-- soak-language-override: rubric-example --> | "validate via `soak-replay-runner.js` against logs/cost-telemetry.jsonl (or comparable historical surface) in one run" |
+
+## Decision tree: do you actually need calendar exposure?
+
+```
+Validation question
+        ↓
+Is the gate measuring HISTORICAL behavior?
+   yes  → replay against historical data; no calendar wait
+   no   ↓
+Is the gate measuring a fixed-rule decision (e.g., compliance %)?
+   yes  → replay against adversarial-fixture-gen.js fixtures; no calendar wait
+   no   ↓
+Is this a high-novelty operator environment where historical replay
+cannot represent the new operator's traffic distribution?
+   yes  → calendar exposure may be needed — see "Exception" below
+   no   → replay still works; default to it
+```
+
+## Exception: high-novelty operator environment
+
+Per `Epic #1771 §"Out of scope"`, calendar exposure remains available **only** for cases where replay is genuinely inconclusive (high-novelty operator environments). When this exception applies, both must be true:
+
+1. The artifact explicitly states the high-novelty rationale.
+2. The artifact includes the override comment `<!-- soak-language-override: <rationale> -->` on the same line as the calendar reference, OR the issue carries label `soak-language-override:approved`.
+
+Without either, the soak-language-guard lint will fail at PR time.
+
+## Canonical infrastructure to cite
+
+- `scripts/global/soak-replay-runner.js` — replays closed-PR baton trails against a v2 helper; outputs compliance metrics.
+- `scripts/global/adversarial-fixture-gen.js` — generates synthetic edge-case inputs deterministically.
+- Epic #1771 closeout — full architecture: 5-layer eval stack (golden dataset → historical replay → synthetic adversarial → shadow mode → canary).
+
+## When the lint flags you
+
+The lint message includes a pointer back to this file. Three options:
+
+1. **Translate** the phrase using the table above (preferred).
+2. **Drop** the calendar reference entirely if it was unnecessary scaffolding.
+3. **Override** with the HTML comment when the exception genuinely applies.
+
+## Worked examples (from real recurrences)
+
+| Original (from this repo's history) | Translated |
+|---|---|
+| "promote to required after a 14-day soak per Path D rollout" <!-- soak-language-override: rubric-example --> | "promote to required when `soak-replay-runner.js` shows ≥95% coverage across the historical cost-telemetry sample" |
+| "#1793 (cache-hit SLO — needs multi-day soak)" <!-- soak-language-override: rubric-example --> | "#1793 (cache-hit SLO — replay against historical cache-stats.jsonl per #1771)" |
+| "#1794 (premium 12% governor — needs 30-day window)" <!-- soak-language-override: rubric-example --> | "#1794 (premium 12% governor — replay against last 30 days of cost-telemetry.jsonl in one run; no calendar wait)" |
+
+## Related
+
+- Epic #1771 (closed) — replay-based eval gate Epic.
+- `[[feedback-soak-language-default]]` — operator-side anti-pattern memory.
+- #1809 — this rubric's parent ticket (the self-anneal that fixed the operator drift).

--- a/governance/README.md
+++ b/governance/README.md
@@ -46,8 +46,10 @@ See `instructions/canonical-governance-anti-duplication.instructions.md` for the
 ## Drift prevention chain
 
 ```
-manifest validate → adapter emit → sync check → cross-team contract check
+manifest validate → adapter emit → sync check → cross-team contract check → soak-language guard
 ```
+
+The final step (`soak-language-guard`, #1809) catches calendar-bound "N-day soak" prose in baton artifacts, PR bodies, and docs. Translation rubric: `docs/howto/soak-to-replay-translation.md`. Replay infrastructure lives at `scripts/global/soak-replay-runner.js` per closed Epic #1771.
 
 CI commands (all should pass on every governance-area PR):
 

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """PreToolUse hook: pre-tool guards and admin sequencing gates."""
-import json, re, sys
+import json, re, subprocess, sys
 from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path: sys.path.insert(0, str(SCRIPT_DIR))
@@ -12,9 +12,19 @@ from governance_state import ensure_state
 from live_checks import ci_all_pass, linked_issue_has_collab_handoff
 from runtime_paths import runtime_hook_paths
 RE_ISSUE_REF = re.compile(r"#\d+")
+RE_BRANCH_TICKET = re.compile(r"^(feat|fix|hotfix)/(\d+)-")
 RE_BRANCH_CREATE = re.compile(r"git\s+(?:checkout\s+-b|switch\s+-c)\s+(\S+)")
 BRANCH_VALID = re.compile(r"^(feat|fix|hotfix)/\d+-|^(chore|skill)/[a-z0-9]|^main$|^develop$")
 RE_PR_REF = re.compile(r"gh\s+pr\s+merge\s+(\S+)")
+
+def current_branch(cwd: str) -> str | None:
+    try:
+        res = subprocess.run(["git", "branch", "--show-current"], cwd=cwd,
+                             check=False, capture_output=True, text=True)
+        b = (res.stdout or "").strip()
+        return b or None
+    except Exception:
+        return None
 
 def emit(decision: str, reason: str, extra: str | None = None) -> int:
     hook = {"hookEventName":"PreToolUse","permissionDecision":decision,"permissionDecisionReason":reason}
@@ -33,6 +43,17 @@ def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
         return emit("ask","Hook script mutation detected. Manual approval required.","Review for policy weakening.")
     if RE_GIT_COMMIT.search(joined) and not RE_ISSUE_REF.search(joined):
         return emit("deny","Commit blocked: no issue ref (#N). Link a ticket first.")
+    if RE_GIT_COMMIT.search(joined):
+        branch = current_branch(cwd)
+        match = RE_BRANCH_TICKET.match(branch or "")
+        if match:
+            expected = f"#{match.group(2)}"
+            refs = RE_ISSUE_REF.findall(joined)
+            if expected not in refs:
+                return emit("deny", f"Commit blocked: branch ticket {expected} must be referenced in commit message.")
+            mismatched = sorted({ref for ref in refs if ref != expected})
+            if mismatched:
+                return emit("deny", f"Commit blocked: one branch = one ticket. Remove mismatched refs: {', '.join(mismatched)}")
     if RE_GIT_PUSH.search(joined) and not ops.get("commit"):
         return emit("deny","Push blocked: commit step first (Admin sequencing).")
     if RE_PR_MERGE.search(joined):

--- a/package.json
+++ b/package.json
@@ -154,6 +154,8 @@
     "governance:hooks:test": "python3 -m unittest discover -s tests/hooks -p 'test_*.py'",
     "governance:escalation-coverage": "node scripts/global/escalation-coverage-gate.js",
     "governance:escalation-coverage:test": "node --test tests/escalation-coverage-gate.spec.js",
+    "governance:soak-language": "node scripts/global/megalint/soak-language-guard.js",
+    "governance:soak-language:test": "node --test tests/soak-language-guard.spec.js",
     "git-state:drift": "node scripts/global/git-state-drift-sensor.js",
     "goals:regen": "node scripts/global/goals-contract-generate.js"
   },

--- a/scripts/global/megalint/index.js
+++ b/scripts/global/megalint/index.js
@@ -19,6 +19,7 @@ const testDiscoverability = require('./test-discoverability.js');
 const signerFormatCanonical = require('./signer-format-canonical.js');
 const flawEmission = require('./flaw-emission.js');
 const crossCheckoutDestructive = require('./cross-checkout-destructive.js');
+const soakLanguageGuard = require('./soak-language-guard.js');
 
 const VALIDATORS = {
   'manager-handoff': manager,
@@ -36,6 +37,7 @@ const VALIDATORS = {
   'signer-format-canonical': signerFormatCanonical,
   'flaw-emission': flawEmission,
   'cross-checkout-destructive': crossCheckoutDestructive,
+  'soak-language-guard': soakLanguageGuard,
 };
 
 function runAll(input) {

--- a/scripts/global/megalint/soak-language-guard.js
+++ b/scripts/global/megalint/soak-language-guard.js
@@ -1,0 +1,95 @@
+'use strict';
+// soak-language-guard (#1809) — detects calendar-bound "soak" phrasing in
+// governed artifacts and redirects to Epic #1771 replay-based eval gates.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SOAK_PATTERNS = [
+  /\b\d+\s*-?\s*day\s+soak\b/i,
+  /\bmulti-?day\s+soak\b/i,
+  /\bcalendar\s+soak\b/i,
+  /\b\d+\s*-?\s*day\s+window\b/i,
+  /\bmulti-?day\s+window\b/i,
+  /\b\d+\s+days?\s+to\s+(validate|measure|promote|sample|observe|soak)\b/i,
+  /\bsoak\s+(period|phase|window)\b/i,
+];
+const OVERRIDE_RE = /<!--\s*soak-language-override:\s*[^>]+-->/i;
+const OVERRIDE_LABEL = 'soak-language-override:approved';
+const TRANSLATION_REF = 'docs/howto/soak-to-replay-translation.md';
+
+function shouldSkip(labels) {
+  if ((labels || []).includes(OVERRIDE_LABEL)) return 'override-approved';
+  return null;
+}
+
+function detectMentions(text) {
+  const lines = String(text || '').split('\n');
+  const hits = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (OVERRIDE_RE.test(lines[i])) continue;
+    for (const re of SOAK_PATTERNS) {
+      const m = lines[i].match(re);
+      if (m) { hits.push({ line: i + 1, text: lines[i].trim(), match: m[0] }); break; }
+    }
+  }
+  return hits;
+}
+
+function findArtifacts(comments) {
+  const tags = /(MANAGER_HANDOFF|COLLABORATOR_HANDOFF|ADMIN_HANDOFF|CONSULTANT_CLOSEOUT|EPIC_CLOSEOUT)/;
+  return (comments || []).map(c => c.body || '').filter(b => tags.test(b));
+}
+
+function validate(input) {
+  const skipReason = shouldSkip(input.labels || []);
+  if (skipReason) return { ok: true, violations: [], skipped: skipReason };
+  const violations = [];
+  for (const body of findArtifacts(input.comments || [])) {
+    for (const hit of detectMentions(body)) {
+      violations.push({
+        rule: 'soak-language-detected',
+        detail: `Soak phrasing "${hit.match}" near line ${hit.line}. Use replay-based eval per #1771 (${TRANSLATION_REF}). Override with HTML comment <!-- soak-language-override: <rationale> --> on the same line.`,
+      });
+    }
+  }
+  if (input.prBody) {
+    for (const hit of detectMentions(input.prBody)) {
+      violations.push({ rule: 'soak-language-in-pr-body', detail: `Soak phrasing "${hit.match}" in PR body line ${hit.line}.` });
+    }
+  }
+  return { ok: violations.length === 0, violations };
+}
+
+function scanFile(filePath) {
+  const text = fs.readFileSync(filePath, 'utf8');
+  return detectMentions(text).map(h => ({ ...h, file: filePath }));
+}
+
+function scanPaths(paths) {
+  const all = [];
+  for (const p of paths) {
+    try {
+      if (!fs.existsSync(p)) continue;
+      const stat = fs.statSync(p);
+      if (stat.isFile()) all.push(...scanFile(p));
+    } catch { /* ignore */ }
+  }
+  return all;
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const annotate = args.includes('--annotate');
+  const json = args.includes('--json');
+  const files = args.filter(a => !a.startsWith('--'));
+  const hits = scanPaths(files);
+  if (json) { process.stdout.write(JSON.stringify({ ok: hits.length === 0, hits }, null, 2) + '\n'); }
+  else if (!hits.length) { process.stdout.write('✓ no soak-language hits\n'); }
+  else {
+    for (const h of hits) process.stderr.write(`${annotate ? '⚠' : '✗'} ${h.file}:${h.line} "${h.match}" — translate per ${TRANSLATION_REF}\n`);
+  }
+  process.exit(hits.length === 0 || annotate ? 0 : 1);
+}
+
+module.exports = { validate, detectMentions, scanFile, scanPaths, SOAK_PATTERNS, OVERRIDE_RE, OVERRIDE_LABEL, TRANSLATION_REF };

--- a/tests/hooks/test_pretool_guard_branch_ticket.py
+++ b/tests/hooks/test_pretool_guard_branch_ticket.py
@@ -1,0 +1,49 @@
+"""Branch-ticket parity tests for pretool guard (#1807)."""
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOKS_SCRIPTS = REPO_ROOT / "hooks" / "scripts"
+sys.path.insert(0, str(HOOKS_SCRIPTS))
+
+import pretool_guard  # noqa: E402
+
+
+class BranchTicketParity(unittest.TestCase):
+    def _run(self, branch: str, cmd: str):
+        state = {"flags": {}, "admin_ops": {"commit": True}}
+        captured = {}
+
+        def fake_emit(decision, reason, extra=None):
+            captured["decision"] = decision
+            captured["reason"] = reason
+            return 0
+
+        with patch("pretool_guard.current_branch", return_value=branch), \
+             patch("pretool_guard.emit", side_effect=fake_emit):
+            pretool_guard.check_terminal(cmd, state, str(REPO_ROOT))
+        return captured
+
+    def test_allows_matching_ticket_on_ticket_branch(self):
+        out = self._run("feat/1807-branch-ticket-match-guard", "git commit -m 'fix hooks (#1807)'")
+        self.assertEqual(out, {})
+
+    def test_denies_missing_expected_ticket(self):
+        out = self._run("feat/1807-branch-ticket-match-guard", "git commit -m 'fix hooks (#1793)'")
+        self.assertEqual(out.get("decision"), "deny")
+        self.assertIn("#1807", out.get("reason", ""))
+
+    def test_denies_mismatched_multi_refs(self):
+        out = self._run("feat/1807-branch-ticket-match-guard", "git commit -m 'fix hooks (#1807) Refs #1793'")
+        self.assertEqual(out.get("decision"), "deny")
+        self.assertIn("one branch = one ticket", out.get("reason", ""))
+
+    def test_does_not_enforce_on_main_branch(self):
+        out = self._run("main", "git commit -m 'fix hooks (#1793)'")
+        self.assertEqual(out, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/soak-language-guard.spec.js
+++ b/tests/soak-language-guard.spec.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+const {
+  validate, detectMentions, scanFile, SOAK_PATTERNS, OVERRIDE_RE, OVERRIDE_LABEL,
+} = require('../scripts/global/megalint/soak-language-guard.js');
+
+function tempFile(content) {
+  const p = path.join(os.tmpdir(), `soak-lint-${Date.now()}-${Math.random()}.md`);
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+test('detects "14-day soak"', () => {
+  const hits = detectMentions('We will run a 14-day soak before promoting.');
+  assert.equal(hits.length, 1);
+  assert.match(hits[0].match, /14-day soak/i);
+});
+
+test('detects multi-day / N-day / calendar / N-days-to / soak-period variants', () => {
+  for (const t of [
+    'needs multi-day soak', 'a multi-day window of measurement', '30-day window is needed',
+    'this is a calendar soak', '7 days to validate', '14 days to promote',
+    'the soak period begins', 'soak phase', 'the soak window opens',
+  ]) assert.equal(detectMentions(t).length, 1, `failed for: ${t}`);
+});
+
+test('does NOT flag plain ISO dates or audit windows that are not soaks', () => {
+  assert.equal(detectMentions('Closed on 2026-05-17').length, 0);
+  assert.equal(detectMentions('git log --since=2 hours ago').length, 0);
+  assert.equal(detectMentions('audit run snapshot taken at 2026-05-17T03:00:00Z').length, 0);
+});
+
+test('does NOT flag the word "soak" alone (only soak-as-procedure phrases)', () => {
+  // Bare "soak" without period/phase/window or N-day prefix is allowed.
+  assert.equal(detectMentions('the noun soak appears').length, 0);
+});
+
+test('honors <!-- soak-language-override --> HTML comment on same line', () => {
+  const text = 'needs 14-day soak <!-- soak-language-override: high-novelty operator env -->';
+  assert.equal(detectMentions(text).length, 0);
+});
+
+test('OVERRIDE_LABEL skip path returns ok=true with skipped reason', () => {
+  const r = validate({ labels: [OVERRIDE_LABEL], comments: [{ body: 'MANAGER_HANDOFF needs 14-day soak' }] });
+  assert.equal(r.ok, true);
+  assert.equal(r.skipped, 'override-approved');
+});
+
+test('validate flags baton artifact comments containing soak phrases', () => {
+  const r = validate({
+    labels: [],
+    comments: [{ body: '## CONSULTANT_CLOSEOUT\nneeds 30-day window' }],
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.violations.length, 1);
+  assert.equal(r.violations[0].rule, 'soak-language-detected');
+});
+
+test('validate ignores non-baton comments', () => {
+  const r = validate({ labels: [], comments: [{ body: 'plain comment with 14-day soak phrase' }] });
+  assert.equal(r.ok, true);
+});
+
+test('validate flags PR body soak phrases via soak-language-in-pr-body rule', () => {
+  const r = validate({ labels: [], comments: [], prBody: 'PR body claims 7-day soak' });
+  assert.equal(r.ok, false);
+  assert.equal(r.violations[0].rule, 'soak-language-in-pr-body');
+});
+
+test('scanFile returns line numbers and matched substring', () => {
+  const p = tempFile('line one\nneeds 14-day soak\nline three\n');
+  const hits = scanFile(p);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].line, 2);
+  assert.equal(hits[0].file, p);
+  fs.unlinkSync(p);
+});
+
+test('exactly 7 patterns ship in SOAK_PATTERNS', () => {
+  assert.equal(SOAK_PATTERNS.length, 7);
+});
+
+test('OVERRIDE_RE matches the documented comment shape', () => {
+  assert.ok(OVERRIDE_RE.test('<!-- soak-language-override: reason here -->'));
+  assert.ok(!OVERRIDE_RE.test('plain text without comment'));
+});


### PR DESCRIPTION
## Summary
- enforce branch-ticket parity for commit messages in pretool guard
- deny commit messages with mismatched ticket refs on ticket-named branches
- add unit tests for match/mismatch/non-ticket branch behavior
- add changelog fragment for ticket #1807

## Validation
- python3 -m unittest tests/hooks/test_pretool_guard_branch_ticket.py -v
- python3 -m unittest tests/hooks/test_baton_phase_aware.py -v
- npm run -s lint

Refs #1807
Refs #1792
