### PR TITLE
fix(skills): MD018 hotfix in breaking-change-recovery SKILL.md #1999

### DIFF
--- a/skills/breaking-change-recovery/SKILL.md
+++ b/skills/breaking-change-recovery/SKILL.md
@@ -52,8 +52,8 @@ Role: admin
 
 ## Worked example
 
-Chain: #1917 (cause) → #1951 (triage) → #1952 / `c857ce8` (fix) →
-#1953 (casualty closed) → #1954 (casualty refiled).
+Chain: #1917 (cause) → #1951 (triage) → #1952 / `c857ce8` (fix)
+→ #1953 (casualty closed) → #1954 (casualty refiled).
 
 See full narrative in `instructions/breaking-change-recovery.instructions.md`
 Phase 6 "Worked Example" section.


### PR DESCRIPTION
Refs #1999
Closes #1999

## Summary
One-line markdown fix to skills/breaking-change-recovery/SKILL.md unblocking the lint-required CI gate (was failing MD018 on every PR since the file landed).

## Verification
- `npm run lint:md` returns 0 errors across 418 files (was 1 error before)

## Baton
All 4 artifacts on #1999. Lane: trivial. test_strategy: manual-verify.

[skip-doc-gate] — single-line markdown formatting fix to unblock lint gate; no behavior change
