### PR TITLE
docs(instructions): add cross-team artifact-write contract

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -16,3 +16,4 @@
 - Apply harness goal priority for decisions: Governance > Quality > Zero Cost > Privacy > Portability > Resilience > Throughput > Observability > Interoperability > Maintainability.
 - HAMR routing canonical contract: `instructions/hamr-routing.instructions.md` (cost levers, /quota, /mcp, cache-hit gate). Complementary to the Global Task Router lane policy.
 - OWASP Agentic security mapping: `instructions/owasp-agentic-mapping.instructions.md` (OA1-OA10 risk-to-goal mapping; G1-G10 coverage classification).
+- Cross-team artifact-write contract: `instructions/cross-team-artifact-write.instructions.md` (target-runtime team owns schema/contract test; required before manager-handoff on cross-runtime config writes).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,7 +94,7 @@ All governed provider calls route through HAMR (`https://hamr.chf3198.workers.de
 ## Harness Goal Constitution (priority)
 
 Apply this decision order: Governance > Quality > Zero Cost > Privacy > Portability > Resilience > Throughput > Observability > Interoperability > Maintainability. Record rationale in ticket/PR evidence when a lower-priority goal wins.
-
+## Cross-Team Artifact-Write Contract — see `instructions/cross-team-artifact-write.instructions.md` (target-runtime team owns schema/contract test; required before manager-handoff on cross-runtime config writes).
 ## Hook Behavior Overrides — see `instructions/hook-behavior-overrides.instructions.md` (advisory-vs-blocking contract; Tier-2 self-anneal threshold).
 ## OWASP Agentic Security — see `instructions/owasp-agentic-mapping.instructions.md` (OA1-OA10 risk-to-goal mapping; G1-G10 coverage classification).
 ## Skill Index — auto-derived per `docs/skills-copilot.md`; regenerate via `node scripts/global/skill-views-derive.js`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ and AI agent governance. All instructions below are binding for Claude Code sess
 @instructions/hamr-routing.instructions.md
 @instructions/observability.instructions.md
 @instructions/owasp-agentic-mapping.instructions.md
+@instructions/cross-team-artifact-write.instructions.md
 
 ## Runtime Context
 

--- a/instructions/cross-team-artifact-write.instructions.md
+++ b/instructions/cross-team-artifact-write.instructions.md
@@ -1,0 +1,64 @@
+---
+name: Cross-Team Artifact-Write Contract
+description: Governs accountability when Team A authors a config/artifact that Team B's runtime parses. Target-runtime team owns the schema/contract test.
+applyTo: "**"
+---
+
+# Cross-Team Artifact-Write Contract
+
+A cross-team artifact write occurs when Team A (the authoring team) creates or
+modifies a file that is **consumed and parsed by Team B's runtime**. The canonical
+example is a Codex team authoring `.claude/settings.json` (a Claude Code config).
+Without an explicit contract, schema-correctness accountability is ambiguous, and
+the manager-handoff can be marked complete without validating runtime parseability.
+
+## Authoring-Team Responsibilities
+
+1. **Signal the write** — The MANAGER_HANDOFF must list every cross-runtime file
+   created or modified under `cross_runtime_writes: [<path>, ...]`.
+2. **Reference the schema** — The branch must include a citation to the target
+   runtime's schema (doc link, JSON Schema file, or template path).
+3. **Functional intent only** — The authoring team is responsible for correct
+   functional intent (the right hook, key name, or value). Parse-validity is
+   owned by the target team (see below).
+4. **Tag target team** — Post a `TEAM_QUESTION` comment on the issue naming the
+   target team and requesting schema-validation sign-off before manager-handoff.
+
+## Target-Runtime-Team Responsibilities
+
+1. **Own the schema test** — The target-runtime team is accountable for a
+   passing schema/contract test that validates any cross-team-written config
+   against the runtime's accepted format.
+2. **Sign off before manager-handoff** — The target team must post a
+   `TEAM_RESPONSE` comment with `verdict: schema-valid` or `verdict: schema-invalid`
+   before the authoring team's MANAGER_HANDOFF can be marked complete.
+3. **Maintain the test** — The schema test lives in the target team's test suite
+   and is updated whenever the runtime schema changes.
+
+## Required Artifacts Before Manager-Handoff Completes
+
+For any ticket with `cross_runtime_writes` populated, the MANAGER_HANDOFF
+evidence block must include:
+
+```
+cross_runtime_writes:
+  - path: <file>
+    target_team: <team>
+    schema_source: <schema doc or file path>
+    target_team_sign_off: <TEAM_RESPONSE comment URL or "pending">
+```
+
+A manager-handoff with `target_team_sign_off: pending` is incomplete. The baton
+does NOT advance to Collaborator until sign-off is received.
+
+## Failure Mode: Schema Regression Recovery
+
+If a cross-team artifact write causes a runtime schema rejection after merge,
+invoke the Breaking-Change Recovery Protocol from
+`instructions/breaking-change-recovery.instructions.md`.
+
+## Cross-References
+
+- `instructions/role-baton-routing.instructions.md` — MANAGER_HANDOFF gate
+- `instructions/team-model-signing.instructions.md` — TEAM_QUESTION/TEAM_RESPONSE signing
+- `skills/repo-standards-router/SKILL.md` — when to flag a cross-team artifact write

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -181,6 +181,12 @@ The brief evidence MUST include the 4 structured fields: `Signed-by`, `Team&Mode
 
 A repo may override via `.github/copilot-instructions.md`; local wins on conflict.
 
+## Cross-Team Artifact-Write Gate
+
+When a MANAGER_HANDOFF involves writing files consumed by another team's runtime,
+the `cross_runtime_writes` field is required and must include `target_team_sign_off`
+before the baton advances. See `instructions/cross-team-artifact-write.instructions.md`.
+
 ## Skill Mapping
 
 Manager: `role-manager-execution` | Collaborator: `role-collaborator-execution`

--- a/instructions/team-model-signing.instructions.md
+++ b/instructions/team-model-signing.instructions.md
@@ -60,3 +60,9 @@ applyTo: "**"
 ## Override rule
 
 - When local rules differ, use the local alias/trailer format and keep canonical `Team&Model` provenance present.
+
+## Cross-Team Artifact-Write Signing
+
+`TEAM_QUESTION` and `TEAM_RESPONSE` comments in the cross-team artifact-write
+sign-off workflow must carry standard signing fields. See
+`instructions/cross-team-artifact-write.instructions.md` for the full contract.

--- a/skills/repo-standards-router/SKILL.md
+++ b/skills/repo-standards-router/SKILL.md
@@ -127,3 +127,10 @@ Recommend adding a new branch only if all are true:
 1. Repeated need appears in at least 2 repositories.
 2. At least 3 controls are not covered by existing primary types + overlays.
 3. Risk is meaningful if left as ad-hoc guidance.
+
+## Cross-Team Artifact-Write Flag
+
+When routing a repo that authors config files consumed by another team's runtime
+(e.g., Codex team writing `.claude/settings.json`), flag the ticket for the
+cross-team artifact-write contract. See
+`instructions/cross-team-artifact-write.instructions.md`.


### PR DESCRIPTION
## Summary

Establishes the cross-team artifact-write governance contract for cases where one orchestrating team authors a config file consumed by another team's runtime.

## Changes

- `instructions/cross-team-artifact-write.instructions.md` (new) — full contract with authoring-team and target-runtime-team responsibilities, required handoff artifacts, failure-mode recovery, and cross-references
- `instructions/role-baton-routing.instructions.md` — Cross-Team Artifact-Write Gate section added
- `instructions/team-model-signing.instructions.md` — Cross-Team Artifact-Write Signing section added
- `skills/repo-standards-router/SKILL.md` — Cross-Team Artifact-Write Flag section added
- `CLAUDE.md`, `.codex/AGENTS.md`, `.github/copilot-instructions.md` — runtime adapters updated

## Validation Evidence

- `npm run lint` ✅ — all 490 files within 100-line limit
- `npm run governance:instructional-coverage` ✅ — 18 MUST statements (baseline preserved; zero new orphans)
- No file conflict with open PR #1990 (feat/1971-cyclomatic-complexity)

Closes #1958

Signed-by: Soren Reyes
Team&Model: copilot:claude-sonnet-4-6@anthropic
Role: admin