### PR TITLE
feat(governance): enforce orchestrator parity

### DIFF
--- a/.changes/unreleased/1921.md
+++ b/.changes/unreleased/1921.md
@@ -1,0 +1,9 @@
+## #1921 Orchestrator parity CI
+
+- Adds a strict orchestrator parity workflow for runtime adapter changes.
+- Documents waiver expectations for justified runtime parity exceptions.
+- Extends parity tests to exercise strict-mode execution.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/.github/workflows/orchestrator-governance-parity.yml
+++ b/.github/workflows/orchestrator-governance-parity.yml
@@ -1,0 +1,53 @@
+name: Orchestrator Governance Parity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.claude/**'
+      - '.codex/**'
+      - '.github/workflows/orchestrator-governance-parity.yml'
+      - 'hooks/**'
+      - 'inventory/orchestrator-governance-parity.json'
+      - 'scripts/deploy.sh'
+      - 'scripts/sync.sh'
+      - 'scripts/global/orchestrator-governance-parity.js'
+      - 'skills/**'
+      - 'tests/orchestrator-governance-parity.spec.js'
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [main]
+    paths:
+      - '.claude/**'
+      - '.codex/**'
+      - '.github/workflows/orchestrator-governance-parity.yml'
+      - 'hooks/**'
+      - 'inventory/orchestrator-governance-parity.json'
+      - 'scripts/deploy.sh'
+      - 'scripts/sync.sh'
+      - 'scripts/global/orchestrator-governance-parity.js'
+      - 'skills/**'
+      - 'tests/orchestrator-governance-parity.spec.js'
+
+concurrency:
+  group: orchestrator-parity-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  parity:
+    name: orchestrator-parity-strict
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+      - name: Parity regression tests
+        run: npm run governance:orchestrator-parity:test
+      - name: Strict parity audit
+        run: |
+          node scripts/global/orchestrator-governance-parity.js
+          node scripts/global/orchestrator-governance-parity.js --strict

--- a/docs/workflow/orchestrator-governance-parity.md
+++ b/docs/workflow/orchestrator-governance-parity.md
@@ -1,0 +1,23 @@
+# Orchestrator Governance Parity
+
+`scripts/global/orchestrator-governance-parity.js` compares the repo-owned
+Claude Code, Copilot, and Codex governance adapters against
+`inventory/orchestrator-governance-parity.json`.
+
+Run the local checks before changing runtime adapters:
+
+```bash
+npm run governance:orchestrator-parity:test
+node scripts/global/orchestrator-governance-parity.js --strict
+```
+
+The strict CI gate runs for changes to `.claude/`, `.codex/`, hooks, skills,
+deploy/sync scripts, the parity manifest, and the parity test.
+
+Waivers must be explicit. Add a manifest note that names the runtime, surface,
+unsupported capability, evidence source, and owner. Do not remove a missing
+adapter from the test surface just to make the audit pass.
+
+Signed-by: Quill Harper
+Team&Model: codex:gpt-5.4@openai
+Role: collaborator

--- a/tests/orchestrator-governance-parity.spec.js
+++ b/tests/orchestrator-governance-parity.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
 const { test } = require('node:test');
 const parity = require('../scripts/global/orchestrator-governance-parity');
 
@@ -37,4 +38,17 @@ test('hook command parser supports flat and grouped hook schemas', () => {
     { command: 'python3 ~/.x/stop_reminder.py' },
   ] }] } };
   assert.deepEqual(parity.hookCommands(config).scripts, ['stop_reminder.py']);
+});
+
+test('strict mode exits cleanly when parity is complete', () => {
+  const result = spawnSync(process.execPath, [
+    'scripts/global/orchestrator-governance-parity.js',
+    '--strict',
+  ], { encoding: 'utf8' });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /"ok": true/);
+});
+
+test('diff helper models strict failure requirements', () => {
+  assert.deepEqual(parity.diff(['goal_lens.py'], []), ['goal_lens.py']);
 });


### PR DESCRIPTION
Refs #1921
Closes #1921
Refs #1912

## Summary

- Adds a strict `Orchestrator Governance Parity` workflow for runtime adapter surfaces.
- Runs parity regression tests and `node scripts/global/orchestrator-governance-parity.js --strict` in CI.
- Documents explicit waiver expectations for justified runtime exceptions.
- Extends parity tests with strict-mode execution coverage.

## Validation

- `npm run governance:orchestrator-parity:test` PASS, 8 tests.
- `node scripts/global/orchestrator-governance-parity.js --strict` PASS, `ok: true`, `findings: []`.
- `npm run lint` PASS.
- `npm run docs:lint` PASS.
- `npm run docs:anchors` PASS.
- `git diff --check` PASS.

Signed-by: Quill Reyes
Team&Model: codex:gpt-5.4@openai
Role: admin