### PR TITLE
feat(governance): changelog-fragment-presence pre-merge validator #2157

### DIFF
--- a/.changes/unreleased/2157.md
+++ b/.changes/unreleased/2157.md
@@ -1,0 +1,2 @@
+### Added
+- Pre-merge changelog-fragment-presence validator (`scripts/global/megalint/changelog-fragment-presence.js`) — fails any `lane:code-change` PR missing `.changes/unreleased/<N>.md` unless `[skip-changelog]` marker present in PR body. Pure function exports `{ok, reason}`. Phase-1 child C5 of Epic #2148. Refs #2157.

--- a/scripts/global/megalint/changelog-fragment-presence.js
+++ b/scripts/global/megalint/changelog-fragment-presence.js
@@ -1,0 +1,59 @@
+'use strict';
+// changelog-fragment-presence — pre-merge validator
+// Fails any PR carrying lane:code-change unless a .changes/unreleased/<N>.md
+// fragment exists OR the PR description carries [skip-changelog].
+// Refs #2157.
+
+const SKIP_MARKER = '[skip-changelog]';
+const FRAGMENT_RE = /^\.changes\/unreleased\/(\d+)\.md$/;
+
+function extractRefsTicket(prBody) {
+  if (!prBody) return null;
+  const match = String(prBody).match(/(?:^|\n)\s*Refs\s+#(\d+)\b/i);
+  return match ? Number(match[1]) : null;
+}
+
+function findFragment(prFiles, ticket) {
+  if (!ticket || !Array.isArray(prFiles)) return null;
+  for (const file of prFiles) {
+    const path = typeof file === 'string' ? file : file.path || file.filename;
+    if (!path) continue;
+    const match = FRAGMENT_RE.exec(path);
+    if (match && Number(match[1]) === ticket) return path;
+  }
+  return null;
+}
+
+function isCodeChangeLane(labels) {
+  return (labels || []).some(label => {
+    const name = typeof label === 'string' ? label : label.name;
+    return name === 'lane:code-change';
+  });
+}
+
+function hasSkipMarker(prBody) {
+  return typeof prBody === 'string' && prBody.includes(SKIP_MARKER);
+}
+
+function validate(input) {
+  if (!isCodeChangeLane(input.labels)) {
+    return { ok: true, reason: 'not-lane-code-change' };
+  }
+  if (hasSkipMarker(input.prBody)) {
+    return { ok: true, reason: 'skip-marker-present' };
+  }
+  const ticket = extractRefsTicket(input.prBody);
+  if (!ticket) {
+    return { ok: false, reason: 'no-refs-ticket-in-pr-body' };
+  }
+  const fragment = findFragment(input.prFiles, ticket);
+  if (!fragment) {
+    return {
+      ok: false,
+      reason: `missing-fragment: lane:code-change PR for #${ticket} requires .changes/unreleased/${ticket}.md or ${SKIP_MARKER}`,
+    };
+  }
+  return { ok: true, reason: `fragment-present: ${fragment}` };
+}
+
+module.exports = { validate, extractRefsTicket, findFragment, isCodeChangeLane, hasSkipMarker, SKIP_MARKER };

--- a/tests/changelog-fragment-presence.spec.js
+++ b/tests/changelog-fragment-presence.spec.js
@@ -1,0 +1,86 @@
+// Refs #2157 - unit tests for changelog-fragment-presence
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { validate, extractRefsTicket, findFragment, isCodeChangeLane, hasSkipMarker } = require('../scripts/global/megalint/changelog-fragment-presence.js');
+
+test('extractRefsTicket: parses Refs #N from PR body', () => {
+  assert.equal(extractRefsTicket('Refs #2157\nCloses #2157'), 2157);
+});
+
+test('extractRefsTicket: returns null when no Refs', () => {
+  assert.equal(extractRefsTicket('No reference here'), null);
+});
+
+test('extractRefsTicket: picks first Refs not Refs Epic', () => {
+  // Strict: matches /Refs\s+#(\d+)/i which catches "Refs Epic #N" too unfortunately
+  // Document the trap explicitly via test
+  assert.equal(extractRefsTicket('Refs #2157\nRefs Epic #2148'), 2157);
+});
+
+test('findFragment: matches by ticket number', () => {
+  const files = ['scripts/foo.js', '.changes/unreleased/2157.md', 'tests/foo.spec.js'];
+  assert.equal(findFragment(files, 2157), '.changes/unreleased/2157.md');
+});
+
+test('findFragment: returns null when no match', () => {
+  assert.equal(findFragment(['src/foo.js'], 2157), null);
+});
+
+test('isCodeChangeLane: detects label by name', () => {
+  assert.ok(isCodeChangeLane(['lane:code-change', 'type:task']));
+  assert.equal(isCodeChangeLane(['lane:docs-research']), false);
+});
+
+test('hasSkipMarker: detects [skip-changelog]', () => {
+  assert.ok(hasSkipMarker('Some text with [skip-changelog] marker'));
+  assert.equal(hasSkipMarker('No marker here'), false);
+});
+
+test('validate: fragment-present-pass', () => {
+  const result = validate({
+    labels: ['lane:code-change'],
+    prBody: 'Refs #2157',
+    prFiles: ['.changes/unreleased/2157.md', 'src/x.js'],
+  });
+  assert.equal(result.ok, true);
+});
+
+test('validate: fragment-missing-fail', () => {
+  const result = validate({
+    labels: ['lane:code-change'],
+    prBody: 'Refs #2157',
+    prFiles: ['src/x.js'],
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /missing-fragment/);
+});
+
+test('validate: skip-marker-pass', () => {
+  const result = validate({
+    labels: ['lane:code-change'],
+    prBody: 'Refs #2157\n\n[skip-changelog]',
+    prFiles: ['src/x.js'],
+  });
+  assert.equal(result.ok, true);
+  assert.match(result.reason, /skip-marker/);
+});
+
+test('validate: lane-docs-only-skip', () => {
+  const result = validate({
+    labels: ['lane:docs-only'],
+    prBody: 'Refs #2157',
+    prFiles: ['src/x.js'],
+  });
+  assert.equal(result.ok, true);
+  assert.match(result.reason, /not-lane-code-change/);
+});
+
+test('validate: no-refs-fails', () => {
+  const result = validate({
+    labels: ['lane:code-change'],
+    prBody: 'No reference here',
+    prFiles: ['src/x.js'],
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /no-refs-ticket/);
+});


### PR DESCRIPTION
## Summary

- Pure-function module at `scripts/global/megalint/changelog-fragment-presence.js`
- Fails any `lane:code-change` PR missing `.changes/unreleased/<N>.md` unless `[skip-changelog]` marker in PR body
- 12 unit tests cover: fragment-present-pass, fragment-missing-fail, skip-marker-pass, lane:docs-only-skip, no-refs-fail, helper functions

Phase-1 child C5 of Epic #2148. Workflow integration deferred to follow-on (advisory in first ship); this PR ships the pure-function module ready for wiring.

Refs #2157
Refs Epic #2148
Refs Phase-0 source #2149
Closes #2157

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2157#issuecomment-4541279495
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2157#issuecomment-4541301807
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2157#issuecomment-4541301911
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2157#issuecomment-4541302001 (rubric min 8/10 ≥ 7)

## Test plan

- [x] npm test — 12/12 pass
- [x] npm run lint — clean
- [ ] CI required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
