### PR TITLE
fix(governance): skip gov-006 branch check for issue-only lanes

### DIFF
--- a/.changes/unreleased/1615.md
+++ b/.changes/unreleased/1615.md
@@ -1,0 +1,9 @@
+## #1615 Fix gov-006 false-positive on issue-only Epic/research closeouts
+
+`consultant-checks.js` gov-006 (branch-naming check) now skips when the
+target ticket carries `lane:docs-research`, `lane:trivial`, or `type:epic`.
+These workflows run from `main` (no implementation branch) so enforcing a
+`feat|fix|skill|hook` prefix was a false positive that blocked valid closeouts.
+
+Helper `isIssueOnlyLane(labels)` added to `consultant-checks-lib.js` and
+covered by five new unit tests.

--- a/scripts/global/consultant-checks-lib.js
+++ b/scripts/global/consultant-checks-lib.js
@@ -12,6 +12,10 @@ const decideGov003 = (fleetLog, eventLog) =>
 
 const decideGov005 = issueBody => !/- \[ \]/.test(issueBody);
 
+// #1615: lanes where no implementation branch or PR is expected
+const ISSUE_ONLY_LANES = /lane:docs-research|lane:trivial|type:epic/;
+const isIssueOnlyLane = labels => ISSUE_ONLY_LANES.test(labels || '');
+
 // #1241: events.jsonl / fleet-health.jsonl are runtime artifacts written by
 // the main checkout; fresh worktrees never have them. When the worktree path
 // is empty, fall through to the main checkout discovered via
@@ -30,4 +34,4 @@ function readWithMainFallback({ fs, path, run, cwdRoot, relPath }) {
   return content;
 }
 
-module.exports = { decideGov002, decideGov003, decideGov005, readWithMainFallback };
+module.exports = { decideGov002, decideGov003, decideGov005, readWithMainFallback, isIssueOnlyLane, ISSUE_ONLY_LANES };

--- a/scripts/global/consultant-checks.js
+++ b/scripts/global/consultant-checks.js
@@ -49,7 +49,16 @@ const checks = [
   }],
   [id('gov', 4), 'governance', () => { const gitLog = run("git log --oneline -99"); const matchCount = (gitLog.match(/#\d+/g) || []).length; const total = gitLog ? gitLog.split('\n').length : 0; return ok(id('gov', 4), 'governance', total > 0 && matchCount / total >= 0.8, `${matchCount}/${total} commit refs`, 'commit-issue-linkage', 'reference issue numbers in commits'); }],
   [id('gov', 5), 'governance', () => issue ? ok(id('gov', 5), 'governance', lib.decideGov005(run(`gh issue view ${issue}`)), 'issue body checklist scanned', 'ac-evidence-completeness', 'complete unchecked ACs') : skip(id('gov', 5), 'governance', 'missing --issue')],
-  [id('gov', 6), 'governance', () => { const branch = run('git branch --show-current'); return ok(id('gov', 6), 'governance', /^(feat|fix|skill|hook)\//.test(branch), branch || 'unknown-branch', 'branch-naming', 'use approved branch prefix'); }],
+  [id('gov', 6), 'governance', () => {
+    const branch = run('git branch --show-current');
+    // #1615: issue-only lanes (docs-research, trivial, Epic closeouts) run from
+    // main — branch-naming does not apply; skip instead of false-positive FAIL.
+    if (issue) {
+      const labels = run(`gh issue view ${issue} --json labels -q '.labels[].name'`);
+      if (lib.isIssueOnlyLane(labels)) return skip(id('gov', 6), 'governance', `issue-only lane (${branch}) — branch-name check not enforced`);
+    }
+    return ok(id('gov', 6), 'governance', /^(feat|fix|skill|hook)\//.test(branch), branch || 'unknown-branch', 'branch-naming', 'use approved branch prefix');
+  }],
   [id('gov', 7), 'governance', () => {
     if (!issue) return skip(id('gov', 7), 'governance', 'missing --issue');
     let comments = [];

--- a/tests/consultant-checks-lib.spec.js
+++ b/tests/consultant-checks-lib.spec.js
@@ -83,3 +83,25 @@ test('#1241 AC1: readWithMainFallback returns empty when neither path has file',
   expect(result).toBe('');
   fs.rmSync(tmp, { recursive: true, force: true });
 });
+
+test('#1615 isIssueOnlyLane: lane:docs-research → true (skip branch check)', () => {
+  expect(lib.isIssueOnlyLane('lane:docs-research\ntype:research\npriority:P1')).toBe(true);
+});
+
+test('#1615 isIssueOnlyLane: type:epic → true (Epic closeout from main is valid)', () => {
+  expect(lib.isIssueOnlyLane('type:epic\nstatus:review\npriority:P2')).toBe(true);
+});
+
+test('#1615 isIssueOnlyLane: lane:trivial → true (no PR expected)', () => {
+  expect(lib.isIssueOnlyLane('lane:trivial\ntype:task')).toBe(true);
+});
+
+test('#1615 isIssueOnlyLane: lane:code-change → false (branch check enforced)', () => {
+  expect(lib.isIssueOnlyLane('lane:code-change\ntype:bug\npriority:P2')).toBe(false);
+});
+
+test('#1615 isIssueOnlyLane: empty/null → false (branch check enforced)', () => {
+  expect(lib.isIssueOnlyLane('')).toBe(false);
+  expect(lib.isIssueOnlyLane(null)).toBe(false);
+  expect(lib.isIssueOnlyLane(undefined)).toBe(false);
+});


### PR DESCRIPTION
## Summary

Skip the gov-006 branch-naming check in `consultant-checks.js` when the target
ticket is an issue-only lane (Epic closeout, docs-research, or trivial).

These workflows close from `main` with no implementation branch, so enforcing
the `/^(feat|fix|skill|hook)\//` pattern was a false-positive that blocked
legitimate Consultant closeouts.

## Changes

- `scripts/global/consultant-checks-lib.js`: add `ISSUE_ONLY_LANES` regex + `isIssueOnlyLane(labels)`
- `scripts/global/consultant-checks.js`: gov-006 calls `isIssueOnlyLane` before regex check
- `tests/consultant-checks-lib.spec.js`: 5 new unit tests
- `.changes/unreleased/1615.md`: changelog fragment

## Validation

- Tests: 15/15 pass
- Lint: all 496 files ≤ 100 lines

Refs #1615