### PR TITLE
docs(instructions): add OWASP Agentic Top 10 mapping instruction and wiki rows

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -15,3 +15,4 @@
 - Always use the OpenAI developer documentation MCP server if you need to work with the OpenAI API, ChatGPT Apps SDK, Codex, or related docs without me having to explicitly ask.
 - Apply harness goal priority for decisions: Governance > Quality > Zero Cost > Privacy > Portability > Resilience > Throughput > Observability > Interoperability > Maintainability.
 - HAMR routing canonical contract: `instructions/hamr-routing.instructions.md` (cost levers, /quota, /mcp, cache-hit gate). Complementary to the Global Task Router lane policy.
+- OWASP Agentic security mapping: `instructions/owasp-agentic-mapping.instructions.md` (OA1-OA10 risk-to-goal mapping; G1-G10 coverage classification).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,5 +96,5 @@ All governed provider calls route through HAMR (`https://hamr.chf3198.workers.de
 Apply this decision order: Governance > Quality > Zero Cost > Privacy > Portability > Resilience > Throughput > Observability > Interoperability > Maintainability. Record rationale in ticket/PR evidence when a lower-priority goal wins.
 
 ## Hook Behavior Overrides — see `instructions/hook-behavior-overrides.instructions.md` (advisory-vs-blocking contract; Tier-2 self-anneal threshold).
-
+## OWASP Agentic Security — see `instructions/owasp-agentic-mapping.instructions.md` (OA1-OA10 risk-to-goal mapping; G1-G10 coverage classification).
 ## Skill Index — auto-derived per `docs/skills-copilot.md`; regenerate via `node scripts/global/skill-views-derive.js`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ and AI agent governance. All instructions below are binding for Claude Code sess
 @instructions/wiki-knowledge.instructions.md
 @instructions/hamr-routing.instructions.md
 @instructions/observability.instructions.md
+@instructions/owasp-agentic-mapping.instructions.md
 
 ## Runtime Context
 

--- a/instructions/owasp-agentic-mapping.instructions.md
+++ b/instructions/owasp-agentic-mapping.instructions.md
@@ -1,0 +1,53 @@
+---
+name: OWASP Agentic Top 10 Risk Mapping
+description: Maps OWASP Top 10 for Agentic Applications (Dec 2025) to harness goals, current enforcement coverage, and candidate mitigations. Load when assessing agentic security posture.
+applyTo: "**"
+---
+
+# OWASP Top 10 for Agentic Applications — Harness Mapping
+
+Source: OWASP Top 10 for Agentic Applications (December 2025; 2026 effective).
+
+## Risk Mapping Table
+
+| # | Risk | Harness Goals | Current Coverage | Candidate Mitigation |
+|---|---|---|---|---|
+| OA1 | Goal Hijacking | G1 G2 | Advisory (`operator-identity-context`, ticket-first) | Goal-hijack-resistance test fixtures; separate planning from execution |
+| OA2 | Tool Misuse | G1 G4 | **Enforced** (`pretool_guard.py`, permissions allowlist) | Per-tool blast-radius declarations |
+| OA3 | Identity Abuse | G1 G4 | **Enforced** (`team-model-signing`, signer-alias-canonical) | Cross-family signer-independence tests |
+| OA4 | Memory Poisoning | G2 G4 | Partial (`memory-watchdog`) | Schema validation on auto-memory writes |
+| OA5 | Cascading Failures | G6 | Partial (header-spillover, sticky-route TTL) | Explicit circuit-breaker contracts |
+| OA6 | Rogue Agents | G1 G9 | **Enforced** (broker quarantine, baton single-thread) | Inter-agent message tamper-evidence |
+| OA7 | Supply Chain | G4 | **Enforced** (dependency-review, secret-scanning, cosign) | SLSA provenance + Artifact Attestation |
+| OA8 | Insecure Communications | G4 | Partial (DPoP for HAMR; not all cross-runtime comms) | Zero-trust mesh for cross-runtime baton |
+| OA9 | Human-Agent Trust Exploitation | G1 G8 | Advisory (closeout evidence required) | Tamper-evident audit ledger (wiki/log.md) |
+| OA10 | Code Execution | G4 | **Enforced** (no LLM eval, no shell from prompts) | Sandbox boundaries auditable |
+
+## Coverage Classification Legend
+
+- **Enforced**: deterministic gate; blocks on violation
+- **Partial**: guardrail present; gaps identified; advisory on breach
+- **Advisory**: guidance required; no blocking gate today
+
+## Relationship to Harness Goals
+
+Every OA risk maps to one or more G1-G10 goals:
+
+- G1 Governance: OA1, OA2, OA3, OA6, OA9
+- G2 Quality: OA1, OA4
+- G4 Privacy & Security: OA2, OA3, OA4, OA7, OA8, OA10
+- G6 Resilience: OA5
+- G8 Observability: OA9
+- G9 Interoperability: OA6
+
+## Sources
+
+- Research: `research/goal-enforcement-2026-05-19.md` §2 (Phase-0 R1, Refs #1963 AC3)
+- goteleport.com/blog/owasp-top-10-agentic-applications
+- paloaltonetworks.com/blog/cloud-security/owasp-agentic-ai-security
+
+## Related
+
+- `wiki/concepts/harness-goal-controls.md` — per-goal enforcement catalog with OWASP risk rows
+- `instructions/harness-goals.instructions.md` — canonical G1-G10 definitions
+- `instructions/global-standards.instructions.md` — always-loaded priority sentence

--- a/wiki/concepts/harness-goal-controls.md
+++ b/wiki/concepts/harness-goal-controls.md
@@ -122,6 +122,23 @@ Each of the nine harness goals has at least one enforcement primitive (lint rule
 | Evidence | G10 in priority sentence across always-loaded surfaces | #1966 (this ticket) |
 | Evidence | Consultant rubric G10 box | `instructions/role-consultant-critique.instructions.md` |
 
+## OWASP Agentic Top 10 Risk Coverage
+
+Source: OWASP Top 10 for Agentic Applications (December 2025). Full mapping in `instructions/owasp-agentic-mapping.instructions.md`.
+
+| # | Risk | Mapped Goals | Coverage | Notes |
+|---|---|---|---|---|
+| OA1 | Goal Hijacking | G1 G2 | Advisory | Ticket-first + operator-identity gates; no blocking test fixture yet |
+| OA2 | Tool Misuse | G1 G4 | Enforced | `pretool_guard.py` permissions allowlist; blast-radius declarations pending |
+| OA3 | Identity Abuse | G1 G4 | Enforced | `team-model-signing`; signer-alias-canonical gate |
+| OA4 | Memory Poisoning | G2 G4 | Partial | `memory-watchdog`; schema validation on auto-writes gap |
+| OA5 | Cascading Failures | G6 | Partial | Header-spillover + sticky-route TTL; circuit-breaker gap |
+| OA6 | Rogue Agents | G1 G9 | Enforced | Broker quarantine + single-thread baton; inter-agent tamper-evidence pending |
+| OA7 | Supply Chain | G4 | Enforced | Dependency-review + secret-scanning + cosign attestation |
+| OA8 | Insecure Communications | G4 | Partial | DPoP for HAMR; cross-runtime zero-trust mesh gap |
+| OA9 | Human-Agent Trust Exploitation | G1 G8 | Advisory | Closeout evidence required; append-only wiki/log.md |
+| OA10 | Code Execution | G4 | Enforced | No LLM eval; no shell-from-prompt; sandbox boundaries auditable |
+
 ## How to use this page
 
 - **Authoring a new control**: pick the goal it primarily serves; add a row under the right Layer (Enforcement vs Evidence). If a control serves multiple goals, list it under each.
@@ -140,4 +157,5 @@ Each of the nine harness goals has at least one enforcement primitive (lint rule
 - `wiki/concepts/harness-goals.md` — priority order + canonical definitions
 - `instructions/harness-goals.instructions.md` — canonical instruction file
 - `instructions/global-standards.instructions.md` — priority sentence (always-loaded)
+- `instructions/owasp-agentic-mapping.instructions.md` — OWASP Agentic Top 10 risk-to-goal mapping
 - Epic #1113 — multi-layer self-annealing goal-governance (consumes this map as sensor input)


### PR DESCRIPTION
## Summary

Creates `instructions/owasp-agentic-mapping.instructions.md` with a 10-risk mapping table (sourced from Phase-0 research #1963 §2), adds OWASP-risk rows to `wiki/concepts/harness-goal-controls.md`, and cross-references the new instruction file in all three runtime adapter files.

Closes #1968

## Changes

- **NEW** `instructions/owasp-agentic-mapping.instructions.md` — 10-risk table, coverage legend, goal mapping, sources (AC1)
- **UPDATED** `wiki/concepts/harness-goal-controls.md` — OWASP Agentic Top 10 Risk Coverage section (AC2)
- **UPDATED** `CLAUDE.md` — added `@instructions/owasp-agentic-mapping.instructions.md` (AC3)
- **UPDATED** `.codex/AGENTS.md` — added OWASP mapping reference (AC3)
- **UPDATED** `.github/copilot-instructions.md` — added OWASP Agentic Security reference line (AC3)

## AC Evidence

- AC1: instruction file created with all 10 OA risks, coverage classification, goal relationships, sources
- AC2: wiki harness-goal-controls.md updated with OWASP risk rows table
- AC3: all three runtime adapters cross-reference the new instruction file
- AC4: no new credential surface introduced (docs-only change)
- AC5: `npm run lint` clean — 489 files scanned, all within 100-line limit
- AC6: instruction file has `applyTo: "**"` with cross-runtime references in CLAUDE.md, .codex/AGENTS.md, .github/copilot-instructions.md

## Validation

```
npm run lint → ✅ All files within 100-line limit
.github/copilot-instructions.md → 100 lines (unchanged)
CLAUDE.md → 44 lines
.codex/AGENTS.md → 18 lines
```

Refs #1963