### PR TITLE
chore(governance): adopt main-checkout residue + gitignore extension #2113

### DIFF
--- a/.changes/unreleased/2113.md
+++ b/.changes/unreleased/2113.md
@@ -1,0 +1,8 @@
+### Changed
+
+- `.gitignore` extended with root-anchored `/dist/` + `/planning/` patterns (matching `/tickets/` from #2051). Build output + operator-local planning area now never tracked; cleans up the cross-team residue accumulation pattern that triggered false-positive stop-hook alarms (~20 alarms per session observed 2026-05-21/22). (#2113)
+- `scripts/analyze-governance-drift.js` adopted into the tracked set (was an orphaned residue file from a prior session; now a legitimate governance utility). (#2113)
+
+### Notes
+
+- Structural prevention: Epic #2091 Phase-1 children (#2103 session-start state rotation, #2106 per-session state keying, #2107 canonical-main read-only enforcer — shipped) eliminate future residue accumulation. This ticket is a one-time adoption of pre-existing residue.

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,10 @@ logs/copilot-usage.json
 /tickets/
 .worktrees/
 
+# Build output + operator-local planning area (#2113): never committed.
+# Root-anchored so wiki/work-log/planning/ (#2054, Wiki B) can exist if filed.
+/dist/
+/planning/
+
 # Operator-local spike outputs (Wave 1 #891/#892/#893) — never committed
 tmp/

--- a/scripts/analyze-governance-drift.js
+++ b/scripts/analyze-governance-drift.js
@@ -1,10 +1,14 @@
 'use strict';
 const cp = require('child_process');
 
-const raw = cp.execFileSync('gh', ['issue', 'list', '--state', 'open', '--limit', '500', '--json', 'number,title,body,labels'], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+const OPEN_LIMIT = '500';
+const ALL_LIMIT = '1000';
+const MAX_BUFFER_BYTES = 50 * 1024 * 1024;
+
+const raw = cp.execFileSync('gh', ['issue', 'list', '--state', 'open', '--limit', OPEN_LIMIT, '--json', 'number,title,body,labels'], { encoding: 'utf8', maxBuffer: MAX_BUFFER_BYTES });
 const issues = JSON.parse(raw);
 
-const rawAllEpics = cp.execFileSync('gh', ['issue', 'list', '--limit', '1000', '--json', 'number,title,body,labels'], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+const rawAllEpics = cp.execFileSync('gh', ['issue', 'list', '--limit', ALL_LIMIT, '--json', 'number,title,body,labels'], { encoding: 'utf8', maxBuffer: MAX_BUFFER_BYTES });
 const allIssues = JSON.parse(rawAllEpics);
 const epicNumbers = new Set(allIssues.filter(i => i.labels.some(l => l.name === 'type:epic')).map(i => i.number));
 

--- a/scripts/analyze-governance-drift.js
+++ b/scripts/analyze-governance-drift.js
@@ -1,0 +1,66 @@
+'use strict';
+const cp = require('child_process');
+
+const raw = cp.execFileSync('gh', ['issue', 'list', '--state', 'open', '--limit', '500', '--json', 'number,title,body,labels'], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+const issues = JSON.parse(raw);
+
+const rawAllEpics = cp.execFileSync('gh', ['issue', 'list', '--limit', '1000', '--json', 'number,title,body,labels'], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+const allIssues = JSON.parse(rawAllEpics);
+const epicNumbers = new Set(allIssues.filter(i => i.labels.some(l => l.name === 'type:epic')).map(i => i.number));
+
+const childTickets = [];
+const trueIndependent = [];
+const activeEpics = [];
+const driftFindings = [];
+
+for (const issue of issues) {
+  const isEpic = issue.labels.some(l => l.name === 'type:epic');
+  if (isEpic) {
+    const isDone = issue.labels.some(l => l.name === 'status:done');
+    if (!isDone) activeEpics.push(issue);
+    continue;
+  }
+  
+  const body = issue.body || '';
+  const title = issue.title || '';
+  const parentMatch = body.match(/parent\s*(?:epic)?\s*:\s*#?(\d+)/i) || body.match(/part\s*of\s*#?(\d+)/i);
+  let parentEpicNum = parentMatch ? Number(parentMatch[1]) : null;
+  
+  const titleEpicMatch = title.match(/\(Epic\s*#?(\d+)\)/i);
+  if (titleEpicMatch && !parentEpicNum) {
+    parentEpicNum = Number(titleEpicMatch[1]);
+    driftFindings.push({
+      issue: issue.number,
+      title: issue.title,
+      type: 'Implicit Parent Drift',
+      message: `Mentions parent Epic #${parentEpicNum} in title, but lacks standard "Parent Epic: #${parentEpicNum}" metadata in its body.`
+    });
+  }
+  
+  if (!parentEpicNum) {
+    for (const epicNum of epicNumbers) {
+      const regex = new RegExp(`\\b(?:Epic|Issue|Parent|under|for)\\s+#${epicNum}\\b`, 'i');
+      if (regex.test(body) || regex.test(title)) {
+        parentEpicNum = epicNum;
+        driftFindings.push({
+          issue: issue.number,
+          title: issue.title,
+          type: 'Unstructured Epic Association',
+          message: `References Epic #${epicNum} without formal parent-child metadata declaration.`
+        });
+        break;
+      }
+    }
+  }
+
+  const isDone = issue.labels.some(l => l.name === 'status:done');
+  if (!isDone) {
+    if (parentEpicNum) {
+      childTickets.push({ number: issue.number, title: issue.title, parentEpicNum });
+    } else {
+      trueIndependent.push(issue);
+    }
+  }
+}
+
+console.log(JSON.stringify({ activeEpics, trueIndependent, childTickets, driftFindings }, null, 2));

--- a/scripts/global/governance-audit-coverage.js
+++ b/scripts/global/governance-audit-coverage.js
@@ -102,7 +102,7 @@ function writeReport(report) {
 }
 
 /** CLI entry: read catalog, audit, write, set exit code.
- * @param {string[]} argv - process argv slice.
+ * @param {string[]} _argv - process argv slice (unused).
  * @returns {number} exit code (0 ok, 1 violations, 2 degraded parse failure). */
 function main(_argv) {
   let md;


### PR DESCRIPTION
Refs #2113
Closes #2113
Closes #2118
Refs Epic #2091
Refs #2051

## Summary

Multi-close batch (lead #2113, sibling #2118 — both area:scripts, both unblock the same CI baseline). Two pieces:

1. **One-time cleanup of main-checkout residue (#2113)** — adopt the 4 main-checkout residue files left by prior cross-team sessions:
   - `.gitignore` extension — adds root-anchored `/dist/` and `/planning/` patterns immediately after the `/tickets/` pattern from #2051. Root-anchoring preserves commitability for future Wiki-B paths (`wiki/work-log/planning/` per #2054).
   - `scripts/analyze-governance-drift.js` (new file) — adopt as a tracked governance utility (read-only `gh issue list` consumer that classifies child vs independent open tickets).

2. **Unblock CI baseline (#2113 quality-required + #2118 lint-required)**:
   - `scripts/analyze-governance-drift.js`: extract gh CLI limits + maxBuffer to named constants (resolves +1 readability warning that pushed gate past 475 threshold).
   - `scripts/global/governance-audit-coverage.js`: align JSDoc `@param argv` → `_argv` to match function signature (resolves the single `jsdoc/check-param-names` error that has blocked multiple recent PRs).

## Changes (5 files, 86 insertions / 3 deletions, 2 commits)

Commit d811035 — main-checkout residue adoption:
- `.gitignore` — +5 lines (root-anchored `/dist/` + `/planning/` block citing #2051 + #2054)
- `scripts/analyze-governance-drift.js` — new file (governance-drift analysis utility)
- `.changes/unreleased/2113.md` — CHANGELOG fragment

Commit 59bf296 — CI baseline unblock:
- `scripts/analyze-governance-drift.js` — magic-number extraction (OPEN_LIMIT/ALL_LIMIT/MAX_BUFFER_BYTES)
- `scripts/global/governance-audit-coverage.js` — JSDoc `@param` argv → _argv

## Lane + test_strategy

- lane: lane:docs-research
- test_strategy: drift-lint (no spec file required; verification is `git check-ignore` pattern match + script preservation + local lint exit code)

## Multi-close batching contract

Per `instructions/role-baton-routing.instructions.md` §"Multi-Close PR batching":
- Related ACs: ✅ both area:scripts, both unblock shared CI baseline
- Single diff: ✅ one branch, one diff, two related commits
- Single test surface: ✅ both fixes verified via shared `npm run lint:js` + `lint-readability` invocations
- One lead + N siblings: ✅ lead #2113, sibling #2118
- Lead receives full 4-role baton; sibling receives brief-evidence closeout — both done on respective issues

## Structural prevention

Recurrence of cross-team residue accumulation on the canonical-main checkout is prevented by Epic #2091's 4-fix root-cause set. Fix #3 (canonical-main read-only enforcer) shipped at #2107. Remaining Phase-1 children continue.

## Notes

- deploy-runtime-impact: none — no hook chain or runtime artifact modifications.
- sync-verification: N/A — change does not touch deployed runtime targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)