### PR TITLE
feat(scripts): annotate plan() with registryError when registry unavailable

### DIFF
--- a/.changes/unreleased/2067.md
+++ b/.changes/unreleased/2067.md
@@ -1,0 +1,6 @@
+## Added
+- `branch-cleanup-plan.js`: `plan()` now includes `registryError: <message>` in
+  its return object when the lease registry is unavailable. Callers can detect
+  the degraded state rather than treating `orphanedLeases: []` as an
+  unconditional success signal. `run()` prints a console warning when
+  `registryError` is present. Refs #2067.

--- a/scripts/global/branch-cleanup-plan.js
+++ b/scripts/global/branch-cleanup-plan.js
@@ -53,9 +53,10 @@ function orphanedLeases(branches, registryFn) {
     reg = readFn(leaseRegistry.DEFAULT_PATH);
   } catch (err) {
     process.stderr.write(`[branch-cleanup-plan] lease registry unavailable (${leaseRegistry.DEFAULT_PATH}): ${err.message}\n`);
-    return [];
+    return { leases: [], error: err.message };
   }
-  return leaseRegistry.active(reg).filter(l => l.branch && !branches.includes(l.branch));
+  const leases = leaseRegistry.active(reg).filter(l => l.branch && !branches.includes(l.branch));
+  return { leases, error: null };
 }
 
 function classify(branch, merged, pr) {
@@ -84,18 +85,20 @@ function plan(overrides = {}) {
   const branches = overrides.branches || localBranches();
   const getIsMerged = overrides.isMergedToMain || isMergedToMain;
   const getPr = overrides.prState || prState;
-  const orphans = overrides.leases !== undefined
-    ? overrides.leases
+  const leaseResult = overrides.leases !== undefined
+    ? { leases: overrides.leases, error: null }
     : orphanedLeases(branches, overrides.leaseRegistryReader);
   const entries = branches.map(branch => {
     const { state, evidence } = classify(branch, getIsMerged(branch), getPr(branch));
     return { branch, cleanupState: state, evidence, commands: commandsFor(branch, state) };
   });
-  return {
+  const report = {
     generatedAt: new Date().toISOString(), mode: 'dry-run',
     branches: entries,
-    orphanedLeases: orphans.map(l => ({ ticket: l.ticket, branch: l.branch, action: 'lease-close' })),
+    orphanedLeases: leaseResult.leases.map(l => ({ ticket: l.ticket, branch: l.branch, action: 'lease-close' })),
   };
+  if (leaseResult.error) report.registryError = leaseResult.error;
+  return report;
 }
 
 function run(argv = process.argv.slice(2)) {
@@ -111,6 +114,9 @@ function run(argv = process.argv.slice(2)) {
   if (report.orphanedLeases.length) {
     console.log('\nOrphaned leases (branch deleted, lease not closed):');
     for (const lease of report.orphanedLeases) console.log(`  ticket #${lease.ticket}: ${lease.branch}`);
+  }
+  if (report.registryError) {
+    console.log(`\n[warn] Orphaned lease list may be incomplete — registry unavailable: ${report.registryError}`);
   }
   return report;
 }

--- a/scripts/global/branch-cleanup-plan.js
+++ b/scripts/global/branch-cleanup-plan.js
@@ -48,15 +48,14 @@ function prState(branch) {
 
 function orphanedLeases(branches, registryFn) {
   const readFn = registryFn || leaseRegistry.read;
-  let reg;
   try {
-    reg = readFn(leaseRegistry.DEFAULT_PATH);
+    const reg = readFn(leaseRegistry.DEFAULT_PATH);
+    const leases = leaseRegistry.active(reg).filter(l => l.branch && !branches.includes(l.branch));
+    return { leases, error: null };
   } catch (err) {
     process.stderr.write(`[branch-cleanup-plan] lease registry unavailable (${leaseRegistry.DEFAULT_PATH}): ${err.message}\n`);
     return { leases: [], error: err.message };
   }
-  const leases = leaseRegistry.active(reg).filter(l => l.branch && !branches.includes(l.branch));
-  return { leases, error: null };
 }
 
 function classify(branch, merged, pr) {

--- a/tests/branch-cleanup-plan.spec.js
+++ b/tests/branch-cleanup-plan.spec.js
@@ -84,7 +84,7 @@ test('plan has no registryError when registry succeeds', () => {
     branches: ['feat/500-active'],
     isMergedToMain: () => false,
     prState: () => null,
-    leases: [],
+    leaseRegistryReader: () => ({ leases: [] }),
   });
   expect(report.registryError).toBeUndefined();
 });

--- a/tests/branch-cleanup-plan.spec.js
+++ b/tests/branch-cleanup-plan.spec.js
@@ -76,6 +76,17 @@ test('plan returns empty orphaned leases and classifies branches when registry t
   expect(report.orphanedLeases).toEqual([]);
   expect(report.branches[0].cleanupState).toBe('merged-clean');
   expect(report.mode).toBe('dry-run');
+  expect(report.registryError).toBe('registry file not found');
+});
+
+test('plan has no registryError when registry succeeds', () => {
+  const report = planner.plan({
+    branches: ['feat/500-active'],
+    isMergedToMain: () => false,
+    prState: () => null,
+    leases: [],
+  });
+  expect(report.registryError).toBeUndefined();
 });
 
 // Refs #2048 — shell-injection defense.


### PR DESCRIPTION
## Summary

Adds `registryError` field to `plan()` return object when the lease registry
is unavailable. Resolves the semantic ambiguity where `orphanedLeases: []`
was indistinguishable between a clean state and a registry read failure.

## Changes

- `orphanedLeases()` return type changed from `array` to `{ leases, error }`
- `plan()` conditionally includes `registryError: <message>` when error present
- `run()` prints a `[warn]` line when `registryError` is set
- Test 9 updated to assert `report.registryError === 'registry file not found'`
- Test 10 added: registry succeeds → `registryError` is `undefined`
- Changelog fragment: `.changes/unreleased/2067.md`

## Evidence

- 10/10 tests pass
- lint: 515 files, all ≤100 lines
- branch-cleanup-plan.js: 97 lines; tests: 90 lines

Refs #2067
Closes #2067