### PR TITLE
feat(governance): doc-coverage-event emitter to incidents.jsonl #2158

### DIFF
--- a/.changes/unreleased/2158.md
+++ b/.changes/unreleased/2158.md
@@ -1,0 +1,2 @@
+### Added
+- `doc_coverage_event` emitter (`scripts/global/doc-coverage-event-emit.js`) — appends event-schema-v3 compliant entries to `~/.megingjord/incidents.jsonl` for doc-coverage decisions. Wraps existing event-schema-v3 + log-redaction modules. Consumed by C2 doc-coverage validator and C5 changelog-fragment-presence validator (future wiring). Phase-1 child C7 of Epic #2148. Refs #2158.

--- a/scripts/global/doc-coverage-event-emit.js
+++ b/scripts/global/doc-coverage-event-emit.js
@@ -1,0 +1,67 @@
+'use strict';
+// doc-coverage-event-emit — appends doc_coverage_event entries to
+// ~/.megingjord/incidents.jsonl. Wraps event-schema-v3 + log-redaction.
+// Refs #2158. Consumed by C2 doc-coverage validator + C5 changelog-fragment-presence.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { isValidV3, normalize } = require('./event-schema-v3');
+const { wrapWrite } = require('./log-redaction');
+
+const DEFAULT_LOG_PATH = path.join(os.homedir(), '.megingjord', 'incidents.jsonl');
+const REQUIRED_KEYS = ['ticket', 'validator', 'verdict'];
+const VALID_VERDICTS = ['pass', 'advisory', 'fail'];
+const VALID_VALIDATORS = ['tech-writer-subphase', 'changelog-fragment-presence', 'wiki-lint-gate', 'doc-coverage'];
+
+function buildEvent(input) {
+  const base = {
+    ts: input.ts || new Date().toISOString(),
+    version: 3,
+    service: input.service || 'megingjord-doc-governance',
+    env: input.env || 'prod',
+    event: 'doc_coverage_event',
+    ticket: input.ticket,
+    validator: input.validator,
+    verdict: input.verdict,
+    surfaces_required: input.surfaces_required || [],
+    surfaces_updated: input.surfaces_updated || [],
+    surfaces_na: input.surfaces_na || [],
+  };
+  if (input.trace_id) base.trace_id = input.trace_id;
+  if (input.session_id) base.session_id = input.session_id;
+  return normalize(base);
+}
+
+function validateInput(input) {
+  for (const key of REQUIRED_KEYS) {
+    if (input[key] === undefined || input[key] === null) {
+      throw new Error(`doc_coverage_event missing required field: ${key}`);
+    }
+  }
+  if (!VALID_VERDICTS.includes(input.verdict)) {
+    throw new Error(`doc_coverage_event invalid verdict: ${input.verdict} (expected one of ${VALID_VERDICTS.join(', ')})`);
+  }
+  if (!VALID_VALIDATORS.includes(input.validator)) {
+    throw new Error(`doc_coverage_event unknown validator: ${input.validator}`);
+  }
+}
+
+function writeToFile(logPath, event) {
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  fs.appendFileSync(logPath, JSON.stringify(event) + '\n');
+}
+
+function emitDocCoverageEvent(input, opts = {}) {
+  validateInput(input);
+  const event = buildEvent(input);
+  if (!isValidV3(event)) {
+    throw new Error('doc_coverage_event failed event-schema-v3 validation');
+  }
+  const logPath = opts.logPath || DEFAULT_LOG_PATH;
+  const safeWrite = wrapWrite((evt) => writeToFile(logPath, evt));
+  safeWrite(event);
+  return event;
+}
+
+module.exports = { emitDocCoverageEvent, buildEvent, validateInput, DEFAULT_LOG_PATH, VALID_VERDICTS, VALID_VALIDATORS };

