### PR TITLE
feat(instructions): add G10 to wiki harness-goals.md #1966

### DIFF
--- a/wiki/concepts/harness-goals.md
+++ b/wiki/concepts/harness-goals.md
@@ -42,7 +42,7 @@ These surfaces inject the priority sentence into every governed session at start
 
 ## Reachable on Demand (NOT auto-included)
 
-- `instructions/harness-goals.instructions.md` — canonical goal constitution with expanded G1..G9 definitions. Contains the full priority sentence + per-goal definitions, but is NOT @-included by any runtime entry point. Read on demand or via `goal_lens.py` keyword trigger. (Per #1105 D-001 cross-team verification: CC + CX both confirmed.)
+- `instructions/harness-goals.instructions.md` — canonical goal constitution with expanded G1..G10 definitions. Contains the full priority sentence + per-goal definitions, but is NOT @-included by any runtime entry point. Read on demand or via `goal_lens.py` keyword trigger. (Per #1105 D-001 cross-team verification: CC + CX both confirmed.)
 
 ## Loading Paths (per runtime)
 
@@ -70,7 +70,7 @@ When a match is found, the hook injects a compact context block containing the p
 
 ### Verification source
 
-This section reflects empirical verification by Claude Code Team and Codex Team during the #1105 cross-team R&D synthesis (2026-05-07). Prior documentation incorrectly claimed `instructions/harness-goals.instructions.md` was always-loaded; cross-team grep against `CLAUDE.md`, `AGENTS.md`, `.codex/AGENTS.md`, and `.github/copilot-instructions.md` confirmed it is NOT @-included by any runtime entry point. Only the priority sentence reaches sessions — via the inline references above. The expanded G1..G9 definitions are reachable on demand only.
+This section reflects empirical verification by Claude Code Team and Codex Team during the #1105 cross-team R&D synthesis (2026-05-07). Prior documentation incorrectly claimed `instructions/harness-goals.instructions.md` was always-loaded; cross-team grep against `CLAUDE.md`, `AGENTS.md`, `.codex/AGENTS.md`, and `.github/copilot-instructions.md` confirmed it is NOT @-included by any runtime entry point. Only the priority sentence reaches sessions — via the inline references above. The expanded G1..G10 definitions are reachable on demand only.
 
 ## Goal Definitions
 
@@ -83,6 +83,7 @@ This section reflects empirical verification by Claude Code Team and Codex Team 
 - Throughput: preserve acceptable speed after higher-priority goals are met.
 - Observability: make decisions and outcomes visible, auditable, attributable.
 - Interoperability: preserve compatibility across agent surfaces and runtimes.
+- Maintainability: files ≤100 lines; cyclomatic complexity ≤10 per function; no dead code at merge; changes documented via GOV-009 EDD before implementation (#1530).
 
 ## Sources
 


### PR DESCRIPTION
Refs #1966
Closes #1966

## Summary

C1 of Epic #1962 Phase-1. Adds G10 Maintainability to the final docs surface (wiki/concepts/harness-goals.md). The other 5 always-loaded surfaces (global-standards.instructions.md, .github/copilot-instructions.md, .codex/AGENTS.md, hooks/scripts/goal_lens.py, wiki/concepts/harness-goal-controls.md) were updated in a prior partial ship (commit b532f4d on main).

## Verification

- All 6 surfaces named in #1966 contain G10 (confirmed by grep)
- `npm run lint` clean (476 files)
- 3 insertions, 2 deletions in 1 file

## Baton

All 4 artifacts posted on #1966: the-manager-handoff-artifact, the-collaborator-handoff-artifact, the-admin-handoff-artifact, the-consultant-closeout-artifact (rubric mean 9.7).

Lane: lane:docs-research. test_strategy: drift-lint.
