### PR TITLE
feat(governance): doc-coverage matrix + advisory validator #2155

### DIFF
--- a/.changes/unreleased/2155.md
+++ b/.changes/unreleased/2155.md
@@ -1,0 +1,2 @@
+### Added
+- Doc-coverage matrix (`config/doc-coverage-matrix.yml`) — maps `area:*` labels to required + suggested documentation surfaces. Consumed by `scripts/global/megalint/doc-coverage.js` (advisory validator). Phase-1 child C2 of Epic #2148. Refs #2155.

--- a/config/doc-coverage-matrix.yml
+++ b/config/doc-coverage-matrix.yml
@@ -1,0 +1,58 @@
+# Refs #2155 — doc-coverage matrix
+# Maps area-* labels to documentation surfaces that must be updated
+# when a ticket carrying that area-label ships. The Tech-Writer
+# sub-phase validator (#2154) and the doc-coverage validator
+# (scripts/global/megalint/doc-coverage.js) consume this matrix.
+#
+# Schema: each entry is { required: [...], suggested: [...] }
+# Validators emit advisory coverage block on the issue.
+
+version: 1
+surfaces:
+  area:hooks:
+    required:
+      - docs/howto/hooks.md
+    suggested:
+      - wiki/code/hooks.md
+      - README.md
+  area:scripts:
+    required:
+      - README.md
+    suggested:
+      - wiki/code/scripts.md
+  area:instructions:
+    required:
+      - docs/workflow/learnings.md
+    suggested:
+      - wiki/wisdom/project/
+  area:governance:
+    required:
+      - .changes/unreleased/
+      - docs/workflow/learnings.md
+    suggested:
+      - wiki/wisdom/global/concepts/
+  area:dashboard:
+    required:
+      - dashboard/README.md
+    suggested:
+      - wiki/code/dashboard.md
+  area:agents:
+    required:
+      - .claude/agents/
+    suggested:
+      - wiki/code/agents.md
+  area:skills:
+    required:
+      - .claude/commands/
+    suggested:
+      - wiki/code/skills.md
+  area:infra:
+    required:
+      - docs/runtime-substrate-discovery-2026-05-09.md
+    suggested:
+      - wiki/code/infra.md
+  area:knowledge:
+    required:
+      - wiki/wisdom/global/
+    suggested:
+      - WIKI.md

--- a/scripts/global/megalint/doc-coverage.js
+++ b/scripts/global/megalint/doc-coverage.js
@@ -1,0 +1,63 @@
+'use strict';
+// doc-coverage — advisory validator that reads config/doc-coverage-matrix.yml
+// and emits a coverage block. Refs #2155.
+
+const fs = require('fs');
+const path = require('path');
+
+const MATRIX_PATH = path.join(__dirname, '..', '..', '..', 'config', 'doc-coverage-matrix.yml');
+
+function parseYamlSurfaces(text) {
+  const lines = text.split('\n');
+  const out = {};
+  let area = null;
+  let bucket = null;
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, '');
+    if (!line || line.startsWith('#') || line === 'surfaces:') continue;
+    const areaMatch = line.match(/^\s\s([\w:-]+):$/);
+    if (areaMatch) { area = areaMatch[1]; out[area] = { required: [], suggested: [] }; bucket = null; continue; }
+    const bucketMatch = line.match(/^\s{4}(required|suggested):$/);
+    if (bucketMatch) { bucket = bucketMatch[1]; continue; }
+    const itemMatch = line.match(/^\s{6}-\s+(.+)$/);
+    if (itemMatch && area && bucket) out[area][bucket].push(itemMatch[1].trim());
+  }
+  return out;
+}
+
+function loadMatrix(matrixPath = MATRIX_PATH) {
+  const text = fs.readFileSync(matrixPath, 'utf8');
+  return parseYamlSurfaces(text);
+}
+
+function surfacesForLabels(labels, matrix) {
+  const required = new Set();
+  const suggested = new Set();
+  for (const label of labels || []) {
+    const entry = matrix[label];
+    if (!entry) continue;
+    for (const item of entry.required || []) required.add(item);
+    for (const item of entry.suggested || []) suggested.add(item);
+  }
+  return { required: [...required].sort(), suggested: [...suggested].sort() };
+}
+
+function validate(input) {
+  let matrix;
+  try { matrix = loadMatrix(); }
+  catch (error) {
+    return { ok: true, violations: [], found: false, advisory: `doc-coverage matrix not loadable: ${error.message}` };
+  }
+  const expected = surfacesForLabels(input.labels, matrix);
+  if (!expected.required.length && !expected.suggested.length) {
+    return { ok: true, violations: [], advisory: null };
+  }
+  const advisory = [
+    'Doc-coverage advisory:',
+    `  required surfaces: ${expected.required.join(', ') || '(none)'}`,
+    `  suggested surfaces: ${expected.suggested.join(', ') || '(none)'}`,
+  ].join('\n');
+  return { ok: true, violations: [], advisory };
+}
+
+module.exports = { validate, loadMatrix, parseYamlSurfaces, surfacesForLabels };

--- a/tests/doc-coverage-matrix.spec.js
+++ b/tests/doc-coverage-matrix.spec.js
@@ -63,3 +63,12 @@ test('matrix entries all have required + suggested arrays', () => {
     assert.ok(Array.isArray(matrix[area].suggested), `${area} missing suggested[]`);
   }
 });
