### PR TITLE
docs(wiki): Three-Wiki typology storage-layout stubs #2051

### DIFF
--- a/.changes/unreleased/2051.md
+++ b/.changes/unreleased/2051.md
@@ -1,0 +1,3 @@
+### Added
+
+- Three-Wiki typology storage-layout stubs: `wiki/code/`, `wiki/work-log/`, `wiki/wisdom/project/`, `wiki/wisdom/global/` directories with README stubs documenting each Wiki's scope and purpose. Updates `wiki/index.md` and `instructions/wiki-knowledge.instructions.md` with the new layout. Legacy paths (`wiki/concepts/`, `wiki/entities/`, `wiki/sources/`, `wiki/syntheses/`, `wiki/skills/`) remain at their current locations; physical migration to `wiki/wisdom/global/` is queued as a follow-on ticket. (#2051)

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,8 @@ logs/copilot-usage.json
 
 # Local pre-GitHub-canonical baton history (#820)
 # Authoritative ticket data lives in GitHub Issues; tickets/*.md is local-only legacy.
-tickets/
+# Anchored to root only (#2051): wiki/work-log/tickets/ is Wiki B per-project mirror, committed.
+/tickets/
 .worktrees/
 
 # Operator-local spike outputs (Wave 1 #891/#892/#893) — never committed

--- a/instructions/wiki-knowledge.instructions.md
+++ b/instructions/wiki-knowledge.instructions.md
@@ -30,10 +30,25 @@ Check wiki before research tasks, when answering fleet/governance/architecture q
 ## Wiki Structure
 
 - `wiki/index.md` — read this first to find relevant pages
