### PR TITLE
feat(governance): coordinator label auto-strip on resolution #1830

### DIFF
--- a/.changes/unreleased/1830.md
+++ b/.changes/unreleased/1830.md
@@ -1,0 +1,16 @@
+### Added
+
+- `scripts/global/coordinator-label-cleanup.js` (#1830): pure-module + CLI orphan scanner for `coordinator:cross-team-needs-hand-off`. `evaluateOrphan(candidate, allOpenIssues, allOpenPRs)` returns orphan-status if no active sibling-role conflict + no active parallel-PR reference. CLI mode (`node scripts/global/coordinator-label-cleanup.js [--dry-run]`) lists + removes orphans batch-wise. Manager-runnable via `npm run governance:coordinator-cleanup`.
+- `tests/coordinator-label-cleanup-1830.spec.js`: 10 fixture tests covering orphan detection, resolution detection (sibling moved past role / sibling closed), active-conflict-preservation, parallel-PR-preservation, idempotency (post-cleanup state returns zero orphans), team-via-user fallback.
+- `npm run governance:coordinator-cleanup` script wired in `package.json`.
+
+### Changed
+
+- `.github/workflows/cross-team-edit-warn.yml`: event-driven auto-strip in `issues.labeled` handler — when re-evaluation finds no sibling-role conflict AND coordinator label is present, remove it. Catches resolution on next role-label baton transition.
+- `.github/workflows/cross-team-pr-parallel-check.yml`: event-driven auto-strip — when `pull_request` re-evaluation finds no parallel PRs AND a referenced issue carries the coordinator label, remove it.
+
+Forward-only adoption per ticket constraints: historic orphans cleaned via `npm run governance:coordinator-cleanup` (batch), not retroactive workflow runs. Resolution detection uses event-driven triggers, NOT calendar thresholds (per memory `feedback_calendar_thresholds_in_agentic_systems`).
+
+Live AC5 verification: `node scripts/global/coordinator-label-cleanup.js --dry-run` returns `{ found: 0 }` against current repo state.
+
+Refs #1830.

--- a/.github/workflows/cross-team-edit-warn.yml
+++ b/.github/workflows/cross-team-edit-warn.yml
@@ -64,7 +64,17 @@ jobs:
             const conflicts = siblings.filter(s =>
               s.number !== issue.number && (s.labels || []).some(l => l.name === role) && teamOf(s) !== thisTeam
             );
-            if (!conflicts.length) return core.info('no sibling role conflicts');
+            if (!conflicts.length) {
+              // #1830 auto-strip: if coordinator label is present but no active conflict, remove it.
+              const labelNames = (issue.labels || []).map(l => l.name || l);
+              if (labelNames.includes('coordinator:cross-team-needs-hand-off')) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: issue.number, name: 'coordinator:cross-team-needs-hand-off'
+                }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
+                core.info(`#${issue.number}: stripped stale coordinator label (sibling-role conflict resolved) (#1830)`);
+              }
+              return core.info('no sibling role conflicts');
+            }
             const marker = '<!-- cross-team-role-sibling-warn -->';
             const existing = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number: issue.number, per_page: 100

--- a/.github/workflows/cross-team-pr-parallel-check.yml
+++ b/.github/workflows/cross-team-pr-parallel-check.yml
@@ -55,7 +55,25 @@ jobs:
                 }
               }
             }
-            if (!parallel.length) return core.info('no parallel PRs detected — OK');
+            if (!parallel.length) {
+              // #1830 auto-strip: if any referenced issue carries the coordinator label but no
+              // parallel PR was detected, remove the label (the prior parallel PR was likely merged/closed).
+              for (const ref of refs) {
+                try {
+                  const issueData = (await github.rest.issues.get({
+                    owner, repo, issue_number: Number(ref)
+                  })).data;
+                  const hasCoord = (issueData.labels || []).some(l => (l.name || l) === 'coordinator:cross-team-needs-hand-off');
+                  if (hasCoord) {
+                    await github.rest.issues.removeLabel({
+                      owner, repo, issue_number: Number(ref), name: 'coordinator:cross-team-needs-hand-off'
+                    }).catch(() => {});
+                    core.info(`#${ref}: stripped stale coordinator label (no parallel PR detected) (#1830)`);
+                  }
+                } catch (e) { core.info(`#${ref}: skip coordinator-strip check: ${e.message}`); }
+              }
+              return core.info('no parallel PRs detected — OK');
+            }
             core.warning(`parallel PRs detected: ${JSON.stringify(parallel)}`);
             const marker = '<!-- cross-team-pr-parallel-check -->';
             const existing = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/cross-team-pr-parallel-check.yml
