### PR TITLE
fix: allow absolute outside-repo paths in canonical_main_enforcer (#2132)

### DIFF
--- a/hooks/scripts/canonical_main_enforcer.py
+++ b/hooks/scripts/canonical_main_enforcer.py
@@ -78,7 +78,9 @@ def evaluate_path(path: str, repo_root: str) -> tuple[bool, str]:
       allowed=False → path is tracked OR not ignored; write is rejected.
                       Reason explains and recommends worktree redirection.
 
-    Edge cases handled: empty path → reject; path outside repo → reject;
+    Edge cases handled: empty path → reject; absolute path outside repo →
+    allow (operator-local, other worktrees, /tmp — not canonical-main concerns);
+    relative path escaping repo via `..` → reject (path-traversal guard);
     symlinks resolved by git ls-files / check-ignore semantics.
     """
     if not path:
@@ -96,7 +98,14 @@ def evaluate_path(path: str, repo_root: str) -> tuple[bool, str]:
         repo_norm = Path(os.path.normpath(str(Path(repo_root).absolute())))
         normalized.relative_to(repo_norm)
     except ValueError:
-        return False, f"path outside repo: {path}"
+        # Path is outside the canonical main-checkout repo root.
+        # If the original path was absolute, it is an out-of-scope location
+        # (operator-local memory, another worktree, /tmp, etc.) and is allowed.
+        # If the original path was relative but escaped via `..`, treat it as a
+        # path-traversal attempt and deny it.
+        if Path(path).is_absolute():
+            return True, "allowed: path outside main-checkout repo"
+        return False, f"path-traversal rejected: relative path escapes repo root: {path}"
     rel = str(normalized.relative_to(repo_norm))
     if is_tracked(rel, repo_root):
         return False, (

--- a/tests/canonical-main-enforcer.spec.js
+++ b/tests/canonical-main-enforcer.spec.js
@@ -93,3 +93,23 @@ test('evaluate_path REJECTS empty path', () => {
   const out = callEnforcer('evaluate_path', '', REPO_ROOT);
   expect(out).toMatch(/False/);
 });
+
+test('evaluate_path ALLOWS operator-local memory path outside repo', () => {
+  const memPath = path.join(os.homedir(), '.claude', 'projects', 'abc123', 'memories', 'test.md');
+  const out = callEnforcer('evaluate_path', memPath, REPO_ROOT);
+  expect(out).toMatch(/True/);
+  expect(out).toMatch(/outside main-checkout repo/);
+});
+
+test('evaluate_path ALLOWS other-worktree path (devenv-ops-2116)', () => {
+  const worktreePath = path.join(os.homedir(), 'devenv-ops-2116', 'hooks', 'scripts', 'test.py');
+  const out = callEnforcer('evaluate_path', worktreePath, REPO_ROOT);
+  expect(out).toMatch(/True/);
+  expect(out).toMatch(/outside main-checkout repo/);
+});
+
+test('evaluate_path ALLOWS system tmp path', () => {
+  const out = callEnforcer('evaluate_path', '/tmp/test-artifact-2132.json', REPO_ROOT);
+  expect(out).toMatch(/True/);
+  expect(out).toMatch(/outside main-checkout repo/);
+});


### PR DESCRIPTION
## Summary

Fix a false-positive in `evaluate_path()` in `hooks/scripts/canonical_main_enforcer.py` that blocked writes to operator-local paths, other worktrees, and `/tmp` when CWD was the canonical main checkout.

## Problem

When the agent tried to write to an absolute path outside the main-checkout repo root (e.g. `~/.claude/projects/.../memory.md`, `~/devenv-ops-2116/...`, `/tmp/...`), `evaluate_path()` raised `ValueError` from `.relative_to()` and returned `(False, "path outside repo: ...")` — incorrectly blocking legitimate writes.

## Fix

In the `except ValueError` block: if the original path was **absolute**, it's an out-of-scope location (not a canonical-main concern) — return `(True, "allowed: path outside main-checkout repo")`. If the original path was **relative** and escaped via `../`, it's a path-traversal attempt — still reject.

## Test Evidence

- Unit tests: 19/19 passed (16 existing + 3 new for AC2)
- Stress tests: 5/5 passed (adversarial path-injection test still blocks `../etc/passwd` etc.)
- Lint: clean

Refs #2132