### PR TITLE
feat(ci): wiki-lint-gate advisory pre-merge workflow #2156

### DIFF
--- a/.changes/unreleased/2156.md
+++ b/.changes/unreleased/2156.md
@@ -1,0 +1,2 @@
+### Added
+- `wiki-lint-gate` workflow (`.github/workflows/wiki-lint-gate.yml`) — advisory pre-merge gate wrapping existing `npm run wiki:lint`. Triggers on PRs touching `wiki/`, `README.md`, `vscode-extension/README.md`. Advisory in first ship (continue-on-error: true); admin promotes to required-check after baseline drift is cleared. Phase-1 child C3 of Epic #2148. Refs #2156.

--- a/.github/workflows/wiki-lint-gate.yml
+++ b/.github/workflows/wiki-lint-gate.yml
@@ -1,0 +1,36 @@
+# Refs #2156 — wiki-lint pre-merge gate (advisory in first ship)
+# Wraps existing npm run wiki:lint script. Phase-1 of Epic #2148.
+#
+# ADVISORY MODE: continue-on-error: true. The step result is reported as
+# annotation but does not fail the PR. Admin promotes to required-check
+# after baseline wiki drift is cleared (separate ticket).
+
+name: wiki-lint-gate
+on:
+  pull_request:
+    paths:
+      - 'wiki/**'
+      - 'README.md'
+      - 'vscode-extension/README.md'
+
+permissions: read-all
+
+jobs:
+  wiki-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Run wiki-lint (advisory)
+        id: wikilint
+        continue-on-error: true
+        run: npm run wiki:lint
+      - name: Report status
+        if: steps.wikilint.outcome == 'failure'
+        run: |
+          echo "::warning::wiki:lint reported issues (advisory; not blocking). Refs #2156."

--- a/tests/wiki-lint-gate.spec.js
+++ b/tests/wiki-lint-gate.spec.js
@@ -1,0 +1,51 @@
+// Refs #2156 - YAML schema test for wiki-lint-gate workflow
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const WF_PATH = path.join(__dirname, '..', '.github', 'workflows', 'wiki-lint-gate.yml');
+
+function getYaml() { return fs.readFileSync(WF_PATH, 'utf8'); }
+
+test('workflow file exists', () => {
+  assert.ok(fs.existsSync(WF_PATH));
+});
+
+test('declares name: wiki-lint-gate', () => {
+  assert.match(getYaml(), /^name:\s*wiki-lint-gate\s*$/m);
+});
+
+test('triggers on pull_request', () => {
+  assert.match(getYaml(), /^on:\s*$/m);
+  assert.match(getYaml(), /^\s+pull_request:\s*$/m);
+});
+
+test('path filter includes wiki/, README.md, vscode-extension/README.md', () => {
+  const text = getYaml();
+  assert.match(text, /wiki\/\*\*/);
+  assert.match(text, /'README\.md'/);
+  assert.match(text, /vscode-extension\/README\.md/);
+});
+
+test('permissions: read-all baseline', () => {
+  assert.match(getYaml(), /^permissions:\s*read-all\s*$/m);
+});
+
+test('has timeout-minutes ≤ 5', () => {
+  const match = getYaml().match(/timeout-minutes:\s*(\d+)/);
+  assert.ok(match);
+  assert.ok(Number(match[1]) <= 5);
+});
+
+test('invokes npm run wiki:lint', () => {
+  assert.match(getYaml(), /npm run wiki:lint/);
+});
+
+test('uses pinned setup-node@v4', () => {
+  assert.match(getYaml(), /actions\/setup-node@v4/);
+});
+
+test('uses pinned checkout@v4', () => {
+  assert.match(getYaml(), /actions\/checkout@v4/);
+});


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/wiki-lint-gate.yml` wrapping `npm run wiki:lint` as a pre-merge gate
- Triggers on PRs touching `wiki/`, `README.md`, `vscode-extension/README.md`
- ADVISORY mode (continue-on-error: true) in first ship — admin promotes to required-check after baseline drift (29 existing advisories) cleared

Phase-1 child C3 of Epic #2148.

Refs #2156
Refs Epic #2148
Refs Phase-0 source #2149
Closes #2156

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2156#issuecomment-4541353110
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2156#issuecomment-4541363278
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2156#issuecomment-4541363399
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2156#issuecomment-4541363627 (rubric min 8/10 ≥ 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
