### PR TITLE
feat(scripts): add session-bypass-tracker for Tier-2 anneal signal

### DIFF
--- a/.changes/unreleased/1715.md
+++ b/.changes/unreleased/1715.md
@@ -1,0 +1,8 @@
+## #1715 — session-bypass-tracker: Tier-2 anneal on bypass-env threshold
+
+### Added
+
+- `scripts/global/session-bypass-tracker.js` — counts governance-gate bypass-env invocations per session and emits a Tier-2 anneal advisory to stderr when threshold (2) is reached.
+- `scripts/global/pre-push-gates.js` — wired bypass tracker into bypass path (advisory only).
+- `instructions/workflow-resilience.instructions.md` — new Tier-2 trigger: bypass-env var used 2+ times in a session promotes underlying bug-fix to first-work.
+- `wiki/concepts/feedback-bypass-env-as-first-work-signal.md` — feedback decision rule wiki concept.

--- a/instructions/workflow-resilience.instructions.md
+++ b/instructions/workflow-resilience.instructions.md
@@ -17,6 +17,7 @@ Run `workflow-self-anneal` skill when any of these conditions is true:
 - Reopened issues or defects trend upward.
 - Ticket/epic local markdown state diverges from observable GitHub issue/PR evidence.
 - Any P0/P1 ticket remains `status:ready` for more than 24h without a blocker note.
+- Governance-gate bypass env var (e.g. `SKIP_CLOSEOUT_PREFLIGHT`, `PUSH_GATES_BYPASS`) used 2+ times in the same session — triggers an immediate Tier-2 anneal that promotes the underlying bug-fix to first-work in the current session. Tracked by `scripts/global/session-bypass-tracker.js`.
 
 Ready-stall blocker note required fields: `BLOCKER_NOTE`, `owner`, `unblock_condition`, `eta_or_review_time`.
 