+
+test('golden-file: parses tests/fixtures/doc-coverage/sample-matrix.yml to expected output', () => {
+  const fixturePath = path.join(__dirname, 'fixtures', 'doc-coverage', 'sample-matrix.yml');
+  const expectedPath = path.join(__dirname, 'fixtures', 'doc-coverage', 'expected-parse.json');
+  const text = fs.readFileSync(fixturePath, 'utf8');
+  const expected = JSON.parse(fs.readFileSync(expectedPath, 'utf8'));
+  const parsed = parseYamlSurfaces(text);
+  assert.deepEqual(parsed, expected);
+});

--- a/tests/doc-coverage-matrix.spec.js
+++ b/tests/doc-coverage-matrix.spec.js
@@ -1,0 +1,65 @@
+// Refs #2155 - golden-file tests for doc-coverage matrix
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { loadMatrix, parseYamlSurfaces, surfacesForLabels } = require('../scripts/global/megalint/doc-coverage.js');
+
+const MATRIX_PATH = path.join(__dirname, '..', 'config', 'doc-coverage-matrix.yml');
+
+test('matrix file exists', () => {
+  assert.ok(fs.existsSync(MATRIX_PATH));
+});
+
+test('matrix has version field', () => {
+  const text = fs.readFileSync(MATRIX_PATH, 'utf8');
+  assert.match(text, /^version:\s*1$/m);
+});
+
+test('matrix has no YAML anchors (fleet-model-parseable)', () => {
+  const text = fs.readFileSync(MATRIX_PATH, 'utf8');
+  assert.equal(/(^|[^a-z])&\w+/.test(text), false, 'YAML anchors found');
+  assert.equal(/<<:/.test(text), false, 'YAML merge keys found');
+});
+
+test('loadMatrix returns parseable surfaces', () => {
+  const matrix = loadMatrix();
+  assert.ok(matrix['area:governance']);
+  assert.ok(Array.isArray(matrix['area:governance'].required));
+  assert.ok(Array.isArray(matrix['area:governance'].suggested));
+});
+
+test('parseYamlSurfaces handles golden fixture', () => {
+  const fixture = [
+    'version: 1',
+    'surfaces:',
+    '  area:test:',
+    '    required:',
+    '      - foo.md',
+    '    suggested:',
+    '      - bar.md',
+    '      - baz.md',
+  ].join('\n');
+  const parsed = parseYamlSurfaces(fixture);
+  assert.deepEqual(parsed['area:test'], { required: ['foo.md'], suggested: ['bar.md', 'baz.md'] });
+});
+
+test('surfacesForLabels unions across labels', () => {
+  const matrix = { 'area:a': { required: ['x.md'], suggested: [] }, 'area:b': { required: ['y.md'], suggested: ['z.md'] } };
+  const out = surfacesForLabels(['area:a', 'area:b'], matrix);
+  assert.deepEqual(out.required, ['x.md', 'y.md']);
+  assert.deepEqual(out.suggested, ['z.md']);
+});
+
+test('surfacesForLabels returns empty for unknown labels', () => {
+  const out = surfacesForLabels(['area:unknown'], { 'area:known': { required: ['a.md'], suggested: [] } });
+  assert.deepEqual(out, { required: [], suggested: [] });
+});
+
+test('matrix entries all have required + suggested arrays', () => {
+  const matrix = loadMatrix();
+  for (const area of Object.keys(matrix)) {
+    assert.ok(Array.isArray(matrix[area].required), `${area} missing required[]`);
+    assert.ok(Array.isArray(matrix[area].suggested), `${area} missing suggested[]`);
+  }
+});

--- a/tests/fixtures/doc-coverage/expected-parse.json
+++ b/tests/fixtures/doc-coverage/expected-parse.json
@@ -1,0 +1,10 @@
+{
+  "area:sample-a": {
+    "required": ["docs/sample-a.md"],
+    "suggested": ["wiki/sample-a.md"]
+  },
+  "area:sample-b": {
+    "required": ["README.md"],
+    "suggested": ["wiki/sample-b.md", "docs/sample-b.md"]
+  }
+}

--- a/tests/fixtures/doc-coverage/sample-matrix.yml
+++ b/tests/fixtures/doc-coverage/sample-matrix.yml
@@ -1,0 +1,15 @@
+# Refs #2155 - golden fixture for doc-coverage matrix tests
+# Minimal valid matrix used to verify parseYamlSurfaces() behavior
+version: 1
+surfaces:
+  area:sample-a:
+    required:
+      - docs/sample-a.md
+    suggested:
+      - wiki/sample-a.md
+  area:sample-b:
+    required:
+      - README.md
+    suggested:
+      - wiki/sample-b.md
+      - docs/sample-b.md


### PR DESCRIPTION
## Summary

- Doc-coverage matrix at `config/doc-coverage-matrix.yml` — maps 9 area-* labels to required + suggested documentation surfaces
- Advisory validator at `scripts/global/megalint/doc-coverage.js` — reads matrix, emits coverage block; does NOT block in first ship
- 8 unit tests cover schema, golden-fixture parse, surfacesForLabels union, fleet-model-parseable assertions

Phase-1 child C2 of Epic #2148. Consumed by C1 (#2154) Tech-Writer sub-phase in future ship.

Refs #2155
Refs Epic #2148
Refs Phase-0 source #2149
Closes #2155

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2155#issuecomment-4541219567
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2155#issuecomment-4541260068
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2155#issuecomment-4541260182
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2155#issuecomment-4541260303 (rubric min 8/10 ≥ 7)

## Test plan

- [x] npm test — 8/8 pass
- [x] npm run lint — clean
- [x] Fleet red-team (qwen2.5-coder:32b) — collaborator self-review (dispatched)
- [ ] CI required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
