### PR TITLE
fix(hamr): source .env before provider key check in activation (#1904)

### DIFF
--- a/.changes/unreleased/1904.md
+++ b/.changes/unreleased/1904.md
@@ -1,0 +1,2 @@
+### Fixed
+- `hamr-activate.sh` now sources repo-root `.env` before the provider-key check (step 3), ensuring `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and other keys are available at activation time. Previously, the check always warned "missing env" even when keys were present in `.env`.

--- a/scripts/global/hamr-activate.sh
+++ b/scripts/global/hamr-activate.sh
@@ -7,6 +7,12 @@ set -euo pipefail
 repo_root=$(git rev-parse --show-toplevel)
 echo "▶ HAMR activation for: $repo_root"
 
+# Source repo-root .env for provider keys if present; secrets are never echoed.
+if [ -f "$repo_root/.env" ]; then
+  # shellcheck source=/dev/null
+  set -a; . "$repo_root/.env"; set +a
+fi
+
 step() { echo ""; echo "── $1 ──"; }
 
 step "1/5 install R9.2 git hooks (#934)"


### PR DESCRIPTION
## Summary
Wire repo-root `.env` into `hamr-activate.sh` so provider keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) are available during step 3 provider-key check. Fixes false "missing env" warnings that blocked cloud/escalation routing paths.

## Change
`scripts/global/hamr-activate.sh`: 4-line silent `.env` sourcing block added before step 3. File: 79→85 lines (≤100 cap).
`.changes/unreleased/1904.md`: CHANGELOG fragment added.

## Evidence
- `npm run hamr:activate` → ✅ all required env present (zero missing warnings)
- `npm run hamr:sync-verify` → ok:true, total_missing:0
- `npm run lint` → ✅ All files within 100-line limit

Before: step 3 output: "⚠ missing env: OPENAI_API_KEY" — cloud routing unavailable.
After: step 3 output: "✅ all required env present" — fleet/cloud escalation routing available.

## Security
- Secrets never printed, logged, or echoed.
- Change is localized to activation script only.
- `.env` is already in `.gitignore` — no secret exposure risk.

Closes #1904
Refs #1904