### PR TITLE
feat(governance): fleet red-team comment formatter #2179

### DIFF
--- a/.changes/unreleased/2179.md
+++ b/.changes/unreleased/2179.md
@@ -1,0 +1,2 @@
+### Added
+- `scripts/global/baton-fleet-review-comment.js` (65 LoC) — canonical guest-collaborator comment formatter for fleet red-team output. Exports `formatRedTeamComment({findings, artifactType, dispatchModel, host, iterationN, ticket, warning})`. Renders findings as markdown table; uses hyphenated artifact-name prose to avoid validator collision. Phase-1 child P1-2 of Epic #2041. 10 unit tests pass. Refs #2179.

--- a/scripts/global/baton-fleet-review-comment.js
+++ b/scripts/global/baton-fleet-review-comment.js
@@ -1,0 +1,65 @@
+'use strict';
+// baton-fleet-review-comment — canonical guest-collaborator comment formatter
+// Refs #2179 (Phase-1 P1-2 of Epic #2041). Consumes dispatchRedTeam output (#2175 P1-1).
+// Per Phase-0 dog-food finding: per-iteration table = aggregation primitive.
+
+const ARTIFACT_HEADER_BY_TYPE = {
+  'epic-scope': 'epic-scope review',
+  'child-implementation': 'child-implementation review',
+  'collaborator-handoff': 'the-collaborator-handoff review',
+  'admin-handoff': 'the-admin-handoff review',
+  'pr-diff': 'PR-diff review',
+  'instruction-edit': 'instruction-edit review',
+  'consultant-closeout': 'the-consultant-closeout review',
+};
+
+const VERDICT_RE = /^(?:[-*]\s*)?\*?\*?(ACCEPT|REJECT|PARTIAL)\*?\*?[:\s-]+(.+)$/i;
+
+function classifyFinding(raw) {
+  const match = String(raw || '').trim().match(VERDICT_RE);
+  if (!match) return { verdict: 'UNCLASSIFIED', text: String(raw || '').trim() };
+  return { verdict: match[1].toUpperCase(), text: match[2].trim() };
+}
+
+function renderFindingsTable(findings) {
+  if (!findings || !findings.length) return '_No findings._';
+  const rows = findings.map((finding, idx) => {
+    const { verdict, text } = classifyFinding(finding.raw || finding);
+    const escaped = String(text).replace(/\|/g, '\\|');
+    return `| ${idx + 1} | ${verdict} | ${escaped} |`;
+  });
+  return ['| # | Verdict | Finding |', '|---|---|---|', ...rows].join('\n');
+}
+
+function formatRedTeamComment({
+  findings = [],
+  artifactType = 'pr-diff',
+  dispatchModel = 'qwen2.5-coder:32b',
+  host = '100.91.113.16:11434',
+  iterationN = 1,
+  ticket = null,
+  warning = null,
+} = {}) {
+  const header = ARTIFACT_HEADER_BY_TYPE[artifactType] || 'review';
+  const teamModel = `ollama:${dispatchModel}@fleet/${host}`;
+  const lines = [
+    `## Fleet Red-Team Review (iteration ${iterationN}) — ${header}`,
+    ticket ? `ticket: ${ticket}` : null,
+    '',
+    warning ? `> **Note**: ${warning}` : null,
+    warning ? '' : null,
+    '### Findings',
+    '',
+    renderFindingsTable(findings),
+    '',
+    'This review was produced by a HAMR-routed fleet model (per Epic #2041 systematization).',
+    '',
+    `Signed-by: ollama-${dispatchModel.split(':')[0]}-redteam`,
+    `Team&Model: ${teamModel}`,
+    'Role: red-team-reviewer',
+    `verification-timestamp: ${new Date().toISOString()}`,
+  ].filter((line) => line !== null);
+  return lines.join('\n');
+}
+
+module.exports = { formatRedTeamComment, classifyFinding, renderFindingsTable, ARTIFACT_HEADER_BY_TYPE };

