### PR TITLE
docs: two-tier model and installation guide #1954

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ npm run deploy:both:apply
 | `stress:surface-audit` | `node scripts/global/stress-surface-audit.js` |
 | `stress:surface-audit:test` | `node --test tests/stress-surface-audit.spec.js` |
 | `stress:test` | `node scripts/global/stress-runner.js` |
+| `stress:wiki-metrics:test` | `node --test tests/stress-wiki-metrics.spec.js` |
 | `stress:worktree` | `node --test tests/stress-worktree-isolation.spec.js` |
 | `sync` | `bash scripts/sync.sh` |
 | `sync:all` | `bash scripts/sync.sh --target all` |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,43 @@ flowchart LR
 - LLM wiki integration for reusable institutional knowledge
 - Accessibility + UX baseline checks aligned to WCAG 2.2 and Core Web Vitals
 
+## How it works — two-tier model
+
+Installing Megingjord in a project seeds two independent layers:
+
+**Global layer** — lives in your home directory, shared by all projects:
+
+| Runtime | Path | What lives there |
+|---|---|---|
+| GitHub Copilot Chat | `~/.copilot/` | skills, instructions, hooks, scripts, wiki |
+| Claude Code | `~/.claude/` | commands, agents, hooks, settings |
+| Codex | `~/.codex/` | AGENTS.md, config, hooks, rules |
+
+One `npm run deploy:apply` and every project on the machine inherits the full
+governance toolkit — skills, routing, telemetry, wiki — for all three runtimes.
+
+**Workspace layer** — checked into each project repo, workspace-specific:
+
+| Extension | File(s) | Purpose |
+|---|---|---|
+| Copilot | `.github/copilot-instructions.md` | workspace override + adapter |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json` | workspace override + adapter |
+| Codex | `AGENTS.md`, `.codex/` | workspace override + adapter |
+
+Workspace files extend or override the global layer. Global governance wins by
+default; local files add project-specific context and commands.
+
+**Multi-project reuse**: `npm run deploy:apply` is idempotent. Multiple projects
+share one global skill and governance layer while each keeps its own baton
+history, workspace wiki, and local overrides.
+
+**Multi-runtime parity**: A skill, hook, or governance rule written once deploys
+to all three runtimes — Copilot, Claude Code, and Codex are equal first-class
+citizens.
+
+See [`docs/howto/installation.md`](docs/howto/installation.md) for the full
+install walkthrough, including adding a second project.
+
 ## Quick start
 
 ```bash

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,6 @@
 # Megingjord — Architecture
 
-Governance-first multi-runtime AI agent harness. This document is a navigation
-map; each subsystem links to the canonical source files where details live.
+Navigation map for the governance-first multi-runtime AI agent harness.
 
 ## High-level data flow
 
