### PR TITLE
feat: add catch-empty lint gate for workflows (#2090)

### DIFF
--- a/.changes/unreleased/2090.md
+++ b/.changes/unreleased/2090.md
@@ -1,0 +1,2 @@
+### Added
+- CI lint gate in `lint.yml` blocks unsuppressed `.catch(() => {})` in `github-script` workflow blocks; all 13 existing intentional empty-catch sites annotated with `// catch-empty: <reason>` (#2090)

--- a/.github/workflows/auto-label-area.yml
+++ b/.github/workflows/auto-label-area.yml
@@ -47,7 +47,7 @@ jobs:
             const issue = (await github.rest.issues.get({ owner, repo, issue_number: num })).data;
             const stale = issue.labels.map(l => l.name).filter(l => l.startsWith('area:') && l !== targetLabel);
             for (const l of stale) {
-              await github.rest.issues.removeLabel({ owner, repo, issue_number: num, name: l }).catch(() => {});
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: num, name: l }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
             }
 
             await github.rest.issues.addLabels({ owner, repo, issue_number: num, labels: [targetLabel] });

--- a/.github/workflows/cross-team-auto-apply.yml
+++ b/.github/workflows/cross-team-auto-apply.yml
@@ -41,4 +41,4 @@ jobs:
                     `Auto-applied label \`${decision.label}\` per #1590. ` +
                     `Receiving teams can claim via the \`cross-team-consult-pickup\` skill ` +
                     `(see \`instructions/cross-team-consultant.instructions.md\`).`,
-            }).catch(() => {});
+            }).catch(() => {}); // catch-empty: best-effort notification; comment failure is non-critical

--- a/.github/workflows/cross-team-claim-reaper.yml
+++ b/.github/workflows/cross-team-claim-reaper.yml
@@ -51,11 +51,11 @@ jobs:
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: epic.number, name: 'consultant:cross-team-in-progress',
-              }).catch(() => {});
+              }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
               await github.rest.issues.addLabels({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: epic.number, labels: ['consultant:cross-team-needed'],
-              }).catch(() => {});
+              }).catch(() => {}); // catch-empty: addLabels throws 422 if label already applied
             }
             const summary = `Scanned ${epics.length} cross-team-in-progress Epics; expired ${expired.length} claim(s)`;
             console.log(`cross-team-claim-reaper: ${summary}`);

--- a/.github/workflows/cross-team-edit-warn.yml
+++ b/.github/workflows/cross-team-edit-warn.yml
@@ -75,5 +75,5 @@ jobs:
             await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body: msg });
             await github.rest.issues.addLabels({
               owner, repo, issue_number: issue.number, labels: ['coordinator:cross-team-needs-hand-off']
-            }).catch(() => {});
+            }).catch(() => {}); // catch-empty: addLabels throws 422 if label already applied
             core.info('issues.labeled sibling-role warn posted');

--- a/.github/workflows/cross-team-pr-parallel-check.yml
+++ b/.github/workflows/cross-team-pr-parallel-check.yml
@@ -77,6 +77,6 @@ jobs:
               await github.rest.issues.addLabels({
                 owner, repo, issue_number: Number(ref),
                 labels: ['coordinator:cross-team-needs-hand-off']
-              }).catch(() => {});
+              }).catch(() => {}); // catch-empty: addLabels throws 422 if label already applied
             }
             core.info('parallel-PR warn posted and coordinator label applied');

--- a/.github/workflows/epic-state-sync.yml
+++ b/.github/workflows/epic-state-sync.yml
@@ -79,10 +79,10 @@ jobs:
                 if (decision.dormant && !dryRun) {
                   await github.rest.issues.removeLabel({
                     owner, repo, issue_number: epic.number, name: 'status:in-progress',
-                  }).catch(() => {});
+                  }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
                   await github.rest.issues.addLabels({
                     owner, repo, issue_number: epic.number, labels: ['status:dormant'],
-                  }).catch(() => {});
+                  }).catch(() => {}); // catch-empty: addLabels throws 422 if label already applied
                   await github.rest.issues.createComment({
                     owner, repo, issue_number: epic.number,
                     body: det.autoPauseComment(epic.number, decision.reason, null),
@@ -94,10 +94,10 @@ jobs:
                 if (decision.reactivate && !dryRun) {
                   await github.rest.issues.removeLabel({
                     owner, repo, issue_number: epic.number, name: 'status:dormant',
-                  }).catch(() => {});
+                  }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
                   await github.rest.issues.addLabels({
                     owner, repo, issue_number: epic.number, labels: ['status:in-progress'],
-                  }).catch(() => {});
+                  }).catch(() => {}); // catch-empty: addLabels throws 422 if label already applied
                 }
               }
             }