--- a/tests/doc-coverage-event-emit.spec.js
+++ b/tests/doc-coverage-event-emit.spec.js
@@ -1,0 +1,96 @@
+// Refs #2158 - unit tests for doc-coverage-event emitter
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { emitDocCoverageEvent, buildEvent, validateInput, VALID_VERDICTS, VALID_VALIDATORS } = require('../scripts/global/doc-coverage-event-emit.js');
+
+function sandboxLog() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-cov-evt-'));
+  return path.join(dir, 'incidents.jsonl');
+}
+
+test('buildEvent: shape matches event-schema-v3 expectations', () => {
+  const evt = buildEvent({
+    ticket: '#2158',
+    validator: 'doc-coverage',
+    verdict: 'pass',
+    surfaces_required: ['README.md'],
+    surfaces_updated: ['README.md'],
+  });
+  assert.equal(evt.version, 3);
+  assert.equal(evt.event, 'doc_coverage_event');
+  assert.equal(evt.service, 'megingjord-doc-governance');
+  assert.equal(evt.env, 'prod');
+  assert.equal(evt.verdict, 'pass');
+});
+
+test('validateInput: requires ticket, validator, verdict', () => {
+  assert.throws(() => validateInput({ validator: 'doc-coverage', verdict: 'pass' }), /ticket/);
+  assert.throws(() => validateInput({ ticket: '#1', verdict: 'pass' }), /validator/);
+  assert.throws(() => validateInput({ ticket: '#1', validator: 'doc-coverage' }), /verdict/);
+});
+
+test('validateInput: rejects invalid verdict', () => {
+  assert.throws(() => validateInput({ ticket: '#1', validator: 'doc-coverage', verdict: 'bogus' }), /invalid verdict/);
+});
+
+test('validateInput: rejects unknown validator', () => {
+  assert.throws(() => validateInput({ ticket: '#1', validator: 'unknown-thing', verdict: 'pass' }), /unknown validator/);
+});
+
+test('VALID_VERDICTS exports list of allowed verdicts', () => {
+  assert.deepEqual(VALID_VERDICTS, ['pass', 'advisory', 'fail']);
+});
+
+test('VALID_VALIDATORS exports list of allowed validators', () => {
+  assert.ok(VALID_VALIDATORS.includes('doc-coverage'));
+  assert.ok(VALID_VALIDATORS.includes('changelog-fragment-presence'));
+  assert.ok(VALID_VALIDATORS.includes('tech-writer-subphase'));
+  assert.ok(VALID_VALIDATORS.includes('wiki-lint-gate'));
+});
+
+test('emitDocCoverageEvent: appends JSON line to log file', () => {
+  const logPath = sandboxLog();
+  const evt = emitDocCoverageEvent({
+    ticket: '#2158',
+    validator: 'doc-coverage',
+    verdict: 'pass',
+  }, { logPath });
+  const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+  assert.equal(lines.length, 1);
+  const parsed = JSON.parse(lines[0]);
+  assert.equal(parsed.event, 'doc_coverage_event');
+  assert.equal(parsed.ticket, '#2158');
+  assert.equal(parsed.verdict, 'pass');
+  assert.ok(parsed.ts);
+  assert.equal(evt.ticket, '#2158');
+});
+
+test('emitDocCoverageEvent: redacts API-key-shaped strings via log-redaction', () => {
+  const logPath = sandboxLog();
+  emitDocCoverageEvent({
+    ticket: '#2158',
+    validator: 'doc-coverage',
+    verdict: 'fail',
+    surfaces_required: ['secret sk-ant-api03-aBcDef0123456789ABCDEFabcdef0123456789ABCDEF is here'],
+  }, { logPath });
+  const content = fs.readFileSync(logPath, 'utf8');
+  assert.equal(content.includes('aBcDef0123456789'), false, 'API key leaked');
+});
+
+test('emitDocCoverageEvent: multiple events append to same file', () => {
+  const logPath = sandboxLog();
+  emitDocCoverageEvent({ ticket: '#1', validator: 'doc-coverage', verdict: 'pass' }, { logPath });
+  emitDocCoverageEvent({ ticket: '#2', validator: 'doc-coverage', verdict: 'advisory' }, { logPath });
+  const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+  assert.equal(lines.length, 2);
+});
+
+test('emitDocCoverageEvent: returns event with v3 fields', () => {
+  const logPath = sandboxLog();
+  const evt = emitDocCoverageEvent({ ticket: '#9', validator: 'wiki-lint-gate', verdict: 'fail', trace_id: 't-123' }, { logPath });
+  assert.equal(evt.trace_id, 't-123');
+  assert.equal(evt.version, 3);
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/global/doc-coverage-event-emit.js` — appends event-schema-v3 compliant `doc_coverage_event` entries to `~/.megingjord/incidents.jsonl`
- Wraps existing `event-schema-v3` + `log-redaction` modules; PII-redacted by construction
- 10 unit tests cover buildEvent shape, validateInput, redaction integration, multi-event append, trace_id propagation

Phase-1 child C7 of Epic #2148. Consumed by C2 doc-coverage validator + C5 changelog-fragment-presence validator in future wiring.

Refs #2158
Refs Epic #2148
Refs Phase-0 source #2149
Closes #2158

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2158#issuecomment-4541312767
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2158#issuecomment-4541336891
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2158#issuecomment-4541337109
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2158#issuecomment-4541337304 (rubric min 8/10 ≥ 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
