### PR TITLE
feat(hamr): prompt budget + RAG chunking enforcement #2204

### DIFF
--- a/.changes/unreleased/2204.md
+++ b/.changes/unreleased/2204.md
@@ -1,0 +1,2 @@
+### Added
+- `scripts/global/prompt-budget.js` (60 LoC) + `config/prompt-budget-policy.json` — prompt-payload budget enforcement per Epic #2150 AC3. `enforcePromptBudget({prompt, model, templateBudget})` returns `{ok, action: pass-through|chunked|rag-fallback, chunks?}`. Per-model context/cap/reserve table covers qwen2.5-coder:*, gemma3:1b, claude-opus-4-7, claude-sonnet-4-6. 10 unit tests. Phase-1 child P1-3 of Epic #2150. Refs #2204.

--- a/config/prompt-budget-policy.json
+++ b/config/prompt-budget-policy.json
@@ -1,0 +1,18 @@
+{
+  "_description": "Prompt budget policy per Epic #2150 #2204. Per-model context + prompt-cap + reserve thresholds.",
+  "version": 1,
+  "default": { "context_tokens": 8192, "prompt_cap_tokens": 6144, "reserve_tokens": 1024 },
+  "models": {
+    "qwen2.5-coder:32b": { "context_tokens": 32768, "prompt_cap_tokens": 24576, "reserve_tokens": 4096 },
+    "qwen2.5-coder:14b": { "context_tokens": 32768, "prompt_cap_tokens": 24576, "reserve_tokens": 4096 },
+    "qwen2.5-coder:7b": { "context_tokens": 32768, "prompt_cap_tokens": 24576, "reserve_tokens": 4096 },
+    "gemma3:1b": { "context_tokens": 8192, "prompt_cap_tokens": 6144, "reserve_tokens": 1024 },
+    "claude-opus-4-7": { "context_tokens": 200000, "prompt_cap_tokens": 180000, "reserve_tokens": 16384 },
+    "claude-sonnet-4-6": { "context_tokens": 200000, "prompt_cap_tokens": 180000, "reserve_tokens": 16384 }
+  },
+  "rag_fallback": {
+    "trigger_chars": 80000,
+    "max_chunks": 16,
+    "chunk_overlap_chars": 400
+  }
+}

--- a/scripts/global/prompt-budget.js
+++ b/scripts/global/prompt-budget.js
@@ -1,0 +1,60 @@
+'use strict';
+// prompt-budget — enforce per-model prompt-payload budgets with RAG/chunking fallback.
+// Refs Epic #2150 #2204. Composes with Epic #2041 #2181 expected_token_range schema.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_POLICY_PATH = path.join(__dirname, '..', '..', 'config', 'prompt-budget-policy.json');
+const CHAR_PER_TOKEN_APPROX = 4;
+const DEFAULT_RAG_TRIGGER_CHARS = 80000;
+const DEFAULT_CHUNK_OVERLAP_CHARS = 400;
+
+function loadPolicy(policyPath = DEFAULT_POLICY_PATH) {
+  return JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+}
+
+function modelBudget(model, policy) {
+  if (model && policy.models && policy.models[model]) return policy.models[model];
+  return policy.default;
+}
+
+function estimateTokens(text) {
+  return Math.ceil(String(text || '').length / CHAR_PER_TOKEN_APPROX);
+}
+
+function chunkPrompt(prompt, maxChunkChars, overlapChars) {
+  const chunks = [];
+  let cursor = 0;
+  const text = String(prompt || '');
+  while (cursor < text.length) {
+    const end = Math.min(cursor + maxChunkChars, text.length);
+    chunks.push(text.slice(cursor, end));
+    if (end >= text.length) break;
+    cursor = end - overlapChars;
+    if (cursor < 0) cursor = 0;
+  }
+  return chunks;
+}
+
+function enforcePromptBudget({ prompt, model, templateBudget, policy } = {}) {
+  const policyObj = policy || loadPolicy();
+  const budget = modelBudget(model, policyObj);
+  const tokens = estimateTokens(prompt);
+  const effectiveCap = Math.min(budget.prompt_cap_tokens, templateBudget || Infinity);
+  if (tokens <= effectiveCap) {
+    return { ok: true, tokens, cap: effectiveCap, action: 'pass-through' };
+  }
+  const rag = policyObj.rag_fallback || {};
+  if (String(prompt || '').length >= (rag.trigger_chars || DEFAULT_RAG_TRIGGER_CHARS)) {
+    return { ok: false, tokens, cap: effectiveCap, action: 'rag-fallback', reason: `prompt exceeds rag_fallback.trigger_chars (${rag.trigger_chars}); recommend retrieval-augmented chunking` };
+  }
+  const charsPerChunk = effectiveCap * CHAR_PER_TOKEN_APPROX;
+  const chunks = chunkPrompt(prompt, charsPerChunk, rag.chunk_overlap_chars || DEFAULT_CHUNK_OVERLAP_CHARS);
+  if (rag.max_chunks && chunks.length > rag.max_chunks) {
+    return { ok: false, tokens, cap: effectiveCap, action: 'rag-fallback', reason: `chunk count ${chunks.length} > rag_fallback.max_chunks ${rag.max_chunks}` };
+  }
+  return { ok: true, tokens, cap: effectiveCap, action: 'chunked', chunks };
+}
+
+module.exports = { enforcePromptBudget, modelBudget, estimateTokens, chunkPrompt, loadPolicy, DEFAULT_POLICY_PATH };

