### PR TITLE
fix: guard orphanedLeases() against registry unavailability

### DIFF
--- a/.changes/unreleased/2050.md
+++ b/.changes/unreleased/2050.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- `scripts/global/branch-cleanup-plan.js`: `orphanedLeases()` now guards against
+  lease registry unavailability. A missing, malformed, or locked registry no
+  longer crashes the tool — it returns an empty array and logs a warning to
+  stderr, leaving branch classification output unaffected. (#2050)

--- a/scripts/global/branch-cleanup-plan.js
+++ b/scripts/global/branch-cleanup-plan.js
@@ -26,13 +26,14 @@ function prState(branch) {
 
 function orphanedLeases(branches, registryFn) {
   const readFn = registryFn || leaseRegistry.read;
+  let reg;
   try {
-    const reg = readFn(leaseRegistry.DEFAULT_PATH);
-    return leaseRegistry.active(reg).filter(l => l.branch && !branches.includes(l.branch));
+    reg = readFn(leaseRegistry.DEFAULT_PATH);
   } catch (err) {
-    process.stderr.write(`[branch-cleanup-plan] lease registry unavailable: ${err.message}\n`);
+    process.stderr.write(`[branch-cleanup-plan] lease registry unavailable (${leaseRegistry.DEFAULT_PATH}): ${err.message}\n`);
     return [];
   }
+  return leaseRegistry.active(reg).filter(l => l.branch && !branches.includes(l.branch));
 }
 
 function classify(branch, merged, pr) {

--- a/scripts/global/branch-cleanup-plan.js
+++ b/scripts/global/branch-cleanup-plan.js
@@ -24,9 +24,15 @@ function prState(branch) {
   try { return raw ? JSON.parse(raw) : null; } catch { return null; }
 }
 
-function orphanedLeases(branches) {
-  const reg = leaseRegistry.read(leaseRegistry.DEFAULT_PATH);
-  return leaseRegistry.active(reg).filter(l => l.branch && !branches.includes(l.branch));
+function orphanedLeases(branches, registryFn) {
+  const readFn = registryFn || leaseRegistry.read;
+  try {
+    const reg = readFn(leaseRegistry.DEFAULT_PATH);
+    return leaseRegistry.active(reg).filter(l => l.branch && !branches.includes(l.branch));
+  } catch (err) {
+    process.stderr.write(`[branch-cleanup-plan] lease registry unavailable: ${err.message}\n`);
+    return [];
+  }
 }
 
 function classify(branch, merged, pr) {
@@ -51,7 +57,7 @@ function plan(overrides = {}) {
   const getPr = overrides.prState || prState;
   const orphans = overrides.leases !== undefined
     ? overrides.leases
-    : orphanedLeases(branches);
+    : orphanedLeases(branches, overrides.leaseRegistryReader);
   const entries = branches.map(branch => {
     const { state, evidence } = classify(branch, getIsMerged(branch), getPr(branch));
     return { branch, cleanupState: state, evidence, commands: commandsFor(branch, state) };

--- a/tests/branch-cleanup-plan.spec.js
+++ b/tests/branch-cleanup-plan.spec.js
@@ -65,3 +65,15 @@ test('plan flags merged clean branches and skips active ones', () => {
   expect(merged.cleanupState).toBe('merged-clean');
   expect(active.cleanupState).toBe('keep-active');
 });
+
+test('plan returns empty orphaned leases and classifies branches when registry throws', () => {
+  const report = planner.plan({
+    branches: ['feat/400-merged'],
+    isMergedToMain: () => true,
+    prState: () => ({ number: 401, state: 'MERGED' }),
+    leaseRegistryReader: () => { throw new Error('registry file not found'); },
+  });
+  expect(report.orphanedLeases).toEqual([]);
+  expect(report.branches[0].cleanupState).toBe('merged-clean');
+  expect(report.mode).toBe('dry-run');
+});


### PR DESCRIPTION
## Summary

Guard `orphanedLeases()` in `scripts/global/branch-cleanup-plan.js` against lease registry unavailability. When the registry file is absent, malformed, or locked, the function previously propagated the exception through `plan()` crashing the entire tool. With this fix it returns `[]` safely and logs a warning to stderr, leaving branch classification unaffected.

## Changes

- `orphanedLeases()`: accepts optional `registryFn` for test injection; wrapped in try/catch; returns `[]` + stderr on error
- `plan()`: passes `overrides.leaseRegistryReader` to `orphanedLeases()`
- Test 9 added: registry-throws path, verifies empty `orphanedLeases` + branch classification intact

## Test Evidence

```
9/9 tests pass
npm run lint: 512 files — all within 100-line limit
branch-cleanup-plan.js: 90 lines
tests/branch-cleanup-plan.spec.js: 79 lines
```

Refs #2050
Closes #2050