### PR TITLE
feat(hamr): adaptive timeout policy engine #2201

### DIFF
--- a/.changes/unreleased/2201.md
+++ b/.changes/unreleased/2201.md
@@ -1,0 +1,2 @@
+### Added
+- `scripts/global/timeout-policy.js` (38 lines) + `config/timeout-policy.json` — adaptive timeout policy. Default table addresses Phase-0 #2174 observation: qwen2.5-coder:32b hit 907s p99 against 600s bound. 14 unit tests. Phase-1 child P1-1 of Epic #2150. Refs #2201.

--- a/config/timeout-policy.json
+++ b/config/timeout-policy.json
@@ -1,0 +1,33 @@
+{
+  "_description": "Adaptive timeout policy per Epic #2150 #2201. Defaults derived from Phase-0 #2174 dog-food observations.",
+  "version": 1,
+  "default_ms": 600000,
+  "classes": {
+    "fleet-red-team-rate": {
+      "ms": 1200000,
+      "rationale": "qwen2.5-coder:32b on Tailscale fleet hit 907s p99 per Phase-0 #2174; 1200s adds 30% headroom"
+    },
+    "fleet-dispatch-basic": {
+      "ms": 300000,
+      "rationale": "qwen2.5-coder:7b or smaller fleet models; faster turnaround"
+    },
+    "hamr-cache-stat": {
+      "ms": 30000,
+      "rationale": "local file append; should never exceed 30s"
+    },
+    "hamr-substrate-health": {
+      "ms": 60000,
+      "rationale": "remote KV poll; bounded retry"
+    },
+    "ollama-chromebook-local": {
+      "ms": 180000,
+      "rationale": "local gemma3:1b fallback; CPU-bound"
+    }
+  },
+  "lane_overrides": {
+    "lane:trivial": { "multiplier": 0.5, "rationale": "trivial work shouldn't exceed half the class budget" },
+    "lane:code-change": { "multiplier": 1.0 },
+    "lane:docs-research": { "multiplier": 1.0 },
+    "lane:config-only": { "multiplier": 0.75 }
+  }
+}

--- a/scripts/global/timeout-policy.js
+++ b/scripts/global/timeout-policy.js
@@ -1,0 +1,38 @@
+'use strict';
+// timeout-policy — adaptive timeout per lane/model/workload class.
+// Refs Epic #2150 #2201. Addresses Phase-0 #2174 observation: 600s hardcoded
+// bound was insufficient for qwen2.5-coder:32b (907s p99 actual).
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_POLICY_PATH = path.join(__dirname, '..', '..', 'config', 'timeout-policy.json');
+
+function loadPolicy(policyPath = DEFAULT_POLICY_PATH) {
+  return JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+}
+
+function classFromModel(model) {
+  if (!model) return null;
+  if (model.includes('qwen2.5-coder:32b') || model.includes('qwen2.5-coder:14b')) return 'fleet-red-team-rate';
+  if (model.includes('qwen2.5-coder')) return 'fleet-dispatch-basic';
+  if (model.includes('gemma3:1b')) return 'ollama-chromebook-local';
+  return null;
+}
+
+function getTimeout({ lane, model, workloadClass, policy } = {}) {
+  const policyObj = policy || loadPolicy();
+  const cls = workloadClass || classFromModel(model);
+  const classEntry = cls && policyObj.classes && policyObj.classes[cls];
+  const baseMs = (classEntry && classEntry.ms) || policyObj.default_ms;
+  const laneOverride = lane && policyObj.lane_overrides && policyObj.lane_overrides[lane];
+  const multiplier = (laneOverride && laneOverride.multiplier) || 1.0;
+  return Math.floor(baseMs * multiplier);
+}
+
+function listClasses(policy) {
+  const policyObj = policy || loadPolicy();
+  return Object.keys(policyObj.classes || {});
+}
+
+module.exports = { getTimeout, loadPolicy, classFromModel, listClasses, DEFAULT_POLICY_PATH };