+++ b/.github/workflows/cross-team-pr-parallel-check.yml
@@ -67,7 +67,7 @@ jobs:
                   if (hasCoord) {
                     await github.rest.issues.removeLabel({
                       owner, repo, issue_number: Number(ref), name: 'coordinator:cross-team-needs-hand-off'
-                    }).catch(() => {});
+                    }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
                     core.info(`#${ref}: stripped stale coordinator label (no parallel PR detected) (#1830)`);
                   }
                 } catch (e) { core.info(`#${ref}: skip coordinator-strip check: ${e.message}`); }

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ npm run deploy:both:apply
 | `governance:audit` | `node scripts/global/governance-audit.js` |
 | `governance:collab-handoff-rebase:test` | `node --test tests/collab-handoff-rebase-freshness.spec.js` |
 | `governance:compatibility:matrix` | `node scripts/global/governance-compatibility-matrix.js` |
+| `governance:coordinator-cleanup` | `node scripts/global/coordinator-label-cleanup.js` |
 | `governance:cross-team-check` | `node scripts/global/cross-team-contract-check.js` |
 | `governance:cross-team-check:test` | `node --test tests/cross-team-contract-check.spec.js` |
 | `governance:delegation-lint` | `node scripts/global/delegation-phrase-lint.js` |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "megingjord-harness",
   "version": "3.3.8",
