### PR TITLE
feat(governance): fleet-red-team HAMR-wrapped dispatch script #2175

### DIFF
--- a/.changes/unreleased/2175.md
+++ b/.changes/unreleased/2175.md
@@ -1,0 +1,2 @@
+### Added
+- `scripts/global/fleet-red-team-dispatch.js` — HAMR-wrapped Ollama dispatcher for adversarial review. Exports `dispatchRedTeam({artifactType, content, model, host})` returning `{findings, raw, hamrStats}`. Uses `tier='fleet-local'` (per #2178 P1-7) so cache-stats records ollama. ≤2 retries with exponential backoff (1s, 4s). Strips arxiv-hallucination URLs. Detects fleet refusals. Phase-1 child P1-1 of Epic #2041. Refs #2175. 11 unit tests pass.

--- a/scripts/global/fleet-red-team-dispatch.js
+++ b/scripts/global/fleet-red-team-dispatch.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// fleet-red-team-dispatch — HAMR-wrapped Ollama dispatcher for adversarial review.
+// Refs #2175 (Phase-1 P1-1 of Epic #2041). Consumes templates from #2181 P1-3.
+// Uses tier='fleet-local' (per #2178 P1-7) so cache-stats records ollama provider correctly.
+
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const { wrapProviderCall } = require('/home/curtisfranks/devenv-ops/scripts/global/hamr-provider-wrapper');
+
+const DEFAULT_HOST = 'http://100.91.113.16:11434';
+const DEFAULT_MODEL = 'qwen2.5-coder:32b';
+const TIER = 'fleet-local';
+const RETRY_DELAYS_MS = [1000, 4000];
+const REQUEST_TIMEOUT_MS = 600_000;
+const TEMPLATES_PATH = path.join(__dirname, '..', '..', 'config', 'fleet-red-team-prompts.json');
+const TOKEN_BUDGET_HEADROOM = 200;
+const MAX_NUM_PREDICT = 2000;
+const REFUSAL_PATTERNS = [/^i cannot help with/i, /^i'm sorry, but i cannot/i, /^i am unable to/i];
+const ARXIV_HALLUCINATION_RE = /arxiv\.org\/abs\/[0-9]{4}\.[0-9]{4,5}/gi;
+
+function loadTemplate(artifactType, templatesPath = TEMPLATES_PATH) {
+  const obj = JSON.parse(fs.readFileSync(templatesPath, 'utf8'));
+  const tmpl = obj.templates[artifactType];
+  if (!tmpl) throw new Error(`unknown artifact-type: ${artifactType}`);
+  return tmpl;
+}
+
+function buildPrompt(template, content) {
+  return template.prompt_template.replace('{{content}}', content);
+}
+
+function stripArxivHallucinations(text) {
+  return String(text).replace(ARXIV_HALLUCINATION_RE, '[arxiv-ref-stripped]');
+}
+
+function detectRefusal(text) {
+  const trimmed = String(text).trim();
+  return REFUSAL_PATTERNS.some((re) => re.test(trimmed));
+}
+
+async function callOllamaOnce({ host, model, prompt, num_predict }) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${host}/api/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model, prompt, stream: false, options: { temperature: 0.3, num_predict } }),
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return await response.json();
+  } finally { clearTimeout(timeout); }
+}
+
+async function callWithRetry({ host, model, prompt, num_predict }) {
+  const attempts = RETRY_DELAYS_MS.length + 1;
+  let lastErr;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try { return await callOllamaOnce({ host, model, prompt, num_predict }); }
+    catch (err) {
+      lastErr = err;
+      if (attempt < RETRY_DELAYS_MS.length) {
+        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAYS_MS[attempt]));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+function parseFindings(raw) {
+  const text = (raw && raw.response) || '';
+  if (!text || text.length < 50) return { findings: [], warning: 'empty-or-short-response' };
+  if (detectRefusal(text)) return { findings: [], warning: 'fleet-refused' };
+  const cleaned = stripArxivHallucinations(text);
+  const lines = cleaned.split('\n').filter((l) => /^\s*(?:[-*]\s*)?\*?\*?(ACCEPT|REJECT|PARTIAL)/i.test(l));
+  return { findings: lines.map((line) => ({ raw: line.trim() })), warning: null };
+}
+
+async function dispatchRedTeam({ artifactType, content, model = DEFAULT_MODEL, host = DEFAULT_HOST, templatesPath = TEMPLATES_PATH } = {}) {
+  const template = loadTemplate(artifactType, templatesPath);
+  const prompt = buildPrompt(template, content);
+  const numPredict = Math.min(template.expected_token_range[1] + TOKEN_BUDGET_HEADROOM, MAX_NUM_PREDICT);
+  const start = Date.now();
+  const envelope = await wrapProviderCall('ollama', () => callWithRetry({ host, model, prompt, num_predict: numPredict }), { tier: TIER });
+  const elapsed = Date.now() - start;
+  if (!envelope.ok) {
+    return { findings: [], raw: null, hamrStats: { ok: false, elapsed, error: envelope.error } };
+  }
+  const { findings, warning } = parseFindings(envelope.value);
+  return { findings, raw: envelope.value, hamrStats: { ok: true, elapsed, sticky: envelope.sticky, warning } };
+}
+
+module.exports = { dispatchRedTeam, loadTemplate, buildPrompt, callWithRetry, parseFindings, stripArxivHallucinations, detectRefusal, TIER, RETRY_DELAYS_MS };

--- a/tests/fleet-red-team-dispatch.spec.js
+++ b/tests/fleet-red-team-dispatch.spec.js
@@ -1,0 +1,71 @@
+// Refs #2175 - tests for fleet-red-team-dispatch
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { loadTemplate, buildPrompt, parseFindings, stripArxivHallucinations, detectRefusal, RETRY_DELAYS_MS, TIER } = require('../scripts/global/fleet-red-team-dispatch.js');
+
+const TEMPLATES_PATH = path.join(__dirname, '..', 'config', 'fleet-red-team-prompts.json');
+
+test('loadTemplate: returns valid template object for known type', () => {
+  const tmpl = loadTemplate('epic-scope', TEMPLATES_PATH);
+  assert.ok(tmpl.prompt_template);
+  assert.equal(typeof tmpl.iteration_target, 'number');
+  assert.ok(Array.isArray(tmpl.focus_areas));
+});
+
+test('loadTemplate: throws on unknown artifact type', () => {
+  assert.throws(() => loadTemplate('does-not-exist', TEMPLATES_PATH), /unknown artifact-type/);
+});
+
+test('buildPrompt: substitutes {{content}} placeholder', () => {
+  const tmpl = { prompt_template: 'before {{content}} after' };
+  assert.equal(buildPrompt(tmpl, 'X'), 'before X after');
+});
+
+test('stripArxivHallucinations: removes fake arxiv refs', () => {
+  const text = 'see arxiv.org/abs/2402.02172 and arxiv.org/abs/2603.11078 for details';
+  const out = stripArxivHallucinations(text);
+  assert.equal(out.includes('2402.02172'), false);
+  assert.match(out, /arxiv-ref-stripped/);
+});
+
+test('detectRefusal: matches "I cannot help with..."', () => {
+  assert.ok(detectRefusal("I cannot help with that."));
+  assert.ok(detectRefusal("I'm sorry, but I cannot do that."));
+  assert.equal(detectRefusal("Here are findings: ACCEPT something"), false);
+});
+
+test('parseFindings: extracts ACCEPT/REJECT/PARTIAL lines', () => {
+  const raw = { response: 'Here are findings:\nACCEPT: real defect\nREJECT: not a real issue\nPARTIAL: maybe\nignored line' };
+  const { findings, warning } = parseFindings(raw);
+  assert.equal(findings.length, 3);
+  assert.equal(warning, null);
+});
+
+test('parseFindings: empty response returns warning', () => {
+  const { findings, warning } = parseFindings({ response: '' });
+  assert.equal(findings.length, 0);
+  assert.equal(warning, 'empty-or-short-response');
+});
+
+test('parseFindings: detects refusal', () => {
+  const { findings, warning } = parseFindings({ response: 'I cannot help with that request because it could be misused.' });
+  assert.equal(findings.length, 0);
+  assert.equal(warning, 'fleet-refused');
+});
+
+test('parseFindings: handles markdown-bold ACCEPT formatting', () => {
+  const raw = { response: '**ACCEPT**: finding A\n**REJECT**: finding B\n**PARTIAL**: finding C' };
+  const { findings } = parseFindings(raw);
+  assert.equal(findings.length, 3);
+});
+
+test('TIER constant is "fleet-local" (per P1-7 #2178)', () => {
+  assert.equal(TIER, 'fleet-local');
+});
+
+test('RETRY_DELAYS_MS is [1000, 4000] per Phase-0 finding', () => {
+  assert.deepEqual(RETRY_DELAYS_MS, [1000, 4000]);
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/global/fleet-red-team-dispatch.js` (93 LoC) — HAMR-wrapped Ollama dispatcher
- Uses `tier='fleet-local'` (per P1-7 #2178 merged) so cache-stats records ollama correctly
- ≤2 retries with exponential backoff (1s, 4s) per Phase-0 fleet finding
- Strips arxiv-hallucination URLs; detects fleet refusals
- 11 unit tests pass

Phase-1 child P1-1 of Epic #2041. Depends on P1-7 (merged) + P1-3 (PR #2184) for config templates.

Refs #2175
Refs Epic #2041
Refs Phase-0 source #2174
Closes #2175

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2175#issuecomment-4547943689
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2175#issuecomment-4547972762
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2175#issuecomment-4547972938
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2175#issuecomment-4547973202 (rubric min 9/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