@@ -28,15 +27,14 @@ Codex                          policy.json          OR Cloud (Claude /        + 
 - `scripts/global/cascade-dispatch.js` — fleet-first cascade (Free → Fleet → Haiku → Premium)
 - `scripts/global/model-routing-policy.json` — capability matrix, lane order
 - `scripts/global/task-router-dispatch.js` — direct dispatch to a tier
-- `scripts/global/free-router.js` — free-model orchestrator MVP (#786): classifier + signal stack picks a tier, calls a free LLM (Groq) when available, falls back to deterministic cascade-dispatch
+- `scripts/global/free-router.js` — free-model orchestrator; classifier + signal stack, falls back to cascade-dispatch
 - `agents/router.agent.md` — Routing role definition
 
-### Capability detection / cost-reduction (ADR-013)
+### Capability detection (ADR-013)
 
-- `scripts/global/capability-probe.js` + `capability-show.js` — probe providers, fleet hosts, toolchain; write/read `.dashboard/capabilities.json`
-- `scripts/global/rag-search.js` (#784) — repo-context search; MCP-first with ripgrep fallback
-- `scripts/global/state-offload-client.js` (#792) — per-turn state offload to a Worker
-- Optional features gate on the capability manifest, so a missing provider or offline fleet host degrades gracefully
+- `scripts/global/capability-probe.js` + `capability-show.js` — probe providers, fleet hosts, toolchain
+- `scripts/global/rag-search.js` — repo-context search; MCP-first with ripgrep fallback
+- `scripts/global/state-offload-client.js` — per-turn state offload to a Worker
 
 ### Governance
 
@@ -62,36 +60,40 @@ Codex                          policy.json          OR Cloud (Claude /        + 
 
 ### Fleet
 
-- `inventory/devices.json` — Tailscale IPs, Ollama models, GPU/CPU class (reconciliation tracked in #765)
+- `inventory/devices.json` — Tailscale IPs, Ollama models, GPU/CPU class
 - `scripts/health-check.js` — fleet connectivity probe
 - `wiki/entities/{36gbwinresource,openclaw,penguin-1}.md` — per-device authoritative state
-- Runtime targets (post-2026-05-01 IT pass, SYSTEM-service Ollama):
-  - `36gbwinresource` — Win11 Pro, Quadro T2000 4 GB VRAM; starcoder2:3b at 95 TPS (full GPU), qwen2.5-coder:32b at 1.6 TPS (max-quality)
-  - `openclaw` — CPU-only Win10, 16 GB RAM; deepseek-coder-v2:lite at 8.4 TPS (16B MoE primary)
-  - `penguin-1` — ChromeOS LXC, ~880 MB free RAM; SLM utility role (qwen3:0.6b, gemma3:270m, nomic-embed-text, snowflake-arctic-embed:m)
 
 ## Data flows
 
-- **Events** — agents/tools append JSONL to `.dashboard/events.jsonl`; dashboard server tails the file and broadcasts via SSE; clients render in Live Activity / Baton panels.
-- **Baton** — every issue is a baton; roles transition Manager → Collaborator → Admin → Consultant; each posts a named handoff comment; CI gates verify the trail.
+- **Events** — agents/tools append JSONL to `.dashboard/events.jsonl`; dashboard SSE broadcasts to clients.
+- **Baton** — every issue is a baton; roles transition Manager → Collaborator → Admin → Consultant; CI gates verify the trail.
 - **State** — short-term state in `.dashboard/state/` (gitignored); long-term truth in GitHub issues/PRs.
 
-## Deployment targets
+## Deployment model — two layers
 
-- `~/.copilot/` — Copilot runtime install root (skills, hooks, scripts, wiki)
-- `~/.claude/` — Claude Code install root (commands, agents, hooks)
-- `~/.codex/` — Codex runtime install root
-- Megingjord repo — source of truth; nothing is edited in deployed roots directly
+The harness operates in two independent layers per machine:
+
+**Global layer** (deployed once, shared by all projects):
+- `~/.copilot/` — Copilot skills, instructions, hooks, scripts, wiki
+- `~/.claude/` — Claude Code commands, agents, hooks
+- `~/.codex/` — Codex AGENTS.md, config, rules
+
+**Workspace layer** (per-project, committed to each project repo):
+- `.github/copilot-instructions.md`, `CLAUDE.md`, `AGENTS.md`
+- `.claude/settings.json`, `.codex/`
+
+All three runtimes (Copilot, Claude Code, Codex) are first-class: the same
+source deploys to all three. See [`docs/howto/installation.md`](howto/installation.md).
 
 ## Cross-runtime sync
 
-- `scripts/sync.sh` — copy from repo to runtime root (copilot/claude/codex/all)
-- `scripts/deploy.sh` — sync + post-deploy hooks (`npm run deploy:apply`)
-- Per-runtime targets via `--target` flag
+- `scripts/sync.sh` — pull from runtime root into repo
+- `scripts/deploy.sh` — deploy repo to global runtime roots; `--target copilot|claude|codex|both|all`
 
 ## Related documents
 
+- `docs/howto/installation.md` — install walkthrough, two-layer model
 - `docs/HELP-GUIDELINES.md` — HELP panel UX patterns
-- `docs/DECISIONS.md` — index of architecture decision records
-- `docs/STYLE-GUIDE.md` — terminology
+- `docs/DECISIONS.md` — architecture decision records; `docs/STYLE-GUIDE.md` — terminology
 - `research/adr/` — full ADR set

--- a/docs/howto/installation.md
+++ b/docs/howto/installation.md
@@ -1,0 +1,82 @@
+# Installing the Megingjord Harness
+
+## Prerequisites
+
+- Node >= 22, Git, GitHub CLI (`gh`)
+- VS Code with at least one of: GitHub Copilot Chat, Claude Code, or Codex
+
+## Install on a new machine
+
+```bash
+git clone https://github.com/chf3198/megingjord-harness.git
+cd megingjord-harness
+npm install
+npm run deploy:both:apply   # seeds ~/.copilot/ + ~/.claude/ + ~/.codex/
+```
+
+After this, every project on the machine inherits the global governance
+layer — skills, routing, hooks, wiki, and instructions — for all three runtimes.
+
+## Initialize a project workspace
+
+From inside any project repo (not the harness repo itself):
+
+1. Copy the workspace adapter files into the project:
+
+   ```bash
+   cp /path/to/megingjord-harness/.github/copilot-instructions.md .github/
+   cp /path/to/megingjord-harness/CLAUDE.md .
+   cp /path/to/megingjord-harness/AGENTS.md .
+   cp -r /path/to/megingjord-harness/.claude .
+   ```
+
+2. Customize each adapter file to reflect the project's purpose.
+3. Commit the workspace files to the project repo.
+
+The global layer is already live — no further setup needed for Copilot, Claude
+Code, or Codex to pick up the harness skills and governance hooks.
+
+## Two-layer model
+
+```
+Machine global layer                     Project workspace layer
+─────────────────────────────────        ──────────────────────────────
+~/.copilot/skills/                       .github/copilot-instructions.md
+~/.copilot/instructions/                 CLAUDE.md + .claude/settings.json
+~/.copilot/hooks/scripts/                AGENTS.md + .codex/
+~/.claude/agents/ + commands/            (workspace-specific wiki, overrides)
+~/.codex/AGENTS.md + config/
+
+Deployed once, shared by all projects    Unique per project, committed to git
+```
+
+## Adding a second project
+
+Run the workspace initialization steps in the new repo. The global layer is
+already in place — `npm run deploy:apply` is idempotent and safe to re-run
+to pick up harness updates in existing projects.
+
+## Workspace overrides
+
+Each workspace file can override global behavior for its extension:
+
+- **Copilot**: add rules to `.github/copilot-instructions.md`
+- **Claude Code**: add to `CLAUDE.md` or `.claude/settings.json`
+- **Codex**: add to `AGENTS.md` or `.codex/`
+
+Local wins on conflict per the provider-neutral governance contract.
+
+## Updating the harness
+
+```bash
+cd megingjord-harness && git pull
+npm run deploy:both:apply   # re-deploys global layer; idempotent
+```
+
+All projects sharing the machine automatically get the update.
+
+## Workspace wiki
+
+Each project can maintain its own `wiki/` source that compiles into
+`~/.copilot/wiki/`. Run `npm run wiki:ingest` from the harness repo after
+copying updated source to refresh the compiled wiki.


### PR DESCRIPTION
## Summary

Adds missing documentation that makes the Megingjord Harness portability architecture obvious to new users, contributors, and developers.

## Changes

- **README.md**: new 'How it works — two-tier model' section with global/workspace layer tables, multi-runtime parity explanation, multi-project reuse, link to installation howto
- **docs/ARCHITECTURE.md**: 'Deployment targets' replaced with 'Deployment model — two layers'; all three runtimes named first-class; file trimmed to 99 lines
- **docs/howto/installation.md**: new 82-line how-to covering machine install, workspace init, two-layer diagram, adding a second project, workspace overrides, harness updates

## Verification

`npm run lint` — no new failures (pre-existing orchestrator-governance-parity.json at 150 lines remains)

Refs #1954