-  "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex \u2014 multi-runtime skills, hooks, agents, wiki, and install tooling",
+  "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex — multi-runtime skills, hooks, agents, wiki, and install tooling",
   "private": true,
   "scripts": {
     "anneal:detect": "node scripts/global/workflow-anneal-detect.js",
@@ -174,7 +174,7 @@
     "routing:report": "node scripts/global/routing-baseline-report.js --days 7",
     "routing:telemetry": "node scripts/global/token-telemetry-report.js --json",
     "quality:parity": "node scripts/global/quality-parity-report.js --json",
-    "setup": "npm install && echo '\u2705 megingjord ready \u2014 run: npm start'",
+    "setup": "npm install && echo '✅ megingjord ready — run: npm start'",
     "start": "node scripts/dashboard-server.js",
     "state:offload": "node scripts/global/state-offload-client.js",
     "stress": "MEGINGJORD_STRESS_TIER=A node scripts/global/stress-orchestrator.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "megingjord-harness",
   "version": "3.3.8",
-  "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex — multi-runtime skills, hooks, agents, wiki, and install tooling",
+  "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex \u2014 multi-runtime skills, hooks, agents, wiki, and install tooling",
   "private": true,
   "scripts": {
     "anneal:detect": "node scripts/global/workflow-anneal-detect.js",
@@ -174,7 +174,7 @@
     "routing:report": "node scripts/global/routing-baseline-report.js --days 7",
     "routing:telemetry": "node scripts/global/token-telemetry-report.js --json",
     "quality:parity": "node scripts/global/quality-parity-report.js --json",
-    "setup": "npm install && echo '✅ megingjord ready — run: npm start'",
+    "setup": "npm install && echo '\u2705 megingjord ready \u2014 run: npm start'",
     "start": "node scripts/dashboard-server.js",
     "state:offload": "node scripts/global/state-offload-client.js",
     "stress": "MEGINGJORD_STRESS_TIER=A node scripts/global/stress-orchestrator.js",
@@ -235,7 +235,8 @@
     "governance:ticket-redundancy:test": "node --test tests/validate-ticket-redundancy.spec.js",
     "governance:wiki-catalog:test": "node --test tests/validate-wiki-catalog.spec.js",
     "git-state:drift": "node scripts/global/git-state-drift-sensor.js",
-    "goals:regen": "node scripts/global/goals-contract-generate.js"
+    "goals:regen": "node scripts/global/goals-contract-generate.js",
+    "governance:coordinator-cleanup": "node scripts/global/coordinator-label-cleanup.js"
   },
   "keywords": [
     "devops",

--- a/scripts/global/coordinator-label-cleanup.js
+++ b/scripts/global/coordinator-label-cleanup.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+'use strict';
+// coordinator-label-cleanup (#1830) — orphan-label scanner for
+// `coordinator:cross-team-needs-hand-off`. Pure module + CLI.
+// Mirrors the cross-team-edit-warn.yml + cross-team-pr-parallel-check.yml
+// detection logic so resolution paths match the application paths.
+
+const { execFileSync } = require('node:child_process');
+
+const COORDINATOR_LABEL = 'coordinator:cross-team-needs-hand-off';
+const ERROR_MSG_PREVIEW_MAX = 200;
+const ROLE_LABELS = new Set(['role:collaborator', 'role:admin', 'role:consultant']);
+const EPIC_BODY_RE = /-\s*Epic:\s*#(\d+)/i;
+
+function teamOf(issue) {
+  const teamLabel = (issue.labels || []).find(l => (l.name || l).startsWith?.('team:'));
+  if (teamLabel) return teamLabel.name || teamLabel;
+  return `user:${issue.user?.login || issue.author?.login || 'unknown'}`;
+}
+
+function rolesOn(issue) {
+  return (issue.labels || []).map(l => l.name || l).filter(n => ROLE_LABELS.has(n));
+}
+
+// Pure: given a candidate issue + the full open-issue corpus, determine if
+// it's an orphan (carries coordinator label but has NO active sibling-role
+// conflict + NO active parallel-PR). Used for both event-driven cleanup
+// in workflows and Manager-runnable batch cleanup.
+function evaluateOrphan(candidate, allOpenIssues, allOpenPRs) {
+  const labelNames = (candidate.labels || []).map(l => l.name || l);
+  if (!labelNames.includes(COORDINATOR_LABEL)) return { orphan: false, reason: 'no-coordinator-label' };
+  const myRoles = rolesOn(candidate);
+  const epicMatch = (candidate.body || '').match(EPIC_BODY_RE);
+  if (epicMatch && myRoles.length > 0) {
+    const epic = epicMatch[1];
+    const myTeam = teamOf(candidate);
+    const conflict = allOpenIssues.some(s => s.number !== candidate.number
+      && (s.body || '').includes(`Epic: #${epic}`)
+      && rolesOn(s).some(r => myRoles.includes(r))
+      && teamOf(s) !== myTeam);
+    if (conflict) return { orphan: false, reason: 'active-sibling-role-conflict' };
+  }
+  const parallelPR = (allOpenPRs || []).some(pr => (pr.body || '').includes(`#${candidate.number}`));
+  if (parallelPR) return { orphan: false, reason: 'active-parallel-pr-reference' };
+  return { orphan: true, reason: 'no-active-conflict-or-parallel-pr' };
+}
+
+function findOrphans(allOpenIssues, allOpenPRs) {
+  return allOpenIssues
+    .filter(i => (i.labels || []).map(l => l.name || l).includes(COORDINATOR_LABEL))
+    .map(i => ({ issue: i, eval: evaluateOrphan(i, allOpenIssues, allOpenPRs) }))
+    .filter(r => r.eval.orphan);
+}
+
+function ghJson(args) {
+  return JSON.parse(execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 }));
+}
+
+function removeLabel(issueNumber) {
+  try {
+    execFileSync('gh', ['issue', 'edit', String(issueNumber), '--remove-label', COORDINATOR_LABEL], { encoding: 'utf8' });
+    return { ok: true };
+  } catch (e) { return { ok: false, error: e.message.slice(0, ERROR_MSG_PREVIEW_MAX) }; }
+}
+
+function runCli({ dryRun = false } = {}) {
+  // gh issue list does not support --json body; use gh api for full body + labels.
+  const ALL_ISSUES_API = `/repos/{owner}/{repo}/issues?state=open&per_page=100`;
+  const issues = ghJson(['api', '--paginate', ALL_ISSUES_API]).filter(i => !i.pull_request)
+    .map(i => ({ number: i.number, title: i.title, body: i.body, labels: i.labels, user: i.user }));
+  const prs = ghJson(['pr', 'list', '--state', 'open', '--limit', '100', '--json', 'number,body']);
+  const orphans = findOrphans(issues, prs);
+  const carriers = issues.filter(i => (i.labels||[]).map(l => l.name || l).includes(COORDINATOR_LABEL));
+  const result = { found: orphans.length, removed: 0, kept: carriers.length - orphans.length, dryRun, actions: [] };
+  for (const orphan of orphans) {
+    if (dryRun) { result.actions.push({ issue: orphan.issue.number, action: 'would-remove', reason: orphan.eval.reason }); continue; }
+    const removeResult = removeLabel(orphan.issue.number);
+    result.actions.push({ issue: orphan.issue.number, action: removeResult.ok ? 'removed' : 'failed', reason: orphan.eval.reason, error: removeResult.error });
+    if (removeResult.ok) result.removed++;
+  }
+  return result;
+}
+
+if (require.main === module) {
+  const dryRun = process.argv.includes('--dry-run');
+  try { console.log(JSON.stringify(runCli({ dryRun }), null, 2)); }
+  catch (e) { console.error(e.message); process.exit(1); }
+}
+
+module.exports = { evaluateOrphan, findOrphans, runCli, COORDINATOR_LABEL, ROLE_LABELS };

