### PR TITLE
fix(hooks): gate code-changed on recent-commits; add ops guard to post_merge_messages

### DIFF
--- a/hooks/scripts/git_checks.py
+++ b/hooks/scripts/git_checks.py
@@ -24,12 +24,17 @@ def detect_session_signals(cwd: str) -> list[str]:
         )
         if result.returncode == 0:
             changed = [f for f in result.stdout.strip().split("\n") if f]
-            if any(f.endswith(e) for f in changed for e in CODE_EXTS):
-                signals.append("code-changed")
+            # Gate on recent-commits: only signal code changes from the current
+            # session. git diff HEAD~1 HEAD reflects permanent repo history;
+            # without this guard, the warning fires in every new session after
+            # any code-changing merge (Gap 2, #2005).
+            if "recent-commits" in signals:
+                if any(f.endswith(e) for f in changed for e in CODE_EXTS):
+                    signals.append("code-changed")
+                if any(f.startswith("vscode-extension/") for f in changed):
+                    signals.append("extension-changed")
             if any("README" in f or "CHANGELOG" in f for f in changed):
                 signals.append("docs-updated")
-            if any(f.startswith("vscode-extension/") for f in changed):
-                signals.append("extension-changed")
     except Exception:
         pass
     return signals

--- a/hooks/scripts/stop_checks.py
+++ b/hooks/scripts/stop_checks.py
@@ -85,7 +85,13 @@ def check_admin_ops(
     return None, None
 
 
-def post_merge_messages(signals: list[str], has_messages: bool) -> list[str]:
+def post_merge_messages(
+    signals: list[str], has_messages: bool, ops: dict | None = None
+) -> list[str]:
+    # Completion guard (#2005 Gap 1): if merge op is confirmed, admin cycle is
+    # done — suppress the checklist regardless of session signals.
+    if ops and ops.get("merge"):
+        return []
     if "code-changed" in signals or "extension-changed" in signals:
         return [post_merge_checklist()]
     if not has_messages:

--- a/hooks/scripts/stop_reminder.py
+++ b/hooks/scripts/stop_reminder.py
@@ -57,7 +57,7 @@ def main() -> int:
         if msg:
             messages.append(msg)
 
-    messages.extend(post_merge_messages(signals, bool(messages)))
+    messages.extend(post_merge_messages(signals, bool(messages), ops))
     wiki_msg = wiki_pending_message(cwd, flags, ops)
     if wiki_msg:
         messages.append(wiki_msg)

--- a/tests/hooks/test_stop_hook_completion_guard.py
+++ b/tests/hooks/test_stop_hook_completion_guard.py
@@ -1,0 +1,139 @@
+"""Tests for #2005: Stop hook false-positive warning after admin cycle complete.
+
+Gap 1: post_merge_messages() completion guard via ops parameter.
+Gap 2: detect_session_signals() code-changed gated on recent-commits.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "hooks" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from stop_checks import post_merge_messages  # noqa: E402
+
+
+class TestPostMergeCompletionGuard(unittest.TestCase):
+    """Gap 1 (#2005): ops completion guard suppresses checklist after merge."""
+
+    def test_suppresses_when_merge_complete(self):
+        """No messages when ops['merge'] is True, even with code-changed signal."""
+        result = post_merge_messages(
+            signals=["code-changed", "recent-commits"],
+            has_messages=False,
+            ops={"merge": True},
+        )
+        self.assertEqual(result, [])
+
+    def test_fires_when_merge_not_complete(self):
+        """Checklist fires when code-changed present and merge not done."""
+        result = post_merge_messages(
+            signals=["code-changed"],
+            has_messages=False,
+            ops={"merge": False},
+        )
+        self.assertEqual(len(result), 1)
+        self.assertIn("Post-merge", result[0])
+
+    def test_fires_when_ops_none(self):
+        """Backward-compat: None ops falls through to signal-based check."""
+        result = post_merge_messages(
+            signals=["code-changed"],
+            has_messages=False,
+            ops=None,
+        )
+        self.assertEqual(len(result), 1)
+
+    def test_no_signal_no_messages_returns_fallback(self):
+        """No code-changed + no messages → generic reminder (unchanged behavior)."""
+        result = post_merge_messages(
+            signals=[],
+            has_messages=False,
+            ops={"merge": False},
+        )
+        self.assertEqual(len(result), 1)
+        self.assertIn("confirm checks", result[0])
+
+    def test_no_signal_has_messages_returns_empty(self):
+        """No code-changed + already has messages → no additional message."""
+        result = post_merge_messages(
+            signals=[],
+            has_messages=True,
+            ops={"merge": False},
+        )
+        self.assertEqual(result, [])
+
+
+class TestCodeChangedGatedOnRecentCommits(unittest.TestCase):
+    """Gap 2 (#2005): code-changed only emitted when recent-commits present."""
+
+    def _run_detect(self, recent_stdout: str, diff_stdout: str) -> list[str]:
+        """Helper: mock git subprocess and return detect_session_signals result."""
+        from git_checks import detect_session_signals
+
+        call_count = {"n": 0}
+
+        def fake_run(cmd, **_kw):
+            r = MagicMock()
+            r.returncode = 0
+            if "log" in cmd:
+                r.stdout = recent_stdout
+            else:
+                r.stdout = diff_stdout
+            call_count["n"] += 1
+            return r
+
+        with patch("git_checks.subprocess.run", side_effect=fake_run):
+            return detect_session_signals("/fake/cwd")
+
+    def test_code_changed_requires_recent_commits(self):
+        """code-changed is NOT emitted when there are no recent commits."""
+        signals = self._run_detect(
+            recent_stdout="",  # no recent commits
+            diff_stdout="scripts/global/some.js\n",
+        )
+        self.assertNotIn("code-changed", signals)
+        self.assertNotIn("extension-changed", signals)
+
+    def test_code_changed_emitted_with_recent_commits(self):
+        """code-changed IS emitted when recent commits and diff shows .js files."""
+        signals = self._run_detect(
+            recent_stdout="abc1234 feat: something",
+            diff_stdout="scripts/global/some.js\n",
+        )
+        self.assertIn("recent-commits", signals)
+        self.assertIn("code-changed", signals)
+
+    def test_docs_updated_independent_of_recent_commits(self):
+        """docs-updated does not require recent-commits (independent signal)."""
+        signals = self._run_detect(
+            recent_stdout="",  # no recent commits
+            diff_stdout="CHANGELOG.md\n",
+        )
+        self.assertIn("docs-updated", signals)
+        self.assertNotIn("code-changed", signals)
+
+    def test_extension_changed_requires_recent_commits(self):
+        """extension-changed is NOT emitted without recent-commits."""
+        signals = self._run_detect(
+            recent_stdout="",
+            diff_stdout="vscode-extension/src/foo.ts\n",
+        )
+        self.assertNotIn("extension-changed", signals)
+
+    def test_extension_changed_with_recent_commits(self):
+        """extension-changed IS emitted when recent commits and extension path."""
+        signals = self._run_detect(
+            recent_stdout="abc1234 feat: ext change",
+            diff_stdout="vscode-extension/src/foo.ts\n",
+        )
+        self.assertIn("extension-changed", signals)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes two gaps causing the Stop hook to emit a persistent false-positive post-merge warning after all admin work is complete.

Refs #2005

## Root Cause

### Gap 1 — no completion guard in `post_merge_messages()`
The function fired the post-merge checklist whenever `"code-changed"` was in signals, with no check that admin ops (merge, issue_close) were already complete.

### Gap 2 — `code-changed` signal from permanent git history, not session activity
`detect_session_signals()` used `git diff HEAD~1 HEAD` which reflects permanent repo history. After a branch change resets the session state, `ops` and `flags` are cleared, but the git diff still shows `.js` files from the previous merge commit — so the warning fired indefinitely in every new session.

## Changes

| File | Change |
|---|---|
| `hooks/scripts/git_checks.py` | Gap 2: gate `code-changed`/`extension-changed` on `recent-commits` being present |
| `hooks/scripts/stop_checks.py` | Gap 1: add `ops` param; return [] when `ops.get('merge')` is True |
| `hooks/scripts/stop_reminder.py` | Pass `ops` dict to `post_merge_messages()` |
| `tests/hooks/test_stop_hook_completion_guard.py` | 10 new unit tests for both gaps |

## G5 Portability

Fix lives in shared `hooks/scripts/` source — applies identically to **Copilot**, **Claude Code**, and **Codex** runtimes on next deploy. No agent-specific code paths.

## Test Evidence

```
Ran 56 tests in 0.140s — OK
npm run lint: ✅ All 493 files within 100-line limit
```