--- a/tests/baton-fleet-review-comment.spec.js
+++ b/tests/baton-fleet-review-comment.spec.js
@@ -1,0 +1,62 @@
+// Refs #2179 - tests for fleet-review comment formatter
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { formatRedTeamComment, classifyFinding, renderFindingsTable } = require('../scripts/global/baton-fleet-review-comment.js');
+
+test('classifyFinding: ACCEPT verdict extracted', () => {
+  const r = classifyFinding('ACCEPT: real defect');
+  assert.equal(r.verdict, 'ACCEPT');
+  assert.equal(r.text, 'real defect');
+});
+
+test('classifyFinding: handles markdown-bold formatting', () => {
+  const r = classifyFinding('**REJECT**: hallucination');
+  assert.equal(r.verdict, 'REJECT');
+  assert.equal(r.text, 'hallucination');
+});
+
+test('classifyFinding: returns UNCLASSIFIED for non-matching text', () => {
+  const r = classifyFinding('random unstructured prose');
+  assert.equal(r.verdict, 'UNCLASSIFIED');
+});
+
+test('renderFindingsTable: empty findings returns placeholder', () => {
+  assert.match(renderFindingsTable([]), /No findings/);
+});
+
+test('renderFindingsTable: produces markdown table with header', () => {
+  const out = renderFindingsTable([{ raw: 'ACCEPT: x' }, { raw: 'REJECT: y' }]);
+  assert.match(out, /\| # \| Verdict \| Finding \|/);
+  assert.match(out, /ACCEPT/);
+  assert.match(out, /REJECT/);
+});
+
+test('renderFindingsTable: escapes pipe chars in finding text', () => {
+  const out = renderFindingsTable([{ raw: 'ACCEPT: contains | pipe' }]);
+  assert.match(out, /contains \\\| pipe/);
+});
+
+test('formatRedTeamComment: includes canonical Role: red-team-reviewer signature', () => {
+  const out = formatRedTeamComment({ findings: [{ raw: 'ACCEPT: x' }], artifactType: 'pr-diff' });
+  assert.match(out, /Signed-by: ollama-/);
+  assert.match(out, /Team&Model: ollama:/);
+  assert.match(out, /Role: red-team-reviewer/);
+  assert.match(out, /verification-timestamp:/);
+});
+
+test('formatRedTeamComment: hyphenated artifact-name prose (no validator collision)', () => {
+  const out = formatRedTeamComment({ findings: [], artifactType: 'collaborator-handoff' });
+  assert.match(out, /the-collaborator-handoff/);
+  // Critical: must NOT contain literal uppercase artifact name in prose
+  assert.equal(out.includes('COLLABORATOR_HANDOFF'), false);
+});
+
+test('formatRedTeamComment: iteration number in header', () => {
+  const out = formatRedTeamComment({ findings: [], iterationN: 3 });
+  assert.match(out, /iteration 3/);
+});
+
+test('formatRedTeamComment: warning rendered as blockquote', () => {
+  const out = formatRedTeamComment({ findings: [], warning: 'fleet-refused' });
+  assert.match(out, /> \*\*Note\*\*: fleet-refused/);
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/global/baton-fleet-review-comment.js` (65 LoC) — canonical guest-collaborator comment formatter
- Renders fleet red-team findings as markdown table with Signed-by + Team&Model + Role: red-team-reviewer
- Uses hyphenated artifact-name prose internally (avoids validator prose-collision per memory)
- 10 unit tests pass

Phase-1 child P1-2 of Epic #2041. Consumes #2175 P1-1 output.

Refs #2179
Refs Epic #2041
Refs Phase-0 source #2174
Closes #2179

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2179#issuecomment-4548020953
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2179#issuecomment-4548036759
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2179#issuecomment-4548036901
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2179#issuecomment-4548037023 (rubric min 8/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
