### PR TITLE
feat(claude-code): /fleet-review skill wrapper #2176

### DIFF
--- a/.changes/unreleased/2176.md
+++ b/.changes/unreleased/2176.md
@@ -1,0 +1,2 @@
+### Added
+- `.claude/commands/fleet-review.md` — Claude Code skill wrapper invoking `dispatchRedTeam` (#2175) + `formatRedTeamComment` (#2179) with HAMR-routed Ollama fleet (`tier='fleet-local'` per #2178). Cross-team Codex + Copilot wrappers DEFERRED to those teams per `instructions/cross-team-artifact-write.instructions.md` — TEAM_QUESTION posted on issue. Phase-1 child P1-5 of Epic #2041. Refs #2176.

--- a/.claude/commands/fleet-review.md
+++ b/.claude/commands/fleet-review.md
@@ -1,0 +1,35 @@
+# /fleet-review — dispatch HAMR-routed fleet adversarial red-team
+
+Run a cross-family fleet-model red-team review of a harness artifact (epic-scope, child-implementation, the-collaborator-handoff, the-admin-handoff, PR-diff, instruction-edit, the-consultant-closeout).
+
+## Usage
+
+```bash
+node -e "
+  const { dispatchRedTeam } = require('./scripts/global/fleet-red-team-dispatch');
+  const { formatRedTeamComment } = require('./scripts/global/baton-fleet-review-comment');
+  (async () => {
+    const result = await dispatchRedTeam({
+      artifactType: 'pr-diff',
+      content: process.argv[1],
+    });
+    process.stdout.write(formatRedTeamComment({
+      findings: result.findings,
+      artifactType: 'pr-diff',
+      warning: result.hamrStats.warning,
+    }));
+  })();
+" "$ARGS"
+```
+
+## Notes
+
+- HAMR-routed via `wrapProviderCall('ollama', {tier: 'fleet-local'})` per Epic #2041 P1-7 #2178
+- Templates from `config/fleet-red-team-prompts.json` (P1-3 #2181)
+- Findings classified ACCEPT/REJECT/PARTIAL per Phase-0 #2174 AC-R4
+- Operator runbook: `docs/howto/fleet-red-team-workflow.md` (P1-4 #2180)
+
+## Pre-flight
+
+- Fleet host reachable: `curl -s http://100.91.113.16:11434/api/tags`
+- HAMR active: `cat ~/.copilot/hamr-config.json | jq .enabled`


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/fleet-review.md` — Claude Code skill wrapper invoking `dispatchRedTeam` + `formatRedTeamComment`
- Cross-team Codex + Copilot wrappers EXPLICITLY DEFERRED per `instructions/cross-team-artifact-write.instructions.md`; TEAM_QUESTION posted on issue
- Self-team write only; no cross-runtime writes in this PR

Phase-1 child P1-5 of Epic #2041 — final Phase-1 child.

Refs #2176
Refs Epic #2041
Refs Phase-0 source #2174
Closes #2176

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2176#issuecomment-4548098244
- TEAM_QUESTION — https://github.com/chf3198/megingjord-harness/issues/2176#issuecomment-4548103719
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2176#issuecomment-4548111731
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2176#issuecomment-4548111977
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2176#issuecomment-4548112200 (rubric min 9/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