--- a/tests/coordinator-label-cleanup-1830.spec.js
+++ b/tests/coordinator-label-cleanup-1830.spec.js
@@ -1,0 +1,82 @@
+// #1830 — coordinator-label-cleanup orphan-detection coverage.
+// Covers AC3: orphan detection + resolution detection + idempotency.
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const C = require(path.resolve(__dirname, '..', 'scripts', 'global', 'coordinator-label-cleanup.js'));
+
+const COORD = C.COORDINATOR_LABEL;
+
+const epicBody = (n) => `## Scope\n- Epic: #${n}\n\nstuff\n`;
+const issue = (n, opts = {}) => ({
+  number: n,
+  title: opts.title || `Issue ${n}`,
+  body: opts.body || '',
+  labels: (opts.labels || []).map(name => ({ name })),
+  user: { login: opts.user || 'alice' },
+});
+
+test('#1830 AC3: candidate without coordinator label is NOT orphan', () => {
+  const c = issue(1, { labels: ['role:collaborator'] });
+  expect(C.evaluateOrphan(c, [c], []).orphan).toBe(false);
+});
+
+test('#1830 AC3: candidate with coordinator + active sibling-role conflict is NOT orphan', () => {
+  const c = issue(1, { labels: ['role:collaborator', 'team:claude-code', COORD], body: epicBody(100), user: 'alice' });
+  const sibling = issue(2, { labels: ['role:collaborator', 'team:codex'], body: epicBody(100), user: 'bob' });
+  expect(C.evaluateOrphan(c, [c, sibling], []).orphan).toBe(false);
+});
+
+test('#1830 AC3: candidate with coordinator + sibling-role conflict RESOLVED is orphan', () => {
+  // sibling moved past role:collaborator to role:admin
+  const c = issue(1, { labels: ['role:collaborator', 'team:claude-code', COORD], body: epicBody(100), user: 'alice' });
+  const sibling = issue(2, { labels: ['role:admin', 'team:codex'], body: epicBody(100), user: 'bob' });
+  const r = C.evaluateOrphan(c, [c, sibling], []);
+  expect(r.orphan).toBe(true);
+  expect(r.reason).toBe('no-active-conflict-or-parallel-pr');
+});
+
+test('#1830 AC3: candidate with coordinator + sibling CLOSED is orphan', () => {
+  const c = issue(1, { labels: ['role:collaborator', 'team:claude-code', COORD], body: epicBody(100), user: 'alice' });
+  // No sibling at all in the open-issue list = sibling closed
+  expect(C.evaluateOrphan(c, [c], []).orphan).toBe(true);
+});
+
+test('#1830 AC3: candidate with coordinator + active parallel PR reference is NOT orphan', () => {
+  const c = issue(5, { labels: [COORD] });
+  const parallelPR = { number: 100, body: 'Refs #5\nCloses #5' };
+  expect(C.evaluateOrphan(c, [c], [parallelPR]).orphan).toBe(false);
+});
+
+test('#1830 AC3: candidate with coordinator + parallel PRs all merged is orphan', () => {
+  const c = issue(5, { labels: [COORD] });
+  // No open PRs reference #5 (all merged/closed)
+  expect(C.evaluateOrphan(c, [c], []).orphan).toBe(true);
+});
+
+test('#1830 AC3: candidate without role labels + no parallel PR is orphan (sibling-role check skipped gracefully)', () => {
+  const c = issue(5, { labels: [COORD], body: epicBody(100) });
+  expect(C.evaluateOrphan(c, [c], []).orphan).toBe(true);
+});
+
+test('#1830 AC3 findOrphans: returns only true orphans, ignores non-coordinator-labeled', () => {
+  const orphan = issue(1, { labels: [COORD, 'role:collaborator', 'team:claude-code'], body: epicBody(100) });
+  const sibling = issue(2, { labels: ['role:admin', 'team:codex'], body: epicBody(100) });
+  const noCoordLabel = issue(3, { labels: ['role:collaborator'] });
+  const result = C.findOrphans([orphan, sibling, noCoordLabel], []);
+  expect(result.length).toBe(1);
+  expect(result[0].issue.number).toBe(1);
+});
+
+test('#1830 AC3 idempotency: findOrphans on a corpus where orphans were already cleaned = empty', () => {
+  // simulate post-cleanup state
+  const orphan = issue(1, { labels: ['role:collaborator', 'team:claude-code'], body: epicBody(100) });  // no COORD
+  const sibling = issue(2, { labels: ['role:admin', 'team:codex'], body: epicBody(100) });
+  expect(C.findOrphans([orphan, sibling], []).length).toBe(0);
+});
+
+test('#1830: team detection falls back to user.login when no team:* label', () => {
+  const c = issue(1, { labels: ['role:collaborator', COORD], body: epicBody(100), user: 'alice' });
+  const sib = issue(2, { labels: ['role:collaborator'], body: epicBody(100), user: 'bob' });
+  // Different users (alice vs bob) → conflict still detected via user-fallback
+  expect(C.evaluateOrphan(c, [c, sib], []).orphan).toBe(false);
+});


