### PR TITLE
feat(governance): add orchestrator parity audit

### DIFF
--- a/inventory/orchestrator-governance-parity.json
+++ b/inventory/orchestrator-governance-parity.json
@@ -1,0 +1,49 @@
+{
+  "epic": 1912,
+  "goal": "Equivalent governance outcomes across Claude Code, Copilot, and Codex",
+  "runtimes": ["claude-code", "copilot", "codex"],
+  "canonicalSurfaces": [
+    "instructions",
+    "skills_or_commands",
+    "agents_or_subagents",
+    "hooks_or_gates",
+    "state_store",
+    "deploy_sync",
+    "hamr_routing",
+    "ticket_lifecycle",
+    "team_model_signing",
+    "dedicated_worktrees",
+    "visual_qa",
+    "wiki_docs_memory"
+  ],
+  "commonHookEvents": [
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PostToolUse",
+    "Stop"
+  ],
+  "requiredHookScripts": [
+    "session_context.py",
+    "hamr_activation_check.py",
+    "manager_ticket_gate.py",
+    "goal_lens.py",
+    "userprompt_gate.py",
+    "commit_ticket_gate.py",
+    "pretool_guard.py",
+    "posttool_reminders.py",
+    "stop_reminder.py"
+  ],
+  "runtimeEventNotes": {
+    "codex": ["PermissionRequest is Codex-native and must be mapped or waived"],
+    "copilot": ["PreCompact and SubagentStart are currently wired"],
+    "claude-code": ["Claude Code supports hooks through settings.json"]
+  },
+  "deployTargets": ["copilot", "codex", "claude", "all"],
+  "strictAcceptance": {
+    "hooks": "Every supported runtime has equivalent gate outcomes",
+    "deploy": "Operators can deploy one, any pair, or all three runtimes clearly",
+    "skills": "Every canonical skill has an adapter or explicit waiver per runtime",
+    "tests": "Parity checks inspect registrations, not only copied script bytes"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "governance:no-sync-http": "node scripts/global/no-sync-http-handlers.js",
     "governance:operator-ownership:eval": "node scripts/global/operator-ownership-eval.js",
     "governance:operator-ownership:test": "node --test tests/operator-ownership-rules.spec.js tests/delegation-phrase-lint.spec.js tests/operator-ownership-eval.spec.js tests/runtime-side-effect-guard.spec.js",
+    "governance:orchestrator-parity": "node scripts/global/orchestrator-governance-parity.js --json",
+    "governance:orchestrator-parity:test": "node --test tests/orchestrator-governance-parity.spec.js",
     "governance:runtime-guard:test": "node --test tests/runtime-side-effect-guard.spec.js",
     "governance:tokens": "node scripts/global/governance-token-lint.js",
     "governance:reconcile": "node scripts/global/ticket-reconcile.js --json",

--- a/research/epic-1912-orchestrator-governance-parity-2026-05-19.md
+++ b/research/epic-1912-orchestrator-governance-parity-2026-05-19.md
@@ -1,0 +1,46 @@
+# Epic 1912 Orchestrator Governance Parity
+
+## Result
+
+The harness does not yet prove exact governance parity across Claude Code,
+Copilot, and Codex. It has strong shared governance intent, but adapter coverage
+is uneven enough that portability needs follow-up implementation.
+
+## Evidence Matrix
+
+| Surface | Claude Code | Copilot | Codex | Rating |
+|---|---|---|---|---|
+| Instructions | `CLAUDE.md` adapter | `.github/copilot-instructions.md` | `.codex/AGENTS.md` | good |
+| Hooks/gates | no `hooks` in repo settings | seven events wired | five events wired | weak |
+| Prompt gates | skill route only | includes `goal_lens.py` | missing `goal_lens.py` | weak |
+| Permission gates | native possible | no native event | `PermissionRequest` unmapped | weak |
+| Deploy/sync | `.claude/` only | broad asset deploy | codex runtime deploy | weak |
+| Skills/commands | missing command adapters | skills deployed | agent skills available | partial |
+| Parity tests | not covered | partial | partial | weak |
+
+## Must-Fix Development Children
+
+1. #1917: Add a Claude Code hook/settings adapter for governance gates.
+2. #1918: Normalize deploy/sync targets so `all` means all three runtimes.
+3. #1919: Wire Codex parity gates for `goal_lens.py` and `PermissionRequest`.
+4. #1920: Generate or waive Claude command adapters for canonical skills.
+5. #1921: Promote `governance:orchestrator-parity` to strict CI.
+
+## Sources
+
+- OpenAI Codex docs: <https://developers.openai.com/codex/cli/slash-commands>
+- OpenAI Codex config: <https://developers.openai.com/codex/config-reference#configtoml>
+- Claude Code hooks: <https://docs.anthropic.com/en/docs/claude-code/hooks>
+- Copilot instructions: <https://docs.github.com/en/copilot/how-tos/custom-instructions/adding-repository-custom-instructions-for-github-copilot>
+- Copilot coding agent: <https://docs.github.com/en/copilot/using-github-copilot/coding-agent/about-assigning-tasks-to-copilot>
+
+## Recommendation
+
+Treat #1912 as complete when this planning artifact, the parity manifest, the
+audit command, and the follow-up tickets land. Do not close the implementation
+gap silently inside this Epic; each adapter change should use a focused child
+ticket with single-team file ownership.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/scripts/global/orchestrator-governance-parity.js
+++ b/scripts/global/orchestrator-governance-parity.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const MANIFEST = path.join(ROOT, 'inventory', 'orchestrator-governance-parity.json');
+
+function readJson(rel) {
+  return JSON.parse(fs.readFileSync(path.join(ROOT, rel), 'utf8'));
+}
+
+function read(rel) {
+  const full = path.join(ROOT, rel);
+  return fs.existsSync(full) ? fs.readFileSync(full, 'utf8') : '';
+}
+
+function hookCommands(config) {
+  const events = Object.keys(config.hooks || {});
+  const scripts = new Set();
+  for (const groups of Object.values(config.hooks || {})) {
+    const list = Array.isArray(groups) ? groups : [groups];
+    for (const group of list) {
+      const hooks = group.hooks || (group.command ? [group] : []);
+      for (const hook of hooks) {
+        const match = String(hook.command || '').match(/([^/\s"]+\.py)\b/);
+        if (match) scripts.add(match[1]);
+      }
+    }
+  }
+  return { events, scripts: [...scripts].sort() };
+}
+
+function listNames(rel, suffix = '') {
+  const full = path.join(ROOT, rel);
+  if (!fs.existsSync(full)) return [];
+  return fs.readdirSync(full, { withFileTypes: true })
+    .filter(e => suffix ? e.name.endsWith(suffix) : e.isDirectory())
+    .map(e => suffix ? e.name.replace(suffix, '') : e.name)
+    .sort();
+}
+
+function diff(expected, actual) {
+  const actualSet = new Set(actual);
+  return expected.filter(item => !actualSet.has(item));
+}
+
+function add(findings, id, severity, summary, evidence, recommendation) {
+  findings.push({ id, severity, summary, evidence, recommendation });
+}
+
+function run() {
+  const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+  const copilot = hookCommands(readJson('hooks/global-standards.json'));
+  const codex = hookCommands(readJson('.codex/runtime-hooks.json'));
+  const claude = readJson('.claude/settings.json');
+  const findings = [];
+  const missingCodexScripts = diff(manifest.requiredHookScripts, codex.scripts);
+  const missingCommon = diff(manifest.commonHookEvents, codex.events);
+  if (!claude.hooks) add(findings, 'claude-hooks-missing', 'high',
+    'Claude Code has no repo-owned hook adapter configured.',
+    '.claude/settings.json has no hooks key',
+    'Add a Claude settings hook adapter or explicit parity waiver.');
+  if (missingCodexScripts.length) add(findings, 'codex-hook-script-gap', 'high',
+    'Codex does not wire every canonical gate script.',
+    `missing: ${missingCodexScripts.join(', ')}`,
+    'Map goal/context gates into Codex hooks or document waivers.');
+  if (missingCommon.length) add(findings, 'codex-hook-event-gap', 'medium',
+    'Codex is missing common lifecycle events.',
+    `missing: ${missingCommon.join(', ')}`,
+    'Wire supported events; waive unsupported runtime events only with proof.');
+  if (!codex.events.includes('PermissionRequest')) add(findings, 'codex-permission-gap',
+    'medium', 'Codex native PermissionRequest event is unmapped.',
+    '.codex/runtime-hooks.json has no PermissionRequest entry',
+    'Add a PermissionRequest adapter or documented no-op gate.');
+  if (!/all/.test(read('scripts/deploy.sh')) || !/all/.test(read('scripts/sync.sh')))
+    add(findings, 'all-target-missing',
+    'high', 'Deploy/sync lacks an explicit all-three-runtimes target.',
+    'scripts support copilot|codex|claude|both; both excludes Claude',
+    'Add all target; keep both as compatibility alias only if documented.');
+  const missingCommands = diff(listNames('skills'), listNames('.claude/commands', '.md'));
+  if (missingCommands.length) add(findings, 'claude-command-gap', 'medium',
+    'Claude Code command adapters do not cover all repo skills.',
+    `missing ${missingCommands.length}: ${missingCommands.join(', ')}`,
+    'Generate adapters or record per-skill waivers in the parity manifest.');
+  return { ok: findings.length === 0, manifest: path.relative(ROOT, MANIFEST),
+    checkedAt: new Date().toISOString(), observations: { copilot, codex },
+    findings };
+}
+
+if (require.main === module) {
+  const result = run();
+  const json = process.argv.includes('--json') || process.argv.includes('--strict');
+  if (json) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  else for (const f of result.findings) process.stdout.write(`${f.severity}: ${f.id} - ${f.summary}\n`);
+  process.exit(process.argv.includes('--strict') && !result.ok ? 1 : 0);
+}
+
+module.exports = { run, hookCommands, diff };

--- a/tests/orchestrator-governance-parity.spec.js
+++ b/tests/orchestrator-governance-parity.spec.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const parity = require('../scripts/global/orchestrator-governance-parity');
+
+test('parity audit reports structured findings without throwing', () => {
+  const result = parity.run();
+  assert.equal(Array.isArray(result.findings), true);
+  assert.equal(typeof result.checkedAt, 'string');
+  assert.equal(result.manifest, 'inventory/orchestrator-governance-parity.json');
+});
+
+test('parity audit detects current Claude hook adapter gap', () => {
+  const ids = parity.run().findings.map(f => f.id);
+  assert.ok(ids.includes('claude-hooks-missing'));
+});
+
+test('parity audit detects Codex canonical gate coverage gap', () => {
+  const ids = parity.run().findings.map(f => f.id);
+  assert.ok(ids.includes('codex-hook-script-gap'));
+  assert.ok(ids.includes('codex-permission-gap'));
+});
+
+test('parity audit detects all-target deploy and sync semantics gap', () => {
+  const ids = parity.run().findings.map(f => f.id);
+  assert.ok(ids.includes('all-target-missing'));
+});
+
+test('parity audit detects Claude command adapter gap', () => {
+  const result = parity.run();
+  const gap = result.findings.find(f => f.id === 'claude-command-gap');
+  assert.ok(gap);
+  assert.match(gap.evidence, /missing \d+:/);
+});
+
+test('hook command parser supports flat and grouped hook schemas', () => {
+  const config = { hooks: { Stop: [{ hooks: [
+    { command: 'python3 ~/.x/stop_reminder.py' },
+  ] }] } };
+  assert.deepEqual(parity.hookCommands(config).scripts, ['stop_reminder.py']);
+});


### PR DESCRIPTION
Refs #1912
Closes #1912
Refs #1913

## Summary

- Adds `inventory/orchestrator-governance-parity.json` as the canonical manifest for cross-orchestrator governance parity surfaces.
- Adds `npm run governance:orchestrator-parity` as an advisory audit for Claude Code, Copilot, and Codex parity gaps.
- Adds regression tests for the audit and a research note with the development child-ticket plan.
- Creates follow-up child tickets #1917, #1918, #1919, #1920, and #1921 for the detected must-fix adapter gaps.

## Validation

- `npm run governance:orchestrator-parity:test` PASS, 6 tests.
- `npm run governance:orchestrator-parity` PASS as advisory command, reporting expected current gaps.
- `npm run lint` PASS, 463 files within 100-line limit.
- `npm run governance:verify` PASS.
- `git diff --check` PASS.
- `npx eslint -c lint-configs/eslint.config.devenv.js --max-warnings 9999 scripts/global/orchestrator-governance-parity.js` PASS with 3 JSDoc warnings and 0 errors.

## Governance

Dedicated worktree: `/home/curtisfranks/devenv-ops-codex-1912`
Branch: `feat/1912-orchestrator-governance-parity`

Signed-by: Quill Reyes
Team&Model: codex:gpt-5.4@openai
Role: admin