--- a/.github/workflows/label-lint.yml
+++ b/.github/workflows/label-lint.yml
@@ -82,7 +82,7 @@ jobs:
                 if (isEpic && role === 'role:consultant') continue; // #1828 E2 v2 — transient review role
                 await github.rest.issues.removeLabel({
                   owner, repo, issue_number: issueNum, name: role,
-                }).catch(() => {});
+                }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
               }
             }
 
@@ -97,7 +97,7 @@ jobs:
               const conflict = statusCardinality.resolveTerminalConflict(labels);
               if (conflict.hasConflict) {
                 for (const name of conflict.removeLabels) {
-                  await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNum, name }).catch(() => {});
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNum, name }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
                 }
                 console.log(`#${issueNum}: #1380 auto-stripped stale status labels (${conflict.removeLabels.join(', ')}) → ${conflict.keepLabel}`);
               } else {

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,3 +72,13 @@ jobs:
           reporter: github-pr-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: No unsuppressed empty catch in github-script blocks
+        run: |
+          if grep -rn '\.catch(() => {})' .github/workflows/ | grep -v '// catch-empty:'; then
+            echo ""
+            echo "ERROR: Found an unsuppressed empty catch in a workflow file."
+            echo "Replace the empty catch with error handling, or add"
+            echo "  '// catch-empty: <reason>'  on the same line to mark it intentional."
+            exit 1
+          fi
+          echo "OK: no unsuppressed empty catches found."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,12 +73,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: No unsuppressed empty catch in github-script blocks
-        run: |
-          if grep -rn '\.catch(() => {})' .github/workflows/ | grep -v '// catch-empty:'; then
-            echo ""
-            echo "ERROR: Found an unsuppressed empty catch in a workflow file."
-            echo "Replace the empty catch with error handling, or add"
-            echo "  '// catch-empty: <reason>'  on the same line to mark it intentional."
-            exit 1
-          fi
-          echo "OK: no unsuppressed empty catches found."
+        run: bash scripts/global/catch-empty-lint.sh .github/workflows

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -49,7 +49,7 @@ jobs:
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: linkedNum, name: l,
-              }).catch(() => {});
+              }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
             }
             await github.rest.issues.addLabels({
               owner: context.repo.owner, repo: context.repo.repo,

--- a/scripts/global/catch-empty-lint.sh
+++ b/scripts/global/catch-empty-lint.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# catch-empty-lint.sh — detect unsuppressed empty-body catches in workflow files
+# Ref: #2090. Covers single-line, named-param, and multiline forms.
+set -euo pipefail
+
+DIR="${1:-.github/workflows}"
+SUPPRESS='// catch-empty:'
+
+# Matches single-line: .catch(() => {}), .catch((e) => {}), .catch((_) => {})
+SINGLE='\.catch\(\s*\(?[a-z_]*\)?\s*=>\s*\{\s*\}\)'
+
+# Matches multiline opening: .catch(... => {  (end of line)
+MULTI='\.catch\(\s*\(?[a-z_]*\)?\s*=>\s*\{\s*$'
+
+found=0
+
+# Single-line detection (exclude YAML comment lines)
+while IFS= read -r hit; do
+  echo "  $hit"; found=1
+done < <(grep -rEn "$SINGLE" "$DIR" | grep -v "$SUPPRESS" | grep -v '^\S*:[0-9]*:\s*#' || true)
+
+# Multiline detection: opening line followed by }) on the very next line
+while IFS=: read -r file lineno rest; do
+  if printf '%s' "$rest" | grep -qE '^\s*#'; then continue; fi
+  nextline=$(sed -n "$((lineno+1))p" "$file")
+  if printf '%s' "$nextline" | grep -qE '^\s*\}\)'; then
+    echo "  $file:$lineno: $rest [multiline empty catch]"; found=1
+  fi
+done < <(grep -rEn "$MULTI" "$DIR" | grep -v "$SUPPRESS" || true)
+
+if [ "$found" -eq 1 ]; then
+  echo ""
+  echo "ERROR: unsuppressed empty catch block(s) found above."
+  echo "Replace with error handling, or add '// catch-empty: <reason>' on the catch line."
+  exit 1
+fi
+echo "OK: no unsuppressed empty catches found."

--- a/tests/fixtures/catch-empty/bad.yml
+++ b/tests/fixtures/catch-empty/bad.yml
@@ -1,0 +1,14 @@
+# catch-empty golden-file fixture: UNSUPPRESSED empty catch — lint gate MUST FAIL
+# Used by test-evidence-validator (golden-file strategy) for ticket #2090.
+# This file intentionally contains a bare .catch(() => {}) with no suppression comment.
+# The lint.yml grep step should flag this file.
+on: [push]
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({ owner: 'x', repo: 'y', issue_number: 1, name: 'z' })
+              .catch(() => {})

--- a/tests/fixtures/catch-empty/bad.yml
+++ b/tests/fixtures/catch-empty/bad.yml
@@ -1,10 +1,12 @@
-# catch-empty golden-file fixture: UNSUPPRESSED empty catch — lint gate MUST FAIL
+# catch-empty golden-file fixture: UNSUPPRESSED forms — lint gate MUST FAIL
 # Used by test-evidence-validator (golden-file strategy) for ticket #2090.
-# This file intentionally contains a bare .catch(() => {}) with no suppression comment.
-# The lint.yml grep step should flag this file.
+# BAD-1: bare single-line form (original pattern)
+# BAD-2: named-param form — .catch((e) => {}) bypasses naive grep
+# BAD-3: multiline form — .catch(() => {\n}) bypasses naive grep
+# The scripts/global/catch-empty-lint.sh should flag all three.
 on: [push]
 jobs:
-  example:
+  bad-single-line:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
@@ -12,3 +14,20 @@ jobs:
           script: |
             await github.rest.issues.removeLabel({ owner: 'x', repo: 'y', issue_number: 1, name: 'z' })
               .catch(() => {})
+  bad-named-param:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({ owner: 'x', repo: 'y', issue_number: 1, name: 'z' })
+              .catch((e) => {})
+  bad-multiline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({ owner: 'x', repo: 'y', issue_number: 1, name: 'z' })
+              .catch(() => {
+              })

--- a/tests/fixtures/catch-empty/good.yml
+++ b/tests/fixtures/catch-empty/good.yml
@@ -1,0 +1,13 @@
+# catch-empty golden-file fixture: SUPPRESSED empty catch — lint gate MUST PASS
+# Used by test-evidence-validator (golden-file strategy) for ticket #2090.
+# The suppression comment // catch-empty: <reason> on the same line satisfies the gate.
+on: [push]
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({ owner: 'x', repo: 'y', issue_number: 1, name: 'z' })
+              .catch(() => {}) // catch-empty: label may not exist; 404 is expected and safe to ignore

--- a/tests/fixtures/catch-empty/good.yml
+++ b/tests/fixtures/catch-empty/good.yml
@@ -1,13 +1,32 @@
-# catch-empty golden-file fixture: SUPPRESSED empty catch — lint gate MUST PASS
+# catch-empty golden-file fixture: SUPPRESSED forms — lint gate MUST PASS
 # Used by test-evidence-validator (golden-file strategy) for ticket #2090.
-# The suppression comment // catch-empty: <reason> on the same line satisfies the gate.
+# GOOD-1: single-line suppressed (original pattern)
+# GOOD-2: named-param suppressed
+# GOOD-3: multiline suppressed — annotation on opening line
 on: [push]
 jobs:
-  example:
+  good-single-line:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
         with:
           script: |
             await github.rest.issues.removeLabel({ owner: 'x', repo: 'y', issue_number: 1, name: 'z' })
-              .catch(() => {}) // catch-empty: label may not exist; 404 is expected and safe to ignore
+              .catch(() => {}) // catch-empty: label may not exist; 404 is expected
+  good-named-param:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({ owner: 'x', repo: 'y', issue_number: 1, name: 'z' })
+              .catch((e) => {}) // catch-empty: best-effort; error logged via console above
+  good-multiline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({ owner: 'x', repo: 'y', issue_number: 1, name: 'z' })
+              .catch(() => { // catch-empty: label may not exist; 404 is safe to ignore
+              })


### PR DESCRIPTION
Adds a CI grep check to `lint.yml` that blocks any unsuppressed `.catch(() => {})` in `.github/workflows/*.yml`. Annotates all 13 existing intentional empty-catch sites with `// catch-empty: <reason>` suppression comment. Includes golden-file test fixtures and changelog fragment.

Refs #2090
Closes #2090