### PR TITLE
feat(governance): fleet-red-team prompt template library #2181

### DIFF
--- a/.changes/unreleased/2181.md
+++ b/.changes/unreleased/2181.md
@@ -1,0 +1,2 @@
+### Added
+- `config/fleet-red-team-prompts.json` — 7-template library for fleet adversarial red-team dispatch (per Phase-0 #2174 AC-R2). Templates: epic-scope, child-implementation, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, PR-diff, instruction-edit, CONSULTANT_CLOSEOUT. Each template carries `prompt_template` (≤500 chars), `iteration_target`, `findings_cap` (4 or 6), `focus_areas[]`, and `expected_token_range` (per Phase-0 dog-food finding). 8 golden-file tests verify schema + key set + per-template field presence. Phase-1 child P1-3 of Epic #2041. Refs #2181.

--- a/config/fleet-red-team-prompts.json
+++ b/config/fleet-red-team-prompts.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "_description": "Fleet adversarial red-team prompt library per Epic #2041 Phase-0 #2174 AC-R2. Templates referenced by scripts/global/fleet-red-team-dispatch.js (Phase-1 P1-1 #2175).",
+  "templates": {
+    "epic-scope": {
+      "prompt_template": "Adversarial red-team of Epic scope. Find scope-creep, cross-Epic conflicts, goal-lens misalignment. Classify each finding ACCEPT/REJECT/PARTIAL. Max 6 findings. Be skeptical.\n\n=== EPIC ===\n{{content}}",
+      "iteration_target": 2,
+      "findings_cap": 6,
+      "focus_areas": ["scope-creep", "goal-lens alignment", "cross-Epic conflict", "AC measurability"],
+      "expected_token_range": [800, 1500]
+    },
+    "child-implementation": {
+      "prompt_template": "Adversarial red-team of child-ticket implementation plan. Find AC gaps, edge-case omissions, matrix-fit mismatches. Classify ACCEPT/REJECT/PARTIAL. Max 6 findings.\n\n=== CHILD ===\n{{content}}",
+      "iteration_target": 2,
+      "findings_cap": 6,
+      "focus_areas": ["AC completeness", "edge-case coverage", "test-strategy fit", "dependencies"],
+      "expected_token_range": [800, 1500]
+    },
+    "collaborator-handoff": {
+      "prompt_template": "Adversarial review of COLLABORATOR_HANDOFF artifact. Verify per-AC PASS claims; spot missing evidence; flag any AC marked PASS without supporting test/lint/manual-check. Classify ACCEPT/REJECT/PARTIAL. Max 4 findings.\n\n=== HANDOFF ===\n{{content}}",
+      "iteration_target": 1,
+      "findings_cap": 4,
+      "focus_areas": ["per-AC evidence", "missing test artifacts", "lint claims", "doc-coverage block"],
+      "expected_token_range": [500, 1000]
+    },
+    "admin-handoff": {
+      "prompt_template": "Adversarial review of ADMIN_HANDOFF. Verify signer-independence, sync-verification, deploy-impact claims. Classify ACCEPT/REJECT/PARTIAL. Max 4 findings.\n\n=== HANDOFF ===\n{{content}}",
+      "iteration_target": 1,
+      "findings_cap": 4,
+      "focus_areas": ["signer-independence", "sync-verification accuracy", "deploy-impact claims", "branch-name conformance"],
+      "expected_token_range": [500, 1000]
+    },
+    "pr-diff": {
+      "prompt_template": "Adversarial code-review of PR diff. Find concurrency bugs, security risks, perf regressions, merge-safety hazards. Classify ACCEPT/REJECT/PARTIAL. Max 6 findings.\n\n=== DIFF ===\n{{content}}",
+      "iteration_target": 2,
+      "findings_cap": 6,
+      "focus_areas": ["concurrency", "security", "perf", "merge-safety", "test coverage"],
+      "expected_token_range": [1000, 2000]
+    },
+    "instruction-edit": {
+      "prompt_template": "Adversarial review of instruction-edit. Find breaking-change risk, prose-collision-with-validator-regex risk, forward-compat concerns. Classify ACCEPT/REJECT/PARTIAL. Max 4 findings.\n\n=== EDIT ===\n{{content}}",
+      "iteration_target": 1,
+      "findings_cap": 4,
+      "focus_areas": ["breaking-change risk", "prose-collision with validators", "forward-compat", "lint clean"],
+      "expected_token_range": [500, 1000]
+    },
+    "consultant-closeout": {
+      "prompt_template": "Adversarial review of CONSULTANT_CLOSEOUT. Verify rubric integrity (min ≥ 7 across G1-G9), goal-lens override audit, anneal-decision honesty. Classify ACCEPT/REJECT/PARTIAL. Max 4 findings.\n\n=== CLOSEOUT ===\n{{content}}",
+      "iteration_target": 1,
+      "findings_cap": 4,
+      "focus_areas": ["rubric integrity", "goal-lens override audit", "anneal-decision honesty", "mid-flight-flaws accounting"],
+      "expected_token_range": [500, 1000]
+    }
+  }
+}

