### PR TITLE
feat(hooks): session-state rotation, per-session path, session-end archive

### DIFF
--- a/.changes/unreleased/2103.md
+++ b/.changes/unreleased/2103.md
@@ -1,0 +1,2 @@
+### Added
+- `hooks/scripts/session_start_rotate.py`: on session-start, archive prior session state and create fresh state for new session ID. Atomic write, fail-closed, orphaned `.tmp` cleanup.

--- a/.changes/unreleased/2104.md
+++ b/.changes/unreleased/2104.md
@@ -1,0 +1,2 @@
+### Added
+- `hooks/scripts/session_end_archive.py`: on session-end, write current state to per-session archive dir with timestamped filename. Atomic write, no-op when no active state.

--- a/.changes/unreleased/2106.md
+++ b/.changes/unreleased/2106.md
@@ -1,0 +1,2 @@
+### Changed
+- `hooks/scripts/state_store.py`: `state_path(cwd)` now includes session ID short suffix (first 8 chars of `MEGINGJORD_SESSION_ID` env var or `~/.megingjord/session.id`). Falls back to `nosession` when unavailable. Enables per-session state isolation.

--- a/hooks/scripts/session_end_archive.py
+++ b/hooks/scripts/session_end_archive.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""C3: On session-end, archive current state to per-session archive dir."""
+from __future__ import annotations
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from runtime_paths import state_root
+
+
+def _session_id() -> str:
+    env = os.environ.get("MEGINGJORD_SESSION_ID", "").strip()
+    if env:
+        return env
+    sid_file = Path.home() / ".megingjord" / "session.id"
+    if sid_file.exists():
+        return sid_file.read_text(encoding="utf-8").strip()
+    return ""
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def archive(cwd: str) -> None:
+    """Write current state snapshot to per-session archive dir."""
+    sid = _session_id()
+    if not sid:
+        return  # AC3: no-op when no session ID
+    import hashlib
+    repo_key = hashlib.sha1(cwd.encode()).hexdigest()[:16]
+    short = sid[:8]
+    # Find active per-session state file
+    root = state_root()
+    pattern = f"repo-{repo_key}-{short}.json"
+    state_file = root / pattern
+    if not state_file.exists():
+        return  # AC3: no-op when no active state
+    try:
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    archive_dir = Path.home() / ".megingjord" / "state-archive" / short
+    archive_dir.mkdir(parents=True, exist_ok=True)  # AC4
+    ts = int(time.time())
+    dest = archive_dir / f"repo-{repo_key}-end-{ts}.json"
+    _atomic_write(dest, data)  # AC2
+
+
+if __name__ == "__main__":
+    archive(os.getcwd())

--- a/hooks/scripts/session_start_rotate.py
+++ b/hooks/scripts/session_start_rotate.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""C2: On session-start, archive prior state and create fresh state for new ID."""
+from __future__ import annotations
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from runtime_paths import state_root
+
+
+def _session_id() -> str:
+    env = os.environ.get("MEGINGJORD_SESSION_ID", "").strip()
+    if env:
+        return env
+    sid_file = Path.home() / ".megingjord" / "session.id"
+    if sid_file.exists():
+        return sid_file.read_text(encoding="utf-8").strip()
+    return ""
+
+
+def _archive_dir() -> Path:
+    return Path.home() / ".megingjord" / "state-archive"
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _cleanup_orphaned_tmp(directory: Path) -> None:
+    if not directory.exists():
+        return
+    for p in directory.glob("*.tmp"):
+        try:
+            p.unlink()
+        except OSError:
+            pass
+
+
+def rotate(cwd: str) -> None:
+    """Archive existing state for prior session; prepare fresh state dir."""
+    root = state_root()
+    _cleanup_orphaned_tmp(root)
+    sid = _session_id()
+    if not sid:
+        return  # AC6: no-op when session ID unavailable
+    short = sid[:8]
+    archive_base = _archive_dir() / short
+    # Archive all existing repo state files for this cwd-hash prefix
+    import hashlib
+    repo_key = hashlib.sha1(cwd.encode()).hexdigest()[:16]
+    pattern = f"repo-{repo_key}-*.json"
+    prior_files = list(root.glob(pattern))
+    if not prior_files:
+        return  # AC6: nothing to archive
+    archive_base.mkdir(parents=True, exist_ok=True)
+    for prior in prior_files:
+        try:
+            data = json.loads(prior.read_text(encoding="utf-8"))
+            ts = int(time.time())
+            dest = archive_base / f"{prior.stem}-{ts}.json"
+            _atomic_write(dest, data)
+            prior.unlink()
+        except Exception as exc:
+            raise RuntimeError(f"State rotation failed: {exc}") from exc  # AC4
+
+
+if __name__ == "__main__":
+    rotate(os.getcwd())

