### PR TITLE
fix(knowledge): wiki log chronology back-correct #1681

### DIFF
--- a/tests/wiki-io.spec.js
+++ b/tests/wiki-io.spec.js
@@ -23,6 +23,15 @@ test('appendLog rejects far future dates', () => {
   expect(() => W.appendLog('2099-01-01', 'test', 'future guard')).toThrow(/Refusing future wiki log date/);
 });
 
+test('appendLog rejects dates 2 days in the future (boundary precision per #1681)', () => {
+  const twoDaysAhead = new Date(Date.now() + 2 * 86400000).toISOString().slice(0, 10);
+  expect(() => W.appendLog(twoDaysAhead, 'test', 'two-day boundary')).toThrow(/Refusing future wiki log date/);
+});
+
+test('appendLog rejects malformed date strings (Invalid wiki log date)', () => {
+  expect(() => W.appendLog('not-a-date', 'test', 'invalid input')).toThrow(/Invalid wiki log date/);
+});
+
 test('appendLog date tolerance constant remains 1 day', () => {
   expect(W.DATE_TOLERANCE_DAYS).toBe(1);
 });

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -234,7 +234,7 @@ self-annealing, wiki-pattern, governance-enforcement.
 Cross-linked with [[wikilinks]]. Epic #85 ticket #87.
 Total wiki pages now: 33.
 
-## [2026-07-14] create | Dashboard Codebase Gold Rules
+## [2026-04-18] create | Dashboard Codebase Gold Rules
 Synthesis from deep audit of 40 JS files. 10 gold rules
 covering namespace isolation, error handling, Alpine v3 API,
 Playwright config, script loading. Epic #290.


### PR DESCRIPTION
Refs #1681
Closes #1681

## Summary

The chronology guard in `scripts/wiki/wiki-io.js` `appendLog()` (lines 62-70) already rejects entries dated more than `DATE_TOLERANCE_DAYS` (=1) in the future. Two follow-up gaps remained per #1681 ACs:

1. **wiki/log.md line 237**: stale `2026-07-14` entry pre-dating the guard. Back-corrected to `2026-04-18` per git blame on the line (commit `6dbd633`, Curtis Franks 2026-04-18 23:19:35 -0500). That is the actual creation date.
2. **tests/wiki-io.spec.js**: only covered the far-future case (`2099-01-01`). Added two targeted tests per the #1681 spec:
   - `2-days-in-the-future` boundary case
   - malformed-date input (Invalid wiki log date branch)

## Verification

- `npx playwright test tests/wiki-io.spec.js`: 5/5 passed
- `npm run lint`: clean (476 files all within 100-line limit)
- `scripts/wiki/wiki-io.js` remains 94 lines (under cap)

## Cross-team baton

- the-manager-handoff-artifact: Codex Team (Quill Mason / codex:gpt-5.4@openai) — in issue body
- the-collaborator-handoff-artifact, the-admin-handoff-artifact, the-consultant-closeout-artifact: Claude Code Team (Orla Harper/Reyes/Vale / claude-code:opus-4-7@local) — posted on #1681

Lane: lane:code-change. test_strategy: tdd-pyramid.