--- a/tests/fixtures/fleet-red-team/expected-keys.json
+++ b/tests/fixtures/fleet-red-team/expected-keys.json
@@ -1,0 +1,1 @@
+["epic-scope", "child-implementation", "collaborator-handoff", "admin-handoff", "pr-diff", "instruction-edit", "consultant-closeout"]

--- a/tests/fleet-prompts-schema.spec.js
+++ b/tests/fleet-prompts-schema.spec.js
@@ -1,0 +1,67 @@
+// Refs #2181 - golden-file tests for fleet-red-team-prompts schema
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const PROMPTS_PATH = path.join(__dirname, '..', 'config', 'fleet-red-team-prompts.json');
+const EXPECTED_KEYS_PATH = path.join(__dirname, 'fixtures', 'fleet-red-team', 'expected-keys.json');
+
+const REQUIRED_FIELDS = ['prompt_template', 'iteration_target', 'findings_cap', 'focus_areas', 'expected_token_range'];
+
+test('fleet-red-team-prompts.json exists', () => {
+  assert.ok(fs.existsSync(PROMPTS_PATH));
+});
+
+test('parses as valid JSON', () => {
+  const obj = JSON.parse(fs.readFileSync(PROMPTS_PATH, 'utf8'));
+  assert.equal(obj.version, 1);
+  assert.ok(obj.templates);
+});
+
+test('contains all 7 expected template keys (golden fixture)', () => {
+  const obj = JSON.parse(fs.readFileSync(PROMPTS_PATH, 'utf8'));
+  const expected = JSON.parse(fs.readFileSync(EXPECTED_KEYS_PATH, 'utf8')).sort();
+  const actual = Object.keys(obj.templates).sort();
+  assert.deepEqual(actual, expected);
+});
+
+test('each template has all required fields', () => {
+  const obj = JSON.parse(fs.readFileSync(PROMPTS_PATH, 'utf8'));
+  for (const [key, tmpl] of Object.entries(obj.templates)) {
+    for (const field of REQUIRED_FIELDS) {
+      assert.ok(tmpl[field] !== undefined, `${key}.${field} missing`);
+    }
+  }
+});
+
+test('each prompt_template ≤500 chars', () => {
+  const obj = JSON.parse(fs.readFileSync(PROMPTS_PATH, 'utf8'));
+  for (const [key, tmpl] of Object.entries(obj.templates)) {
+    assert.ok(tmpl.prompt_template.length <= 500, `${key}: ${tmpl.prompt_template.length} chars >500`);
+  }
+});
+
+test('each prompt_template contains {{content}} placeholder', () => {
+  const obj = JSON.parse(fs.readFileSync(PROMPTS_PATH, 'utf8'));
+  for (const [key, tmpl] of Object.entries(obj.templates)) {
+    assert.match(tmpl.prompt_template, /\{\{content\}\}/);
+  }
+});
+
+test('expected_token_range is [min, max] integer pair', () => {
+  const obj = JSON.parse(fs.readFileSync(PROMPTS_PATH, 'utf8'));
+  for (const [key, tmpl] of Object.entries(obj.templates)) {
+    const range = tmpl.expected_token_range;
+    assert.ok(Array.isArray(range) && range.length === 2);
+    assert.ok(Number.isInteger(range[0]) && Number.isInteger(range[1]));
+    assert.ok(range[0] < range[1], `${key}: range min >= max`);
+  }
+});
+
+test('findings_cap is 4 or 6 (matches Zenflow guidance 6-8 max)', () => {
+  const obj = JSON.parse(fs.readFileSync(PROMPTS_PATH, 'utf8'));
+  for (const [key, tmpl] of Object.entries(obj.templates)) {
+    assert.ok([4, 6].includes(tmpl.findings_cap), `${key}: findings_cap=${tmpl.findings_cap}`);
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `config/fleet-red-team-prompts.json` — 7 templates (epic-scope, child-implementation, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, PR-diff, instruction-edit, CONSULTANT_CLOSEOUT)
- Each template ≤500 chars + carries iteration_target / findings_cap / focus_areas / expected_token_range
- 8 golden-file tests verify schema integrity

Phase-1 child P1-3 of Epic #2041.

Refs #2181
Refs Epic #2041
Refs Phase-0 source #2174
Closes #2181

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2181#issuecomment-4547826232
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2181#issuecomment-4547849370
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2181#issuecomment-4547849553
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2181#issuecomment-4547849723

🤖 Generated with [Claude Code](https://claude.com/claude-code)