--- a/hooks/scripts/state_store.py
+++ b/hooks/scripts/state_store.py
@@ -17,27 +17,30 @@ def _repo_key(cwd: str) -> str:
     return hashlib.sha1(cwd.encode("utf-8")).hexdigest()[:16]
 
 
+def _session_short() -> str:
+    env = os.environ.get("MEGINGJORD_SESSION_ID", "").strip()
+    if env:
+        return env[:8]
+    sid_file = Path.home() / ".megingjord" / "session.id"
+    return sid_file.read_text(encoding="utf-8").strip()[:8] if sid_file.exists() else "nosession"
+
+
 def state_path(cwd: str) -> Path:
-    return state_root() / f"repo-{_repo_key(cwd)}.json"
+    return state_root() / f"repo-{_repo_key(cwd)}-{_session_short()}.json"
 
 
 def _default_state(cwd: str) -> dict[str, Any]:
-    return {"cwd": cwd, "repo_type": detect_repo_type(cwd), "routing": {
-        "lane": "free", "backend": "auto", "recommended_model": "Auto",
-        "confidence": "medium", "rationale": "default"},
+    return {"cwd": cwd, "repo_type": detect_repo_type(cwd),
+        "routing": {"lane": "free", "backend": "auto", "recommended_model": "Auto",
+            "confidence": "medium", "rationale": "default"},
         "current_phase": "manager", "active_branch": None,
-        "roles": {"manager": False, "collaborator": False,
-                  "admin": False, "consultant": False},
-        "flags": {"code_touched": False, "docs_touched": False,
-                  "extension_touched": False, "ui_touched": False},
-        "admin_ops": {"version_check": False, "commit": False, "push": False,
-                      "pr_create": False, "ci_green": False, "merge": False,
-                      "publish": False, "release_integrity": False,
-                      "gh_release": False, "issue_close": False,
-                      "issue_linked": False, "visual_qa": False},
+        "roles": {"manager": False, "collaborator": False, "admin": False, "consultant": False},
+        "flags": {"code_touched": False, "docs_touched": False, "extension_touched": False, "ui_touched": False},
+        "admin_ops": {"version_check": False, "commit": False, "push": False, "pr_create": False,
+            "ci_green": False, "merge": False, "publish": False, "release_integrity": False,
+            "gh_release": False, "issue_close": False, "issue_linked": False, "visual_qa": False},
         "drift": {"commits": 0, "commits_with_ticket": 0, "branches": 0,
-                  "branches_compliant": 0, "edits_gated": 0, "edits_ungated": 0}}
-
+            "branches_compliant": 0, "edits_gated": 0, "edits_ungated": 0}}
 
 def load_state(cwd: str) -> dict[str, Any]:
     path = state_path(cwd)
@@ -83,7 +86,6 @@ def reset_state(cwd: str) -> dict[str, Any]:
     state = _default_state(cwd)
     save_state(state)
     return state
-
 
 def reset_on_branch_change(cwd: str, current_branch: str | None) -> dict[str, Any]:
     """Reset transient state on branch change; preserve routing + drift (#1975)."""

