### PR TITLE
docs(governance): document baton gate entry conditions #1944

### DIFF
--- a/.changes/unreleased/1944.md
+++ b/.changes/unreleased/1944.md
@@ -1,0 +1,3 @@
+### Documentation
+
+- Codified baton gate entry conditions in `instructions/role-baton-routing.instructions.md` and `instructions/feature-completion-governance.instructions.md`. New four-facet specification (trigger artifact, role-label transition, status-label transition, preconditions + validators) for the in-progress → testing and testing → review transitions. Cross-references the megalint validators that enforce each facet. Resolves the recurring "what triggers the next gate" ambiguity. (#1944)

--- a/instructions/feature-completion-governance.instructions.md
+++ b/instructions/feature-completion-governance.instructions.md
@@ -4,6 +4,15 @@ applyTo: "**"
 
 When asked to "complete" a feature-add, all four baton roles are required. Tests passing only closes Collaborator — do not stop there.
 
+## Gate entry conditions (Refs #1944)
+
+The four baton role transitions advance under explicit, validator-enforced entry conditions. Canonical specification lives in `instructions/role-baton-routing.instructions.md` §"Gate entry conditions — Admin and Consultant". Summary applicable to "complete this feature" requests:
+
+- **Admin gate** (Collaborator → Admin): triggers when COLLABORATOR_HANDOFF is posted with all four signing fields plus per-AC verification PASS; role-label flips `role:collaborator → role:admin`; status-label flips `status:in-progress → status:testing`; preconditions enforced by `collaborator-handoff` + `test-discoverability` validators.
+- **Consultant gate** (Admin → Consultant): triggers when ADMIN_HANDOFF is posted with signing + branch/commit/signer-independence fields; role-label flips `role:admin → role:consultant`; status-label flips `status:testing → status:review`; preconditions enforced by `admin-handoff` + `signer-fidelity` + `merge-evidence-pr-gate` validators plus signer-independence Admin-vs-Collaborator alias-difference check.
+- **Close gate** (Consultant → done): triggers when CONSULTANT_CLOSEOUT carries verdict + rubric + anneal-tickets-filed + mid-flight-flaws blocks; role-label removed; status-label flips `status:review → status:done`; issue closes atomically; preconditions enforced by `consultant-closeout` validator and the merge-recorded admin_ops state.
+
+
 Completion intent semantics are strict:
 - "complete", "finish", or "ship" means terminal workflow delivery in one session when feasible once the active role identifies that intent in task scope.
 - Do not pause after implementation to wait for another user nudge to run Admin or Consultant phases.

--- a/instructions/feature-completion-governance.instructions.md
+++ b/instructions/feature-completion-governance.instructions.md
@@ -12,7 +12,6 @@ The four baton role transitions advance under explicit, validator-enforced entry
 - **Consultant gate** (Admin → Consultant): triggers when ADMIN_HANDOFF is posted with signing + branch/commit/signer-independence fields; role-label flips `role:admin → role:consultant`; status-label flips `status:testing → status:review`; preconditions enforced by `admin-handoff` + `signer-fidelity` + `merge-evidence-pr-gate` validators plus signer-independence Admin-vs-Collaborator alias-difference check.
 - **Close gate** (Consultant → done): triggers when CONSULTANT_CLOSEOUT carries verdict + rubric + anneal-tickets-filed + mid-flight-flaws blocks; role-label removed; status-label flips `status:review → status:done`; issue closes atomically; preconditions enforced by `consultant-closeout` validator and the merge-recorded admin_ops state.
 
-
 Completion intent semantics are strict:
 - "complete", "finish", or "ship" means terminal workflow delivery in one session when feasible once the active role identifies that intent in task scope.
 - Do not pause after implementation to wait for another user nudge to run Admin or Consultant phases.

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -52,6 +52,32 @@ deferred       role:manager                     Epic-only: blocked, no ETA (Rule
 - `in-progress ↔ deferred` (Epic-only): Manager flags external blocker; carries `role:manager`.
 - Manager ticket-health checks, AC edits, and label fixes are out-of-band; no handoff required.
 
+## Gate entry conditions — Admin and Consultant (Refs #1944)
+
+The two most-failure-prone transitions in the baton are `in-progress → testing` (Collaborator → Admin) and `testing → review` (Admin → Consultant). Both gates carry four facets that ALL must hold before the next role may pick up.
+
+### Admin gate (entry to `status:testing`)
+
+| Facet | Requirement |
+|---|---|
+| Trigger artifact | `COLLABORATOR_HANDOFF` comment posted on the linked issue. The comment must carry the four signing fields (`Signed-by`, `Team&Model`, `Role: collaborator`, plus `test_strategy:`) and the per-AC verification block. Validator: `scripts/global/megalint/collaborator-handoff.js`. |
+| Role-label transition | Remove `role:collaborator`; add `role:admin`. Single-role invariant holds at every instant per Rule 1. |
+| Status-label transition | Remove `status:in-progress`; add `status:testing`. Single-status invariant per the §"Single-status invariant" rule above. |
+| Preconditions | (a) ALL declared ACs verified PASS in the COLLABORATOR_HANDOFF per-AC block. (b) `test_strategy` evidence present per `instructions/test-methodology-matrix.instructions.md` — validator `scripts/global/megalint/test-discoverability.js`. (c) Lint clean for the lane (lane:code-change requires `npm run lint` green; lane:docs-research requires `wiki-lint` if wiki touched). |
+
+### Consultant gate (entry to `status:review`)
+
+| Facet | Requirement |
+|---|---|
+| Trigger artifact | `ADMIN_HANDOFF` comment posted on the linked issue. Must carry signing fields with `Role: admin`, plus `branch:`, `commit:`, `signer-independence-check: PASS`, and `deploy-runtime-impact:` (or `sync-verification: N/A` per `feature-completion-governance.instructions.md`). Validator: `scripts/global/megalint/admin-handoff.js`. |
+| Role-label transition | Remove `role:admin`; add `role:consultant`. |
+| Status-label transition | Remove `status:testing`; add `status:review`. |
+| Preconditions | (a) Signer-independence: Admin signer alias MUST differ from Collaborator signer alias — validator `scripts/global/megalint/signer-fidelity.js`. (b) ALL required CI checks PASS on the linked PR — observed via `gh pr checks <PR#>` or `live_checks.ci_all_pass()`; pre-merge gate `merge-evidence-pr-gate.js` enforces. (c) PR merged OR merge-evidence-override-approved label present on the linked issue per the merge-evidence batch contract. (d) For lane:code-change touching deployed runtime artifacts: `npm run sync:codex` + `npm run sync:claude` + `npm run hamr:sync-verify` outputs cited per `feature-completion-governance.instructions.md`. |
+
+### Validation evidence — recent practice (memory-codified)
+
+The gates above match observed practice in: PR #2045 (Epic #2038 ship; three iterations of cross-family rater + four baton artifacts before PR), PR #2047 (#1943 Three-Wiki synthesis; cross-team file bundling with explicit attribution). Memory anchors: `feedback-all-baton-artifacts-before-pr` (post all four before `gh pr create`; seven consecutive clean ships once applied), `feedback-admin-ci-gate` (Admin verifies ALL required checks green before merge), `feedback-baton-artifacts-in-pr` (PR body must include handoff strings).
+
 ## Collaborator role
 
 Per v1.1 taxonomy, the active label is `role:collaborator` (not the older `role:collab-{type}` form). Capability profile is reflected in ticket area labels (`area:scripts`, `area:hooks`, `area:dashboard`, etc.) rather than role-suffix typing. Each Collaborator may have only **1 `in-progress` ticket at a time** (enforced by baton-gates Action).


### PR DESCRIPTION
Refs #1944
Refs #2063
Refs #2064

## Summary

Document the EXACT Admin and Consultant gate entry conditions in the harness instructions. Resolves narrowed scope of #1944 (AC1+AC2 only after Manager scope amendment 2026-05-21). Adds a four-facet specification (trigger artifact, role-label transition, status-label transition, preconditions + validators) for the two most-failure-prone baton transitions: in-progress to testing (Collaborator to Admin) and testing to review (Admin to Consultant).

## Changes

- `instructions/role-baton-routing.instructions.md` (+26 lines): new section "Gate entry conditions -- Admin and Consultant" with two facet tables plus a recent-practice validation paragraph citing PR #2045 (Epic #2038 ship) and PR #2047 (#1943 Three-Wiki synthesis) plus three memory anchors.
- `instructions/feature-completion-governance.instructions.md` (+9 lines): cross-reference summary subsection pointing at the canonical specification in role-baton-routing.

## Test plan

- [x] AC1 — Admin gate entry condition documented with all 4 facets
- [x] AC2 — Consultant gate entry condition documented with all 4 facets
- [x] AC3 — Validation evidence cited (PR #2045, PR #2047, 3 memory anchors)
- [x] All 4 baton artifacts on #1944

## Deferred ACs (from original 6-AC body)

- AC3 (workflow latency measurement) -> #2063 (P3 backlog)
- AC4 (zero manual steps) -> dropped as wrong-shaped per operator-identity contract
- AC5 (end-to-end baton fixture) -> #2064 (P3 backlog)
- AC6 (file follow-ups) -> dropped as operational not a deliverable

## Notes

- Lane: docs-research. No deployed runtime artifact touched. sync-verification: N/A.
- test_strategy: drift-lint (no spec file required for instruction edits).
- Cross-references between the two edited instructions verified consistent.