### PR TITLE
feat(governance): audit title-case + body-structure drift #1438

### DIFF
--- a/.changes/unreleased/1438.md
+++ b/.changes/unreleased/1438.md
@@ -1,0 +1,6 @@
+### Added
+
+- `scripts/global/governance-audit.js` (#1438): 3 new `detectViolations` checks for title-case + body-structure drift surfaced by the 2026-05-10 Copilot Team governance audit. Rules: `title-case` (issue titles must not start with lowercase per `instructions/github-governance.instructions.md`), `title-conventional-prefix` (Conventional Commits prefixes are commit-only, forbidden on issue titles), `body-structure` (issue bodies must contain at least one canonical `## Summary|Problem|Goal|Why|Acceptance Criteria` H2 header, case-insensitive). Empty bodies skipped (not all tickets need bodies). New violations surface in the existing `npm run governance:audit` failure summary (AC5).
+- `tests/governance-audit-title-body-1438.spec.js` (#1438): 11 fixture tests covering positive + negative cases for each AC plus a combined-drift case + a regression check that existing Rule 4 still fires. All pass locally; existing 31 audit tests continue to pass with no regression.
+
+Refs #1438.

--- a/scripts/global/governance-audit.js
+++ b/scripts/global/governance-audit.js
@@ -50,6 +50,22 @@ function detectViolations(tickets) {
     if (isEpic && status === 'status:backlog' && !labels.includes('role:manager')) {
       violations.push({ ticket: ticket.number, rule: 'Rule E2', detail: 'Epic backlog missing role:manager' });
     }
+    // #1438 AC1: title-case (issues must be imperative sentences per github-governance.instructions.md)
+    if (ticket.title && /^[a-z]/.test(ticket.title)) {
+      violations.push({ ticket: ticket.number, rule: 'title-case',
+        detail: `title starts with lowercase: "${ticket.title.slice(0, 60)}"` });
+    }
+    // #1438 AC2: title-conventional-commits prefix forbidden on issues (commit/PR-only style)
+    if (ticket.title && /^[a-z]+(\([^)]+\))?:\s/.test(ticket.title)) {
+      violations.push({ ticket: ticket.number, rule: 'title-conventional-prefix',
+        detail: `commit-style prefix in issue title: "${ticket.title.slice(0, 60)}"` });
+    }
+    // #1438 AC3: body-structure missing — at least one canonical section heading required
+    const body = ticket.body || '';
+    if (body.length > 0 && !/^##\s+(Summary|Problem|Goal|Why|Acceptance Criteria)/im.test(body)) {
+      violations.push({ ticket: ticket.number, rule: 'body-structure',
+        detail: 'body missing structured section (Summary/Problem/Goal/Why/Acceptance Criteria)' });
+    }
   }
   return violations;
 }

--- a/scripts/global/governance-audit.js
+++ b/scripts/global/governance-audit.js
@@ -50,24 +50,26 @@ function detectViolations(tickets) {
     if (isEpic && status === 'status:backlog' && !labels.includes('role:manager')) {
       violations.push({ ticket: ticket.number, rule: 'Rule E2', detail: 'Epic backlog missing role:manager' });
     }
-    // #1438 AC1: title-case (issues must be imperative sentences per github-governance.instructions.md)
-    if (ticket.title && /^[a-z]/.test(ticket.title)) {
-      violations.push({ ticket: ticket.number, rule: 'title-case',
-        detail: `title starts with lowercase: "${ticket.title.slice(0, 60)}"` });
-    }
-    // #1438 AC2: title-conventional-commits prefix forbidden on issues (commit/PR-only style)
-    if (ticket.title && /^[a-z]+(\([^)]+\))?:\s/.test(ticket.title)) {
-      violations.push({ ticket: ticket.number, rule: 'title-conventional-prefix',
-        detail: `commit-style prefix in issue title: "${ticket.title.slice(0, 60)}"` });
-    }
-    // #1438 AC3: body-structure missing — at least one canonical section heading required
-    const body = ticket.body || '';
-    if (body.length > 0 && !/^##\s+(Summary|Problem|Goal|Why|Acceptance Criteria)/im.test(body)) {
-      violations.push({ ticket: ticket.number, rule: 'body-structure',
-        detail: 'body missing structured section (Summary/Problem/Goal/Why/Acceptance Criteria)' });
-    }
+    detectTitleBodyDrift(ticket, violations);
   }
   return violations;