--- a/tests/timeout-policy.spec.js
+++ b/tests/timeout-policy.spec.js
@@ -1,0 +1,75 @@
+// Refs #2201 - tests for adaptive timeout policy
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const { getTimeout, loadPolicy, classFromModel, listClasses } = require('../scripts/global/timeout-policy.js');
+
+const POLICY = loadPolicy();
+
+test('loadPolicy: returns object with default_ms and classes', () => {
+  assert.equal(typeof POLICY.default_ms, 'number');
+  assert.ok(POLICY.classes && Object.keys(POLICY.classes).length > 0);
+});
+
+test('classFromModel: qwen2.5-coder:32b -> fleet-red-team-rate', () => {
+  assert.equal(classFromModel('qwen2.5-coder:32b'), 'fleet-red-team-rate');
+});
+
+test('classFromModel: qwen2.5-coder:7b -> fleet-dispatch-basic', () => {
+  assert.equal(classFromModel('qwen2.5-coder:7b'), 'fleet-dispatch-basic');
+});
+
+test('classFromModel: gemma3:1b -> ollama-chromebook-local', () => {
+  assert.equal(classFromModel('gemma3:1b'), 'ollama-chromebook-local');
+});
+
+test('classFromModel: unknown model -> null', () => {
+  assert.equal(classFromModel('unknown-model'), null);
+});
+
+test('classFromModel: undefined -> null', () => {
+  assert.equal(classFromModel(undefined), null);
+});
+
+test('getTimeout: qwen2.5-coder:32b returns fleet-red-team-rate budget (1200s)', () => {
+  const ms = getTimeout({ model: 'qwen2.5-coder:32b' });
+  assert.equal(ms, 1200000);
+});
+
+test('getTimeout: hamr-cache-stat workload returns 30s', () => {
+  const ms = getTimeout({ workloadClass: 'hamr-cache-stat' });
+  assert.equal(ms, 30000);
+});
+
+test('getTimeout: unknown class falls back to default_ms', () => {
+  const ms = getTimeout({ workloadClass: 'does-not-exist' });
+  assert.equal(ms, POLICY.default_ms);
+});
+
+test('getTimeout: lane:trivial multiplier halves budget', () => {
+  const ms = getTimeout({ model: 'qwen2.5-coder:32b', lane: 'lane:trivial' });
+  assert.equal(ms, 600000);
+});
+
+test('getTimeout: lane:code-change preserves budget (multiplier 1.0)', () => {
+  const ms = getTimeout({ model: 'qwen2.5-coder:32b', lane: 'lane:code-change' });
+  assert.equal(ms, 1200000);
+});
+
+test('getTimeout: lane:config-only applies 0.75 multiplier', () => {
+  const ms = getTimeout({ workloadClass: 'fleet-dispatch-basic', lane: 'lane:config-only' });
+  assert.equal(ms, 225000);
+});
+
+test('listClasses: returns ≥5 class names', () => {
+  const names = listClasses();
+  assert.ok(names.length >= 5);
+  assert.ok(names.includes('fleet-red-team-rate'));
+  assert.ok(names.includes('hamr-cache-stat'));
+});
+
+test('REGRESSION: 600s hardcoded ceiling replaced by 1200s for qwen2.5-coder:32b', () => {
+  // Phase-0 #2174 dog-food observed 907s p99 against 600s bound — this should now bound at 1200s.
+  const ms = getTimeout({ model: 'qwen2.5-coder:32b' });
+  assert.ok(ms >= 900000, `qwen2.5-coder:32b timeout=${ms}ms — must accommodate observed 907s p99`);
+});


### PR DESCRIPTION
## Summary

Phase-1 child P1-1 of Epic #2150. `scripts/global/timeout-policy.js` (38 LoC) + `config/timeout-policy.json` — adaptive timeout policy per lane / model / workload class. Default table addresses Phase-0 #2174 observation: qwen2.5-coder:32b dispatch hit 907s p99 against current 600s hardcoded bound (validated again in #2200 fleet review: 907,692ms).

- `getTimeout({lane, model, workloadClass})` returns ms-budget
- 5 classes (fleet-red-team-rate=1200s; fleet-dispatch-basic=300s; hamr-cache-stat=30s; hamr-substrate-health=60s; ollama-chromebook-local=180s) + 4 lane overrides
- 14 unit tests including explicit REGRESSION assertion against the 907s observation
- `wrapProviderCall` integration via `opts.timeoutMs` propagation DEFERRED to follow-on (HAMR wrapper change)

Refs #2201
Refs Epic #2150
Refs Phase-0 source #2200
Closes #2201

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2201#issuecomment-4549700830
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2201#issuecomment-4549723685
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2201#issuecomment-4549723765
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2201#issuecomment-4549723848 (rubric min 9/10, mean 9.7/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
