### PR TITLE
fix(gov): cap ticket-presenter DEFAULT_LIMIT at GraphQL 100 #1905

### DIFF
--- a/scripts/global/ticket-presenter.js
+++ b/scripts/global/ticket-presenter.js
@@ -45,7 +45,7 @@ function isChild(item, parentMap) {
   return Boolean(m && parentMap[Number(m[1])] === 'OPEN');
 }
 
-const DEFAULT_LIMIT = 200;
+const DEFAULT_LIMIT = 100;
 const SORT_KEY_LENGTH = 3;
 const labelsOf = issue => issue.labels.nodes.map(node => node.name);
 const priOf = labels => { for (const label of labels) if (label in PRI) return label; return 'priority:P3'; };


### PR DESCRIPTION
Refs #1905

## Summary

Hotfix for #1905 ship: GitHub GraphQL caps `issues(first:N)` at 100 per page. Default of 200 returned `EXCESSIVE_PAGINATION` error. Lowered DEFAULT_LIMIT to 100.

Smoke-tested live: `npm run governance:list-tickets` now produces the expected markdown landscape.

## Test plan

- [x] node --test tests/ticket-presenter.spec.js (18/18)
- [x] npm run governance:list-tickets (live demo with all 50+ open tickets)

For >100 issues, pagination can be filed as follow-on when needed. Current open ticket count is ~50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
