### PR TITLE
docs(governance): merge-time doc governance operator runbook #2159

### DIFF
--- a/.changes/unreleased/2159.md
+++ b/.changes/unreleased/2159.md
@@ -1,0 +1,2 @@
+### Added
+- Operator runbook at `docs/howto/merge-time-doc-governance.md` describing how Epic #2148 children (C0 graph-builder, C1 Tech-Writer sub-phase, C2 doc-coverage matrix, C3 wiki-lint gate, C5 changelog presence, C7 audit emitter) compose into the four-surface (Issues / Release notes / Project docs / Wikis) merge-time documentation governance system. Fleet-model-readable format with 8 sections. Cross-referenced from `instructions/release-docs-hygiene.instructions.md`. Phase-1 child C8 of Epic #2148. Refs #2159.

--- a/docs/howto/merge-time-doc-governance.md
+++ b/docs/howto/merge-time-doc-governance.md
@@ -1,0 +1,89 @@
+# Merge-time Documentation Governance
+
+This runbook describes how the harness enforces documentation across four surfaces at merge time. Phase-1 of Epic #2148. Fleet-model-readable: short paragraphs, concrete examples, no nuanced interpretation required.
+
+## 1. Goal
+
+Every change merged to `main` documents itself across four parallel surfaces. The documentation is enforced by hard gates (CI required-checks + pre-merge validators) rather than relying on agent instruction-following. The system works with non-frontier fleet models that cannot reliably parse multi-page nuanced instructions.
+
+## 2. The four surfaces
+
+| # | Surface | Example | Validator |
+|---|---|---|---|
+| 1 | GitHub Issues | Every merge has `Closes #N` + complete baton trail on the issue | `closeout-schema` workflow, `baton-gates` |
+| 2 | Release notes | Each `lane:code-change` PR ships `.changes/unreleased/<N>.md` | `changelog-fragment-presence` validator (#2157 / C5) |
+| 3 | Project docs | README, design docs, dev guide — updated per area-label coverage matrix | `doc-coverage` advisory (#2155 / C2) + Tech-Writer sub-phase (#2154 / C1) |
+| 4 | Wikis | `wiki/code/`, `wiki/wisdom/project/`, `wiki/work-log/` — updated when scoped | `wiki-lint-gate` workflow (#2156 / C3) |
+
+## 3. The pre-merge gates
+
+| Surface | Gate | Failure mode | Remediation |
+|---|---|---|---|
+| Issues | `baton-gates` CI | Missing handoff or role-mismatch | Post the missing baton artifact in canonical format |
+| Release notes | `changelog-fragment-presence` | No `.changes/unreleased/<N>.md` and no `[skip-changelog]` | Add `.changes/unreleased/<N>.md` or marker |
+| Project docs | `doc-coverage` advisory | Missing `doc-coverage:` block in COLLABORATOR_HANDOFF | Add block declaring UPDATED/N-A per surface |
+| Wikis | `wiki-lint-gate` advisory | wiki:lint reports issues | Currently advisory; promoted to required after baseline cleanup |
+
+## 4. The Tech-Writer sub-phase
+
+Before posting COLLABORATOR_HANDOFF on a `lane:code-change` ticket, include a `doc-coverage:` block:
+
+```yaml
+doc-coverage:
+  UPDATED: README.md — describes new flag
+  UPDATED: CHANGELOG fragment — see .changes/unreleased/N.md
+  N/A: design docs — internal-only validator; no public surface change
+```
+
+The advisory validator parses the block. Missing block on `lane:code-change` emits a warning but does not block merge in first ship. Promotion to blocking happens after Epic #2148 close.
+
+## 5. The doc-coverage matrix
+
+`config/doc-coverage-matrix.yml` maps `area:*` labels to required + suggested surfaces. Example:
+
+```yaml
+surfaces:
+  area:governance:
+    required:
+      - .changes/unreleased/
+      - docs/workflow/learnings.md
+    suggested:
+      - wiki/wisdom/global/concepts/
+```
+
+To extend: add a new area-label entry. Validator picks it up on next run.
+
+## 6. Skip markers
+
+| Marker | When legitimate |
+|---|---|
+| `[skip-changelog]` in PR body | Trivial PRs warranting no changelog entry (typo, formatting, dep lockfile bump) |
+
+Skip markers are auditable — they appear in the PR body and are logged in `doc_coverage_event` audit trail.
+
+## 7. Audit trail
+
+All doc-coverage decisions emit `doc_coverage_event` entries to `~/.megingjord/incidents.jsonl`:
+
+```json
+{"ts":"2026-...","version":3,"event":"doc_coverage_event","ticket":"#N","validator":"doc-coverage","verdict":"pass","surfaces_required":["..."]}
+```
+
+Schema: `scripts/global/event-schema-v3.js`. PII-redacted via `scripts/global/log-redaction.js`. Query via `jq '.event=="doc_coverage_event"' ~/.megingjord/incidents.jsonl`.
+
+## 8. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `changelog-fragment-presence: FAIL missing-fragment` | No `.changes/unreleased/<N>.md` | Create fragment OR add `[skip-changelog]` to PR body |
+| `doc-coverage-advisory` warning | COLLABORATOR_HANDOFF lacks `doc-coverage:` block | Add block per template in section 4 |
+| `wiki-lint-gate` advisory failed | Pre-existing baseline drift in wiki/ | Currently advisory only; admin tracks baseline cleanup separately |
+| `baton-gates: artifact-role-mismatch` | Stale or malformed baton artifact on issue | Delete stale comments; re-post canonical artifacts (see [[feedback-baton-governance-iterates-all-comments]]) |
+
+## See also
+
+- Round-5 design rationale: see [[Epic #2148 round-5 comment]] for agent-speed-lens scope decisions
+- Phase-0 research synthesis: see [[Epic #2148 Phase-0 #2149]]
+- Related instructions: `instructions/release-docs-hygiene.instructions.md`, `instructions/role-baton-routing.instructions.md`, `instructions/wiki-knowledge.instructions.md`
+
+Refs Epic #2148. Refs #2159.

--- a/instructions/release-docs-hygiene.instructions.md
+++ b/instructions/release-docs-hygiene.instructions.md
@@ -18,3 +18,7 @@ After every PR merge or deployment that changes user-facing behavior, run these 
 7. **Artifact attestation**: Tag-triggered releases MUST produce both cosign-bundle signature AND GitHub Artifact Attestation (Sigstore-backed; via `actions/attest-build-provenance`). C13 (#999) enables the parallel attestation signal alongside the existing cosign path.
 
 Do not consider a PR merge or deployment task complete until steps 1-7 are explicitly addressed (either completed or confirmed not applicable).
+
+## Merge-time documentation governance
+
+For the operator-facing runbook describing how Epic #2148 children (C0+C1+C2+C3+C5+C7) compose into the four-surface merge-time documentation governance system, see [docs/howto/merge-time-doc-governance.md](../docs/howto/merge-time-doc-governance.md).


### PR DESCRIPTION
## Summary

- Adds `docs/howto/merge-time-doc-governance.md` — 8-section fleet-model-readable operator runbook
- Describes how Epic #2148 children (C0/C1/C2/C3/C5/C7) compose into the four-surface documentation governance system
- Cross-referenced from `instructions/release-docs-hygiene.instructions.md`

Phase-1 child C8 of Epic #2148.

Refs #2159
Refs Epic #2148
Refs Phase-0 source #2149
Closes #2159

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2159#issuecomment-4545151850
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2159#issuecomment-4545161758
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2159#issuecomment-4545162034
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2159#issuecomment-4545162298 (rubric min 8/10 ≥ 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
