### PR TITLE
feat(graph): markdown wikilink graph-builder #2153

### DIFF
--- a/.changes/unreleased/2153.md
+++ b/.changes/unreleased/2153.md
@@ -1,0 +1,2 @@
+### Added
+- Markdown wikilink graph-builder (`scripts/global/doc-graph-builder.js` + `npm run doc-graph`) — deterministic JSON adjacency-list at `generated/doc-graph.json`; scans `docs/`, `wiki/`, `instructions/`, `README.md`, `CHANGELOG.md` for `[[wikilink]]` syntax. Re-runnable in <50ms on current repo. Phase-1 of Epic #2148. Refs #2153.

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ logs/copilot-usage.json
 
 # Operator-local spike outputs (Wave 1 #891/#892/#893) — never committed
 tmp/
+
+# Refs #2153 — doc-graph artifact (rebuilt on demand)
+generated/doc-graph.json

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ npm run deploy:both:apply
 | `deps:augment` | `node scripts/global/dep-graph-augment.js` |
 | `deps:render` | `node scripts/global/dep-graph-render.js` |
 | `deps:review` | `node scripts/global/dep-proposals-review.js` |
+| `doc-graph` | `node scripts/global/doc-graph-builder.js` |
 | `docs:anchors` | `node scripts/global/docs-anchors.js` |
 | `docs:compile` | `node scripts/docs-compile.js` |
 | `docs:exec` | `node scripts/global/docs-exec.js` |

--- a/package.json
+++ b/package.json
@@ -236,7 +236,8 @@
     "governance:wiki-catalog:test": "node --test tests/validate-wiki-catalog.spec.js",
     "git-state:drift": "node scripts/global/git-state-drift-sensor.js",
     "goals:regen": "node scripts/global/goals-contract-generate.js",
