### PR TITLE
feat(governance): Tech-Writer sub-phase + doc-coverage advisory #2154

### DIFF
--- a/.changes/unreleased/2154.md
+++ b/.changes/unreleased/2154.md
@@ -1,0 +1,5 @@
+### Added
+- Tech-Writer sub-phase contract added to `instructions/role-baton-routing.instructions.md` — COLLABORATOR_HANDOFF on `lane:code-change` SHOULD include a `doc-coverage:` block declaring UPDATED/N-A per applicable doc surface from `config/doc-coverage-matrix.yml`.
+- `scripts/global/megalint/collaborator-handoff.js` validator gains `checkDocCoverageAdvisory()` — emits advisory when block missing on `lane:code-change`; silent on lightweight lanes. Promotion to blocking gate tracked as follow-on after Epic #2148 close.
+- 4 unit tests cover advisory emission, block-present skip, lightweight-lane skip, regex case-insensitivity.
+- Phase-1 child C1 of Epic #2148. Refs #2154.

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -65,6 +65,18 @@ The two most-failure-prone transitions in the baton are `in-progress → testing
 | Status-label transition | Remove `status:in-progress`; add `status:testing`. Single-status invariant per the §"Single-status invariant" rule above. |
 | Preconditions | (a) ALL declared ACs verified PASS in the COLLABORATOR_HANDOFF per-AC block. (b) `test_strategy` evidence present per `instructions/test-methodology-matrix.instructions.md` — validator `scripts/global/megalint/test-discoverability.js`. (c) Lint clean for the lane (lane:code-change requires `npm run lint` green; lane:docs-research requires `wiki-lint` if wiki touched). |
 
+### Tech-Writer sub-phase (mandatory before posting the-collaborator-handoff per Epic #2148 / #2154)
+
+Before the role-collaborator-label holder posts the-collaborator-handoff, the comment MUST include a doc-coverage block per applicable surface in [config/doc-coverage-matrix.yml](../config/doc-coverage-matrix.yml). For each required + suggested surface the area-label maps to, declare one of:
+
+```
+doc-coverage:
+  UPDATED: <path-or-link> — <one-line summary of update>
+  N/A: <surface> — <reason: out-of-scope | covered-by-sibling-pr | docs-only-no-functional-change>
+```
+
+ADVISORY in first ship (Epic #2148 C1 #2154); the-collaborator-handoff validator (`scripts/global/megalint/collaborator-handoff.js`) parses the block when present and emits an advisory; missing block on lane:code-change emits a warning. Promotion to BLOCKING happens after Epic #2148 close, tracked as a follow-on.
+
 ### Consultant gate (entry to `status:review`)
 
 | Facet | Requirement |

--- a/scripts/global/megalint/collaborator-handoff.js
+++ b/scripts/global/megalint/collaborator-handoff.js
@@ -11,6 +11,16 @@ function findCollaboratorHandoff(comments) {
   return [...(comments || [])].reverse().find(c => headerRe.test(c.body || ''));
 }
 
+const DOC_COVERAGE_RE = /(^|\n)\s*doc-coverage\s*:/i;
+
+function checkDocCoverageAdvisory(body, lane) {
+  // Refs Epic #2148 / #2154 - Tech-Writer sub-phase advisory
+  if (lane !== 'lane:code-change') return [];
+  if (DOC_COVERAGE_RE.test(body)) return [];
+  return [{ rule: 'doc-coverage-advisory', severity: 'advisory',
+    detail: 'COLLABORATOR_HANDOFF lacks doc-coverage block (Tech-Writer sub-phase advisory per Epic #2148).' }];
+}
+
 function checkSignerFields(body) {
   const violations = [];
   if (!/Signed-by:/i.test(body)) {
@@ -38,8 +48,9 @@ function validate(input) {
       detail: 'COLLABORATOR_HANDOFF comment not found on issue' }], found: false };
   }
   const violations = checkSignerFields(handoff.body || '');
+  const advisory = checkDocCoverageAdvisory(handoff.body || '', input.lane);
   const signer = roleIdentity({ body: handoff.body, author: handoff.user && handoff.user.login });
-  return { ok: violations.length === 0, violations, found: true, signer };
+  return { ok: violations.length === 0, violations, advisory, found: true, signer };
 }
 
-module.exports = { validate, findCollaboratorHandoff };
+module.exports = { validate, findCollaboratorHandoff, checkDocCoverageAdvisory };

--- a/tests/collaborator-handoff-doc-coverage.spec.js
+++ b/tests/collaborator-handoff-doc-coverage.spec.js
@@ -1,0 +1,28 @@
+// Refs #2154 - tests for Tech-Writer sub-phase doc-coverage advisory
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { checkDocCoverageAdvisory } = require('../scripts/global/megalint/collaborator-handoff.js');
+
+test('checkDocCoverageAdvisory: emits advisory when doc-coverage missing on lane:code-change', () => {
+  const result = checkDocCoverageAdvisory('## COLLABORATOR_HANDOFF\nbody no doc-coverage here', 'lane:code-change');
+  assert.equal(result.length, 1);
+  assert.equal(result[0].rule, 'doc-coverage-advisory');
+  assert.equal(result[0].severity, 'advisory');
+});
+
+test('checkDocCoverageAdvisory: silent when doc-coverage block present', () => {
+  const body = '## COLLABORATOR_HANDOFF\n\ndoc-coverage:\n  UPDATED: README.md\n';
+  assert.deepEqual(checkDocCoverageAdvisory(body, 'lane:code-change'), []);
+});
+
+test('checkDocCoverageAdvisory: silent on lightweight lanes', () => {
+  assert.deepEqual(checkDocCoverageAdvisory('no coverage', 'lane:docs-research'), []);
+  assert.deepEqual(checkDocCoverageAdvisory('no coverage', 'lane:docs-only'), []);
+  assert.deepEqual(checkDocCoverageAdvisory('no coverage', 'lane:trivial'), []);
+  assert.deepEqual(checkDocCoverageAdvisory('no coverage', 'lane:config-only'), []);
+});
+
+test('checkDocCoverageAdvisory: regex case-insensitive', () => {
+  const body = '## COLLABORATOR_HANDOFF\nDOC-COVERAGE: present';
+  assert.deepEqual(checkDocCoverageAdvisory(body, 'lane:code-change'), []);
+});


### PR DESCRIPTION
## Summary

- Tech-Writer sub-phase contract added to `instructions/role-baton-routing.instructions.md`
- `scripts/global/megalint/collaborator-handoff.js` gains `checkDocCoverageAdvisory()` — advisory severity when `doc-coverage:` block missing on `lane:code-change`
- 4 unit tests cover emit/skip/lightweight-lane/case-insensitive
- Promotion to blocking gate tracked as follow-on after Epic #2148 close

Phase-1 child C1 of Epic #2148.

Refs #2154
Refs Epic #2148
Refs Phase-0 source #2149
Closes #2154

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2154#issuecomment-4541375399
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2154#issuecomment-4545139568
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2154#issuecomment-4545139771
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2154#issuecomment-4545140059 (rubric min 8/10 ≥ 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
