### PR TITLE
docs(governance): codify research-first epic phase gate

### DIFF
--- a/.changes/unreleased/1399.md
+++ b/.changes/unreleased/1399.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Added a new "Research-First Epic Phase Gate" section to `instructions/epic-governance.instructions.md` with the five binding clauses from #1397, codifying when implementation work may begin after Phase-0 research in research-first epics.

--- a/instructions/epic-governance.instructions.md
+++ b/instructions/epic-governance.instructions.md
@@ -49,6 +49,16 @@ Auto-transition posts an `EPIC_AUTO_PAUSE` comment naming the implicit resume tr
 
 **Inverse transition** (`dormant → in-progress`): triggered when a child ticket moves to `status:in-progress` OR a new PR is opened against any linked child. Mirrors the entry rule.
 
+## Research-First Epic Phase Gate
+
+A research-first Epic (label `type:epic` + presence of `AC-R*` acceptance criteria in body) MUST satisfy the following gate before any implementation child tickets or development ACs may be authored:
+
+1. All research children (`AC-R1` through `AC-Rn-1`) MUST be closed with Consultant peer-review rubric >= 7 across all G1-G9 goals.
+2. The terminal research child (`AC-Rn`, this rule itself) MUST be closed with Consultant approval.
+3. The Epic MUST receive a Manager `EPIC_RESCOPE` or equivalent comment summarizing Phase-0 outcomes before transitioning out of `status:in-progress`.
+4. Phase-1 implementation child tickets MUST cite the Phase-0 research children they consume in their body (`Refs #N` per source child).
+5. If any Phase-0 child is reopened, the gate re-arms and Phase-1 work is paused until the reopened child closes again.
+
 ## Epic Progress Comment Protocol
 
 When any child ticket is closed, the Manager posts a progress update to the epic:


### PR DESCRIPTION
Refs #1399

## Summary
- add "Research-First Epic Phase Gate" section to `instructions/epic-governance.instructions.md`
- codify the 5 binding sub-clauses from #1397 verbatim
- add changelog fragment `.changes/unreleased/1399.md`

## Validation
- npm run lint
- npm run docs:lint

## Lane
- lane:docs-only (Manager->Admin->Consultant; collaborator skipped per ticket AC4)