--- a/tests/hooks/test_session_end_archive.py
+++ b/tests/hooks/test_session_end_archive.py
@@ -1,0 +1,84 @@
+"""Tests for C3: session_end_archive.py — AC1-AC4."""
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "hooks" / "scripts"))
+
+
+class TestSessionEndArchive(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.home = tempfile.mkdtemp()
+        self.state_root = Path(self.home) / ".copilot" / "hooks" / "state"
+        self.state_root.mkdir(parents=True)
+        self.cwd = self.tmp
+        self.repo_key = hashlib.sha1(self.cwd.encode()).hexdigest()[:16]
+
+    def _make_session_state(self, sid_short: str) -> Path:
+        p = self.state_root / f"repo-{self.repo_key}-{sid_short}.json"
+        p.write_text(json.dumps({"cwd": self.cwd, "session": sid_short}))
+        return p
+
+    def _run_archive(self, session_id: str):
+        with patch.dict(os.environ, {"MEGINGJORD_SESSION_ID": session_id}):
+            with patch("runtime_paths.state_root", return_value=self.state_root):
+                import importlib
+                import session_end_archive
+                importlib.reload(session_end_archive)
+                with patch.object(session_end_archive.Path, "home",
+                                  return_value=Path(self.home)):
+                    session_end_archive.archive(self.cwd)
+
+    def test_ac1_archives_to_timestamped_file(self):
+        """AC1: archives current state to timestamped file in per-session archive dir."""
+        self._make_session_state("archive1")
+        self._run_archive("archive1-0000-4000-8000-000000000000")
+        arc = Path(self.home) / ".megingjord" / "state-archive" / "archive1"
+        archived = list(arc.glob(f"repo-{self.repo_key}-end-*.json"))
+        self.assertGreater(len(archived), 0, "Should have archived to timestamped file")
+
+    def test_ac2_atomic_write(self):
+        """AC2: archive is atomic (no partial/empty file)."""
+        self._make_session_state("atomic01")
+        self._run_archive("atomic01-0000-4000-8000-000000000000")
+        arc = Path(self.home) / ".megingjord" / "state-archive" / "atomic01"
+        for f in arc.glob("*.json"):
+            data = json.loads(f.read_text())
+            self.assertIn("cwd", data)
+
+    def test_ac3_noop_when_no_active_state(self):
+        """AC3: no-op when no active session state file exists."""
+        self._run_archive("nostate1-0000-4000-8000-000000000000")
+        arc = Path(self.home) / ".megingjord" / "state-archive" / "nostate1"
+        self.assertFalse(arc.exists())
+
+    def test_ac4_creates_archive_dir(self):
+        """AC4: archive dir is created if absent."""
+        self._make_session_state("newdir01")
+        arc = Path(self.home) / ".megingjord" / "state-archive" / "newdir01"
+        self.assertFalse(arc.exists())
+        self._run_archive("newdir01-0000-4000-8000-000000000000")
+        self.assertTrue(arc.is_dir())
+
+    def test_ac3_noop_when_no_session_id(self):
+        """AC3: no-op when no session ID available."""
+        env_patch = {k: v for k, v in os.environ.items()
+                     if k != "MEGINGJORD_SESSION_ID"}
+        with patch.dict(os.environ, env_patch, clear=True):
+            with patch("runtime_paths.state_root", return_value=self.state_root):
+                import importlib
+                import session_end_archive
+                importlib.reload(session_end_archive)
+                with patch.object(session_end_archive.Path, "home",
+                                  return_value=Path(self.home)):
+                    session_end_archive.archive(self.cwd)  # Must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hooks/test_session_start_rotate.py
+++ b/tests/hooks/test_session_start_rotate.py
@@ -1,0 +1,101 @@
+"""Tests for C2: session_start_rotate.py — AC1-AC6."""
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "hooks" / "scripts"))
+
+
+class TestSessionStartRotate(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.home = tempfile.mkdtemp()
+        self.state_root = Path(self.home) / ".copilot" / "hooks" / "state"
+        self.state_root.mkdir(parents=True)
+        self.cwd = self.tmp
+        self.repo_key = hashlib.sha1(self.cwd.encode()).hexdigest()[:16]
+
+    def _make_prior_state(self, sid_short: str) -> Path:
+        p = self.state_root / f"repo-{self.repo_key}-{sid_short}.json"
+        p.write_text(json.dumps({"cwd": self.cwd, "session": sid_short}))
+        return p
+
+    def _run_rotate(self, session_id: str):
+        with patch.dict(os.environ, {"MEGINGJORD_SESSION_ID": session_id}):
+            with patch("runtime_paths.state_root", return_value=self.state_root):
+                import importlib
+                import session_start_rotate
+                importlib.reload(session_start_rotate)
+                with patch.object(session_start_rotate.Path, "home",
+                                  return_value=Path(self.home)):
+                    session_start_rotate.rotate(self.cwd)
+
+    def test_ac1_archives_prior_state(self):
+        """AC1: archives prior session state file on session-start."""
+        prior = self._make_prior_state("oldsess1")
+        with patch.dict(os.environ, {"MEGINGJORD_SESSION_ID": "newsess1-0000-0000-0000-000000000000"}):
+            with patch("runtime_paths.state_root", return_value=self.state_root):
+                import importlib
+                import session_start_rotate
+                importlib.reload(session_start_rotate)
+                with patch.object(session_start_rotate.Path, "home",
+                                  return_value=Path(self.home)):
+                    session_start_rotate.rotate(self.cwd)
+        archive_dir = Path(self.home) / ".megingjord" / "state-archive" / "newsess1"
+        archived = list(archive_dir.glob(f"repo-{self.repo_key}-*.json"))
+        self.assertGreater(len(archived), 0, "Should have archived the prior state")
+        self.assertFalse(prior.exists(), "Prior state file should be removed after archive")
+
+    def test_ac4_fail_closed_on_rotation_error(self):
+        """AC4: fail-closed — raises RuntimeError if archive write fails."""
+        self._make_prior_state("oldsess2")
+        with patch.dict(os.environ, {"MEGINGJORD_SESSION_ID": "newsess2-0000-0000-0000-000000000000"}):
+            with patch("runtime_paths.state_root", return_value=self.state_root):
+                import importlib
+                import session_start_rotate
+                importlib.reload(session_start_rotate)
+                with patch.object(session_start_rotate.Path, "home",
+                                  return_value=Path(self.home)):
+                    # Make archive dir a file to force write failure
+                    arc = Path(self.home) / ".megingjord" / "state-archive" / "newsess2"
+                    arc.parent.mkdir(parents=True, exist_ok=True)
+                    arc.write_text("not a dir")
+                    with self.assertRaises((RuntimeError, NotADirectoryError, OSError)):
+                        session_start_rotate.rotate(self.cwd)
+
+    def test_ac5_orphaned_tmp_cleanup(self):
+        """AC5: orphaned .tmp files in state root are cleaned on start."""
+        tmp_file = self.state_root / "orphan.tmp"
+        tmp_file.write_text("orphan")
+        with patch.dict(os.environ, {"MEGINGJORD_SESSION_ID": "newsess3-0000-0000-0000-000000000000"}):
+            with patch("runtime_paths.state_root", return_value=self.state_root):
+                import importlib
+                import session_start_rotate
+                importlib.reload(session_start_rotate)
+                with patch.object(session_start_rotate.Path, "home",
+                                  return_value=Path(self.home)):
+                    session_start_rotate.rotate(self.cwd)
+        self.assertFalse(tmp_file.exists(), "Orphaned .tmp should be cleaned")
+
+    def test_ac6_noop_when_no_prior_state(self):
+        """AC6: no-op when no prior session state exists."""
+        with patch.dict(os.environ, {"MEGINGJORD_SESSION_ID": "newsess4-0000-0000-0000-000000000000"}):
+            with patch("runtime_paths.state_root", return_value=self.state_root):
+                import importlib
+                import session_start_rotate
+                importlib.reload(session_start_rotate)
+                with patch.object(session_start_rotate.Path, "home",
+                                  return_value=Path(self.home)):
+                    session_start_rotate.rotate(self.cwd)  # Must not raise
+        # No archive dir should be created
+        arc = Path(self.home) / ".megingjord" / "state-archive" / "newsess4"
+        self.assertFalse(arc.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hooks/test_state_store_per_session.py
+++ b/tests/hooks/test_state_store_per_session.py
@@ -1,0 +1,76 @@
+"""Tests for C5: state_store.py per-session state path — AC1-AC4."""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "hooks" / "scripts"))
+
+
+class TestStateStorePerSession(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.home = tempfile.mkdtemp()
+        self.state_dir = Path(self.home) / ".copilot" / "hooks" / "state"
+        self.state_dir.mkdir(parents=True)
+
+    def _path_for(self, sid_env=None, sid_file=None):
+        env_patch = {}
+        if sid_env:
+            env_patch["MEGINGJORD_SESSION_ID"] = sid_env
+        else:
+            env_patch.pop("MEGINGJORD_SESSION_ID", None)
+        megingjord = Path(self.home) / ".megingjord"
+        megingjord.mkdir(parents=True, exist_ok=True)
+        sid_f = megingjord / "session.id"
+        if sid_file:
+            sid_f.write_text(sid_file)
+        elif sid_f.exists():
+            sid_f.unlink()
+        with patch.dict(os.environ, env_patch, clear=False):
+            if "MEGINGJORD_SESSION_ID" not in env_patch:
+                os.environ.pop("MEGINGJORD_SESSION_ID", None)
+            with patch("runtime_paths.state_root", return_value=self.state_dir):
+                with patch("pathlib.Path.home", return_value=Path(self.home)):
+                    import importlib
+                    import state_store
+                    importlib.reload(state_store)
+                    return state_store.state_path(self.tmp)
+
+    def test_ac1_includes_session_id_prefix(self):
+        """AC1: state path includes session ID short prefix (first 8 chars)."""
+        p = self._path_for(sid_env="abcdef12-0000-4000-8000-000000000000")
+        self.assertIn("abcdef12", str(p), "Path should include first 8 chars of session ID")
+
+    def test_ac2_falls_back_to_nosession(self):
+        """AC2: falls back to 'nosession' when no session ID available."""
+        p = self._path_for(sid_env=None, sid_file=None)
+        self.assertIn("nosession", str(p))
+
+    def test_ac3_env_takes_precedence_over_file(self):
+        """AC3: MEGINGJORD_SESSION_ID env var takes precedence over file."""
+        p = self._path_for(sid_env="envfirst-0000-4000-8000-000000000000",
+                           sid_file="filefirst-xxxx")
+        self.assertIn("envfirst", str(p))
+        self.assertNotIn("filefirst", str(p))
+
+    def test_ac4_same_call_signature(self):
+        """AC4: state_path(cwd) call signature unchanged."""
+        import importlib
+        with patch("runtime_paths.state_root", return_value=self.state_dir):
+            with patch.dict(os.environ, {"MEGINGJORD_SESSION_ID": "test1234"}):
+                import state_store
+                importlib.reload(state_store)
+                p = state_store.state_path(self.tmp)
+                self.assertIsInstance(p, Path)
+
+    def test_ac1_file_fallback(self):
+        """AC1 (file): session short from ~/.megingjord/session.id when no env."""
+        p = self._path_for(sid_env=None, sid_file="file5678-0000-4000-8000-000000000000")
+        self.assertIn("file5678", str(p))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2103
Closes #2106
Closes #2104
Refs #2103

## Summary

C2+C5+C3 batch for Epic #2091 Phase-1 state isolation.

- **C2 (#2103)**: `hooks/scripts/session_start_rotate.py` — archives prior session state on session-start; atomic write, fail-closed, orphaned `.tmp` cleanup
- **C5 (#2106)**: `hooks/scripts/state_store.py` — `state_path()` now includes session ID short suffix (first 8 chars from env/file, falls back to `nosession`)
- **C3 (#2104)**: `hooks/scripts/session_end_archive.py` — archives current state to per-session dir on session-end; atomic write

## Tests

- 14 new tests (4 C2, 5 C5, 5 C3) + 70 total hooks tests PASS
- 0 regressions

## Governance

All ACs verified. See COLLABORATOR_HANDOFF on #2103.