### PR TITLE
feat(claude): add command skill adapters

### DIFF
--- a/.changes/unreleased/1920.md
+++ b/.changes/unreleased/1920.md
@@ -1,0 +1,9 @@
+## #1920 Claude command skill adapters
+
+- Adds missing Claude Code command adapters for canonical repo skills.
+- Keeps adapters as thin pointers to `skills/<name>/SKILL.md` to prevent rule forks.
+- Updates the orchestrator parity regression test to keep skill-command parity closed.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/fleet-model-optimizer.md
+++ b/.claude/commands/fleet-model-optimizer.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical fleet-model-optimizer skill."
+argument-hint: "[mode: audit|recommend|transition] [inventory: inventory/devices.json]"
+---
+
+# Fleet Model Optimizer
+
+Use the source skill at `skills/fleet-model-optimizer/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+analyze fleet inventory, recommend Ollama models by device capability, and
+produce safe pull/delete/transition guidance without forking governance rules.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/fleet-portable-config.md
+++ b/.claude/commands/fleet-portable-config.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical fleet-portable-config skill."
+argument-hint: "[mode: activate|audit|remediate] [fleet-root]"
+---
+
+# Fleet Portable Config
+
+Use the source skill at `skills/fleet-portable-config/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+adapt Megingjord harness inventory and topology for a new operator fleet without
+hand-editing runtime-home resources or forking governance rules.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/global-skills-bootstrap.md
+++ b/.claude/commands/global-skills-bootstrap.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical global-skills-bootstrap skill."
+argument-hint: "[mode: init|audit|repair] [repo]"
+---
+
+# Global Skills Bootstrap
+
+Use the source skill at `skills/global-skills-bootstrap/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+bootstrap global skill discovery for the repo, preserve installed-skill
+semantics, and avoid direct deployed-runtime edits.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/global-task-router.md
+++ b/.claude/commands/global-task-router.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical global-task-router skill."
+argument-hint: "[task-summary]"
+---
+
+# Global Task Router
+
+Use the source skill at `skills/global-task-router/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+classify work into the correct free, fleet, or premium lane and persist the
+escalation rationale for the active session without changing governance rules.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/llm-wiki-ops.md
+++ b/.claude/commands/llm-wiki-ops.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical llm-wiki-ops skill."
+argument-hint: "[mode: read|write|curate|audit] [topic]"
+---
+
+# LLM Wiki Ops
+
+Use the source skill at `skills/llm-wiki-ops/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+operate the Karpathy-style LLM Wiki knowledge system, route durable learnings
+to wiki/research storage, and preserve source-of-truth governance.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/mem-watchdog-ops.md
+++ b/.claude/commands/mem-watchdog-ops.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical mem-watchdog-ops skill."
+argument-hint: "[mode: status|triage|tune|repair]"
+---
+
+# Mem Watchdog Ops
+
+Use the source skill at `skills/mem-watchdog-ops/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+inspect Crostini memory watchdog state, interpret logs, and recommend safe
+threshold changes without bypassing operator safety controls.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/network-platform-resources.md
+++ b/.claude/commands/network-platform-resources.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical network-platform-resources skill."
+argument-hint: "[mode: inventory|route|audit] [platform]"
+---
+
+# Network Platform Resources
+
+Use the source skill at `skills/network-platform-resources/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+inspect network-accessible compute platforms, route work to appropriate
+resources, and respect credentials and privacy boundaries.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/openclaw-availability-utilization.md
+++ b/.claude/commands/openclaw-availability-utilization.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical openclaw-availability-utilization skill."
+argument-hint: "[mode: preflight|route|failover|audit]"
+---
+
+# OpenClaw Availability Utilization
+
+Use the source skill at `skills/openclaw-availability-utilization/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+keep OpenClaw available and actively used through preflight checks, routing,
+observability, and failover controls.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/openclaw-universal-system.md
+++ b/.claude/commands/openclaw-universal-system.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical openclaw-universal-system skill."
+argument-hint: "[mode: configure|audit|standardize]"
+---
+
+# OpenClaw Universal System
+
+Use the source skill at `skills/openclaw-universal-system/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+standardize OpenClaw as a reusable machine-global execution system while
+preserving repository-local governance and routing evidence.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/openrouter-free-failover.md
+++ b/.claude/commands/openrouter-free-failover.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical openrouter-free-failover skill."
+argument-hint: "[mode: configure|refresh|troubleshoot]"
+---
+
+# OpenRouter Free Failover
+
+Use the source skill at `skills/openrouter-free-failover/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+configure and maintain the free-model failover cascade for OpenClaw while
+respecting zero-cost routing and availability evidence.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/operator-identity-context.md
+++ b/.claude/commands/operator-identity-context.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical operator-identity-context skill."
+argument-hint: ""
+---
+
+# Operator Identity Context
+
+Use the source skill at `skills/operator-identity-context/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+establish operator identity, access authority, and execution mandate before
+planning or acting, while preserving baton handoff rules.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/playwright-vision-low-resource.md
+++ b/.claude/commands/playwright-vision-low-resource.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical playwright-vision-low-resource skill."
+argument-hint: "[mode: plan|run|triage] [target-url]"
+---
+
+# Playwright Vision Low Resource
+
+Use the source skill at `skills/playwright-vision-low-resource/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+run visual QA with low-resource browser discipline, capture evidence, and keep
+the harness visual gate semantics intact.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.claude/commands/role-admin-execution.md
+++ b/.claude/commands/role-admin-execution.md
@@ -1,0 +1,16 @@
+---
+description: "Claude Code adapter for the canonical role-admin-execution skill."
+argument-hint: "[scope: pr|merge|deploy|closeout]"
+---
+
+# Role Admin Execution
+
+Use the source skill at `skills/role-admin-execution/SKILL.md`.
+
+This command is a thin Claude Code adapter. Follow the canonical skill exactly:
+perform Admin baton operations, verify CI/merge evidence, and avoid overlapping
+Manager, Collaborator, or Consultant authority.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/tests/orchestrator-governance-parity.spec.js
+++ b/tests/orchestrator-governance-parity.spec.js
@@ -28,10 +28,8 @@ test('parity audit detects all-target deploy and sync semantics coverage', () =>
 });
 
 test('parity audit detects Claude command adapter gap', () => {
-  const result = parity.run();
-  const gap = result.findings.find(f => f.id === 'claude-command-gap');
-  assert.ok(gap);
-  assert.match(gap.evidence, /missing \d+:/);
+  const ids = parity.run().findings.map(f => f.id);
+  assert.equal(ids.includes('claude-command-gap'), false);
 });
 
 test('hook command parser supports flat and grouped hook schemas', () => {


### PR DESCRIPTION
Refs #1920
Closes #1920
Refs #1912

## Summary

- Adds missing Claude Code command adapters for 13 canonical repo skills.
- Keeps each adapter as a thin pointer to `skills/<name>/SKILL.md` so semantics remain canonical and unforked.
- Updates the parity regression test so `claude-command-gap` stays closed.
- Adds `.changes/unreleased/1920.md` for runtime-adapter traceability.

## Validation

- `npm run governance:orchestrator-parity:test` PASS, 6 tests.
- `npm run governance:orchestrator-parity` PASS, `ok: true`, `findings: []`.
- `npm run lint` PASS.
- `git diff --check` PASS.

Signed-by: Quill Reyes
Team&Model: codex:gpt-5.4@openai
Role: admin