### PR TITLE
fix(governance): strip stale status labels on terminal status application

### DIFF
--- a/.changes/unreleased/1380.md
+++ b/.changes/unreleased/1380.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **#1380**: Strip stale `status:*` labels when terminal status is applied — prevents Rule 1 multi-status drift. `label-lint.yml` Phase 1.5 now auto-strips non-terminal status labels when `status:done` or `status:cancelled` coexists with other status labels. `label-lint-close-protection.js` auto-transition now strips ALL current `status:*` labels (not just the expected pre-close label).

--- a/.github/workflows/label-lint.yml
+++ b/.github/workflows/label-lint.yml
@@ -84,13 +84,23 @@ jobs:
             const statusCardinality = require('./scripts/global/label-lint-status-cardinality.js');
             const statusEval = statusCardinality.evaluate(labels);
             if (!statusEval.ok && statusEval.rule === 'multi-status') {
-              const statusMarker = '<!-- adr-010-status-cardinality -->';
-              const existingStatusComment = recentComments.find(c => c.body?.includes(statusMarker));
-              const body = statusCardinality.violationComment(statusEval, issueNum);
-              if (!existingStatusComment) {
-                await github.rest.issues.createComment({ owner, repo, issue_number: issueNum, body });
+              // #1380: when a terminal status coexists with non-terminal labels,
+              // auto-strip the stale labels rather than blocking the workflow.
+              const conflict = statusCardinality.resolveTerminalConflict(labels);
+              if (conflict.hasConflict) {
+                for (const name of conflict.removeLabels) {
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNum, name }).catch(() => {});
+                }
+                console.log(`#${issueNum}: #1380 auto-stripped stale status labels (${conflict.removeLabels.join(', ')}) → ${conflict.keepLabel}`);
+              } else {
+                const statusMarker = '<!-- adr-010-status-cardinality -->';
+                const existingStatusComment = recentComments.find(c => c.body?.includes(statusMarker));
+                const body = statusCardinality.violationComment(statusEval, issueNum);
+                if (!existingStatusComment) {
+                  await github.rest.issues.createComment({ owner, repo, issue_number: issueNum, body });
+                }
+                core.setFailed(`Issue #${issueNum}: multi-status violation (Epic #1828 AC6) — ${statusEval.found.join(', ')}`);
               }
-              core.setFailed(`Issue #${issueNum}: multi-status violation (Epic #1828 AC6) — ${statusEval.found.join(', ')}`);
             }
 
             // Phase 2: evaluate via shared rules and post comment