--- a/tests/prompt-budget.spec.js
+++ b/tests/prompt-budget.spec.js
@@ -1,0 +1,68 @@
+// Refs #2204 - tests for prompt-budget policy
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { enforcePromptBudget, modelBudget, estimateTokens, chunkPrompt, loadPolicy } = require('../scripts/global/prompt-budget.js');
+
+const POLICY = loadPolicy();
+
+test('loadPolicy: returns version 1 + models + default', () => {
+  assert.equal(POLICY.version, 1);
+  assert.ok(POLICY.default);
+  assert.ok(POLICY.models);
+});
+
+test('modelBudget: qwen2.5-coder:32b returns 32K context', () => {
+  const b = modelBudget('qwen2.5-coder:32b', POLICY);
+  assert.equal(b.context_tokens, 32768);
+});
+
+test('modelBudget: unknown model returns default', () => {
+  const b = modelBudget('unknown-model', POLICY);
+  assert.deepEqual(b, POLICY.default);
+});
+
+test('estimateTokens: ~4 chars per token', () => {
+  assert.equal(estimateTokens('abcd'), 1);
+  assert.equal(estimateTokens('abcdefgh'), 2);
+  assert.equal(estimateTokens(''), 0);
+});
+
+test('enforcePromptBudget: small prompt passes through', () => {
+  const r = enforcePromptBudget({ prompt: 'small prompt', model: 'qwen2.5-coder:32b' });
+  assert.equal(r.ok, true);
+  assert.equal(r.action, 'pass-through');
+});
+
+test('enforcePromptBudget: oversized prompt for small model chunks', () => {
+  // gemma3:1b has 6144 prompt_cap; build a 30000-char prompt (~7500 tokens)
+  const prompt = 'x'.repeat(30000);
+  const r = enforcePromptBudget({ prompt, model: 'gemma3:1b' });
+  assert.equal(r.ok, true);
+  assert.equal(r.action, 'chunked');
+  assert.ok(r.chunks.length >= 2);
+});
+
+test('enforcePromptBudget: massive prompt triggers RAG fallback (no chunk attempt)', () => {
+  const prompt = 'x'.repeat(100000); // 100K chars > rag.trigger_chars 80K
+  const r = enforcePromptBudget({ prompt, model: 'gemma3:1b' });
+  assert.equal(r.ok, false);
+  assert.equal(r.action, 'rag-fallback');
+  assert.match(r.reason, /rag_fallback/);
+});
+
+test('chunkPrompt: produces chunks with overlap', () => {
+  const chunks = chunkPrompt('a'.repeat(1000), 400, 100);
+  assert.ok(chunks.length >= 3);
+});
+
+test('chunkPrompt: short prompt returns single chunk', () => {
+  const chunks = chunkPrompt('short', 100, 10);
+  assert.equal(chunks.length, 1);
+});
+
+test('enforcePromptBudget: templateBudget caps the effective budget', () => {
+  const prompt = 'x'.repeat(10000); // 2500 tokens
+  // With qwen2.5-coder:32b (24576 cap) AND templateBudget 1000, effective cap is 1000
+  const r = enforcePromptBudget({ prompt, model: 'qwen2.5-coder:32b', templateBudget: 1000 });
+  assert.ok(r.cap === 1000);
+});


### PR DESCRIPTION
## Summary

Phase-1 child P1-3 of Epic #2150 (AC3). Prompt budget + RAG chunking enforcement.

- `scripts/global/prompt-budget.js` (60 LoC) exports `enforcePromptBudget({prompt, model, templateBudget})`
- 3 actions: pass-through / chunked / rag-fallback
- `config/prompt-budget-policy.json` covers qwen2.5-coder:*, gemma3:1b, claude-opus-4-7, claude-sonnet-4-6
- 10 unit tests

Refs #2204
Refs Epic #2150
Refs Phase-0 source #2200
Closes #2204

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2204#issuecomment-4549848489
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2204#issuecomment-4549859889
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2204#issuecomment-4549859959
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2204#issuecomment-4549860019 (rubric min 9/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