-    "governance:coordinator-cleanup": "node scripts/global/coordinator-label-cleanup.js"
+    "governance:coordinator-cleanup": "node scripts/global/coordinator-label-cleanup.js",
+    "doc-graph": "node scripts/global/doc-graph-builder.js"
   },
   "keywords": [
     "devops",

--- a/scripts/global/doc-graph-builder.js
+++ b/scripts/global/doc-graph-builder.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// Refs #2153 — markdown-wikilink graph-builder
+// Scans repo for [[wikilink]] syntax and writes deterministic adjacency-list to generated/doc-graph.json
+
+const fs = require('fs');
+const path = require('path');
+
+const SCAN_DIRS = ['docs', 'wiki', 'instructions'];
+const SCAN_FILES = ['README.md', 'vscode-extension/README.md', 'CHANGELOG.md'];
+const OUTPUT_PATH = 'generated/doc-graph.json';
+
+const WIKILINK_RE = /(?<!\\)\[\[([^\[\]\n]+?)\]\]/g;
+
+function walkMd(rootDir, baseDir) {
+  const out = [];
+  if (!fs.existsSync(rootDir)) return out;
+  for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+    const full = path.join(rootDir, entry.name);
+    const rel = path.relative(baseDir, full);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+      out.push(...walkMd(full, baseDir));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+function extractWikilinks(text) {
+  const links = [];
+  let match;
+  WIKILINK_RE.lastIndex = 0;
+  while ((match = WIKILINK_RE.exec(text)) !== null) {
+    const target = match[1].split('|')[0].trim();
+    if (target) links.push(target);
+  }
+  return links;
+}
+
+function collectScanFiles(baseDir) {
+  const files = [];
+  for (const dir of SCAN_DIRS) files.push(...walkMd(path.join(baseDir, dir), baseDir));
+  for (const file of SCAN_FILES) {
+    const full = path.join(baseDir, file);
+    if (fs.existsSync(full)) files.push(file);
+  }
+  files.sort();
+  return files;
+}
+
+function buildGraph(baseDir) {
+  const files = collectScanFiles(baseDir);
+  const nodes = files.map((file) => ({ id: `file:${file}`, type: 'doc' }));
+  const linkTargets = new Set();
+  const edges = [];
+  for (const file of files) {
+    const text = fs.readFileSync(path.join(baseDir, file), 'utf8');
+    for (const target of extractWikilinks(text)) {
+      edges.push({ from: `file:${file}`, to: `wikilink:${target}`, kind: 'wikilink' });
+      linkTargets.add(target);
+    }
+  }
+  for (const target of [...linkTargets].sort()) {
+    nodes.push({ id: `wikilink:${target}`, type: 'wikilink-target' });
+  }
+  edges.sort((a, b) => a.from.localeCompare(b.from) || a.to.localeCompare(b.to));
+  return { version: 1, nodes, edges };
+}
+
+function writeGraph(baseDir, graph) {
+  const outFull = path.join(baseDir, OUTPUT_PATH);
+  fs.mkdirSync(path.dirname(outFull), { recursive: true });
+  fs.writeFileSync(outFull, JSON.stringify(graph, null, 2) + '\n');
+}
+
+function main(baseDir = process.cwd()) {
+  const graph = buildGraph(baseDir);
+  writeGraph(baseDir, graph);
+  return graph;
+}
+
+if (require.main === module) {
+  const start = Date.now();
+  const graph = main();
+  const elapsed = Date.now() - start;
+  process.stderr.write(
+    `doc-graph: ${graph.nodes.length} nodes, ${graph.edges.length} edges, ${elapsed}ms -> ${OUTPUT_PATH}\n`,
+  );
+}
+
+module.exports = { buildGraph, extractWikilinks, walkMd, collectScanFiles, main };

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -12,6 +12,8 @@ const IGNORE = [
   'node_modules', '.git', 'playwright-report',
   'test-results', 'package-lock.json', '.dashboard',
   'logs', '.claude', '.log4brains', '.worktrees',
+  // Generated artifacts (rebuilt on demand; not committed)
+  'generated',
   // Global resources have their own governance
   'skills', 'hooks'
 ];

--- a/tests/doc-graph-builder.spec.js
+++ b/tests/doc-graph-builder.spec.js
@@ -1,0 +1,100 @@
+// Refs #2153 — unit tests for doc-graph-builder
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildGraph, extractWikilinks, walkMd } = require('../scripts/global/doc-graph-builder.js');
+
+function mkSandbox() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'doc-graph-'));
+}
+
+test('extractWikilinks: parses simple [[link]]', () => {
+  const links = extractWikilinks('see [[foo-bar]] and [[baz]].');
+  assert.deepEqual(links, ['foo-bar', 'baz']);
+});
+
+test('extractWikilinks: skips escaped \\[[notlink]]', () => {
+  const links = extractWikilinks('escaped \\[[notlink]] and [[real]]');
+  assert.deepEqual(links, ['real']);
+});
+
+test('extractWikilinks: strips display-text after pipe', () => {
+  const links = extractWikilinks('[[target|display text]]');
+  assert.deepEqual(links, ['target']);
+});
+
+test('extractWikilinks: ignores nested or malformed brackets', () => {
+  const links = extractWikilinks('[[[wrong]]] and [[ok]]');
+  assert.ok(links.includes('ok'));
+});
+
+test('extractWikilinks: no-link returns empty', () => {
+  assert.deepEqual(extractWikilinks('plain markdown no links here'), []);
+});
+
+test('buildGraph: deterministic across runs (byte-identical)', () => {
+  const sb = mkSandbox();
+  fs.mkdirSync(path.join(sb, 'docs'), { recursive: true });
+  fs.writeFileSync(path.join(sb, 'docs', 'a.md'), 'See [[b-page]] and [[c-page]]');
+  fs.writeFileSync(path.join(sb, 'docs', 'b.md'), '[[a-page]]');
+  fs.writeFileSync(path.join(sb, 'README.md'), '# Root [[a-page]]');
+
+  const g1 = buildGraph(sb);
+  const g2 = buildGraph(sb);
+  assert.equal(JSON.stringify(g1), JSON.stringify(g2));
+  fs.rmSync(sb, { recursive: true, force: true });
+});
+
+test('buildGraph: produces edges with from/to/kind shape', () => {
+  const sb = mkSandbox();
+  fs.mkdirSync(path.join(sb, 'docs'), { recursive: true });
+  fs.writeFileSync(path.join(sb, 'docs', 'a.md'), '[[target-name]]');
+  const g = buildGraph(sb);
+  const edge = g.edges.find((e) => e.to === 'wikilink:target-name');
+  assert.ok(edge);
+  assert.equal(edge.from, 'file:docs/a.md');
+  assert.equal(edge.kind, 'wikilink');
+  fs.rmSync(sb, { recursive: true, force: true });
+});
+
+test('buildGraph: skips node_modules and dotfiles', () => {
+  const sb = mkSandbox();
+  fs.mkdirSync(path.join(sb, 'docs', 'node_modules'), { recursive: true });
+  fs.mkdirSync(path.join(sb, 'docs', '.cache'), { recursive: true });
+  fs.writeFileSync(path.join(sb, 'docs', 'node_modules', 'skip.md'), '[[should-not-appear]]');
+  fs.writeFileSync(path.join(sb, 'docs', '.cache', 'skip.md'), '[[should-not-appear]]');
+  fs.writeFileSync(path.join(sb, 'docs', 'real.md'), '[[ok]]');
+  const g = buildGraph(sb);
+  assert.equal(
+    g.edges.find((e) => e.to === 'wikilink:should-not-appear'),
+    undefined,
+  );
+  assert.ok(g.edges.find((e) => e.to === 'wikilink:ok'));
+  fs.rmSync(sb, { recursive: true, force: true });
+});
+
+test('buildGraph: runs under 5 seconds on sandbox of 50 small files', () => {
+  const sb = mkSandbox();
+  fs.mkdirSync(path.join(sb, 'docs'), { recursive: true });
+  for (let i = 0; i < 50; i++) {
+    fs.writeFileSync(path.join(sb, 'docs', `f${i}.md`), `[[link-${i}]] [[shared-target]]`);
+  }
+  const start = Date.now();
+  const g = buildGraph(sb);
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 5000, `expected <5s, got ${elapsed}ms`);
+  assert.equal(g.nodes.filter((n) => n.type === 'doc').length, 50);
+  fs.rmSync(sb, { recursive: true, force: true });
+});
+
+test('walkMd: returns relative paths', () => {
+  const sb = mkSandbox();
+  fs.mkdirSync(path.join(sb, 'sub'), { recursive: true });
+  fs.writeFileSync(path.join(sb, 'sub', 'x.md'), 'content');
+  const files = walkMd(path.join(sb, 'sub'), sb);
+  assert.deepEqual(files, ['sub/x.md']);
+  fs.rmSync(sb, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary

- Markdown wikilink graph-builder at `scripts/global/doc-graph-builder.js` (npm run doc-graph)
- Deterministic JSON adjacency-list at `generated/doc-graph.json` (gitignored)
- 10 unit tests covering wikilink-parse edge cases, determinism, node_modules skip, perf budget

Phase-1 child C0 of Epic #2148 (merge-time documentation governance).

Real-repo run: 449 nodes, 916 edges, 35ms.

Refs #2153
Refs Epic #2148
Refs Phase-0 source #2149
Closes #2153

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2153#issuecomment-4541193126
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2153#issuecomment-4541128699 (includes fleet red-team triage; 8 findings, 0 fleet-ACCEPT stand)
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2153#issuecomment-4541167161
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2153#issuecomment-4541193377 (rubric min 8/10 ≥ 7)

## Test plan

- [x] npm test — 10/10 pass
- [x] npm run lint — clean
- [x] npm run docs:compile — README.md regenerated
- [x] Fleet red-team (qwen2.5-coder:32b) — collaborator self-review
- [ ] Fleet red-team (qwen2.5-coder:32b) — admin pre-merge (in flight)
- [ ] CI required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