+}
+
+// Three governance-audit checks for title-case and body-structure drift.
+function detectTitleBodyDrift(ticket, violations) {
+  if (ticket.title && /^[a-z]/.test(ticket.title)) {
+    violations.push({ ticket: ticket.number, rule: 'title-case',
+      detail: `title starts with lowercase: "${ticket.title.slice(0, 60)}"` });
+  }
+  if (ticket.title && /^[a-z]+(\([^)]+\))?:\s/.test(ticket.title)) {
+    violations.push({ ticket: ticket.number, rule: 'title-conventional-prefix',
+      detail: `commit-style prefix in issue title: "${ticket.title.slice(0, 60)}"` });
+  }
+  const body = ticket.body || '';
+  if (body.length > 0 && !/^##\s+(Summary|Problem|Goal|Why|Acceptance Criteria)/im.test(body)) {
+    violations.push({ ticket: ticket.number, rule: 'body-structure',
+      detail: 'body missing structured section (Summary/Problem/Goal/Why/Acceptance Criteria)' });
+  }
 }
 
 function computeGoalHealth(violationCount) {

--- a/tests/governance-audit-title-body-1438.spec.js
+++ b/tests/governance-audit-title-body-1438.spec.js
@@ -1,0 +1,92 @@
+// #1438 — Title-case + title-prefix + body-structure checks added to
+// governance-audit.js detectViolations(). Covers AC1 (lowercase title),
+// AC2 (Conventional Commits prefix on issues), AC3 (body missing
+// structured section). AC4 satisfied by this spec.
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const A = require(path.resolve(__dirname, '..', 'scripts', 'global', 'governance-audit.js'));
+
+// --- AC1: title-case ---
+test('#1438 AC1: detectViolations flags lowercase-starting title', () => {
+  const v = A.detectViolations([
+    { number: 100, title: 'this should be flagged', body: '## Summary\nx', labels: ['type:task', 'status:backlog'] },
+  ]);
+  expect(v.find(x => x.rule === 'title-case')).toBeTruthy();
+  expect(v.find(x => x.rule === 'title-case').ticket).toBe(100);
+});
+
+test('#1438 AC1 negative: capitalized title passes', () => {
+  const v = A.detectViolations([
+    { number: 101, title: 'This is properly capitalized', body: '## Summary\nx', labels: ['type:task', 'status:triage'] },
+  ]);
+  expect(v.find(x => x.rule === 'title-case')).toBeUndefined();
+});
+
+// --- AC2: title-conventional-prefix ---
+test('#1438 AC2: detectViolations flags Conventional Commits prefix on issue', () => {
+  const v = A.detectViolations([
+    { number: 200, title: 'fix(infra): bump nginx', body: '## Summary\nx', labels: ['type:task', 'status:triage'] },
+  ]);
+  expect(v.find(x => x.rule === 'title-conventional-prefix')).toBeTruthy();
+});
+
+test('#1438 AC2: detectViolations flags scopeless commit prefix (feat:, chore:)', () => {
+  const v = A.detectViolations([
+    { number: 201, title: 'feat: add cache layer', body: '## Summary\nx', labels: ['type:task', 'status:triage'] },
+  ]);
+  expect(v.find(x => x.rule === 'title-conventional-prefix')).toBeTruthy();
+});
+
+test('#1438 AC2 negative: plain imperative title with colon-after-noun passes', () => {
+  // "Tier-2 anneal: ..." starts with uppercase noun + colon — NOT a commit prefix
+  const v = A.detectViolations([
+    { number: 202, title: 'Tier-2 anneal: signer-alias canonical extension', body: '## Summary\nx', labels: ['type:task', 'status:triage'] },
+  ]);
+  expect(v.find(x => x.rule === 'title-conventional-prefix')).toBeUndefined();
+});
+
+// --- AC3: body-structure ---
+test('#1438 AC3: detectViolations flags body missing structured section', () => {
+  const v = A.detectViolations([
+    { number: 300, title: 'Properly capitalized title', body: 'just freeform text, no H2 headers', labels: ['type:task', 'status:triage'] },
+  ]);
+  expect(v.find(x => x.rule === 'body-structure')).toBeTruthy();
+});
+
+test('#1438 AC3 negative: body with ## Summary passes', () => {
+  const v = A.detectViolations([
+    { number: 301, title: 'Properly capitalized', body: '## Summary\n\nclear description here.', labels: ['type:task', 'status:triage'] },
+  ]);
+  expect(v.find(x => x.rule === 'body-structure')).toBeUndefined();
+});
+
+test('#1438 AC3 negative: body with ## Acceptance Criteria passes (case-insensitive)', () => {
+  const v = A.detectViolations([
+    { number: 302, title: 'Properly capitalized', body: '## acceptance criteria\n\n- [ ] AC1', labels: ['type:task', 'status:triage'] },
+  ]);
+  expect(v.find(x => x.rule === 'body-structure')).toBeUndefined();
+});
+
+test('#1438 AC3: empty body is NOT flagged (not all tickets need bodies)', () => {
+  const v = A.detectViolations([
+    { number: 303, title: 'Properly capitalized', body: '', labels: ['type:task', 'status:triage'] },
+  ]);
+  expect(v.find(x => x.rule === 'body-structure')).toBeUndefined();
+});
+
+// --- combined: ticket with multiple drift kinds emits multiple violations ---
+test('#1438 combined: title-case + title-prefix + body-structure all flag together', () => {
+  const v = A.detectViolations([
+    { number: 400, title: 'fix(scripts): do thing', body: 'no header here', labels: ['type:task', 'status:triage'] },
+  ]);
+  const ticket400 = v.filter(x => x.ticket === 400).map(x => x.rule).sort();
+  expect(ticket400).toEqual(['body-structure', 'title-case', 'title-conventional-prefix']);
+});
+
+// --- existing rules continue to fire (no regression) ---
+test('#1438 regression: Rule 4 (non-Epic backlog with role) still fires', () => {
+  const v = A.detectViolations([
+    { number: 500, title: 'Valid title', body: '## Summary\nx', labels: ['type:task', 'status:backlog', 'role:manager'] },
+  ]);
+  expect(v.find(x => x.rule === 'Rule 4')).toBeTruthy();
+});


### PR DESCRIPTION
Refs #1438
Closes #1438
Refs #1317

## Summary

Adds 3 new `detectViolations` checks to `scripts/global/governance-audit.js` for title-case + body-structure drift surfaced by the 2026-05-10 Copilot Team audit. Pure regex; no new dependencies.

## Changes (3 files, 114 insertions)

- `scripts/global/governance-audit.js` — 3 new rules in `detectViolations()`:
  - `title-case` — issue title starts with lowercase
  - `title-conventional-prefix` — title matches `^[a-z]+(\(...\))?:\s` (Conventional Commits style; commits-only)
  - `body-structure` — non-empty body lacks `## Summary|Problem|Goal|Why|Acceptance Criteria` H2 (case-insensitive)
- `tests/governance-audit-title-body-1438.spec.js` — 11 fixture tests
- `.changes/unreleased/1438.md` — CHANGELOG fragment

## Test plan

- [x] AC1 — title-case rule + positive + negative tests
- [x] AC2 — title-conventional-prefix rule + scopeless + scoped + negative tests
- [x] AC3 — body-structure rule + multiple negative cases + empty-body skip
- [x] AC4 — 11 fixture tests
- [x] AC5 — rule names surface in `npm run governance:audit` summary via the rule-agnostic printer (`governance-audit.js:142-143`); no extra wiring needed
- [x] All 4 baton artifacts posted on #1438
- [x] 31 existing audit tests + 11 new = 42 total PASS

## Notes

- Lane: code-change. test_strategy: tdd-pyramid.
- deploy-runtime-impact: low (CI/local-script; not deployed runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
