### PR TITLE
fix(governance): polish completion intent framing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Every task follows the **role baton sequence**: Manager → Collaborator → Adm
 See `role-baton-routing` for rules. Local repos may override via `.github/copilot-instructions.md`.
 Shared governance is provider-neutral; runtime-specific setup belongs in adapters.
 See `instructions/provider-neutral-governance.instructions.md`.
-Completion intent is strict: when the user asks to complete/finish/ship, execute full baton delivery through Admin and Consultant gates; do not stop at implementation unless blocked by evidence or explicit design/UAT input.
+Completion intent is strict: when the active role identifies complete/finish/ship terminal-delivery intent in task scope, execute full baton delivery through Admin and Consultant gates; do not stop at implementation unless blocked by evidence or explicit design/UAT input.
 
 ## Repo Purpose
 

--- a/instructions/feature-completion-governance.instructions.md
+++ b/instructions/feature-completion-governance.instructions.md
@@ -5,7 +5,7 @@ applyTo: "**"
 When asked to "complete" a feature-add, all four baton roles are required. Tests passing only closes Collaborator — do not stop there.
 
 Completion intent semantics are strict:
-- "complete", "finish", or "ship" means terminal workflow delivery in one session when feasible.
+- "complete", "finish", or "ship" means terminal workflow delivery in one session when feasible once the active role identifies that intent in task scope.
 - Do not pause after implementation to wait for another user nudge to run Admin or Consultant phases.
 - Escalate only for blockers, missing evidence, or explicit design/UAT decisions.
 

--- a/tests/completion-intent-contract.spec.js
+++ b/tests/completion-intent-contract.spec.js
@@ -11,14 +11,17 @@ function read(rel) {
 test('copilot adapter defines completion intent contract', () => {
   const text = read('.github/copilot-instructions.md');
   assert.match(text, /Completion intent is strict/);
+  assert.match(text, /when the active role identifies complete\/finish\/ship terminal-delivery intent in task scope/);
   assert.match(text, /execute full baton delivery through Admin and Consultant gates/);
   assert.match(text, /do not stop at implementation/);
+  assert.doesNotMatch(text, /when the user asks to complete\/finish\/ship/);
 });
 
 test('feature completion governance defines completion intent semantics', () => {
   const text = read('instructions/feature-completion-governance.instructions.md');
   assert.match(text, /Completion intent semantics are strict/);
-  assert.match(text, /"complete", "finish", or "ship" means terminal workflow delivery/);
+  assert.match(text, /"complete", "finish", or "ship" means terminal workflow delivery in one session when feasible once the active role identifies that intent in task scope/);
   assert.match(text, /Do not pause after implementation/);
+  assert.match(text, /Do not pause after implementation to wait for another user nudge/);
   assert.match(text, /Escalate only for blockers, missing evidence, or explicit design\/UAT decisions/);
 });


### PR DESCRIPTION
Closes #1874

## Summary
- align completion-intent language to operator-identity model (active role recognizes terminal intent)
- remove user-orchestrator implication from completion semantics
- strengthen contract test to enforce operator-centric wording and reject prior phrasing

## Validation
- npm run lint
- node --test tests/completion-intent-contract.spec.js

## Context
Follow-up to Claude Code red-team analysis comment on #1874.

Refs #1874
