### PR TITLE
fix(hooks): phase-guard userprompt_gate.py #1815

### DIFF
--- a/.changes/unreleased/1815.md
+++ b/.changes/unreleased/1815.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Phase-blind Admin warning in `userprompt_gate.py`** (#1815 — Epic #1798 missed surface). The UserPromptSubmit hook `hooks/scripts/userprompt_gate.py:_admin_missing` had the same phase-blindness bug as `stop_checks.check_admin_ops` (fixed in Epic #1798 F2), but lived in a second hook that the original audit didn't enumerate. Observed live in a Copilot Team session: prompt `"Complete the work on each of 1794, 1795, and 1796"` (a Manager-phase scoping request) emitted `"Governance gate: completion requested before required Admin steps were recorded"` even though no implementation had started. Fix: added the same `roles.collaborator` phase guard. Pre-collab returns empty missing-list; post-collab firing preserved.
+
+### Added
+
+- `tests/hooks/test_baton_phase_aware.py` — `UserPromptGatePhaseGuard` class covering pre-collab silence + post-collab firing of `userprompt_gate._admin_missing`. Total spec count: 13 (was 11).
+
+### Deployment
+
+After merge, operators on Copilot/Codex runtimes must run `npm run deploy:both:apply` to propagate the patched hook to `~/.copilot/hooks/scripts/userprompt_gate.py` and `~/.codex/devenv-ops/hooks/userprompt_gate.py`. Same pattern as Epic #1798 deploy.
+
+Refs Epic #1798 (sibling defect)
+Closes #1815

--- a/hooks/scripts/userprompt_gate.py
+++ b/hooks/scripts/userprompt_gate.py
@@ -25,6 +25,9 @@ _EXT_KEYS = ("publish", "release_integrity", "gh_release")
 
 
 def _admin_missing(state: dict) -> list[str]:
+    # Phase guard (#1815 / #1798 sibling): pre-collab "complete work on #N" is scoping, not finish.
+    if not state.get("roles", {}).get("collaborator", False):
+        return []
     flags, ops = state.get("flags", {}), state.get("admin_ops", {})
     missing = []
     if flags.get("code_touched"):

--- a/tests/hooks/test_baton_phase_aware.py
+++ b/tests/hooks/test_baton_phase_aware.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(HOOKS_SCRIPTS))
 import manager_ticket_gate  # noqa: E402
 import state_store  # noqa: E402
 import stop_checks  # noqa: E402
+import userprompt_gate  # noqa: E402
 
 
 class StopChecksPhaseGuard(unittest.TestCase):
@@ -104,6 +105,29 @@ class CurrentPhaseField(unittest.TestCase):
         # ensure_state writes defaults including current_phase.
         state = state_store.ensure_state(str(REPO_ROOT))
         self.assertIn("current_phase", state)
+
+
+class UserPromptGatePhaseGuard(unittest.TestCase):
+    """#1815 — userprompt_gate._admin_missing honors baton phase (Epic #1798 sibling)."""
+
+    def test_admin_missing_silent_pre_collab_even_with_code_touched(self):
+        # Reproduces the screenshot: prompt "Complete the work..." pre-collab.
+        state = {
+            "roles": {"manager": True, "collaborator": False, "admin": False, "consultant": False},
+            "flags": {"code_touched": True},
+            "admin_ops": {"commit": False, "push": False, "pr_create": False, "ci_green": False, "merge": False},
+        }
+        self.assertEqual(userprompt_gate._admin_missing(state), [])
+
+    def test_admin_missing_fires_post_collab(self):
+        state = {
+            "roles": {"manager": True, "collaborator": True, "admin": False, "consultant": False},
+            "flags": {"code_touched": True},
+            "admin_ops": {"commit": False, "push": False, "pr_create": False, "ci_green": False, "merge": False},
+        }
+        missing = userprompt_gate._admin_missing(state)
+        self.assertTrue(len(missing) > 0)
+        self.assertIn("commit", missing)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1815. Epic #1798 missed-surface sibling fix.

## Symptom (from Copilot Team session)

Prompt: `Complete the work on each of 1794, 1795, and 1796` (Manager-phase scoping) emitted:

> Warning from User Prompt Submit hook — Governance gate: completion requested before required Admin steps were recorded.

## Root cause

`hooks/scripts/userprompt_gate.py:_admin_missing` had the same phase-blindness bug as `stop_checks.check_admin_ops` (fixed via Epic #1798 #1799). The original audit (this turn earlier in session) enumerated `stop_checks.py` and `manager_ticket_gate.py` but missed the second UserPromptSubmit hook `userprompt_gate.py`.

## Fix

Added `roles.collaborator` phase guard. Pre-collab returns `[]`; post-collab firing preserved.

## Deploy required

After merge: `npm run deploy:both:apply` (parallel pattern to Epic #1798 deploy).

## Test plan

- 13/13 unittest cases pass (was 11; +2 for UserPromptGatePhaseGuard)
- lint clean

Refs Epic #1798
Closes #1815

🤖 Generated with [Claude Code](https://claude.com/claude-code)