### PR TITLE
docs(instructions): add replay-eval cross-ref to test-methodology-matrix #1982

### DIFF
--- a/instructions/test-methodology-matrix.instructions.md
+++ b/instructions/test-methodology-matrix.instructions.md
@@ -86,3 +86,4 @@ Open a `type:research` ticket against `area:governance` proposing the surface de
 - Visual QA: `instructions/visual-qa-governance.instructions.md`
 - Goal-lens: `instructions/global-standards.instructions.md`
 - Schema: `instructions/role-baton-routing.instructions.md` (`MANAGER_HANDOFF` `test_strategy` field)
+- Replay-eval over calendar waits: `docs/howto/soak-to-replay-translation.md` (#1809) — when writing validation prose, translate "N-day soak" language to replay-based eval per Epic #1771 infrastructure.


### PR DESCRIPTION
Adds a cross-reference line pointing authors to the soak-to-replay translation guide so they avoid calendar-soak language in validation prose.

Refs #1982