### PR TITLE
feat(governance): add Claude hook adapter

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,5 +15,53 @@
     "additionalDirectories": [
       "/home/curtisfranks/devenv-ops/.claude"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "python3 ~/.claude/hooks/scripts/session_context.py"
+      },
+      {
+        "type": "command",
+        "command": "python3 ~/.claude/hooks/scripts/hamr_activation_check.py"
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "type": "command",
+        "command": "python3 ~/.claude/hooks/scripts/manager_ticket_gate.py"
+      },
+      {
+        "type": "command",
+        "command": "python3 ~/.claude/hooks/scripts/goal_lens.py"
+      },
+      {
+        "type": "command",
+        "command": "python3 ~/.claude/hooks/scripts/userprompt_gate.py"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "python3 ~/.claude/hooks/scripts/commit_ticket_gate.py"
+      },
+      {
+        "type": "command",
+        "command": "python3 ~/.claude/hooks/scripts/pretool_guard.py"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "type": "command",
+        "command": "python3 ~/.claude/hooks/scripts/posttool_reminders.py"
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "command": "python3 ~/.claude/hooks/scripts/stop_reminder.py"
+      }
+    ]
   }
 }

--- a/tests/orchestrator-governance-parity.spec.js
+++ b/tests/orchestrator-governance-parity.spec.js
@@ -11,9 +11,9 @@ test('parity audit reports structured findings without throwing', () => {
   assert.equal(result.manifest, 'inventory/orchestrator-governance-parity.json');
 });
 
-test('parity audit detects current Claude hook adapter gap', () => {
+test('parity audit detects Claude hook adapter coverage', () => {
   const ids = parity.run().findings.map(f => f.id);
-  assert.ok(ids.includes('claude-hooks-missing'));
+  assert.equal(ids.includes('claude-hooks-missing'), false);
 });
 
 test('parity audit detects Codex canonical gate coverage gap', () => {


### PR DESCRIPTION
Refs #1917
Closes #1917
Refs #1912

## Summary

- Adds source-controlled Claude Code hook mappings in `.claude/settings.json` for the shared governance gates.
- Updates orchestrator parity tests so `claude-hooks-missing` must stay resolved.

## Validation

- `npm run governance:orchestrator-parity:test` PASS, 6 tests.
- `npm run governance:orchestrator-parity` PASS as advisory, no `claude-hooks-missing` finding.
- `npm run lint` PASS.
- `git diff --check` PASS.

Signed-by: Quill Reyes
Team&Model: codex:gpt-5.4@openai
Role: admin