### PR TITLE
fix(scripts): defend branch-cleanup vs shell injection #2048

### DIFF
--- a/.changes/unreleased/2048.md
+++ b/.changes/unreleased/2048.md
@@ -1,0 +1,3 @@
+### Security
+
+- Defend `scripts/global/branch-cleanup-plan.js` against shell command injection. `isMergedToMain` and `prState` now validate branch names against a conservative allowlist and use `spawnSync` with argv arrays (no shell interpolation). `commandsFor` single-quotes branch names in operator-review output for defense-in-depth. (#2048)

--- a/scripts/global/branch-cleanup-plan.js
+++ b/scripts/global/branch-cleanup-plan.js
@@ -1,8 +1,22 @@
 'use strict';
-// Operator-safe branch cleanup policy (dry-run only). Refs #1610.
+// Operator-safe branch cleanup policy (dry-run only). Refs #1610 #2048.
 // Sandbox/ launchers and active leases are never flagged (three-team safety).
-const { execSync } = require('child_process');
+const { execSync, spawnSync } = require('child_process');
 const leaseRegistry = require('./cross-team-lease-registry');
+
+// Conservative branch-name allowlist — git permits broader names, but the cleanup
+// planner only ever acts on Conventional-Commit-shaped branches plus sandbox/launcher
+// prefixes. Anything outside this set is treated as untrusted input and routed to
+// keep-active (safe classification). Refs #2048 (shell-injection defense).
+const SAFE_BRANCH_RE = /^[a-zA-Z0-9][a-zA-Z0-9/_.@-]*$/;
+const SAFE_BRANCH_MAX_LEN = 200;
+
+function isSafeBranchName(name) {
+  return typeof name === 'string'
+    && name.length > 0
+    && name.length <= SAFE_BRANCH_MAX_LEN
+    && SAFE_BRANCH_RE.test(name);
+}
 
 function sh(cmd) {
   try { return execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim(); }
@@ -16,11 +30,19 @@ function localBranches() {
 }
 
 function isMergedToMain(branch) {
-  return sh(`git merge-base --is-ancestor "refs/heads/${branch}" origin/main && echo yes`) === 'yes';
+  if (!isSafeBranchName(branch)) return false;
+  const res = spawnSync('git', ['merge-base', '--is-ancestor', `refs/heads/${branch}`, 'origin/main'],
+    { stdio: ['pipe', 'pipe', 'pipe'] });
+  return res.status === 0;
 }
 
 function prState(branch) {
-  const raw = sh(`gh pr list --head "${branch}" --state all --json number,state --jq '.[0]'`);
+  if (!isSafeBranchName(branch)) return null;
+  const res = spawnSync('gh',
+    ['pr', 'list', '--head', branch, '--state', 'all', '--json', 'number,state', '--jq', '.[0]'],
+    { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+  if (res.status !== 0) return null;
+  const raw = (res.stdout || '').trim();
   try { return raw ? JSON.parse(raw) : null; } catch { return null; }
 }
 
@@ -46,9 +68,15 @@ function classify(branch, merged, pr) {
 }
 
 function commandsFor(branch, state) {
+  // Output commands are presented to operator review (dry-run plan), not executed
+  // automatically. Single-quote branch names so any shell metacharacter that leaked
+  // through earlier classification is inert when the operator pastes the command.
+  // Defense-in-depth pairs with the SAFE_BRANCH_RE allowlist at the call sites of
+  // isMergedToMain + prState. Refs #2048.
+  const q = `'${String(branch).replace(/'/g, "'\\''")}'`;
   if (state === 'merged-clean' || state === 'merged-no-pr')
-    return [`git branch -d ${branch}`, `git push origin --delete ${branch} || true`];
-  if (state === 'closed-pr') return [`git branch -d ${branch}`];
+    return [`git branch -d ${q}`, `git push origin --delete ${q} || true`];
+  if (state === 'closed-pr') return [`git branch -d ${q}`];
   return [];
 }
 
@@ -88,4 +116,4 @@ function run(argv = process.argv.slice(2)) {
 }
 
 if (require.main === module) run();
-module.exports = { classify, commandsFor, plan };
+module.exports = { classify, commandsFor, plan, isSafeBranchName, isMergedToMain, prState };

--- a/tests/branch-cleanup-plan.spec.js
+++ b/tests/branch-cleanup-plan.spec.js
@@ -12,8 +12,8 @@ test('classifies merged branch with merged PR as merged-clean', () => {
   expect(result.state).toBe('merged-clean');
   expect(result.evidence).toContain('PR #55');
   const cmds = planner.commandsFor('feat/123-done', 'merged-clean');
-  expect(cmds[0]).toContain('git branch -d feat/123-done');
-  expect(cmds[1]).toContain('git push origin --delete feat/123-done');
+  expect(cmds[0]).toBe("git branch -d 'feat/123-done'");
+  expect(cmds[1]).toBe("git push origin --delete 'feat/123-done' || true");
 });
 
 test('classifies merged branch with no PR as merged-no-pr', () => {
@@ -25,7 +25,7 @@ test('classifies merged branch with no PR as merged-no-pr', () => {
 test('classifies branch with closed PR as closed-pr', () => {
   const result = planner.classify('feat/125-stale', false, { number: 77, state: 'CLOSED' });
   expect(result.state).toBe('closed-pr');
-  expect(planner.commandsFor('feat/125-stale', 'closed-pr')).toEqual(['git branch -d feat/125-stale']);
+  expect(planner.commandsFor('feat/125-stale', 'closed-pr')).toEqual(["git branch -d 'feat/125-stale'"]);
 });
 
 test('keeps active branches untouched', () => {
@@ -76,4 +76,72 @@ test('plan returns empty orphaned leases and classifies branches when registry t
   expect(report.orphanedLeases).toEqual([]);
   expect(report.branches[0].cleanupState).toBe('merged-clean');
   expect(report.mode).toBe('dry-run');
+});
+
+// Refs #2048 — shell-injection defense.
+test('isSafeBranchName accepts conventional names and rejects injection payloads', () => {
+  expect(planner.isSafeBranchName('feat/123-done')).toBe(true);
+  expect(planner.isSafeBranchName('fix/2048-shell-injection')).toBe(true);
+  expect(planner.isSafeBranchName('sandbox/copilot')).toBe(true);
+  expect(planner.isSafeBranchName('main')).toBe(true);
+  expect(planner.isSafeBranchName('hotfix/9.9.9')).toBe(true);
+  // Injection payloads.
+  expect(planner.isSafeBranchName('feat/x" ; rm -rf / ; echo "y')).toBe(false);
+  expect(planner.isSafeBranchName('feat/x`whoami`')).toBe(false);
+  expect(planner.isSafeBranchName('feat/x$(whoami)')).toBe(false);
+  expect(planner.isSafeBranchName('feat/x;cat /etc/passwd')).toBe(false);
+  expect(planner.isSafeBranchName("feat/x'whoami'")).toBe(false);
+  expect(planner.isSafeBranchName('feat/x|whoami')).toBe(false);
+  expect(planner.isSafeBranchName('feat/x\nwhoami')).toBe(false);
+  expect(planner.isSafeBranchName('feat/x whoami')).toBe(false);
+  // Edge cases.
+  expect(planner.isSafeBranchName('')).toBe(false);
+  expect(planner.isSafeBranchName(null)).toBe(false);
+  expect(planner.isSafeBranchName(undefined)).toBe(false);
+  expect(planner.isSafeBranchName(123)).toBe(false);
+  expect(planner.isSafeBranchName('a'.repeat(201))).toBe(false);
+});
+
+test('isMergedToMain returns false for malicious branch name (no shell execution)', () => {
+  // If the branch name passed validation and were interpolated, this would
+  // execute `rm -rf /tmp/shell-injection-evidence` or similar. The validator
+  // gate must short-circuit BEFORE any subprocess is spawned.
+  const malicious = 'feat/x" ; touch /tmp/shell-injection-evidence-2048 ; echo "y';
+  expect(planner.isMergedToMain(malicious)).toBe(false);
+  // Belt-and-suspenders: the evidence sentinel must not have been created.
+  // We don't assert on filesystem here (CI sandboxing varies), the assertion
+  // above is sufficient since isMergedToMain short-circuits at validation.
+});
+
+test('prState returns null for malicious branch name (no shell execution)', () => {
+  const malicious = 'feat/x`id`';
+  expect(planner.prState(malicious)).toBeNull();
+});
+
+test('plan classifies malicious branch as keep-active and emits no destructive commands', () => {
+  const malicious = 'feat/x" ; rm -rf / ; echo "y';
+  const report = planner.plan({
+    branches: [malicious],
+    // No overrides for isMergedToMain / prState — exercise the real
+    // (validator-gated) implementations so the AC verifies the actual
+    // production path, not a mocked one.
+    leases: [],
+  });
+  const entry = report.branches[0];
+  expect(entry.branch).toBe(malicious);
+  expect(entry.cleanupState).toBe('keep-active');
+  expect(entry.commands).toEqual([]);
+});
+
+test('commandsFor single-quotes branch names (defense-in-depth)', () => {
+  // Even if a non-conformant name reaches commandsFor (e.g. via direct API call),
+  // the output command strings must be inert under shell expansion.
+  const cmds = planner.commandsFor('feat/x" ; rm -rf / ; echo "y', 'merged-clean');
+  // Single-quotes must enclose the whole branch token; no unquoted metachars allowed.
+  for (const cmd of cmds) {
+    // Each command starts with the verb and contains the branch wrapped in single quotes.
+    expect(cmd).toMatch(/^git (branch -d|push origin --delete) '/);
+    // No backtick / dollar-paren that would survive single-quoting.
+    expect(cmd).not.toMatch(/[`]/);
+  }
 });


### PR DESCRIPTION
Refs #2048
Closes #2048
Refs #1610

## Summary

Defend `scripts/global/branch-cleanup-plan.js` against shell command injection. Two `execSync` calls (`isMergedToMain` and `prState`) interpolated branch names directly into shell command strings — a local branch with shell metacharacters would have executed arbitrary code. Switch both to `spawnSync` with an argv array (no shell interpretation), gate them with a conservative `isSafeBranchName` allowlist that short-circuits invalid input before any subprocess spawn, and single-quote branch names in `commandsFor` output as defense-in-depth for the operator-review surface.

## Changes

- `scripts/global/branch-cleanup-plan.js` (+30 lines net): `isSafeBranchName` allowlist (`/^[a-zA-Z0-9][a-zA-Z0-9/_.@-]*$/`, max 200 chars); `isMergedToMain` and `prState` now validate + use `spawnSync(['git', ...args])` / `spawnSync(['gh', ...args])`; `commandsFor` single-quotes branch names with the standard escape sequence for embedded single quotes; module exports extended with `isSafeBranchName`, `isMergedToMain`, `prState` for test coverage.
- `tests/branch-cleanup-plan.spec.js` (+75 lines net): 5 new tests covering payload-rejection across the canonical injection classes (quote, backtick, dollar-paren, semicolon, single-quote, pipe, newline, space), `isMergedToMain`/`prState` short-circuit, end-to-end `plan` classification of a malicious branch as `keep-active` with no destructive commands, and `commandsFor` single-quote invariant. Existing 2 tests updated for the new single-quoted output format.

## Test plan

- [x] AC1 — `isMergedToMain` uses `spawnSync` with argv array (no shell interpolation)
- [x] AC2 — `prState` same
- [x] AC3 — `commandsFor` output strings single-quote branch names
- [x] AC4 — Unit test verifies malicious branch classifies as `keep-active`
- [x] 14/14 tests PASS locally (`npx playwright test tests/branch-cleanup-plan.spec.js`, 1.4s)
- [x] All 4 baton artifacts posted on #2048

## Notes

- Lane: code-change. No deployed runtime artifact touched. sync-verification: N/A.
- test_strategy: tdd-pyramid.
- Threat origin: Consultant red-team on #1610.
- 1 pre-existing baseline lint error in `scripts/global/fleet-live-indicator.js:105` (not introduced by this PR).