--- a/scripts/global/label-lint-close-protection.js
+++ b/scripts/global/label-lint-close-protection.js
@@ -32,10 +32,13 @@ function decide({ state, labels = [], comments = [] }) {
   const closeoutPresent = hasCloseoutComment(comments);
   const preCloseLabel = VALID_PRE_CLOSE_LABELS.find((l) => labels.includes(l));
   if (closeoutPresent && preCloseLabel) {
+    // #1380: strip ALL status:* labels (not just preCloseLabel) to prevent
+    // Rule 1 multi-status drift when a stale label like status:backlog lingers.
+    const allStatusLabels = labels.filter(l => l.startsWith('status:'));
     return {
       action: 'auto-transition',
       from: preCloseLabel,
-      removeLabels: [preCloseLabel, 'role:consultant'],
+      removeLabels: [...allStatusLabels, 'role:consultant'],
       addLabels: ['status:done', 'resolution:completed'],
       reason: `closeout-present-from-${preCloseLabel}`,
     };

--- a/scripts/global/label-lint-status-cardinality.js
+++ b/scripts/global/label-lint-status-cardinality.js
@@ -41,6 +41,21 @@ function violationComment(result, issueNumber) {
   return null;
 }
 
+// #1380: auto-strip helper — returns which labels to remove when a terminal
+// status (done/cancelled) coexists with non-terminal ones (Rule 1 fix).
+const TERMINAL_STATUSES = ['status:done', 'status:cancelled'];
+function resolveTerminalConflict(labels) {
+  const found = statusLabels(labels);
+  if (found.length < 2) return { hasConflict: false };
+  const terminal = found.find(l => TERMINAL_STATUSES.includes(l));
+  if (!terminal) return { hasConflict: false };
+  return {
+    hasConflict: true,
+    keepLabel: terminal,
+    removeLabels: found.filter(l => l !== terminal),
+  };
+}
+
 if (require.main === module) {
   // CLI: pass --labels "a,b,c" or read from stdin JSON.
   const idx = process.argv.indexOf('--labels');
@@ -61,4 +76,4 @@ if (require.main === module) {
   process.exit(result.ok ? 0 : 1);
 }
 
-module.exports = { evaluate, statusLabels, violationComment, STATUS_PREFIX };
+module.exports = { evaluate, statusLabels, violationComment, resolveTerminalConflict, TERMINAL_STATUSES, STATUS_PREFIX };

--- a/tests/label-lint-close-protection.spec.js
+++ b/tests/label-lint-close-protection.spec.js
@@ -120,3 +120,29 @@ test('#1515: hasCloseoutComment exported and usable in isolation', () => {
   expect(lib.hasCloseoutComment([{ body: 'no closeout here' }])).toBe(false);
   expect(lib.hasCloseoutComment([])).toBe(false);
 });
+
+// #1380: expanded removeLabels — strips ALL status:* labels on auto-transition
+test('#1380 auto-transition with lingering status:backlog strips it (not just pre-close label)', () => {
+  const result = lib.decide({
+    state: 'closed',
+    labels: ['type:task', 'status:review', 'status:backlog', 'role:consultant', 'priority:P2'],
+    comments: [closeoutComment()],
+  });
+  expect(result.action).toBe('auto-transition');
+  expect(result.removeLabels).toContain('status:review');
+  expect(result.removeLabels).toContain('status:backlog');
+  expect(result.removeLabels).toContain('role:consultant');
+  expect(result.addLabels).toEqual(['status:done', 'resolution:completed']);
+});
+
+test('#1380 auto-transition with only expected pre-close label still works (regression)', () => {
+  const result = lib.decide({
+    state: 'closed',
+    labels: ['type:task', 'status:testing', 'role:admin'],
+    comments: [closeoutComment()],
+  });
+  expect(result.action).toBe('auto-transition');
+  expect(result.removeLabels).toContain('status:testing');
+  expect(result.removeLabels).toContain('role:consultant');
+  expect(result.removeLabels).not.toContain('status:backlog');
+});

--- a/tests/label-lint-status-cardinality.spec.js
+++ b/tests/label-lint-status-cardinality.spec.js
@@ -86,3 +86,49 @@ test('queued + backlog flagged as multi-status (correctly forbidden)', () => {
   assert.equal(r.ok, false);
   assert.equal(r.rule, 'multi-status');
 });
+
+// #1380: resolveTerminalConflict golden-file tests
+const { resolveTerminalConflict, TERMINAL_STATUSES } = require('../scripts/global/label-lint-status-cardinality.js');
+
+test('#1380 TERMINAL_STATUSES exported (done + cancelled)', () => {
+  assert.ok(TERMINAL_STATUSES.includes('status:done'));
+  assert.ok(TERMINAL_STATUSES.includes('status:cancelled'));
+});
+
+test('#1380 status:cancelled + status:backlog → hasConflict, strip backlog', () => {
+  const r = resolveTerminalConflict(['type:bug', 'status:backlog', 'status:cancelled', 'priority:P3']);
+  assert.equal(r.hasConflict, true);
+  assert.equal(r.keepLabel, 'status:cancelled');
+  assert.deepEqual(r.removeLabels, ['status:backlog']);
+});
+
+test('#1380 status:done + status:backlog → hasConflict, strip backlog', () => {
+  const r = resolveTerminalConflict(['status:done', 'status:backlog', 'resolution:completed']);
+  assert.equal(r.hasConflict, true);
+  assert.equal(r.keepLabel, 'status:done');
+  assert.deepEqual(r.removeLabels, ['status:backlog']);
+});
+
+test('#1380 status:done + status:backlog + status:in-progress → strip both non-terminal', () => {
+  const r = resolveTerminalConflict(['status:done', 'status:backlog', 'status:in-progress']);
+  assert.equal(r.hasConflict, true);
+  assert.equal(r.keepLabel, 'status:done');
+  assert.ok(r.removeLabels.includes('status:backlog'));
+  assert.ok(r.removeLabels.includes('status:in-progress'));
+  assert.equal(r.removeLabels.length, 2);
+});
+
+test('#1380 no terminal in multi-status → hasConflict false (still a violation)', () => {
+  const r = resolveTerminalConflict(['status:in-progress', 'status:backlog']);
+  assert.equal(r.hasConflict, false);
+});
+
+test('#1380 single status → hasConflict false', () => {
+  const r = resolveTerminalConflict(['type:task', 'status:in-progress', 'priority:P1']);
+  assert.equal(r.hasConflict, false);
+});
+
+test('#1380 no status labels → hasConflict false', () => {
+  const r = resolveTerminalConflict(['type:task', 'priority:P1']);
+  assert.equal(r.hasConflict, false);
+});


### PR DESCRIPTION
## Summary

Strip stale `status:*` labels when a terminal status (`status:done` / `status:cancelled`) is applied, preventing Rule 1 multi-status drift.

## Changes

- **`scripts/global/label-lint-close-protection.js`**: `decide()` now strips ALL current `status:*` labels (not just the pre-close label) on auto-transition — covers lingering labels like `status:backlog`
- **`scripts/global/label-lint-status-cardinality.js`**: Added `resolveTerminalConflict(labels)` + `TERMINAL_STATUSES` export
- **`.github/workflows/label-lint.yml`**: Phase 1.5 auto-strips non-terminal status labels when terminal present (instead of blocking)
- Tests: 7 golden-file tests for `resolveTerminalConflict` + 2 lingering-label regression tests (14/14 pass)
- `.changes/unreleased/1380.md`: changelog fragment

## Validation

- `npm run lint`: ✅ 495 files within 100-line limit
- Unit tests: ✅ 14/14 pass (status-cardinality + close-protection specs)

Refs #1380