### PR TITLE
fix(hooks): add IT-ops bypass markers to pretool guard

### DIFF
--- a/.changes/unreleased/2142.md
+++ b/.changes/unreleased/2142.md
@@ -1,0 +1,4 @@
+## Fixed
+- Added an auditable IT-ops bypass path to the commit ticket gate in `hooks/scripts/pretool_guard.py`.
+- Commit commands can now bypass `#N` enforcement only when one of these markers is present: `MEGINGJORD_IT_OPS=1`, `[it-ops]`, or `chore(it-ops):`.
+- Non-bypass commit behavior is unchanged: missing ticket references are still denied.

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """PreToolUse hook: pre-tool guards and admin sequencing gates."""
-import json, re, subprocess, sys
+import json, os, re, subprocess, sys
 from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path: sys.path.insert(0, str(SCRIPT_DIR))
@@ -14,6 +14,7 @@ from live_checks import ci_all_pass, linked_issue_has_collab_handoff
 from runtime_paths import runtime_hook_paths
 RE_ISSUE_REF = re.compile(r"#\d+")
 RE_BRANCH_TICKET = re.compile(r"^(feat|fix|hotfix)/(\d+)-")
+RE_IT_OPS_MARKERS = re.compile(r"\[it-ops\]|\bchore\(it-ops\)\s*:", re.IGNORECASE)
 RE_BRANCH_CREATE = re.compile(r"git\s+(?:checkout\s+-b|switch\s+-c)\s+(\S+)")
 RE_BRANCH_SWITCH = re.compile(r"git\s+(?:switch|checkout)\s+(?!-[bcCq])([^\s-]\S*)")
 BRANCH_VALID = re.compile(r"^(feat|fix|hotfix)/\d+-|^(chore|skill)/[a-z0-9]|^main$|^develop$")
@@ -34,6 +35,17 @@ def emit(decision: str, reason: str, extra: str | None = None) -> int:
     print(json.dumps({"hookSpecificOutput": hook}))
     return 0
 
+
+
+def detect_it_ops_bypass(joined: str, env: dict[str, str] | None = None) -> tuple[bool, str | None]:
+    environment = env if env is not None else os.environ
+    if environment.get("MEGINGJORD_IT_OPS") == "1":
+        return True, "MEGINGJORD_IT_OPS=1"
+    marker = RE_IT_OPS_MARKERS.search(joined)
+    if marker:
+        return True, marker.group(0)
+    return False, None
+
 def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
     flags, ops = state.get("flags", {}), state.get("admin_ops", {})
     repo_type = state.get("repo_type", "generic")
@@ -47,6 +59,10 @@ def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
         return emit("deny",f"Branch '{m.group(1)}' violates naming. Use feat/<ticket#>-desc.")
     if any(marker in joined for marker in runtime_hook_paths()):
         return emit("ask","Hook script mutation detected. Manual approval required.","Review for policy weakening.")
+    if RE_GIT_COMMIT.search(joined):
+        bypass, marker = detect_it_ops_bypass(joined)
+        if bypass:
+            return emit("allow", f"IT-ops commit bypass (#2142): {marker}")
     if RE_GIT_COMMIT.search(joined) and not RE_ISSUE_REF.search(joined):
         return emit("deny","Commit blocked: no issue ref (#N). Link a ticket first.")
     if RE_GIT_COMMIT.search(joined):

--- a/tests/hooks/test_pretool_guard_it_ops_bypass.py
+++ b/tests/hooks/test_pretool_guard_it_ops_bypass.py
@@ -1,0 +1,73 @@
+"""IT-ops bypass tests for pretool_guard commit gate (#2142)."""
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOKS_SCRIPTS = REPO_ROOT / "hooks" / "scripts"
+sys.path.insert(0, str(HOOKS_SCRIPTS))
+
+import pretool_guard  # noqa: E402
+
+
+class ItOpsBypassDetector(unittest.TestCase):
+    def test_detects_env_marker(self):
+        ok, marker = pretool_guard.detect_it_ops_bypass("git commit -m 'maintenance'", {"MEGINGJORD_IT_OPS": "1"})
+        self.assertTrue(ok)
+        self.assertEqual(marker, "MEGINGJORD_IT_OPS=1")
+
+    def test_detects_literal_marker(self):
+        ok, marker = pretool_guard.detect_it_ops_bypass("git commit -m 'chore: refresh [it-ops]'", {})
+        self.assertTrue(ok)
+        self.assertEqual(marker, "[it-ops]")
+
+    def test_detects_conventional_prefix(self):
+        ok, marker = pretool_guard.detect_it_ops_bypass("git commit -m 'chore(it-ops): pull model'", {})
+        self.assertTrue(ok)
+        self.assertEqual(marker.lower(), "chore(it-ops):")
+
+    def test_no_bypass_when_marker_absent(self):
+        ok, marker = pretool_guard.detect_it_ops_bypass("git commit -m 'chore: update docs'", {})
+        self.assertFalse(ok)
+        self.assertIsNone(marker)
+
+
+class ItOpsBypassCheckTerminal(unittest.TestCase):
+    def _run(self, cmd: str, env: dict[str, str] | None = None, branch: str = "fix/2142-pretool-itops-bypass"):
+        state = {"flags": {}, "admin_ops": {"commit": True}, "repo_type": "generic"}
+        captured = {}
+
+        def fake_emit(decision, reason, extra=None):
+            captured["decision"] = decision
+            captured["reason"] = reason
+            return 0
+
+        patch_env = env if env is not None else {}
+        with patch("pretool_guard.current_branch", return_value=branch),              patch("pretool_guard.emit", side_effect=fake_emit),              patch.dict("pretool_guard.os.environ", patch_env, clear=True):
+            pretool_guard.check_terminal(cmd, state, str(REPO_ROOT))
+        return captured
+
+    def test_bypass_allows_env_without_ticket(self):
+        out = self._run("git commit -m 'maintenance'", {"MEGINGJORD_IT_OPS": "1"})
+        self.assertEqual(out.get("decision"), "allow")
+        self.assertIn("MEGINGJORD_IT_OPS=1", out.get("reason", ""))
+
+    def test_bypass_allows_literal_without_ticket(self):
+        out = self._run("git commit -m 'refresh cache [it-ops]'")
+        self.assertEqual(out.get("decision"), "allow")
+        self.assertIn("[it-ops]", out.get("reason", ""))
+
+    def test_bypass_allows_conventional_prefix_without_ticket(self):
+        out = self._run("git commit -m 'chore(it-ops): rotate model list'")
+        self.assertEqual(out.get("decision"), "allow")
+        self.assertIn("chore(it-ops)", out.get("reason", "").lower())
+
+    def test_non_bypass_without_ticket_still_denied(self):
+        out = self._run("git commit -m 'maintenance update'")
+        self.assertEqual(out.get("decision"), "deny")
+        self.assertIn("no issue ref", out.get("reason", "").lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add IT-ops bypass detection to the commit ticket gate in `hooks/scripts/pretool_guard.py`
- support three bypass markers: `MEGINGJORD_IT_OPS=1`, `[it-ops]`, and `chore(it-ops):`
- keep non-bypass commit enforcement unchanged
- add targeted unit tests and changelog fragment

## Why
Issue #2142 was in drift state (OPEN + status:done with stale artifacts). This PR delivers the missing code now present on `main`.

## Verification
- python3 -m unittest tests.hooks.test_pretool_guard_it_ops_bypass tests.hooks.test_pretool_guard_branch_ticket
- npm run lint

Refs #2142
