### PR TITLE
feat(governance): provider price-cap gate #1796

### DIFF
--- a/.changes/unreleased/1796.md
+++ b/.changes/unreleased/1796.md
@@ -1,0 +1,13 @@
+### Added
+
+- **Provider per-request price-cap gate** (#1796 — Epic #1792 G3 cost-minimization child). `scripts/global/provider-price-cap-gate.js` (84 lines) enforces a per-request maximum-cost ceiling for paid routes (`haiku`, `premium`). Returns `{allow, lane, model, estimated_cost_usd, cap_usd, over_cap, override_used, escalation_reason, policy_version}`. Default caps: haiku $0.05, premium $0.25 (env-overrideable via `MEGINGJORD_PRICE_CAP_HAIKU` / `MEGINGJORD_PRICE_CAP_PREMIUM`). Explicit `--override` flag flips deny→allow with `escalation_reason: "price-cap-override"` (auditable).
+- `tests/provider-price-cap-gate.spec.js` — 10-case spec covering ∞-cap for free/fleet, at/under/over-cap for haiku, premium block + override, boundary-equality semantics, unknown-lane fallback to premium cap, output shape, determinism.
+- `docs/howto/provider-price-cap-gate.md` — operator guide + future-enhancement deferrals.
+- `npm run governance:price-cap` + `:test` scripts.
+
+### Telemetry integration
+
+CLI-mode blocks emit `escalation_reason: "price-cap"` (or `"price-cap-override"` for approved overrides) to `logs/cost-telemetry.jsonl` via `recordCostEvent`, composing with #1797 escalation-coverage gate. Module-API callers invoke `recordTelemetry(decision)` explicitly.
+
+Refs Epic #1792
+Closes #1796

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ npm run deploy:both:apply
 | `governance:manifest:validate` | `node scripts/global/governance-manifest-validate.js` |
 | `governance:no-sync-http` | `node scripts/global/no-sync-http-handlers.js` |
 | `governance:parity:test` | `node scripts/global/governance-parity.spec.js` |
+| `governance:price-cap` | `node scripts/global/provider-price-cap-gate.js` |
+| `governance:price-cap:test` | `node --test tests/provider-price-cap-gate.spec.js` |
 | `governance:reconcile` | `node scripts/global/ticket-reconcile.js --json` |
 | `governance:review-score` | `node scripts/global/review-score-classifier.js` |
 | `governance:review-score:test` | `node --test tests/review-score-classifier.spec.js` |

--- a/docs/howto/provider-price-cap-gate.md
+++ b/docs/howto/provider-price-cap-gate.md
@@ -1,0 +1,88 @@
+# Provider price-cap gate
+
+`scripts/global/provider-price-cap-gate.js` (#1796) enforces a per-request maximum-cost ceiling for paid routes (`haiku`, `premium`). Closes Epic #1792 child. Composes with #1797 escalation-reason taxonomy: `escalation_reason: "price-cap"` for blocked attempts; `"price-cap-override"` when explicit override approved.
+
+## Default caps
+
+| Lane | Default cap | Env override |
+|---|---:|---|
+| `free` | none (∞) | — |
+| `fleet` | none (∞) | — |
+| `haiku` | $0.05 | `MEGINGJORD_PRICE_CAP_HAIKU` |
+| `premium` | $0.25 | `MEGINGJORD_PRICE_CAP_PREMIUM` |
+
+Defaults are placeholders calibrated against the 30-day premium-share governor (#1794). Tighten/loosen via env when operator-specific budget allows.
+
+## CLI usage
+
+```bash
+# Allow check (exit 0 = allow; exit 1 = blocked)
+node scripts/global/provider-price-cap-gate.js --lane premium --cost 0.20
+
+# Blocked
+node scripts/global/provider-price-cap-gate.js --lane premium --cost 0.30
+
+# Override an over-cap request
+node scripts/global/provider-price-cap-gate.js --lane premium --cost 0.30 --override
+
+# JSON output for downstream tooling
+node scripts/global/provider-price-cap-gate.js --lane premium --cost 0.30 --json
+```
+
+## Module API
+
+```js
+const { evaluate } = require('./scripts/global/provider-price-cap-gate');
+const decision = evaluate({ lane: 'premium', model: 'claude-opus-4-7', estimatedCostUsd: 0.30 });
+// → { allow: false, over_cap: true, escalation_reason: 'price-cap', ... }
+```
+
+Output shape:
+
+```json
+{
+  "allow": false,
+  "lane": "premium",
+  "model": "claude-opus-4-7",
+  "estimated_cost_usd": 0.30,
+  "cap_usd": 0.25,
+  "over_cap": true,
+  "override_used": false,
+  "escalation_reason": "price-cap",
+  "policy_version": "2026-05-17"
+}
+```
+
+## Telemetry integration
+
+When CLI mode and a decision crosses the cap, `recordTelemetry()` appends to `logs/cost-telemetry.jsonl` with the appropriate `escalation_reason`, feeding the #1797 coverage gate. Module-API callers should invoke `recordTelemetry(decision)` explicitly if telemetry is desired.
+
+## Override semantics
+
+An explicit operator override (`--override` flag OR `evaluate({override: true})`) flips the decision to `allow=true` AND sets `escalation_reason: "price-cap-override"`. Auditable: future audit can query for override usage trends.
+
+Use only when the high-cost call is genuinely necessary (e.g., security audit, frontier-reasoning required). Operator records rationale in baton artifact.
+
+## Composition
+
+- **Epic #1792** (G3 cost-minimization wave) — this gate is one of the cluster (#1793 cache-hit, #1794 premium-budget-governor, #1795 batch-routing, #1796 this ticket, #1797 escalation-coverage).
+- **#1797 escalation-coverage** — emits `escalation_reason: "price-cap"` so the coverage gate counts these events.
+- **`scripts/global/model-routing-policy.json`** — source of truth for per-lane `costPer1kTokens`; can derive cap values from `cap = costPer1kTokens × max_tokens_per_request`.
+
+## Future enhancements (out of #1796 scope)
+
+- Per-provider caps (currently per-lane only).
+- Dynamic caps reading recent rolling spend (today they are constants).
+- Integration with `wrapProviderCall` in HAMR wrapper to enforce pre-call.
+
+## Tests
+
+`tests/provider-price-cap-gate.spec.js` — 10 cases covering free/fleet ∞-cap, haiku at/under/over cap, premium block + override, boundary at cap-equal, unknown-lane fallback, output shape, determinism.
+
+Run via `npm run governance:price-cap:test`.
+
+## Related
+
+- Closes #1796 (Epic #1792 G3 child).
+- Composes with #1797 escalation-coverage gate.
+- See `docs/howto/escalation-coverage-gate.md` for the broader telemetry coverage contract.

--- a/package.json
+++ b/package.json
@@ -158,6 +158,8 @@
     "governance:soak-language:test": "node --test tests/soak-language-guard.spec.js",
     "governance:review-score": "node scripts/global/review-score-classifier.js",
     "governance:review-score:test": "node --test tests/review-score-classifier.spec.js",
+    "governance:price-cap": "node scripts/global/provider-price-cap-gate.js",
+    "governance:price-cap:test": "node --test tests/provider-price-cap-gate.spec.js",
     "git-state:drift": "node scripts/global/git-state-drift-sensor.js",
     "goals:regen": "node scripts/global/goals-contract-generate.js"
   },

--- a/scripts/global/provider-price-cap-gate.js
+++ b/scripts/global/provider-price-cap-gate.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// provider-price-cap-gate (#1796) — per-request max-price ceiling for paid routes.
+// Closes Epic #1792 child. Composes with #1797 escalation_reason taxonomy (uses "price-cap").
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const POLICY_PATH = path.join(__dirname, 'model-routing-policy.json');
+
+const DEFAULT_CAPS_USD = {
+  free:    Infinity,
+  fleet:   Infinity,
+  haiku:   Number(process.env.MEGINGJORD_PRICE_CAP_HAIKU || '0.05'),
+  premium: Number(process.env.MEGINGJORD_PRICE_CAP_PREMIUM || '0.25'),
+};
+
+function loadPolicy() {
+  try { return JSON.parse(fs.readFileSync(POLICY_PATH, 'utf8')); } catch { return null; }
+}
+
+function capForLane(lane) {
+  const v = DEFAULT_CAPS_USD[lane];
+  return (typeof v === 'number') ? v : DEFAULT_CAPS_USD.premium;
+}
+
+function evaluate(opts = {}) {
+  const lane = String(opts.lane || 'free');
+  const model = String(opts.model || 'unknown');
+  const estimatedCostUsd = Number(opts.estimatedCostUsd ?? 0);
+  const override = !!opts.override;
+  const cap = capForLane(lane);
+  const overCap = estimatedCostUsd > cap && Number.isFinite(cap);
+  const allow = !overCap || override;
+  return {
+    allow, lane, model,
+    estimated_cost_usd: estimatedCostUsd,
+    cap_usd: Number.isFinite(cap) ? cap : null,
+    over_cap: overCap,
+    override_used: overCap && override,
+    escalation_reason: overCap ? (override ? 'price-cap-override' : 'price-cap') : null,
+    policy_version: '2026-05-17',
+  };
+}
+
+function recordTelemetry(decision) {
+  // Lazy require to keep this module fast when used as pure fn.
+  if (!decision.over_cap) return;
+  try {
+    const { recordCostEvent } = require('./cost-telemetry');
+    recordCostEvent(decision.lane, decision.model, {
+      outcome: decision.allow ? 'ok' : 'fail',
+      escalation_reason: decision.escalation_reason,
+      costUsd: decision.estimated_cost_usd,
+    });
+  } catch { /* no-op if cost-telemetry missing */ }
+}
+
+function arg(name) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? process.argv[i + 1] : null;
+}
+
+if (require.main === module) {
+  const decision = evaluate({
+    lane: arg('--lane') || 'free',
+    model: arg('--model') || 'unknown',
+    estimatedCostUsd: Number(arg('--cost') || '0'),
+    override: process.argv.includes('--override'),
+  });
+  recordTelemetry(decision);
+  if (process.argv.includes('--json')) {
+    process.stdout.write(JSON.stringify(decision, null, 2) + '\n');
+  } else if (!decision.allow) {
+    process.stderr.write(`✗ price-cap blocked: lane=${decision.lane} cost=$${decision.estimated_cost_usd.toFixed(4)} > cap=$${decision.cap_usd.toFixed(4)}\n`);
+  } else if (decision.override_used) {
+    process.stdout.write(`⚠ price-cap override: lane=${decision.lane} cost=$${decision.estimated_cost_usd.toFixed(4)} > cap=$${decision.cap_usd.toFixed(4)}\n`);
+  } else {
+    process.stdout.write(`✓ price-cap ok: lane=${decision.lane} cost=$${decision.estimated_cost_usd.toFixed(4)}\n`);
+  }
+  process.exit(decision.allow ? 0 : 1);
+}
+
+module.exports = { evaluate, recordTelemetry, capForLane, loadPolicy, DEFAULT_CAPS_USD };

--- a/tests/provider-price-cap-gate.spec.js
+++ b/tests/provider-price-cap-gate.spec.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const { evaluate, capForLane, DEFAULT_CAPS_USD } = require('../scripts/global/provider-price-cap-gate.js');
+
+test('free + fleet lanes always allow (no cap)', () => {
+  const r1 = evaluate({ lane: 'free', estimatedCostUsd: 999 });
+  const r2 = evaluate({ lane: 'fleet', estimatedCostUsd: 999 });
+  assert.equal(r1.allow, true);
+  assert.equal(r2.allow, true);
+  assert.equal(r1.over_cap, false);
+});
+
+test('haiku allowed under cap', () => {
+  const r = evaluate({ lane: 'haiku', estimatedCostUsd: 0.01 });
+  assert.equal(r.allow, true);
+  assert.equal(r.over_cap, false);
+  assert.equal(r.escalation_reason, null);
+});
+
+test('premium blocked when over cap, no override', () => {
+  const r = evaluate({ lane: 'premium', estimatedCostUsd: 0.30 });
+  assert.equal(r.allow, false);
+  assert.equal(r.over_cap, true);
+  assert.equal(r.override_used, false);
+  assert.equal(r.escalation_reason, 'price-cap');
+});
+
+test('premium allowed when over cap WITH explicit override', () => {
+  const r = evaluate({ lane: 'premium', estimatedCostUsd: 0.30, override: true });
+  assert.equal(r.allow, true);
+  assert.equal(r.over_cap, true);
+  assert.equal(r.override_used, true);
+  assert.equal(r.escalation_reason, 'price-cap-override');
+});
+
+test('haiku blocked at boundary above cap', () => {
+  const cap = DEFAULT_CAPS_USD.haiku;
+  const just_over = cap + 0.001;
+  const r = evaluate({ lane: 'haiku', estimatedCostUsd: just_over });
+  assert.equal(r.allow, false);
+  assert.equal(r.escalation_reason, 'price-cap');
+});
+
+test('cost exactly equal to cap is allowed (≤ semantics)', () => {
+  const cap = DEFAULT_CAPS_USD.premium;
+  const r = evaluate({ lane: 'premium', estimatedCostUsd: cap });
+  assert.equal(r.allow, true);
+  assert.equal(r.over_cap, false);
+});
+
+test('capForLane returns Infinity for free/fleet', () => {
+  assert.equal(capForLane('free'), Infinity);
+  assert.equal(capForLane('fleet'), Infinity);
+});
+
+test('unknown lane falls back to premium cap', () => {
+  const cap = capForLane('mystery-lane');
+  assert.equal(cap, DEFAULT_CAPS_USD.premium);
+});
+
+test('output shape includes policy_version + escalation_reason fields per #1797 taxonomy', () => {
+  const r = evaluate({ lane: 'premium', estimatedCostUsd: 0.30 });
+  assert.equal(typeof r.policy_version, 'string');
+  assert.ok(['price-cap', 'price-cap-override', null].includes(r.escalation_reason));
+  assert.equal(typeof r.cap_usd, 'number');
+});
+
+test('decision is deterministic / pure (no side effects in evaluate)', () => {
+  const a = evaluate({ lane: 'haiku', estimatedCostUsd: 0.01 });
+  const b = evaluate({ lane: 'haiku', estimatedCostUsd: 0.01 });
+  assert.deepEqual(a, b);
+});


### PR DESCRIPTION
Closes #1796 (Epic #1792 G3 cost-minimization child).

Refs #1796

## Summary

`scripts/global/provider-price-cap-gate.js` (84 lines): per-request max-cost ceiling for paid routes. Default caps: haiku $0.05, premium $0.25 (env-overrideable). Override pathway with auditable `escalation_reason: 'price-cap-override'`. Composes with #1797 escalation-coverage gate.

## ACs

- [x] AC1: Paid routes have explicit price caps (env-overrideable).
- [x] AC2: Over-cap fails unless override present.
- [x] AC3: Routing telemetry captures cap enforcement decisions.

## Test plan

- npm run lint: 449 files ≤100 ✓
- node --test tests/provider-price-cap-gate.spec.js: 10/10 ✓
- governance:verify pass ✓; soak-guard clean

## Baton

All 4 artifacts on #1796.

Closes #1796