### PR TITLE
feat: add catch-empty lint gate for workflows (#2090)

### DIFF
--- a/.github/workflows/auto-label-area.yml
+++ b/.github/workflows/auto-label-area.yml
@@ -47,7 +47,7 @@ jobs:
             const issue = (await github.rest.issues.get({ owner, repo, issue_number: num })).data;
             const stale = issue.labels.map(l => l.name).filter(l => l.startsWith('area:') && l !== targetLabel);
             for (const l of stale) {
-              await github.rest.issues.removeLabel({ owner, repo, issue_number: num, name: l }).catch(() => {});
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: num, name: l }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
             }
 
             await github.rest.issues.addLabels({ owner, repo, issue_number: num, labels: [targetLabel] });

--- a/.github/workflows/cross-team-auto-apply.yml
+++ b/.github/workflows/cross-team-auto-apply.yml
@@ -41,4 +41,4 @@ jobs:
                     `Auto-applied label \`${decision.label}\` per #1590. ` +
                     `Receiving teams can claim via the \`cross-team-consult-pickup\` skill ` +
                     `(see \`instructions/cross-team-consultant.instructions.md\`).`,
-            }).catch(() => {});
+            }).catch(() => {}); // catch-empty: best-effort notification; comment failure is non-critical

--- a/.github/workflows/cross-team-claim-reaper.yml
+++ b/.github/workflows/cross-team-claim-reaper.yml
@@ -51,11 +51,11 @@ jobs:
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: epic.number, name: 'consultant:cross-team-in-progress',
-              }).catch(() => {});
+              }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
               await github.rest.issues.addLabels({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: epic.number, labels: ['consultant:cross-team-needed'],
-              }).catch(() => {});
+              }).catch(() => {}); // catch-empty: addLabels throws 422 if label already applied
             }
             const summary = `Scanned ${epics.length} cross-team-in-progress Epics; expired ${expired.length} claim(s)`;
             console.log(`cross-team-claim-reaper: ${summary}`);

--- a/.github/workflows/cross-team-edit-warn.yml
+++ b/.github/workflows/cross-team-edit-warn.yml
@@ -75,5 +75,5 @@ jobs:
             await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body: msg });
             await github.rest.issues.addLabels({
               owner, repo, issue_number: issue.number, labels: ['coordinator:cross-team-needs-hand-off']
-            }).catch(() => {});
+            }).catch(() => {}); // catch-empty: addLabels throws 422 if label already applied
             core.info('issues.labeled sibling-role warn posted');

--- a/.github/workflows/cross-team-pr-parallel-check.yml
+++ b/.github/workflows/cross-team-pr-parallel-check.yml
@@ -77,6 +77,6 @@ jobs:
               await github.rest.issues.addLabels({
                 owner, repo, issue_number: Number(ref),
                 labels: ['coordinator:cross-team-needs-hand-off']
-              }).catch(() => {});
+              }).catch(() => {}); // catch-empty: addLabels throws 422 if label already applied
             }
             core.info('parallel-PR warn posted and coordinator label applied');

--- a/.github/workflows/epic-state-sync.yml
+++ b/.github/workflows/epic-state-sync.yml
@@ -79,10 +79,10 @@ jobs:
                 if (decision.dormant && !dryRun) {
                   await github.rest.issues.removeLabel({
                     owner, repo, issue_number: epic.number, name: 'status:in-progress',
-                  }).catch(() => {});
+                  }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
                   await github.rest.issues.addLabels({
                     owner, repo, issue_number: epic.number, labels: ['status:dormant'],
-                  }).catch(() => {});
+                  }).catch(() => {}); // catch-empty: addLabels throws 422 if label already applied
                   await github.rest.issues.createComment({
                     owner, repo, issue_number: epic.number,
                     body: det.autoPauseComment(epic.number, decision.reason, null),
@@ -94,10 +94,10 @@ jobs:
                 if (decision.reactivate && !dryRun) {
                   await github.rest.issues.removeLabel({
                     owner, repo, issue_number: epic.number, name: 'status:dormant',
-                  }).catch(() => {});
+                  }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
                   await github.rest.issues.addLabels({
                     owner, repo, issue_number: epic.number, labels: ['status:in-progress'],
-                  }).catch(() => {});
+                  }).catch(() => {}); // catch-empty: addLabels throws 422 if label already applied
                 }
               }
             }

--- a/.github/workflows/label-lint.yml
+++ b/.github/workflows/label-lint.yml
@@ -82,7 +82,7 @@ jobs:
                 if (isEpic && role === 'role:consultant') continue; // #1828 E2 v2 — transient review role
                 await github.rest.issues.removeLabel({
                   owner, repo, issue_number: issueNum, name: role,
-                }).catch(() => {});
+                }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
               }
             }
 
@@ -97,7 +97,7 @@ jobs:
               const conflict = statusCardinality.resolveTerminalConflict(labels);
               if (conflict.hasConflict) {
                 for (const name of conflict.removeLabels) {
-                  await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNum, name }).catch(() => {});
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNum, name }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
                 }
                 console.log(`#${issueNum}: #1380 auto-stripped stale status labels (${conflict.removeLabels.join(', ')}) → ${conflict.keepLabel}`);
               } else {

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,3 +72,13 @@ jobs:
           reporter: github-pr-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: No unsuppressed empty catch in github-script blocks
+        run: |
+          if grep -rn '\.catch(() => {})' .github/workflows/ | grep -v '// catch-empty:'; then
+            echo ""
+            echo "ERROR: Found an unsuppressed empty catch in a workflow file."
+            echo "Replace the empty catch with error handling, or add"
+            echo "  '// catch-empty: <reason>'  on the same line to mark it intentional."
+            exit 1
+          fi
+          echo "OK: no unsuppressed empty catches found."

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -49,7 +49,7 @@ jobs:
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: linkedNum, name: l,
-              }).catch(() => {});
+              }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
             }
             await github.rest.issues.addLabels({
               owner: context.repo.owner, repo: context.repo.repo,


### PR DESCRIPTION
## Summary

Adds a CI lint step to `lint.yml` that blocks any unsuppressed `.catch(() => {})` in workflow files, then annotates all 13 existing sites across 8 workflow files with the `// catch-empty: <reason>` suppression comment.

## Changes

- **`.github/workflows/lint.yml`** — new step: `No unsuppressed empty catch in github-script blocks`
- **`.github/workflows/label-lint.yml`** — 2 sites annotated (removeLabel 404, cardinality auto-strip)
- **`.github/workflows/auto-label-area.yml`** — 1 site annotated (removeLabel 404)
- **`.github/workflows/epic-state-sync.yml`** — 4 sites annotated (removeLabel 404 × 2, addLabels 422 × 2)
- **`.github/workflows/cross-team-edit-warn.yml`** — 1 site annotated (addLabels 422)
- **`.github/workflows/cross-team-pr-parallel-check.yml`** — 1 site annotated (addLabels 422)
- **`.github/workflows/post-merge-automation.yml`** — 1 site annotated (removeLabel 404)
- **`.github/workflows/cross-team-claim-reaper.yml`** — 2 sites annotated (removeLabel 404, addLabels 422)
- **`.github/workflows/cross-team-auto-apply.yml`** — 1 site annotated (best-effort notification)

## Verification

Local check passes:
```
grep -rn '\.catch(() => {})' .github/workflows/ | grep -v '// catch-empty:'
# → no output (zero unsuppressed catches)
```

`npm run lint` → `✅ All files within 100-line limit.`

Refs #2090