--- a/scripts/global/pre-push-gates.js
+++ b/scripts/global/pre-push-gates.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const { spawnSync } = require('node:child_process');
+const bypassTracker = require('./session-bypass-tracker');
 
 const BYPASSED_GATES = [
   'branch-name regex check',
@@ -30,6 +31,7 @@ function run(argv = process.argv.slice(2), env = process.env) {
   const bypass = shouldBypass(argv, env);
   if (bypass) {
     warnBypass(bypass);
+    bypassTracker.record(env);
     return 0;
   }
   if (env.PRE_PUSH_GATES_FAKE_STATUS) {

--- a/scripts/global/session-bypass-tracker.js
+++ b/scripts/global/session-bypass-tracker.js
@@ -1,0 +1,32 @@
+'use strict';
+// session-bypass-tracker.js — count governance-gate bypass-env uses per session
+// Emits advisory warning when THRESHOLD reached; wired into pre-push-gates.js.
+// Refs #1715
+
+const THRESHOLD = 2;
+const BYPASS_VARS = ['SKIP_CLOSEOUT_PREFLIGHT', 'PUSH_GATES_BYPASS'];
+
+let _count = 0;
+
+function reset() { _count = 0; }
+
+function getCount() { return _count; }
+
+function record(env) {
+  const triggered = BYPASS_VARS.filter(v => env[v] === '1');
+  if (triggered.length === 0) return { count: _count, warned: false, triggered: [] };
+  _count += 1;
+  const warned = _count >= THRESHOLD;
+  if (warned) {
+    const msg = [
+      `⚠️  bypass-tracker: bypass env used ${_count} time(s) this session (${triggered.join(', ')}).`,
+      `    Threshold ${THRESHOLD} reached — Tier-2 anneal triggered.`,
+      `    The underlying governance-gate bug should be promoted to first-work.`,
+      `    See instructions/workflow-resilience.instructions.md.`,
+    ].join('\n');
+    process.stderr.write(msg + '\n');
+  }
+  return { count: _count, warned, triggered };
+}
+
+module.exports = { record, reset, getCount, THRESHOLD, BYPASS_VARS };

--- a/tests/session-bypass-tracker.spec.js
+++ b/tests/session-bypass-tracker.spec.js
@@ -1,0 +1,39 @@
+'use strict';
+// Unit tests for session-bypass-tracker.js (AC4, #1715)
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const tracker = require('../scripts/global/session-bypass-tracker');
+
+test('count increments on each bypass-env record call', () => {
+  tracker.reset();
+  assert.equal(tracker.getCount(), 0);
+  tracker.record({ SKIP_CLOSEOUT_PREFLIGHT: '1' });
+  assert.equal(tracker.getCount(), 1);
+  tracker.record({ PUSH_GATES_BYPASS: '1' });
+  assert.equal(tracker.getCount(), 2);
+});
+
+test('threshold-reached: warns when count reaches THRESHOLD', () => {
+  tracker.reset();
+  const msgs = [];
+  const orig = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (s) => { msgs.push(s); return true; };
+  tracker.record({ SKIP_CLOSEOUT_PREFLIGHT: '1' });
+  const r2 = tracker.record({ PUSH_GATES_BYPASS: '1' });
+  process.stderr.write = orig;
+  assert.equal(r2.warned, true, 'warned should be true at threshold');
+  assert.equal(r2.count, 2);
+  assert.ok(msgs.some(m => m.includes('Tier-2 anneal triggered')), 'stderr should mention anneal');
+});
+
+test('threshold-not-reached: no warning on first use', () => {
+  tracker.reset();
+  const msgs = [];
+  const orig = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (s) => { msgs.push(s); return true; };
+  const r1 = tracker.record({ SKIP_CLOSEOUT_PREFLIGHT: '1' });
+  process.stderr.write = orig;
+  assert.equal(r1.warned, false, 'warned should be false below threshold');
+  assert.equal(r1.count, 1);
+  assert.equal(msgs.length, 0, 'no stderr output before threshold');
+});

--- a/wiki/concepts/feedback-bypass-env-as-first-work-signal.md
+++ b/wiki/concepts/feedback-bypass-env-as-first-work-signal.md
@@ -1,0 +1,45 @@
+---
+title: "Feedback: Bypass Env as First-Work Signal"
+type: concept
+created: 2026-05-20
+updated: 2026-05-20
+tags: [governance, anneal, self-anneal, bypass, session-ordering]
+sources: []
+related: ["[[distributed-self-anneal]]", "[[self-annealing]]", "[[andon-pull-protocol]]", "[[feedback-self-anneal-scope]]"]
+status: active
+---
+
+# Feedback: Bypass Env as First-Work Signal
+
+## Pattern
+
+When a governance-gate bypass env var (`SKIP_CLOSEOUT_PREFLIGHT`, `PUSH_GATES_BYPASS`, etc.)
+is used 2+ times in the same session, it is a reliable signal that an infrastructure
+bug is actively blocking normal workflow — and that bug should be promoted to **first-work**
+in the current session rather than worked around repeatedly.
+
+## Anti-pattern this closes
+
+The natural impulse when pre-flight surfaces a governance-gate bug is to set the bypass env
+var and continue with the planned work. The bypass is a documented escape hatch, so each
+individual use is sanctioned. The trap is cumulative: 6+ pushes with `SKIP_CLOSEOUT_PREFLIGHT=1`
+were needed during the 2026-05-16 session before #1639 landed — every one bypassed a live
+governance gate during governance Epic work.
+
+## Decision rule
+
+> If the same bypass env var is triggered ≥ 2 times in a session, stop. Promote
+> the underlying bug-fix to first-work. File a ticket if none exists. Do not
+> accumulate more bypasses.
+
+## Enforcement
+
+`scripts/global/session-bypass-tracker.js` counts per-session bypass invocations and emits
+a Tier-2 anneal advisory on stderr when the threshold (2) is reached. The tracker is wired
+into `scripts/global/pre-push-gates.js`.
+
+## References
+
+- Refs #1715 (shipped this feedback pattern)
+- Refs #1639 (infrastructure bug that prompted the pattern)
+- See `instructions/workflow-resilience.instructions.md` Tier-2 triggers


### PR DESCRIPTION
## Summary

Implements #1715: add session-bypass-tracker.js to count governance-gate bypass-env uses per session and emit a Tier-2 anneal advisory when the threshold (2) is reached.

## Changes

- `scripts/global/session-bypass-tracker.js` — new module: counts bypass-env invocations, emits advisory warning to stderr at threshold 2 (AC2)
- `scripts/global/pre-push-gates.js` — wire tracker into bypass path (AC3)
- `instructions/workflow-resilience.instructions.md` — add bypass-env Tier-2 trigger to self-annealing triggers list (AC1)
- `tests/session-bypass-tracker.spec.js` — 3 unit tests: count, threshold-reached, threshold-not-reached (AC4)
- `wiki/concepts/feedback-bypass-env-as-first-work-signal.md` — feedback wiki concept (AC5)

## Evidence

```
node --test tests/session-bypass-tracker.spec.js
✔ count increments on each bypass-env record call (2.56ms)
✔ threshold-reached: warns when count reaches THRESHOLD (0.64ms)
✔ threshold-not-reached: no warning on first use (0.58ms)
ℹ pass 3 | fail 0
```

```
npm run lint → ✅ All files within 100-line limit.
```

Refs #1715