### PR TITLE
fix(ci): harden closeout-lint transient api failures

### DIFF
--- a/.changes/unreleased/2140.md
+++ b/.changes/unreleased/2140.md
@@ -1,0 +1,5 @@
+## Fixed
+- Hardened closeout-schema workflow API fetches with bounded transient retries.
+- Added advisory degrade path `closeout-schema: api-transient` for exhausted transient API failures.
+- Preserved blocking behavior for non-transient and schema/governance violations.
+- Added operator runbook for rerun handling: docs/howto/closeout-schema-api-transient.md.

--- a/.github/workflows/closeout-lint.yml
+++ b/.github/workflows/closeout-lint.yml
@@ -20,6 +20,31 @@ jobs:
             const megalint = require('./scripts/global/megalint/index.js');
             const alias = require('./scripts/global/signer-alias.js');
 
+
+            const isTransientApiError = (err) => {
+              const status = Number(err?.status || err?.response?.status || 0);
+              const msg = String(err?.message || '').toLowerCase();
+              return [403, 422, 429, 502, 503, 504].includes(status)
+                || msg.includes('resource not accessible by integration')
+                || msg.includes('rate limit')
+                || msg.includes('secondary rate limit');
+            };
+            const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+            const withApiRetry = async (label, fn, retries = 2, backoffMs = 2000) => {
+              let lastErr;
+              for (let attempt = 0; attempt <= retries; attempt++) {
+                try {
+                  return await fn();
+                } catch (err) {
+                  lastErr = err;
+                  if (!isTransientApiError(err) || attempt === retries) break;
+                  core.warning(`${label}: transient API error attempt ${attempt + 1}/${retries + 1}; retrying in ${backoffMs}ms (${err.message})`);
+                  await wait(backoffMs);
+                }
+              }
+              throw lastErr;
+            };
+
             const body = context.payload.pull_request.body || '';
             const refsMatch = body.match(/Refs\s+#(\d+)/i);
             if (!refsMatch) {
@@ -28,24 +53,72 @@ jobs:
             }
             const linkedIssue = parseInt(refsMatch[1], 10);
 
-            const { data: issue } = await github.rest.issues.get({
-              owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: linkedIssue,
-            });
-            const labels = issue.labels.map(l => l.name);
-            const lane = labels.find(l => l.startsWith('lane:')) || 'lane:code-change';
+            const transientMarker = '<!-- closeout-schema-api-transient -->';
+            const postApiTransientAdvisory = async (phase, err) => {
+              const status = err?.status || err?.response?.status || 'unknown';
+              const advisory = `${transientMarker}
+## ⚠️ closeout-schema: api-transient
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: linkedIssue, per_page: 100,
-            });
+`
+                + `Transient GitHub API failure while reading closeout evidence (${phase}).
 
-            // #1554: fetch PR files to detect cross-checkout-destructive
-            // symlink deletions. Advisory-first per Epic #1486 Path D.
-            const { data: prFiles } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner, repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number, per_page: 100,
-            });
+`
+                + `status: ${status}
+message: ${String(err?.message || 'unknown')}
+
+`
+                + `Action: rerun failed jobs once GitHub API access recovers. This transient class is advisory for this run.`;
+              try {
+                const advisoryComments = (await withApiRetry(
+                  'issues.listComments(advisory)',
+                  () => github.rest.issues.listComments({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    issue_number: linkedIssue, per_page: 100,
+                  })
+                )).data;
+                const existing = advisoryComments.find(c => (c.body || '').includes(transientMarker));
+                if (existing) {
+                  await withApiRetry('issues.updateComment(advisory)', () => github.rest.issues.updateComment({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    comment_id: existing.id, body: advisory,
+                  }));
+                } else {
+                  await withApiRetry('issues.createComment(advisory)', () => github.rest.issues.createComment({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    issue_number: linkedIssue, body: advisory,
+                  }));
+                }
+              } catch (advisoryErr) {
+                core.warning(`closeout-schema advisory post failed: ${advisoryErr.message}`);
+              }
+            };
+
+            let issue, labels, lane, comments, prFiles;
+            try {
+              issue = (await withApiRetry('issues.get(linkedIssue)', () => github.rest.issues.get({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: linkedIssue,
+              }))).data;
+              labels = issue.labels.map(l => l.name);
+              lane = labels.find(l => l.startsWith('lane:')) || 'lane:code-change';
+              comments = (await withApiRetry('issues.listComments(linkedIssue)', () => github.rest.issues.listComments({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: linkedIssue, per_page: 100,
+              }))).data;
+              // #1554: fetch PR files to detect cross-checkout-destructive
+              // symlink deletions. Advisory-first per Epic #1486 Path D.
+              prFiles = (await withApiRetry('pulls.listFiles', () => github.rest.pulls.listFiles({
+                owner: context.repo.owner, repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number, per_page: 100,
+              }))).data;
+            } catch (err) {
+              if (isTransientApiError(err)) {
+                await postApiTransientAdvisory('initial-data-fetch', err);
+                core.notice('closeout-schema: api-transient advisory emitted; skipping failure for this transient class.');
+                return;
+              }
+              throw err;
+            }
             const prLabels = (context.payload.pull_request.labels || []).map(l => l.name);
 
             const path = require('path');
@@ -148,10 +221,10 @@ jobs:
                 + `- Add to PR body: \`<!-- cross-checkout-destructive: <reason> -->\`\n`
                 + `- OR apply label: \`cross-checkout-destructive:approved\`\n\n`
                 + `See #1554 and #1539 (the incident this rule guards against).`;
-              const prComments = (await github.rest.issues.listComments({
+              const prComments = (await withApiRetry('issues.listComments(pr)', () => github.rest.issues.listComments({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number, per_page: 50,
-              })).data;
+              }))).data;
               const existing = prComments.find(c => (c.body || '').includes(xcdMarker));
               if (existing) {
                 await github.rest.issues.updateComment({

--- a/docs/howto/closeout-schema-api-transient.md
+++ b/docs/howto/closeout-schema-api-transient.md
@@ -1,0 +1,21 @@
+# closeout-schema API Transient Handling
+
+Issue: #2140
+
+## What Changed
+The `closeout-lint` workflow now retries transient GitHub API failures (403/422/429/5xx and `Resource not accessible by integration`) with bounded retries before deciding outcome.
+
+If retries are exhausted for that transient class, the workflow posts/updates an advisory marker on the linked issue:
+- `<!-- closeout-schema-api-transient -->`
+- heading: `closeout-schema: api-transient`
+
+The run exits advisory for that transient class instead of failing hard.
+
+## Operator Guidance
+1. Open the linked issue and look for the `closeout-schema: api-transient` advisory comment.
+2. Re-run failed checks once GitHub API access stabilizes:
+   - `gh run rerun --failed <run-id>`
+3. If advisory repeats across reruns, treat as platform incident and log recurrence evidence.
+
+## Non-Transient Errors
+Non-transient API and schema violations remain blocking failures.


### PR DESCRIPTION
## Summary
- add bounded transient retry helper for closeout-lint API reads
- degrade exhausted transient API failures to structured advisory marker
- keep non-transient errors and governance violations blocking
- add operator runbook and changelog fragment

## Validation
- npm run lint
- collaborator strongest-fleet adversarial review (qwen3:32b via HAMR) -> pass, no required fixes

Refs #2140