### PR DESCRIPTION
Refs #1830
Closes #1830

## Summary

Self-anneal: adds auto-strip for `coordinator:cross-team-needs-hand-off` label. Currently the label is applied by 2 cross-team workflows on conflict detection but never removed when the conflict resolves — stale labels accumulate (observed 2026-05-17 on Epic #1792).

## Changes (7 files, 224 insertions / 6 deletions)

- `scripts/global/coordinator-label-cleanup.js` (new, 89 lines) — pure module + CLI orphan scanner
- `tests/coordinator-label-cleanup-1830.spec.js` (new, 82 lines) — 10 fixture tests
- `.github/workflows/cross-team-edit-warn.yml` — event-driven auto-strip in `issues.labeled` handler when conflict resolves
- `.github/workflows/cross-team-pr-parallel-check.yml` — event-driven auto-strip when `pull_request` re-evaluation finds no parallel PRs
- `package.json` — `npm run governance:coordinator-cleanup` script wired
- `README.md` — auto-synced via docs:compile
- `.changes/unreleased/1830.md` — CHANGELOG fragment

## AC verification

- [x] AC1 — `cross-team-edit-warn.yml` event-driven auto-strip path
- [x] AC2 — `cross-team-pr-parallel-check.yml` event-driven auto-strip path
- [x] AC3 — `coordinator-label-cleanup.js` + spec (10 tests covering orphan / resolution / idempotency / team-fallback)
- [x] AC4 — `npm run governance:coordinator-cleanup` wired
- [x] AC5 — live dry-run against current repo: `{ found: 0 }`
- [x] AC6 — G5 portability + G3 zero-cost preserved
- [x] All 4 baton artifacts posted on #1830

## Constraints honored

- No new labels (uses existing `coordinator:cross-team-needs-hand-off`)
- Event-driven triggers, NOT calendar thresholds (per memory `feedback_calendar_thresholds_in_agentic_systems`)
- Forward-only adoption — historic orphans cleaned via batch script, not retroactive workflow runs

## Notes

- Lane: code-change. test_strategy: tdd-pyramid.
- deploy-runtime-impact: low (workflow + local script; not deployed runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
