### PR TITLE
test(stress): fleet-red-team-dispatch G6 + G7 #2177

### DIFF
--- a/.changes/unreleased/2177.md
+++ b/.changes/unreleased/2177.md
@@ -1,0 +1,2 @@
+### Added
+- `tests/stress-fleet-red-team-dispatch.spec.js` (8 stress tests) — covers G6 chaos paths (100 concurrent parseFindings, 1000-line adversarial input, empty/null/undefined responses, refusal-under-load) + G7 p99 latency budgets (parseFindings <10ms p99, loadTemplate <5ms p99) + arxiv-strip on 100K-char input. Phase-1 child P1-6 of Epic #2041. Refs #2177.

--- a/tests/stress-fleet-red-team-dispatch.spec.js
+++ b/tests/stress-fleet-red-team-dispatch.spec.js
@@ -1,0 +1,93 @@
+// Refs #2177 — stress test suite for fleet-red-team-dispatch (#2175)
+// G6 chaos + G7 p99 latency per Phase-0 AC-R7 failure-mode taxonomy.
+// Tests pure components (parseFindings, classifyFinding) under contention + load;
+// avoids mocking the HAMR wrapper to keep tests deterministic.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const { parseFindings, stripArxivHallucinations, detectRefusal, loadTemplate, RETRY_DELAYS_MS } = require('../scripts/global/fleet-red-team-dispatch.js');
+
+const TEMPLATES_PATH = path.join(__dirname, '..', 'config', 'fleet-red-team-prompts.json');
+
+function p99(samples) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length * 0.99)] || sorted[sorted.length - 1];
+}
+
+test('G6 chaos: 100 concurrent parseFindings calls do not interfere', async () => {
+  const responses = Array.from({ length: 100 }, (_, i) => ({ response: `ACCEPT: finding ${i}\nREJECT: finding ${i}b\nPARTIAL: finding ${i}c` }));
+  const promises = responses.map((raw) => Promise.resolve(parseFindings(raw)));
+  const results = await Promise.all(promises);
+  for (const r of results) {
+    assert.equal(r.findings.length, 3);
+    assert.equal(r.warning, null);
+  }
+});
+
+test('G6 chaos: adversarial response with 1000 newlines + interleaved arxiv URLs handled', () => {
+  const lines = [];
+  for (let i = 0; i < 1000; i++) {
+    lines.push(i % 3 === 0 ? `ACCEPT: arxiv.org/abs/2402.0${i % 9}172 finding` : `noise line ${i}`);
+  }
+  const start = Date.now();
+  const r = parseFindings({ response: lines.join('\n') });
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 1000, `adversarial parse took ${elapsed}ms`);
+  assert.ok(r.findings.length > 100);
+  for (const finding of r.findings) {
+    assert.equal(finding.raw.match(/arxiv\.org\/abs\/\d{4}\.\d{4,5}/), null, 'arxiv URL leaked');
+  }
+});
+
+test('G6 chaos: empty + null + undefined responses handled without throw', () => {
+  for (const value of [{ response: '' }, { response: null }, { response: undefined }, {}]) {
+    assert.doesNotThrow(() => parseFindings(value));
+  }
+});
+
+test('G6 chaos: refusal pattern under load — 50 calls all detected', () => {
+  const refusalText = 'I cannot help with that request because it could be misused.';
+  for (let i = 0; i < 50; i++) {
+    const r = parseFindings({ response: refusalText });
+    assert.equal(r.findings.length, 0);
+    assert.equal(r.warning, 'fleet-refused');
+  }
+});
+
+test('G7 p99 latency: parseFindings <10ms p99 across 200 samples', () => {
+  const samples = [];
+  const response = { response: 'ACCEPT: a\nREJECT: b\nPARTIAL: c'.repeat(20) };
+  for (let i = 0; i < 200; i++) {
+    const start = process.hrtime.bigint();
+    parseFindings(response);
+    samples.push(Number(process.hrtime.bigint() - start) / 1e6);
+  }
+  const p99Val = p99(samples);
+  assert.ok(p99Val < 10, `parseFindings p99 = ${p99Val.toFixed(3)}ms > 10ms`);
+});
+
+test('G7 p99 latency: loadTemplate <5ms p99 across 100 samples', () => {
+  const samples = [];
+  for (let i = 0; i < 100; i++) {
+    const start = process.hrtime.bigint();
+    loadTemplate('pr-diff', TEMPLATES_PATH);
+    samples.push(Number(process.hrtime.bigint() - start) / 1e6);
+  }
+  const p99Val = p99(samples);
+  assert.ok(p99Val < 5, `loadTemplate p99 = ${p99Val.toFixed(3)}ms > 5ms`);
+});
+
+test('RETRY_DELAYS_MS contract: [1000, 4000] exponential backoff', () => {
+  assert.deepEqual(RETRY_DELAYS_MS, [1000, 4000]);
+  assert.equal(RETRY_DELAYS_MS[1] / RETRY_DELAYS_MS[0], 4);
+});
+
+test('G6 chaos: stripArxivHallucinations handles 100K-char input', () => {
+  const big = 'arxiv.org/abs/2402.02172 '.repeat(5000);
+  const start = Date.now();
+  const out = stripArxivHallucinations(big);
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 500, `strip took ${elapsed}ms`);
+  assert.equal(out.includes('2402.02172'), false);
+});


### PR DESCRIPTION
## Summary

- Adds `tests/stress-fleet-red-team-dispatch.spec.js` per Epic AC-E5 + Phase-0 AC-R7
- 8 stress tests: 4 G6 chaos paths + 2 G7 p99 budgets + arxiv-strip + retry contract

Phase-1 child P1-6 of Epic #2041. Stress coverage for #2175 dispatch script.

Refs #2177
Refs Epic #2041
Refs Phase-0 source #2174
Closes #2177

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2177#issuecomment-4548042821
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2177#issuecomment-4548067977
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2177#issuecomment-4548068197
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2177#issuecomment-4548068384 (rubric min 9/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
