### PR TITLE
fix(hooks): scope visual_qa to ui_touched #1821

### DIFF
--- a/.changes/unreleased/1821.md
+++ b/.changes/unreleased/1821.md
@@ -1,0 +1,23 @@
+### Fixed
+
+- **`visual_qa` Stop-hook + pretool-guard false-positive on non-UI code edits** (#1821 — third audit-missed-surface in the Epic #1798 / #1815 / #1821 chain). Editing test specs, scripts, or hooks in repos containing a `dashboard/` sub-app falsely triggered `Hard governance gate. Missing: visual_qa.` Cause: `stop_checks.check_admin_ops` and `pretool_guard` keyed the visual_qa requirement on `repo_type ∈ {web-app, website-static}` AND `code_touched` — too broad. Fix: introduced path-scoped `ui_touched` flag set only when actual UI paths are edited.
+
+### Added
+
+- `hooks/scripts/repo_detection.py` — new `UI_EXTS` (`.html`, `.css`, `.tsx`, `.jsx`, `.vue`, `.svelte`) and `UI_PREFIXES` (`dashboard/`, `public/`, `src/components/`, `src/pages/`, `src/views/`). `classify_path` returns `"ui"` for matching paths.
+- `hooks/scripts/tool_activity.py` — handles `"ui"` kind: sets both `flags.ui_touched = True` AND `flags.code_touched = True` (parallel to extension handling).
+- `hooks/scripts/state_store.py` — `_default_state` flags dict now includes `"ui_touched": False`. Backward-compatible (additive).
+- `tests/hooks/test_baton_phase_aware.py` `UiTouchedScoping` class — 5 new cases: dashboard/index.html → ui, dashboard/js/foo.js → ui, test specs → code (NOT ui), scripts → code, visual_qa NOT required when only code_touched, visual_qa required when ui_touched. **Total spec count: 18** (was 13).
+
+### Changed
+
+- `hooks/scripts/stop_checks.py:check_admin_ops` — visual_qa condition: `if flags.get("ui_touched"):` (was `repo_type in ("website-static","web-app") and flags.get("code_touched")`).
+- `hooks/scripts/pretool_guard.py:84` — git-tag deny condition: `flags.get("ui_touched")` (same change).
+
+### Deployment
+
+After merge: `npm run deploy:both:apply` to propagate to `~/.copilot/hooks/scripts/` and `~/.codex/devenv-ops/hooks/`. Same pattern as Epic #1798 and #1815 deploys.
+
+Refs Epic #1798
+Refs #1815
+Closes #1821

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -81,8 +81,8 @@ def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
         return emit("ask","CI checks before PR creation. Confirm intentional.")
     if RE_RELEASE_INTEGRITY.search(joined) and repo_type == "vscode-extension" and not ops.get("publish"):
         return emit("ask","Integrity check before publish. Confirm intentional.")
-    if RE_GIT_TAG.search(joined) and repo_type in ("website-static","web-app") and not ops.get("visual_qa"):
-        return emit("deny","Tag blocked: visual QA not recorded for web repo.")
+    if RE_GIT_TAG.search(joined) and flags.get("ui_touched") and not ops.get("visual_qa"):
+        return emit("deny","Tag blocked: visual QA not recorded for UI change.")
     return None
 
 def main() -> int:

--- a/hooks/scripts/repo_detection.py
+++ b/hooks/scripts/repo_detection.py
@@ -49,19 +49,20 @@ def detect_repo_type(cwd: str) -> str:
     return "generic"
 
 
+UI_EXTS = {".html", ".css", ".tsx", ".jsx", ".vue", ".svelte"}
+UI_PREFIXES = ("dashboard/", "public/", "src/components/", "src/pages/", "src/views/")
+
+
 def classify_path(path: str) -> str:
-    """Classify a file path as docs, extension, code, or other."""
+    """Classify a file path as docs, extension, ui, code, or other (#1817)."""
     lp = path.lower()
     ext = Path(lp).suffix
-    if (
-        "/docs/" in lp
-        or lp.endswith("readme.md")
-        or lp.endswith("changelog.md")
-        or ext in DOC_EXTS
-    ):
+    if "/docs/" in lp or lp.endswith("readme.md") or lp.endswith("changelog.md") or ext in DOC_EXTS:
         return "docs"
     if lp.startswith("vscode-extension/") or "/vscode-extension/" in lp:
         return "extension"
+    if ext in UI_EXTS or any(lp.startswith(p) or f"/{p}" in lp for p in UI_PREFIXES):
+        return "ui"
     if ext in CODE_EXTS:
         return "code"
     return "other"

--- a/hooks/scripts/state_store.py
+++ b/hooks/scripts/state_store.py
@@ -29,7 +29,7 @@ def _default_state(cwd: str) -> dict[str, Any]:
         "roles": {"manager": False, "collaborator": False,
                   "admin": False, "consultant": False},
         "flags": {"code_touched": False, "docs_touched": False,
-                  "extension_touched": False},
+                  "extension_touched": False, "ui_touched": False},
         "admin_ops": {"version_check": False, "commit": False, "push": False,
                       "pr_create": False, "ci_green": False, "merge": False,
                       "publish": False, "release_integrity": False,

--- a/hooks/scripts/stop_checks.py
+++ b/hooks/scripts/stop_checks.py
@@ -65,7 +65,7 @@ def check_admin_ops(
     ext: list[str] = []
     if repo_type == "vscode-extension" and flags.get("extension_touched"):
         ext = ["publish", "release_integrity", "gh_release"]
-    if repo_type in ("website-static", "web-app") and flags.get("code_touched"):
+    if flags.get("ui_touched"):  # #1817: scope visual_qa to actual UI paths, not all code in web-app repos
         ext.append("visual_qa")
     missing = [k for k in base + ext if not ops.get(k)]
     if missing:

--- a/hooks/scripts/tool_activity.py
+++ b/hooks/scripts/tool_activity.py
@@ -50,6 +50,10 @@ def mark_tool_activity(state: dict[str, Any], payload: dict[str, Any]) -> None:
             flags["extension_touched"] = True
             flags["code_touched"] = True
             roles["collaborator"] = True
+        elif kind == "ui":  # #1817: scope visual_qa to actual UI paths
+            flags["ui_touched"] = True
+            flags["code_touched"] = True
+            roles["collaborator"] = True
         elif kind == "code":
             flags["code_touched"] = True
             roles["collaborator"] = True

--- a/tests/hooks/test_baton_phase_aware.py
+++ b/tests/hooks/test_baton_phase_aware.py
@@ -107,6 +107,43 @@ class CurrentPhaseField(unittest.TestCase):
         self.assertIn("current_phase", state)
 
 
+class UiTouchedScoping(unittest.TestCase):
+    """#1817 — visual_qa requirement scoped to actual UI path changes."""
+
+    def test_classify_path_ui_for_dashboard(self):
+        from repo_detection import classify_path
+        self.assertEqual(classify_path("dashboard/js/foo.js"), "ui")
+        self.assertEqual(classify_path("dashboard/index.html"), "ui")
+        self.assertEqual(classify_path("dashboard/css/main.css"), "ui")
+
+    def test_classify_path_code_for_test_specs(self):
+        from repo_detection import classify_path
+        self.assertEqual(classify_path("tests/routing-policy.spec.js"), "code")
+        self.assertEqual(classify_path("tests/batch-route.spec.js"), "code")
+        self.assertEqual(classify_path("tests/ide-proxy-runtime.spec.js"), "code")
+
+    def test_classify_path_code_for_scripts(self):
+        from repo_detection import classify_path
+        self.assertEqual(classify_path("scripts/global/foo.js"), "code")
+        self.assertEqual(classify_path("hooks/scripts/bar.py"), "code")
+
+    def test_check_admin_ops_no_visual_qa_when_only_code_touched(self):
+        # Reproduces the Copilot Team screenshot: editing test specs in a web-app-classified repo.
+        flags = {"code_touched": True, "ui_touched": False}
+        ops = {"commit": True, "push": True, "pr_create": True, "ci_green": True, "merge": True, "visual_qa": False}
+        roles = {"collaborator": True, "admin": True}
+        result = stop_checks.check_admin_ops(flags, ops, roles, "website-static")
+        self.assertEqual(result, (None, None), "visual_qa should NOT be required for non-UI code changes")
+
+    def test_check_admin_ops_visual_qa_required_when_ui_touched(self):
+        flags = {"code_touched": True, "ui_touched": True}
+        ops = {"commit": True, "push": True, "pr_create": True, "ci_green": True, "merge": True, "visual_qa": False}
+        roles = {"collaborator": True, "admin": True}
+        block, msg = stop_checks.check_admin_ops(flags, ops, roles, "website-static")
+        self.assertIsNotNone(block)
+        self.assertIn("visual_qa", msg)
+
+
 class UserPromptGatePhaseGuard(unittest.TestCase):
     """#1815 — userprompt_gate._admin_missing honors baton phase (Epic #1798 sibling)."""
 


### PR DESCRIPTION
Closes #1821. Third audit-missed-surface fix (chain: Epic #1798 → #1815 → #1821).

## Symptom (Copilot Team)

Editing `tests/routing-policy.spec.js`, `tests/batch-route.spec.js`, `tests/ide-proxy-runtime.spec.js` (test specs — NOT UI) on PR #1820 triggered "Hard governance gate. Missing: visual_qa." because:
- Repo classifies as website-static (dashboard/*.html + *.css present)
- Any .js edit sets flags.code_touched
- visual_qa requirement was keyed on (repo_type + code_touched) — too broad

## Fix

Path-scoped `ui_touched` flag, parallel to `extension_touched`:

| File | Change |
|---|---|
| repo_detection.py | classify_path returns 'ui' for HTML/CSS/TSX/JSX/Vue/Svelte + dashboard/public/src-component paths |
| tool_activity.py | kind=='ui' sets both ui_touched + code_touched |
| state_store.py | _default_state adds ui_touched:False (additive) |
| stop_checks.py:68 | visual_qa cond: flags.ui_touched (was repo_type+code_touched) |
| pretool_guard.py:84 | git-tag deny same condition change |
| tests/hooks/test_baton_phase_aware.py | +5 UiTouchedScoping cases (13→18) |

## Verification

- node lint 447 files ≤100 ✓
- python3 -m unittest tests.hooks.test_baton_phase_aware → 18/18 ✓
- classify_path correctness verified: tests/*.spec.js → 'code'; dashboard/* → 'ui'; scripts/global/*.js → 'code'

## Deploy

`npm run deploy:both:apply` required post-merge. Same pattern as Epic #1798/#1815.

Refs Epic #1798
Refs #1815
Closes #1821