### PR TITLE
feat(codex): wire parity governance gates

### DIFF
--- a/.changes/unreleased/1919.md
+++ b/.changes/unreleased/1919.md
@@ -1,0 +1,9 @@
+## #1919 Codex parity governance gates
+
+- Wires Codex `goal_lens.py` into the repo-owned prompt hook source.
+- Maps Codex `PermissionRequest` to the existing pre-tool governance guard.
+- Updates the orchestrator parity regression test to keep these gaps closed.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.codex/runtime-hooks.json
+++ b/.codex/runtime-hooks.json
@@ -17,7 +17,13 @@
     "UserPromptSubmit": [{
       "hooks": [
         { "type": "command", "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/manager_ticket_gate.py\"", "timeout": 10 },
+        { "type": "command", "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/goal_lens.py\"", "timeout": 10 },
         { "type": "command", "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/userprompt_gate.py\"", "timeout": 10 }
+      ]
+    }],
+    "PermissionRequest": [{
+      "hooks": [
+        { "type": "command", "command": "DEVENT_OPS_RUNTIME=codex /usr/bin/python3 \"$HOME/.codex/devenv-ops/hooks/pretool_guard.py\"", "timeout": 10 }
       ]
     }],
     "PreToolUse": [{

--- a/tests/orchestrator-governance-parity.spec.js
+++ b/tests/orchestrator-governance-parity.spec.js
@@ -18,8 +18,8 @@ test('parity audit detects Claude hook adapter coverage', () => {
 
 test('parity audit detects Codex canonical gate coverage gap', () => {
   const ids = parity.run().findings.map(f => f.id);
-  assert.ok(ids.includes('codex-hook-script-gap'));
-  assert.ok(ids.includes('codex-permission-gap'));
+  assert.equal(ids.includes('codex-hook-script-gap'), false);
+  assert.equal(ids.includes('codex-permission-gap'), false);
 });
 
 test('parity audit detects all-target deploy and sync semantics coverage', () => {


### PR DESCRIPTION
Refs #1919
Closes #1919
Refs #1912

## Summary

- Adds Codex `goal_lens.py` to the repo-owned `UserPromptSubmit` hook source.
- Maps Codex `PermissionRequest` to the existing `pretool_guard.py` governance path.
- Updates parity regression coverage so `codex-hook-script-gap` and `codex-permission-gap` stay closed.
- Adds `.changes/unreleased/1919.md` for runtime behavior traceability.

## Validation

- `npm run governance:orchestrator-parity:test` PASS, 6 tests.
- `npm run governance:orchestrator-parity` PASS as advisory for #1919; only #1920 `claude-command-gap` remains.
- `npm run lint` PASS.
- `git diff --check` PASS.

Signed-by: Quill Reyes
Team&Model: codex:gpt-5.4@openai
Role: admin