### PR TITLE
feat(instructions): add G10 Maintainability to all priority sentence surfaces

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -13,5 +13,5 @@
 - Preserve Team&Model signing on governed issue, PR, commit, and doc artifacts.
 - Use installed Megingjord skills from `$HOME/.agents/skills/` when relevant.
 - Always use the OpenAI developer documentation MCP server if you need to work with the OpenAI API, ChatGPT Apps SDK, Codex, or related docs without me having to explicitly ask.
-- Apply harness goal priority for decisions: Governance > Quality > Zero Cost > Privacy > Portability > Resilience > Throughput > Observability > Interoperability.
+- Apply harness goal priority for decisions: Governance > Quality > Zero Cost > Privacy > Portability > Resilience > Throughput > Observability > Interoperability > Maintainability.
 - HAMR routing canonical contract: `instructions/hamr-routing.instructions.md` (cost levers, /quota, /mcp, cache-hit gate). Complementary to the Global Task Router lane policy.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -93,7 +93,7 @@ All governed provider calls route through HAMR (`https://hamr.chf3198.workers.de
 
 ## Harness Goal Constitution (priority)
 
-Apply this decision order: Governance > Quality > Zero Cost > Privacy > Portability > Resilience > Throughput > Observability > Interoperability. Record rationale in ticket/PR evidence when a lower-priority goal wins.
+Apply this decision order: Governance > Quality > Zero Cost > Privacy > Portability > Resilience > Throughput > Observability > Interoperability > Maintainability. Record rationale in ticket/PR evidence when a lower-priority goal wins.
 
 ## Hook Behavior Overrides — see `instructions/hook-behavior-overrides.instructions.md` (advisory-vs-blocking contract; Tier-2 self-anneal threshold).
 

--- a/hooks/scripts/goal_lens.py
+++ b/hooks/scripts/goal_lens.py
@@ -17,7 +17,7 @@ from goal_tier_resolver import (
 GOALS = (
     "G1 Governance > G2 Quality > G3 Zero Cost > G4 Privacy > "
     "G5 Portability > G6 Resilience > G7 Throughput > "
-    "G8 Observability > G9 Interoperability"
+    "G8 Observability > G9 Interoperability > G10 Maintainability"
 )
 
 ANNEAL_RE = re.compile(

--- a/instructions/global-standards.instructions.md
+++ b/instructions/global-standards.instructions.md
@@ -31,7 +31,7 @@ applyTo: "**"
 ## Goal-lens decision lint (required)
 
 - Apply this priority order to all governed decisions:
-	`G1 Governance > G2 Quality > G3 Zero Cost > G4 Privacy > G5 Portability > G6 Resilience > G7 Throughput > G8 Observability > G9 Interoperability`.
+	`G1 Governance > G2 Quality > G3 Zero Cost > G4 Privacy > G5 Portability > G6 Resilience > G7 Throughput > G8 Observability > G9 Interoperability > G10 Maintainability`.
 - When tradeoffs occur, explicitly justify why a lower-priority goal overrides a higher one.
 - Keep the justification short and evidence-based in ticket comments, PR body, or closeout notes.
 

--- a/wiki/concepts/harness-goal-controls.md
+++ b/wiki/concepts/harness-goal-controls.md
@@ -112,6 +112,16 @@ Each of the nine harness goals has at least one enforcement primitive (lint rule
 | Evidence | end-to-end provider adapter tests | `tests/hamr-team-integration.spec.js` |
 | Evidence | cross-runtime parity (CC/CP/CX deployed assets sync) | `npm run sync:codex`, `sync:claude` |
 
+## G10 Maintainability
+
+| Layer | Primitive / Signal | File:line |
+| --- | --- | --- |
+| Enforcement | lint: ≤100 lines per file | `npm run lint` |
+| Enforcement | cyclomatic complexity checks (≤10 per fn) | `lint-configs/` |
+| Enforcement | no dead code at merge | Danger `Dangerfile.js` |
+| Evidence | G10 in priority sentence across always-loaded surfaces | #1966 (this ticket) |
+| Evidence | Consultant rubric G10 box | `instructions/role-consultant-critique.instructions.md` |
+
 ## How to use this page
 
 - **Authoring a new control**: pick the goal it primarily serves; add a row under the right Layer (Enforcement vs Evidence). If a control serves multiple goals, list it under each.

--- a/wiki/concepts/harness-goals.md
+++ b/wiki/concepts/harness-goals.md
@@ -23,6 +23,7 @@ cost routing, privacy, runtime behavior, and cross-team compatibility aligned.
 7. Throughput
 8. Observability
 9. Interoperability
+10. Maintainability
 
 ## Decision Rule
 


### PR DESCRIPTION
## Summary

Adds G10 Maintainability to all six always-loaded priority sentence surfaces so sessions inject the complete G1-G10 goal chain at startup.

## Changes

| Surface | Change |
| --- | --- |
| `instructions/global-standards.instructions.md` | Added `> G10 Maintainability` to priority sentence |
| `.github/copilot-instructions.md` | Added `> Maintainability` to decision order line |
| `.codex/AGENTS.md` | Added `> Maintainability` to harness goal priority line |
| `hooks/scripts/goal_lens.py` | Extended GOALS constant string |
| `wiki/concepts/harness-goals.md` | Added item 10 to Canonical Order list |
| `wiki/concepts/harness-goal-controls.md` | Added ## G10 Maintainability section |

## Verification

- `npm run lint` → ✅ All 489 files within 100-line limit
- All 6 grep hits confirmed (grep evidence in COLLABORATOR_HANDOFF on #1966)

Refs #1966