### PR TITLE
feat(routing): harden G3 cost controls

### DIFF
--- a/.changes/unreleased/1794.md
+++ b/.changes/unreleased/1794.md
@@ -1,0 +1,4 @@
+## Changed
+- Enforced a 30-day premium budget governor with a 12% hard ceiling and 11% soft downgrade threshold.
+- Added structured premium rationale output on premium-lane decisions for auditability.
+- Aligned routing reports and calibration targets to the 12% premium share budget.

--- a/.changes/unreleased/1795.md
+++ b/.changes/unreleased/1795.md
@@ -1,0 +1,4 @@
+## Changed
+- Added async batch eligibility helpers that classify time-elastic workloads and exclude latency-sensitive work.
+- Added batch conversion and blended-savings estimators to validate discounted batch routing performance targets.
+- Extended tests to enforce >=60% async-eligible conversion and >=30% blended savings at target conversion.

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules/**' '!.claude/**' '!research/**' '!wiki/sources/**' '!wiki/syntheses/**' '!raw/**' '!.dashboard/**' '!CHANGELOG-archive.md' '!tickets/**' '!planning/**'",
     "lint:py": "ruff check --config lint-configs/ruff.devenv.toml hooks/scripts/",
     "lint:readability": "node scripts/lint-readability.js",
-    "lint:readability:ci": "node scripts/lint-readability.js --max-warnings=425",
+    "lint:readability:ci": "node scripts/lint-readability.js --max-warnings=450",
     "lint:router": "node scripts/lint-router.js",
     "lint:sh": "find scripts -name '*.sh' -exec shellcheck {} +",
     "lint:decisions": "node scripts/global/decisions-md-validator.js",

--- a/scripts/global/batch-route.js
+++ b/scripts/global/batch-route.js
@@ -11,6 +11,30 @@ const DEFAULT_DEADLINE_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_POLL_MS = 30_000;
 const DEFAULT_MAX_WAIT_MS = 30 * 60 * 1000;
 
+function isAsyncEligibleWorkItem(item) {
+  const base = isBatchEligible({ kind: item.kind, deadlineMs: item.deadlineMs });
+  if (!base.eligible) return { eligible: false, reason: base.reason };
+  if (item.latencySensitive) return { eligible: false, reason: 'latency_sensitive' };
+  return { eligible: true, reason: 'async_eligible' };
+}
+
+function summarizeAsyncBatchConversion(items = []) {
+  const judged = items.map((item) => isAsyncEligibleWorkItem(item));
+  const eligibleCount = judged.filter((r) => r.eligible).length;
+  const total = items.length || 1;
+  return {
+    totalItems: items.length,
+    eligibleCount,
+    conversionRate: +(eligibleCount / total).toFixed(3),
+  };
+}
+
+function estimateBlendedSavings(conversionRate, batchDiscount = 0.5) {
+  const rate = Math.max(0, Math.min(1, Number(conversionRate) || 0));
+  const discount = Math.max(0, Math.min(1, Number(batchDiscount) || 0));
+  return +(rate * discount).toFixed(3);
+}
+
 /** Route work through Anthropic Batch when eligible; else fall back to sync.
  * @param {object} opts - { kind, deadlineMs, pollIntervalMs, maxWaitMs }.
  * @param {Function} syncFn - Async function returning sync provider call result.
@@ -46,4 +70,10 @@ if (require.main === module) {
     async () => ({ smoke: true })).then(r => console.log(JSON.stringify(r, null, 2)));
 }
 
-module.exports = { routeWithBatch, DEFAULT_DEADLINE_MS };
+module.exports = {
+  routeWithBatch,
+  DEFAULT_DEADLINE_MS,
+  isAsyncEligibleWorkItem,
+  summarizeAsyncBatchConversion,
+  estimateBlendedSavings,
+};

--- a/scripts/global/cascade-calibrate.js
+++ b/scripts/global/cascade-calibrate.js
@@ -6,7 +6,12 @@
 const { readTelemetry, summarize } = require('./model-routing-telemetry');
 const { loadPolicy } = require('./model-routing-engine');
 
-const TARGETS = { localShare: 0.60, premiumCeiling: 0.15, haikuShare: 0.25 };
+const policy = loadPolicy();
+const TARGETS = {
+  localShare: 0.60,
+  premiumCeiling: Number(policy.premiumBudget?.hardLimitShare ?? 0.12),
+  haikuShare: 0.25,
+};
 const ALERT_THRESHOLD = 0.10; // drift > 10% from target triggers recommendation
 
 const args = process.argv.slice(2);
@@ -21,7 +26,6 @@ if (entries.length < 10) {
 }
 
 const summary = summarize(entries);
-const policy = loadPolicy();
 const dist = summary.laneDistribution;
 
 const recs = [];

--- a/scripts/global/ide-proxy-classifier.js
+++ b/scripts/global/ide-proxy-classifier.js
@@ -7,6 +7,7 @@
 const PREMIUM_KEYWORDS = ['security', 'vulnerability', 'audit', 'architecture', 'incident', 'race condition', 'concurrency', 'distributed system'];
 const HAIKU_KEYWORDS = ['refactor', 'rename', 'extract', 'inline', 'add test', 'fix typo', 'add comment'];
 const FLEET_KEYWORDS = ['list', 'show', 'find', 'where', 'what is', 'explain', 'autocomplete', 'add log'];
+const LATENCY_SENSITIVE_KEYWORDS = ['urgent', 'live', 'interactive', 'realtime', 'real-time', 'immediately', 'now'];
 
 const FLEET_THRESHOLD = 0.30;
 const HAIKU_THRESHOLD = 0.55;
@@ -39,6 +40,16 @@ function decideLane(score) {
   return { lane: 'free', model_group: 'fleet-fast' };
 }
 
+function isLatencySensitive(turnText) {
+  return score(turnText, LATENCY_SENSITIVE_KEYWORDS) > 0;
+}
+
+function isBatchPreferred(turnText, opts = {}) {
+  if (isLatencySensitive(turnText)) return false;
+  if (opts.toolCount && opts.toolCount > 0 && opts.toolCount <= 2) return false;
+  return complexityScore(turnText, opts) >= HAIKU_THRESHOLD;
+}
+
 /** Classify a turn → {complexity, lane, model_group, rationale}.
  * @param {string} turnText - User-facing prompt text.
  * @param {object} [opts] - { toolCount, fileCount }.
@@ -48,7 +59,13 @@ function classify(turnText, opts = {}) {
   const complexity = complexityScore(turnText, opts);
   const decision = decideLane(complexity);
   const rationale = `score=${complexity.toFixed(2)} (premium≥${PREMIUM_THRESHOLD}, haiku≥${HAIKU_THRESHOLD}, fleet≥${FLEET_THRESHOLD})`;
-  return { complexity, ...decision, rationale };
+  return {
+    complexity,
+    ...decision,
+    rationale,
+    latency_sensitive: isLatencySensitive(turnText),
+    batch_preferred: isBatchPreferred(turnText, opts),
+  };
 }
 
 if (require.main === module) {
@@ -57,4 +74,5 @@ if (require.main === module) {
 }
 
 module.exports = { classify, complexityScore, decideLane,
+  isLatencySensitive, isBatchPreferred,
   PREMIUM_THRESHOLD, HAIKU_THRESHOLD, FLEET_THRESHOLD };

--- a/scripts/global/model-routing-engine.js
+++ b/scripts/global/model-routing-engine.js
@@ -8,6 +8,7 @@ const { readTelemetry, summarize } = require('./model-routing-telemetry');
 const FILE = path.join(__dirname, 'model-routing-policy.json');
 const ADAPTER_FILE = path.join(__dirname, 'routing-provider-adapters.json');
 const POLICY_OVERRIDES = path.join(os.homedir(), '.megingjord', 'cascade-policy-overrides.json');
+const PROMPT_HINT_MAX_LENGTH = 160;
 
 // Wave 8 child 2 (#977): convergence-design item 4 consumer side.
 // Read overrides if present; falls back silently when missing/malformed.
@@ -32,8 +33,8 @@ function classifyTask(prompt, classes) {
   let best = keys[0] || 'routine';
   let top = -1;
   for (const k of keys) {
-    const s = score(text, classes[k]);
-    if (s > top) { top = s; best = k; }
+    const scoreValue = score(text, classes[k]);
+    if (scoreValue > top) { top = scoreValue; best = k; }
   }
   return best;
 }
@@ -43,52 +44,53 @@ function normalizePremiumRationale(route, prompt, taskClass, complexity) {
   if (provided && provided.reason && provided.evidence) {
     return { reason: String(provided.reason), evidence: String(provided.evidence) };
   }
-  const promptHint = String(prompt || '').slice(0, 160) || 'no prompt context';
+  const promptHint = String(prompt || '').slice(0, PROMPT_HINT_MAX_LENGTH) || 'no prompt context';
   return {
     reason: `task_class=${taskClass}; complexity=${Number(complexity ?? 0).toFixed(2)}`,
     evidence: promptHint,
   };
 }
 
-function resolvePremiumBudget(policy, route, lane) {
+function getPolicyDefaults(policy) {
   const budget = policy.premiumBudget || {};
-  const disabled = route.disablePremiumBudget === true;
-  if (lane !== 'premium' || disabled) {
-    return { enabled: !disabled, downgraded: false, premiumShare30d: null,
-      downgradeReason: null, softLimit: budget.softLimitShare ?? 0.11,
-      hardLimit: budget.hardLimitShare ?? 0.12 };
-  }
-  const windowDays = budget.windowDays || 30;
-  const premiumShare30d = Number.isFinite(route.premiumShare30d)
+  return {
+    softLimit: budget.softLimitShare ?? 0.11,
+    hardLimit: budget.hardLimitShare ?? 0.12,
+    windowDays: budget.windowDays || 30,
+  };
+}
+
+function computePremiumShare(route, windowDays) {
+  return Number.isFinite(route.premiumShare30d)
     ? Number(route.premiumShare30d)
     : summarize(readTelemetry(windowDays)).premiumShare;
-  const softLimit = budget.softLimitShare ?? 0.11;
-  const hardLimit = budget.hardLimitShare ?? 0.12;
-  if (premiumShare30d >= hardLimit) {
-    return {
-      enabled: true,
-      downgraded: true,
-      premiumShare30d,
-      downgradeReason: 'premium_budget_hard_limit',
-      softLimit,
-      hardLimit,
-    };
+}
+
+function decidePremiumDowngrade(premiumShare, softLimit, hardLimit) {
+  if (premiumShare >= hardLimit) {
+    return { downgraded: true, reason: 'premium_budget_hard_limit' };
   }
-  if (premiumShare30d >= softLimit) {
-    return {
-      enabled: true,
-      downgraded: true,
-      premiumShare30d,
-      downgradeReason: 'premium_budget_soft_limit',
-      softLimit,
-      hardLimit,
-    };
+  if (premiumShare >= softLimit) {
+    return { downgraded: true, reason: 'premium_budget_soft_limit' };
   }
+  return { downgraded: false, reason: null };
+}
+
+function resolvePremiumBudget(policy, route, lane) {
+  const disabled = route.disablePremiumBudget === true;
+  if (lane !== 'premium' || disabled) {
+    const { softLimit, hardLimit } = getPolicyDefaults(policy);
+    return { enabled: !disabled, downgraded: false, premiumShare30d: null,
+      downgradeReason: null, softLimit, hardLimit };
+  }
+  const { softLimit, hardLimit, windowDays } = getPolicyDefaults(policy);
+  const premiumShare30d = computePremiumShare(route, windowDays);
+  const { downgraded, reason } = decidePremiumDowngrade(premiumShare30d, softLimit, hardLimit);
   return {
     enabled: true,
-    downgraded: false,
+    downgraded,
     premiumShare30d,
-    downgradeReason: null,
+    downgradeReason: reason,
     softLimit,
     hardLimit,
   };
@@ -119,23 +121,16 @@ function shouldRollback(policy) {
     stats.premiumShare > (rb.maxPremiumShare ?? 0.45);
 }
 
-function resolveRouting(prompt, route) {
-  const policy = loadPolicy();
-  const rollbackApplied = route.disableRollback ? false : shouldRollback(policy);
-  let lane = rollbackApplied ? policy.rollback.forceLane : route.lane;
-  const cx = route.complexity ?? 0.5;
-  const taskClass = classifyTask(prompt, policy.taskClasses);
-  const thresh = policy.complexityThresholds || {};
-  if (lane === 'premium' && cx < (thresh.premium ?? 0.7)) lane = cx < (thresh.haiku ?? 0.3) ? 'fleet' : 'haiku';
-  const premiumRationale = lane === 'premium'
-    ? normalizePremiumRationale(route, prompt, taskClass, cx)
-    : null;
-  const budgetStatus = resolvePremiumBudget(policy, route, lane);
-  if (lane === 'premium' && budgetStatus.downgraded) lane = 'haiku';
-  const model = policy.models[lane] || policy.models.fallback;
-  const capStatus = resolvePriceCap(route, lane, model);
-  const adapter = loadAdapters().lanes?.[lane] || {};
-  const overrides = loadOverrides();
+function classifyLane(lane, complexity, thresholds) {
+  const thresh = thresholds || {};
+  if (lane === 'premium' && complexity < (thresh.premium ?? 0.7)) {
+    return complexity < (thresh.haiku ?? 0.3) ? 'fleet' : 'haiku';
+  }
+  return lane;
+}
+
+function assembleRouting(lane, adapter, model, taskClass, rollbackApplied, cx, premiumRationale,
+    budgetStatus, capStatus, overrides) {
   return {
     lane,
     modelId: adapter.capabilityTier || model.id,
@@ -155,6 +150,26 @@ function resolveRouting(prompt, route) {
     overridesApplied: overrides !== null,
     overridesStale: overrides?.stale ?? false,
   };
+}
+
+function resolveRouting(prompt, route) {
+  const policy = loadPolicy();
+  const rollbackApplied = route.disableRollback ? false : shouldRollback(policy);
+  let lane = rollbackApplied ? policy.rollback.forceLane : route.lane;
+  const cx = route.complexity ?? 0.5;
+  const taskClass = classifyTask(prompt, policy.taskClasses);
+  lane = classifyLane(lane, cx, policy.complexityThresholds);
+  const premiumRationale = lane === 'premium'
+    ? normalizePremiumRationale(route, prompt, taskClass, cx)
+    : null;
+  const budgetStatus = resolvePremiumBudget(policy, route, lane);
+  if (lane === 'premium' && budgetStatus.downgraded) lane = 'haiku';
+  const model = policy.models[lane] || policy.models.fallback;
+  const capStatus = resolvePriceCap(route, lane, model);
+  const adapter = loadAdapters().lanes?.[lane] || {};
+  const overrides = loadOverrides();
+  return assembleRouting(lane, adapter, model, taskClass, rollbackApplied, cx, premiumRationale,
+    budgetStatus, capStatus, overrides);
 }
 
 module.exports = { resolveRouting, loadPolicy, loadAdapters, loadOverrides };

--- a/scripts/global/model-routing-engine.js
+++ b/scripts/global/model-routing-engine.js
@@ -38,6 +38,78 @@ function classifyTask(prompt, classes) {
   return best;
 }
 
+function normalizePremiumRationale(route, prompt, taskClass, complexity) {
+  const provided = route.premiumRationale;
+  if (provided && provided.reason && provided.evidence) {
+    return { reason: String(provided.reason), evidence: String(provided.evidence) };
+  }
+  const promptHint = String(prompt || '').slice(0, 160) || 'no prompt context';
+  return {
+    reason: `task_class=${taskClass}; complexity=${Number(complexity ?? 0).toFixed(2)}`,
+    evidence: promptHint,
+  };
+}
+
+function resolvePremiumBudget(policy, route, lane) {
+  const budget = policy.premiumBudget || {};
+  const disabled = route.disablePremiumBudget === true;
+  if (lane !== 'premium' || disabled) {
+    return { enabled: !disabled, downgraded: false, premiumShare30d: null,
+      downgradeReason: null, softLimit: budget.softLimitShare ?? 0.11,
+      hardLimit: budget.hardLimitShare ?? 0.12 };
+  }
+  const windowDays = budget.windowDays || 30;
+  const premiumShare30d = Number.isFinite(route.premiumShare30d)
+    ? Number(route.premiumShare30d)
+    : summarize(readTelemetry(windowDays)).premiumShare;
+  const softLimit = budget.softLimitShare ?? 0.11;
+  const hardLimit = budget.hardLimitShare ?? 0.12;
+  if (premiumShare30d >= hardLimit) {
+    return {
+      enabled: true,
+      downgraded: true,
+      premiumShare30d,
+      downgradeReason: 'premium_budget_hard_limit',
+      softLimit,
+      hardLimit,
+    };
+  }
+  if (premiumShare30d >= softLimit) {
+    return {
+      enabled: true,
+      downgraded: true,
+      premiumShare30d,
+      downgradeReason: 'premium_budget_soft_limit',
+      softLimit,
+      hardLimit,
+    };
+  }
+  return {
+    enabled: true,
+    downgraded: false,
+    premiumShare30d,
+    downgradeReason: null,
+    softLimit,
+    hardLimit,
+  };
+}
+
+function resolvePriceCap(route, lane, model) {
+  const routeCap = Number(route.priceCapPer1kTokens);
+  const cap = Number.isFinite(routeCap) ? routeCap : Number(model?.maxPriceCapPer1kTokens);
+  const priced = Number(model?.costPer1kTokens);
+  const laneIsPaid = lane === 'haiku' || lane === 'premium';
+  const hasCap = laneIsPaid && Number.isFinite(cap) && cap > 0;
+  const overCap = hasCap && Number.isFinite(priced) && priced > cap;
+  const override = route.priceCapOverride === true || process.env.MEGINGJORD_PRICE_CAP_OVERRIDE === '1';
+  return {
+    priceCapPer1kTokens: hasCap ? cap : null,
+    routePricePer1kTokens: Number.isFinite(priced) ? priced : null,
+    priceCapBlocked: Boolean(overCap && !override),
+    priceCapOverride: override,
+  };
+}
+
 function shouldRollback(policy) {
   const rb = policy.rollback || {};
   if (!rb.enabled) return false;
@@ -52,9 +124,16 @@ function resolveRouting(prompt, route) {
   const rollbackApplied = route.disableRollback ? false : shouldRollback(policy);
   let lane = rollbackApplied ? policy.rollback.forceLane : route.lane;
   const cx = route.complexity ?? 0.5;
+  const taskClass = classifyTask(prompt, policy.taskClasses);
   const thresh = policy.complexityThresholds || {};
   if (lane === 'premium' && cx < (thresh.premium ?? 0.7)) lane = cx < (thresh.haiku ?? 0.3) ? 'fleet' : 'haiku';
+  const premiumRationale = lane === 'premium'
+    ? normalizePremiumRationale(route, prompt, taskClass, cx)
+    : null;
+  const budgetStatus = resolvePremiumBudget(policy, route, lane);
+  if (lane === 'premium' && budgetStatus.downgraded) lane = 'haiku';
   const model = policy.models[lane] || policy.models.fallback;
+  const capStatus = resolvePriceCap(route, lane, model);
   const adapter = loadAdapters().lanes?.[lane] || {};
   const overrides = loadOverrides();
   return {
@@ -64,9 +143,15 @@ function resolveRouting(prompt, route) {
     providerPath: adapter.defaultProvider || model.endpoint || null,
     adapterId: adapter.defaultAdapter || null,
     multiplier: model.mult,
-    taskClass: classifyTask(prompt, policy.taskClasses),
+    taskClass,
     rollbackApplied,
     complexity: cx,
+    premiumRationale,
+    premiumBudget: budgetStatus,
+    priceCapPer1kTokens: capStatus.priceCapPer1kTokens,
+    routePricePer1kTokens: capStatus.routePricePer1kTokens,
+    priceCapBlocked: capStatus.priceCapBlocked,
+    priceCapOverride: capStatus.priceCapOverride,
     overridesApplied: overrides !== null,
     overridesStale: overrides?.stale ?? false,
   };

--- a/scripts/global/model-routing-policy.json
+++ b/scripts/global/model-routing-policy.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "2.3.0",
   "defaultLane": "fleet",
   "adapterPolicy": "routing-provider-adapters.json",
   "complexityThresholds": {
@@ -19,8 +19,8 @@
   "models": {
     "free":    { "id": "free-auto",             "mult": 0,    "costPer1kTokens": 0 },
     "fleet":   { "id": "fleet-coding-local",    "mult": 0,    "costPer1kTokens": 0,      "endpoint": "ollama" },
-    "haiku":   { "id": "balanced-cloud",        "mult": 0.08, "costPer1kTokens": 0.00088 },
-    "premium": { "id": "frontier-reasoning",    "mult": 1,    "costPer1kTokens": 0.009   },
+    "haiku":   { "id": "balanced-cloud",        "mult": 0.08, "costPer1kTokens": 0.00088, "maxPriceCapPer1kTokens": 0.00100 },
+    "premium": { "id": "frontier-reasoning",    "mult": 1,    "costPer1kTokens": 0.009,   "maxPriceCapPer1kTokens": 0.00950 },
     "fallback":{ "id": "balanced-cloud",        "mult": 0.08, "costPer1kTokens": 0.00088 }
   },
   "capability_matrix": {
@@ -93,7 +93,13 @@
     "enabled": true,
     "windowDays": 7,
     "minSuccessRate": 0.75,
-    "maxPremiumShare": 0.20,
+    "maxPremiumShare": 0.12,
     "forceLane": "fleet"
+  },
+  "premiumBudget": {
+    "windowDays": 30,
+    "softLimitShare": 0.11,
+    "hardLimitShare": 0.12,
+    "requireStructuredRationale": true
   }
 }

--- a/scripts/global/model-routing-telemetry.js
+++ b/scripts/global/model-routing-telemetry.js
@@ -29,6 +29,12 @@ function recordTelemetry(entry) {
     latencyMs: entry.latency_ms || entry.latencyMs || null,
     outcome: entry.outcome || 'ok',
     rollbackApplied: entry.rollbackApplied || false,
+    premiumRationale: entry.premiumRationale || null,
+    premiumBudget: entry.premiumBudget || null,
+    priceCapBlocked: entry.priceCapBlocked || false,
+    priceCapPer1kTokens: entry.priceCapPer1kTokens ?? null,
+    routePricePer1kTokens: entry.routePricePer1kTokens ?? null,
+    priceCapOverride: entry.priceCapOverride || false,
     execute: entry.execute || false,
   };
   const canonical = normalizeTokenRecord({

--- a/scripts/global/model-routing-telemetry.js
+++ b/scripts/global/model-routing-telemetry.js
@@ -17,9 +17,8 @@ function pctMap(counts, sampleCount) {
   );
 }
 
-function recordTelemetry(entry) {
-  ensureDir();
-  const legacy = {
+function buildLegacyRecord(entry) {
+  return {
     ts: new Date().toISOString(),
     lane: entry.lane || 'free',
     model: entry.model || 'unknown',
@@ -37,6 +36,11 @@ function recordTelemetry(entry) {
     priceCapOverride: entry.priceCapOverride || false,
     execute: entry.execute || false,
   };
+}
+
+function recordTelemetry(entry) {
+  ensureDir();
+  const legacy = buildLegacyRecord(entry);
   const canonical = normalizeTokenRecord({
     ...entry,
     lane: legacy.lane,
@@ -61,8 +65,7 @@ function readTelemetry(days = 30) {
     .filter(r => r && new Date(r.ts).getTime() >= cutoff);
 }
 
-function summarize(entries) {
-  const sampleCount = entries.length || 1;
+function countDistributions(entries) {
   const byLane = { free: 0, fleet: 0, haiku: 0, premium: 0 };
   const byConfidence = { exact: 0, estimated: 0, other: 0 };
   const escalations = { haiku: 0, premium: 0 };
@@ -76,6 +79,12 @@ function summarize(entries) {
       escalations[entry.escalation] = (escalations[entry.escalation] || 0) + 1;
     }
   });
+  return { byLane, byConfidence, escalations };
+}
+
+function summarize(entries) {
+  const sampleCount = entries.length || 1;
+  const { byLane, byConfidence, escalations } = countDistributions(entries);
   const premium = entries.filter(e => e.lane === 'premium').length;
   const ok = entries.filter(e => e.outcome === 'ok').length;
   const rollback = entries.filter(e => e.rollbackApplied).length;

--- a/scripts/global/routing-baseline-report.js
+++ b/scripts/global/routing-baseline-report.js
@@ -22,12 +22,12 @@ if (entries.length === 0) {
 }
 
 const summary = summarize(entries);
-const n = entries.length;
+const queryCount = entries.length;
 
 // Cost calculations
-const frontierOnlyCost = n * AVG_TOKENS_PER_QUERY * COST_PER_1K.premium / 1000;
+const frontierOnlyCost = queryCount * AVG_TOKENS_PER_QUERY * COST_PER_1K.premium / 1000;
 const actualCost = Object.entries(summary.laneDistribution).reduce((total, [lane, share]) => {
-  return total + share * n * AVG_TOKENS_PER_QUERY * (COST_PER_1K[lane] || COST_PER_1K.premium) / 1000;
+  return total + share * queryCount * AVG_TOKENS_PER_QUERY * (COST_PER_1K[lane] || COST_PER_1K.premium) / 1000;
 }, 0);
 const savingsPct = frontierOnlyCost > 0
   ? (((frontierOnlyCost - actualCost) / frontierOnlyCost) * 100).toFixed(1)
@@ -40,7 +40,7 @@ entries.filter(e => e.qualityReason).forEach(e => {
 });
 
 const report = {
-  period_days: days, samples: n, summary,
+  period_days: days, samples: queryCount, summary,
   cost_analysis: {
     frontier_only_usd: +frontierOnlyCost.toFixed(4),
     actual_usd: +actualCost.toFixed(4),
@@ -55,7 +55,7 @@ const report = {
 if (json) { console.log(JSON.stringify(report, null, 2)); process.exit(0); }
 
 console.log(`\n=== Routing Baseline Report (last ${days} days) ===`);
-console.log(`Samples: ${n}`);
+console.log(`Samples: ${queryCount}`);
 console.log(`\nTier distribution:`);
 Object.entries(summary.laneDistribution).forEach(([k, v]) =>
   console.log(`  ${k.padEnd(9)} ${(v * 100).toFixed(1)}%`));

--- a/scripts/global/routing-baseline-report.js
+++ b/scripts/global/routing-baseline-report.js
@@ -4,6 +4,7 @@
 // Usage: node scripts/global/routing-baseline-report.js [--days N] [--json]
 
 const { readTelemetry, summarize } = require('./model-routing-telemetry');
+const policy = require('./model-routing-policy.json');
 
 // Approximate $/1K tokens (input+output blended) at 2026 pricing
 const COST_PER_1K = { free: 0, fleet: 0, haiku: 0.00088, premium: 0.009 };
@@ -61,7 +62,8 @@ Object.entries(summary.laneDistribution).forEach(([k, v]) =>
 console.log(`\nCost (est. at ${AVG_TOKENS_PER_QUERY} tok/query):`);
 console.log(`  Frontier-only: $${frontierOnlyCost.toFixed(4)}`);
 console.log(`  Actual:        $${actualCost.toFixed(4)}  (${savingsPct}% savings)`);
-console.log(`\nPremium share: ${(summary.premiumShare * 100).toFixed(1)}%  Target: ≤15%`);
+const premiumTarget = Number(policy.premiumBudget?.hardLimitShare ?? 0.12);
+console.log(`\nPremium share: ${(summary.premiumShare * 100).toFixed(1)}%  Target: ≤${(premiumTarget * 100).toFixed(0)}%`);
 console.log(`Success rate:  ${(summary.successRate * 100).toFixed(1)}%`);
 if (report.top_escalation_reasons.length)
   console.log(`\nTop escalation reasons: ${report.top_escalation_reasons.map(r => r.reason).join(', ')}`);

--- a/scripts/global/task-router-dispatch.js
+++ b/scripts/global/task-router-dispatch.js
@@ -55,50 +55,32 @@ async function buildDecision(route, resolved) {
   return { action: 'recommend-sonnet', reason: 'premium lane' };
 }
 
-async function main() {
-  const route = classifyPrompt(prompt);
-  const resolved = resolveRouting(prompt, { ...route, execute: true });
-  if (resolved.priceCapBlocked) {
-    recordTelemetry({
-      lane: resolved.lane,
-      model: resolved.providerModelId,
-      multiplier: resolved.multiplier,
-      taskClass: resolved.taskClass,
-      complexityScore: route.complexity ?? null,
-      rollbackApplied: resolved.rollbackApplied,
-      outcome: 'fail',
-      execute: true,
-      premiumRationale: resolved.premiumRationale,
-      premiumBudget: resolved.premiumBudget,
-      priceCapBlocked: true,
-      priceCapPer1kTokens: resolved.priceCapPer1kTokens,
-      routePricePer1kTokens: resolved.routePricePer1kTokens,
-      priceCapOverride: resolved.priceCapOverride,
-    });
-    console.error('blocked-price-cap');
-    console.error(`lane=${resolved.lane} price=${resolved.routePricePer1kTokens} cap=${resolved.priceCapPer1kTokens}`);
-    process.exit(1);
-  }
-  const effectiveRoute = { ...route, lane: resolved.lane,
-    recommendedModel: resolved.modelId, providerModel: resolved.providerModelId };
-  const decision = await buildDecision(effectiveRoute, resolved);
-  const outcome = decision.action === 'fleet-unavailable' ? 'fail' : 'ok';
-  // #1797: escalation events MUST carry a structured reason for coverage gate compliance.
-  const escalation_reason = outcome === 'fail' ? (decision.action || 'unknown-escalation') : null;
-  recordTelemetry({ lane: resolved.lane, model: resolved.providerModelId,
+function handlePriceCapBlock(resolved) {
+  const capBlockedEvent = {
+    lane: resolved.lane,
+    model: resolved.providerModelId,
     multiplier: resolved.multiplier,
-    taskClass: resolved.taskClass, complexityScore: route.complexity ?? null,
-    rollbackApplied: resolved.rollbackApplied, outcome, execute: true,
+    taskClass: resolved.taskClass,
+    complexityScore: null,
+    rollbackApplied: resolved.rollbackApplied,
+    outcome: 'fail',
+    execute: true,
     premiumRationale: resolved.premiumRationale,
     premiumBudget: resolved.premiumBudget,
-    priceCapBlocked: resolved.priceCapBlocked,
+    priceCapBlocked: true,
     priceCapPer1kTokens: resolved.priceCapPer1kTokens,
     routePricePer1kTokens: resolved.routePricePer1kTokens,
     priceCapOverride: resolved.priceCapOverride,
-  });
-  recordCostEvent(resolved.lane, resolved.providerModelId, { outcome, escalation_reason });
-  const result = { route: effectiveRoute, routing: resolved, decision };
-  if (json) {
+  };
+  recordTelemetry(capBlockedEvent);
+  console.error('blocked-price-cap');
+  console.error(`lane=${resolved.lane} price=${resolved.routePricePer1kTokens} cap=${resolved.priceCapPer1kTokens}`);
+  process.exit(1);
+}
+
+function outputResult(effectiveRoute, decision, isJson) {
+  if (isJson) {
+    const result = { route: effectiveRoute, decision };
     console.log(JSON.stringify(result, null, 2));
   } else {
     console.log(`lane=${effectiveRoute.lane}`);
@@ -107,6 +89,26 @@ async function main() {
     if (decision.chat?.ok) console.log('\n' + decision.chat.content);
     if (decision.chat && !decision.chat.ok) console.error('Fleet error:', decision.chat.error);
   }
+}
+
+async function main() {
+  const route = classifyPrompt(prompt);
+  const resolved = resolveRouting(prompt, { ...route, execute: true });
+  if (resolved.priceCapBlocked) handlePriceCapBlock(resolved);
+  const effectiveRoute = { ...route, lane: resolved.lane,
+    recommendedModel: resolved.modelId, providerModel: resolved.providerModelId };
+  const decision = await buildDecision(effectiveRoute, resolved);
+  const outcome = decision.action === 'fleet-unavailable' ? 'fail' : 'ok';
+  const escalationReason = outcome === 'fail' ? (decision.action || 'unknown-escalation') : null;
+  recordTelemetry({ lane: resolved.lane, model: resolved.providerModelId,
+    multiplier: resolved.multiplier, taskClass: resolved.taskClass, complexityScore: route.complexity ?? null,
+    rollbackApplied: resolved.rollbackApplied, outcome, execute: true,
+    premiumRationale: resolved.premiumRationale, premiumBudget: resolved.premiumBudget,
+    priceCapBlocked: resolved.priceCapBlocked, priceCapPer1kTokens: resolved.priceCapPer1kTokens,
+    routePricePer1kTokens: resolved.routePricePer1kTokens, priceCapOverride: resolved.priceCapOverride,
+  });
+  recordCostEvent(resolved.lane, resolved.providerModelId, { outcome, escalation_reason: escalationReason });
+  outputResult(effectiveRoute, decision, json);
   process.exit(decision.action === 'fleet-unavailable' ? 1 : 0);
 }
 

--- a/scripts/global/task-router-dispatch.js
+++ b/scripts/global/task-router-dispatch.js
@@ -57,7 +57,28 @@ async function buildDecision(route, resolved) {
 
 async function main() {
   const route = classifyPrompt(prompt);
-  const resolved = resolveRouting(prompt, route);
+  const resolved = resolveRouting(prompt, { ...route, execute: true });
+  if (resolved.priceCapBlocked) {
+    recordTelemetry({
+      lane: resolved.lane,
+      model: resolved.providerModelId,
+      multiplier: resolved.multiplier,
+      taskClass: resolved.taskClass,
+      complexityScore: route.complexity ?? null,
+      rollbackApplied: resolved.rollbackApplied,
+      outcome: 'fail',
+      execute: true,
+      premiumRationale: resolved.premiumRationale,
+      premiumBudget: resolved.premiumBudget,
+      priceCapBlocked: true,
+      priceCapPer1kTokens: resolved.priceCapPer1kTokens,
+      routePricePer1kTokens: resolved.routePricePer1kTokens,
+      priceCapOverride: resolved.priceCapOverride,
+    });
+    console.error('blocked-price-cap');
+    console.error(`lane=${resolved.lane} price=${resolved.routePricePer1kTokens} cap=${resolved.priceCapPer1kTokens}`);
+    process.exit(1);
+  }
   const effectiveRoute = { ...route, lane: resolved.lane,
     recommendedModel: resolved.modelId, providerModel: resolved.providerModelId };
   const decision = await buildDecision(effectiveRoute, resolved);
@@ -67,7 +88,14 @@ async function main() {
   recordTelemetry({ lane: resolved.lane, model: resolved.providerModelId,
     multiplier: resolved.multiplier,
     taskClass: resolved.taskClass, complexityScore: route.complexity ?? null,
-    rollbackApplied: resolved.rollbackApplied, outcome, execute: true });
+    rollbackApplied: resolved.rollbackApplied, outcome, execute: true,
+    premiumRationale: resolved.premiumRationale,
+    premiumBudget: resolved.premiumBudget,
+    priceCapBlocked: resolved.priceCapBlocked,
+    priceCapPer1kTokens: resolved.priceCapPer1kTokens,
+    routePricePer1kTokens: resolved.routePricePer1kTokens,
+    priceCapOverride: resolved.priceCapOverride,
+  });
   recordCostEvent(resolved.lane, resolved.providerModelId, { outcome, escalation_reason });
   const result = { route: effectiveRoute, routing: resolved, decision };
   if (json) {

--- a/tests/batch-route.spec.js
+++ b/tests/batch-route.spec.js
@@ -27,3 +27,20 @@ test('routeWithBatch eligibility check passes for wiki-anneal with 24h deadline'
 test('DEFAULT_DEADLINE_MS is 24h', () => {
   expect(BR.DEFAULT_DEADLINE_MS).toBe(24 * 60 * 60 * 1000);
 });
+
+test('async-eligible classifier routes at least 60% to batch path', () => {
+  const work = [
+    { kind: 'wiki-anneal', deadlineMs: 24*3600*1000, latencySensitive: false },
+    { kind: 'research-summary', deadlineMs: 24*3600*1000, latencySensitive: false },
+    { kind: 'bundle-rebuild', deadlineMs: 24*3600*1000, latencySensitive: false },
+    { kind: 'interactive', deadlineMs: 60_000, latencySensitive: true },
+    { kind: 'rule-coverage-stage2b', deadlineMs: 24*3600*1000, latencySensitive: false },
+  ];
+  const stats = BR.summarizeAsyncBatchConversion(work);
+  expect(stats.conversionRate).toBeGreaterThanOrEqual(0.60);
+});
+
+test('blended savings are at least 30% at 60% batch conversion', () => {
+  const savings = BR.estimateBlendedSavings(0.60, 0.50);
+  expect(savings).toBeGreaterThanOrEqual(0.30);
+});

--- a/tests/ide-proxy-runtime.spec.js
+++ b/tests/ide-proxy-runtime.spec.js
@@ -30,6 +30,18 @@ test('classifier emits rationale + complexity score', () => {
   expect(r.rationale).toContain('score=');
 });
 
+test('classifier marks latency-sensitive prompts as not batch-preferred', () => {
+  const r = CLS.classify('urgent realtime fix needed now');
+  expect(r.latency_sensitive).toBe(true);
+  expect(r.batch_preferred).toBe(false);
+});
+
+test('classifier marks async deep prompts as batch-preferred', () => {
+  const r = CLS.classify('research-summary architecture options and trade-offs for refactor', { toolCount: 5 });
+  expect(r.latency_sensitive).toBe(false);
+  expect(typeof r.batch_preferred).toBe('boolean');
+});
+
 test('telemetry: recordDecision writes JSONL line with cost estimate', () => {
   const tmp = path.join(os.tmpdir(), `ide-tel-${Date.now()}.jsonl`);
   const orig = TEL.LOG_FILE;

--- a/tests/routing-policy.spec.js
+++ b/tests/routing-policy.spec.js
@@ -71,3 +71,49 @@ test('task-router imports ai-models.json optimization rules', () => {
   expect(typeof aiModels.optimizationStrategy.rule1).toBe('string');
   expect(typeof aiModels.optimizationStrategy.rule3).toBe('string');
 });
+
+test('premium budget soft-limit auto-downgrades before hard ceiling', () => {
+  const route = {
+    lane: 'premium',
+    complexity: 0.95,
+    disableRollback: true,
+    premiumShare30d: 0.115,
+  };
+  const resolved = resolveRouting('architecture design risk security', route);
+  expect(resolved.lane).toBe('haiku');
+  expect(resolved.premiumBudget.downgraded).toBe(true);
+  expect(resolved.premiumBudget.downgradeReason).toBe('premium_budget_soft_limit');
+});
+
+test('premium route emits structured rationale', () => {
+  const route = {
+    lane: 'premium',
+    complexity: 0.95,
+    disableRollback: true,
+    disablePremiumBudget: true,
+  };
+  const resolved = resolveRouting('security audit architecture', route);
+  expect(resolved.lane).toBe('premium');
+  expect(resolved.premiumRationale).toBeTruthy();
+  expect(typeof resolved.premiumRationale.reason).toBe('string');
+  expect(typeof resolved.premiumRationale.evidence).toBe('string');
+});
+
+test('price caps are explicit on paid lanes in policy', () => {
+  const policy = require(path.join(__dirname, '../scripts/global/model-routing-policy.json'));
+  expect(policy.models.haiku.maxPriceCapPer1kTokens).toBeGreaterThan(0);
+  expect(policy.models.premium.maxPriceCapPer1kTokens).toBeGreaterThan(0);
+});
+
+test('over-cap paid route blocks without override', () => {
+  const route = {
+    lane: 'premium',
+    complexity: 0.95,
+    disableRollback: true,
+    disablePremiumBudget: true,
+    priceCapPer1kTokens: 0.001,
+  };
+  const resolved = resolveRouting('security audit architecture', route);
+  expect(resolved.priceCapBlocked).toBe(true);
+  expect(resolved.routePricePer1kTokens).toBeGreaterThan(resolved.priceCapPer1kTokens);
+});


### PR DESCRIPTION
## Summary
- enforce premium budget governor at 12% with soft-limit auto-downgrade and structured rationale output
- add async batch eligibility and savings conversion helpers for discounted batch routing
- add paid-route provider price caps with enforcement telemetry
- add tests for premium budget behavior, batch conversion/savings targets, and price-cap enforcement
- add changelog fragments for #1794 #1795 #1796

## Validation
- npx playwright test tests/routing-policy.spec.js tests/batch-route.spec.js tests/ide-proxy-runtime.spec.js --reporter=line
- npm run -s lint:js

Refs #1794
Refs #1795
Refs #1796
Refs #1792