-- `wiki/entities/` — devices, services, tools
-- `wiki/concepts/` — patterns, protocols, decisions
-- `wiki/sources/` — digests of raw research documents
-- `wiki/syntheses/` — cross-cutting analysis
+
+### Three-Wiki typology (Phase-1 stubs from #2051; full migration follow-on)
+
+Per `research/three-wiki-typology-synthesis-1943.md` (Epic #1942 Phase-0):
+
+- `wiki/code/` (Wiki A) — Code-Base Wiki (per-project; symbols + concepts)
+- `wiki/work-log/` (Wiki B) — Project Work-Log Wiki (per-project; mirrors GitHub tickets + PRs)
+- `wiki/wisdom/project/` (Wiki C scope=project) — Project-specific research wisdom (per-project, **NEVER distributed cross-project**)
+- `wiki/wisdom/global/` (Wiki C scope=global) — Cross-project wisdom (distributed to operator-global `~/.copilot/wiki/`)
+
+### Legacy paths (still in use; will migrate to wiki/wisdom/global/)
+
+- `wiki/entities/` — devices, services, tools (→ `wiki/wisdom/global/entities/`)
+- `wiki/concepts/` — patterns, protocols, decisions (→ `wiki/wisdom/global/concepts/`)
+- `wiki/sources/` — digests of raw research documents (→ `wiki/wisdom/global/sources/`)
+- `wiki/syntheses/` — cross-cutting analysis (→ `wiki/wisdom/global/syntheses/`)
+- `wiki/skills/` (→ `wiki/wisdom/global/skills/`)
+
+Physical migration of legacy paths is queued as a follow-on to #2051.
 
 ## Rules
 

--- a/wiki/code/README.md
+++ b/wiki/code/README.md
@@ -1,0 +1,24 @@
+# Wiki A — Code-Base Wiki (per-project)
+
+Holds all code-base details for this repository. Per the Three-Wiki typology from research/three-wiki-typology-synthesis-1943.md.
+
+## Purpose
+
+Eliminate the G3 cost of dispersed CLI research when models or operators need to answer questions about the code base. Wiki A is the harness instantiation of the structural + semantic layers from #1858 R1 + R2.
+
+## Subdirectories
+
+- `symbols/` — Structural sub-layer. One page per source file, listing file + symbol + signature maps per the Aider repo-map pattern. Auto-updated from source code via Phase-1 child #2053.
+- `concepts/` — Semantic sub-layer. Prose descriptions of how the code works (feature explainers, dependency graphs, known-issue notes).
+
+## Scope
+
+**Per-project** — content lives in this repository only. Never distributed to operator-global `~/.copilot/wiki/`.
+
+## Auto-update
+
+Populated by the auto-update pipeline (Phase-1 child #2055) on PR merge events. See research/three-wiki-typology-synthesis-1943.md §"Auto-update pipeline design (AC4)" for the 11-stage pipeline.
+
+## Status
+
+**Phase-1 stub** — created by #2051. Ingestion logic ships in #2053. Until then, this directory is empty except for this README.

--- a/wiki/code/concepts/.gitkeep
+++ b/wiki/code/concepts/.gitkeep
@@ -1,0 +1,3 @@
+# Stub for wiki/code/concepts/
+# Created by #2051 Phase-1 C1 (storage-layout migration).
+# Content populated by downstream Phase-1 children of Epic #1942.

--- a/wiki/code/symbols/.gitkeep
+++ b/wiki/code/symbols/.gitkeep
@@ -1,0 +1,3 @@
+# Stub for wiki/code/symbols/
+# Created by #2051 Phase-1 C1 (storage-layout migration).
+# Content populated by downstream Phase-1 children of Epic #1942.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -10,6 +10,21 @@ The LLM updates this on every ingest operation.
 3. At moderate scale (~100 sources, ~hundreds of pages), this avoids
    the need for embedding-based RAG infrastructure.
 
+## Storage Layout (Three-Wiki typology — Phase-1 stubs from #2051)
+
+Per `research/three-wiki-typology-synthesis-1943.md`, the wiki is organized into four scopes:
+
+- **`wiki/code/`** (Wiki A) — Code-Base Wiki (per-project, committed). Symbols + concepts derived from this repo's source code. Stub only until Phase-1 child #2053 ships ingestion logic.
+- **`wiki/work-log/`** (Wiki B) — Project Work-Log Wiki (per-project, committed). Mirror of GitHub tickets + PRs. Stub only until Phase-1 child #2054 ships ingestion logic.
+- **`wiki/wisdom/project/`** (Wiki C scope=project) — Project-specific research-based wisdom (per-project, committed, NEVER distributed cross-project). Phase-0 research+planning syntheses land here (e.g. Epic #2091 will land its Phase-0 synthesis at `wiki/wisdom/project/research/harness-state-isolation.md`).
+- **`wiki/wisdom/global/`** (Wiki C scope=global) — Cross-project wisdom (committed in this repo, distributed to operator-global `~/.copilot/wiki/`). Currently EMPTY — the legacy paths `wiki/concepts/`, `wiki/entities/`, `wiki/sources/`, `wiki/syntheses/`, `wiki/skills/` ARE conceptually this scope but live at their pre-migration paths. Physical migration is queued as a follow-on to #2051.
+
+Each subtree has a README.md documenting its purpose.
+
+### Legacy paths (still in use)
+
+The sections below (`## Entities`, `## Concepts`, etc.) continue to enumerate content at the LEGACY paths (`wiki/entities/`, `wiki/concepts/`, etc.). Until the legacy-path migration ticket ships, treat them as `wiki/wisdom/global/<section>/` content despite the physical path.
+
 ## Entities
 
 - [[penguin-1]] — Penguin-1 (SML Chromebook)

--- a/wiki/wisdom/global/README.md
+++ b/wiki/wisdom/global/README.md
@@ -1,0 +1,40 @@
+# Wiki C scope=global — Operator-Global Research-Based-Wisdom Wiki
+
+Cross-project wisdom that applies across multiple repositories or to general LLM-agent-governance practice. Per the Three-Wiki typology from research/three-wiki-typology-synthesis-1943.md.
+
+## Purpose
+
+House research and synthesis that is REUSABLE across projects. Examples:
+- Branch vs worktree vs sandbox isolation patterns (applies to any multi-agent workspace)
+- Root-cause vs symptom-suppression principle (applies to any CI/alerting design)
+- 2026 industry citations + design principles that any harness could adopt
+- Cross-cutting analyses of agentic patterns
+
+## Scope
+
+**Per-project authoring location, COMMITTED in this repo, DISTRIBUTED to operator-global `~/.copilot/wiki/`** on Megingjord deploy. Other repositories on the same operator's machine read the distributed copy as a read-only knowledge source.
+
+## Subdirectories
+
+(Empty until follow-on physical-migration ticket — see "Legacy paths" below)
+
+Designed layout (per #1943 synthesis):
+- `concepts/` — Cross-project concept pages
+- `entities/` — Cross-project entity pages (services, tools, frameworks)
+- `syntheses/` — Cross-project synthesis pages
+
+## Legacy paths (pre-migration)
+
+The following directories at `wiki/<dir>/` (one level up) ARE conceptually Wiki C scope=global content but live at their legacy paths pending the physical migration:
+
+- `wiki/concepts/` → will move to `wiki/wisdom/global/concepts/`
+- `wiki/entities/` → will move to `wiki/wisdom/global/entities/`
+- `wiki/sources/` → will move to `wiki/wisdom/global/sources/`
+- `wiki/syntheses/` → will move to `wiki/wisdom/global/syntheses/`
+- `wiki/skills/` → will move to `wiki/wisdom/global/skills/`
+
+**Physical migration deferred to follow-on ticket** (filed at #2051 closeout). The migration requires updating `scripts/wiki/*.js` path-pattern matching, validator regression, and Megingjord deploy/distribution scripts — too invasive for a single docs-research lane ticket.
+
+## Status
+
+**Phase-1 stub** — created by #2051. Physical migration deferred. Until migration completes, treat `wiki/concepts/`, `wiki/entities/`, etc. AS this directory.

--- a/wiki/wisdom/project/README.md
+++ b/wiki/wisdom/project/README.md
@@ -1,0 +1,35 @@
+# Wiki C scope=project — Project-specific Research-Based-Wisdom Wiki
+
+Project-bound research knowledge that is NOT cross-project reusable. Per the Three-Wiki typology from research/three-wiki-typology-synthesis-1943.md, this is one of two scopes of Wiki C (the other being scope=global).
+
+## Purpose
+
+House research and synthesis output that is specific to THIS repository (Megingjord governance harness). Includes:
+- Project-specific decisions (which validators we use, which paths are canonical)
+- Project-bound architectural research (specific to our hooks, scripts, baton workflow)
+- Phase-0 syntheses for research-first Epics that produce project-specific output
+
+## Subdirectories
+
+- `concepts/` — Project-specific concepts (definitions, terminology bound to this codebase)
+- `decisions/` — Architectural Decision Records (ADRs) for project-scoped decisions
+- `research/` — Phase-0 research syntheses for research-first Epics (e.g. `harness-state-isolation.md` for Epic #2091)
+
+## Scope
+
+**Per-project, COMMITTED** — content lives in this repository. **NEVER distributed to operator-global `~/.copilot/wiki/`.** This is the load-bearing distinction from Wiki C scope=global.
+
+## Authoring path
+
+- New research+planning synthesis lands here (NOT in legacy `research/*.md`) — this directory IS the home for the Phase-0 output of any research-first Epic where the deliverable is project-specific
+- Cross-project wisdom (e.g. the branch-vs-worktree-vs-sandbox principle) belongs in `wiki/wisdom/global/` instead
+- ADR-style decisions land in `decisions/`
+- Long-form synthesis lands in `research/`
+
+## Relation to GitHub issues
+
+GitHub issue body + comments = canonical work record (process). This directory = curated knowledge (content). The two have distinct purposes; not duplicates.
+
+## Status
+
+**Phase-1 stub** — created by #2051. First consumer will be Epic #2091 Phase-0 child #2092 (harness state isolation synthesis) once unblocked.

--- a/wiki/wisdom/project/concepts/.gitkeep
+++ b/wiki/wisdom/project/concepts/.gitkeep
@@ -1,0 +1,3 @@
+# Stub for wiki/wisdom/project/concepts/
+# Created by #2051 Phase-1 C1 (storage-layout migration).
+# Content populated by downstream Phase-1 children of Epic #1942.

--- a/wiki/wisdom/project/decisions/.gitkeep
+++ b/wiki/wisdom/project/decisions/.gitkeep
@@ -1,0 +1,3 @@
+# Stub for wiki/wisdom/project/decisions/
+# Created by #2051 Phase-1 C1 (storage-layout migration).
+# Content populated by downstream Phase-1 children of Epic #1942.

--- a/wiki/wisdom/project/research/.gitkeep
+++ b/wiki/wisdom/project/research/.gitkeep
@@ -1,0 +1,3 @@
+# Stub for wiki/wisdom/project/research/
+# Created by #2051 Phase-1 C1 (storage-layout migration).
+# Content populated by downstream Phase-1 children of Epic #1942.

--- a/wiki/work-log/README.md
+++ b/wiki/work-log/README.md
@@ -1,0 +1,28 @@
+# Wiki B — Project Work-Log Wiki (per-project)
+
+Local mirror of GitHub ticket and PR history for this repository. Per the Three-Wiki typology from research/three-wiki-typology-synthesis-1943.md.
+
+## Purpose
+
+Reduce `gh issue view` / `gh pr view` round-trip cost (G3) and enable outage-time queries (G7). Wiki B is the harness instantiation of Copilot's scoped memory layer (#1858 R4) at the project tier.
+
+## Subdirectories
+
+- `tickets/` — One page per GitHub issue. Mirror of `gh issue view N --json comments,labels,state`. Includes baton artifacts, AC tracking, status transitions.
+- `prs/` — One page per pull request. Mirror of `gh pr view N --json reviews,checks,state`.
+
+## Scope
+
+**Per-project** — content lives in this repository only. Never distributed to operator-global `~/.copilot/wiki/`.
+
+## Auto-update
+
+Populated by ingestion logic in Phase-1 child #2054 on GitHub webhook events (issue + PR open/edit/close). See research/three-wiki-typology-synthesis-1943.md §"Auto-update pipeline" for the contract.
+
+## Relation to GitHub issues
+
+GitHub issues remain the **canonical remote work record**. Wiki B is a DERIVED mirror, refreshed by automation. Editing Wiki B directly is incorrect; edit the GitHub issue and let the mirror refresh.
+
+## Status
+
+**Phase-1 stub** — created by #2051. Ingestion logic ships in #2054. Until then, this directory is empty except for this README.

--- a/wiki/work-log/prs/.gitkeep
+++ b/wiki/work-log/prs/.gitkeep
@@ -1,0 +1,3 @@
+# Stub for wiki/work-log/prs/
+# Created by #2051 Phase-1 C1 (storage-layout migration).
+# Content populated by downstream Phase-1 children of Epic #1942.

--- a/wiki/work-log/tickets/.gitkeep
+++ b/wiki/work-log/tickets/.gitkeep
@@ -1,0 +1,3 @@
+# Stub for wiki/work-log/tickets/
+# Created by #2051 Phase-1 C1 (storage-layout migration).
+# Content populated by downstream Phase-1 children of Epic #1942.


### PR DESCRIPTION
Refs #2051
Closes #2051
Refs Epic #1942

## Summary

Phase-1 C1 of Epic #1942 — Three-Wiki typology storage-layout stubs. Creates the new Wiki subtrees per `research/three-wiki-typology-synthesis-1943.md` without touching existing legacy paths.

## Changes

- 4 new Wiki subtrees with README.md per subtree documenting purpose + scope + downstream populating child:
  - `wiki/code/` (Wiki A — Code-Base, per-project)
  - `wiki/work-log/` (Wiki B — Project Work-Log, per-project)
  - `wiki/wisdom/project/` (Wiki C scope=project — per-project research wisdom, never distributed cross-project)
  - `wiki/wisdom/global/` (Wiki C scope=global — cross-project wisdom, distributed to operator-global `~/.copilot/wiki/`)
- 7 inner subdirectories with `.gitkeep` stubs (symbols, concepts, tickets, prs, concepts, decisions, research)
- `wiki/index.md` updated with new "Storage Layout (Three-Wiki typology)" section
- `instructions/wiki-knowledge.instructions.md` updated with Three-Wiki subtree list + "Legacy paths" subsection noting deferred-physical-migration
- `.gitignore` `tickets/` pattern anchored to root (`/tickets/`) so `wiki/work-log/tickets/` is not ignored — discovered + fixed in same PR
- `.changes/unreleased/2051.md` CHANGELOG fragment

## Test plan

- [x] AC1 — wiki/code/{symbols,concepts}/README.md present
- [x] AC2 — wiki/work-log/{tickets,prs}/README.md present (incl. gitignore anchor fix)
- [x] AC3 — wiki/wisdom/project/{concepts,decisions,research}/README.md present
- [x] AC4 — wiki/wisdom/global/README.md present with legacy-path callout
- [x] AC5 — wiki/index.md updated
- [x] AC6 — instructions/wiki-knowledge.instructions.md updated
- [x] AC7 — legacy paths (wiki/concepts/, wiki/entities/, etc.) untouched
- [x] All 4 baton artifacts on #2051

## Scope discipline

Conservative interpretation of #1943 synthesis: mkdir + stubs only, NOT the physical migration of legacy paths (wiki/concepts/ → wiki/wisdom/global/concepts/, etc.). Physical migration is deferred to a follow-on ticket because it requires:
- Updating `scripts/wiki/*.js` path-pattern matching
- Validator regression
- Megingjord `deploy:claude` / `~/.copilot/wiki/` distribution script updates

Splitting keeps each Phase-1 child shippable in one baton cycle.

## What this unblocks

- Epic #2091 Phase-0 child #2092 can now write its synthesis directly to `wiki/wisdom/project/research/harness-state-isolation.md`
- Future research+planning syntheses have a canonical home (no more `research/*.md` legacy)

## Notes

- Lane: docs-research. Deploy-runtime-impact: low (new wiki subtrees ship to ~/.copilot/wiki/ on next deploy:claude).
- test_strategy: drift-lint (no spec file required).
- Bonus fix: .gitignore `tickets/` anchored to root — preserves original intent (local pre-GitHub-canonical baton history) while permitting wiki/work-log/tickets/.
