### PR TITLE
fix(2100): harden catch-empty workflow gates

### DIFF
--- a/.github/workflows/cross-team-claim-reaper.yml
+++ b/.github/workflows/cross-team-claim-reaper.yml
@@ -51,11 +51,11 @@ jobs:
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: epic.number, name: 'consultant:cross-team-in-progress',
-              }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
+              }).catch((err) => { if (err?.status !== 404) throw err; });
               await github.rest.issues.addLabels({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: epic.number, labels: ['consultant:cross-team-needed'],
-              }).catch(() => {}); // catch-empty: addLabels throws 422 if label already applied
+              }).catch((err) => { if (err?.status !== 422) throw err; });
             }
             const summary = `Scanned ${epics.length} cross-team-in-progress Epics; expired ${expired.length} claim(s)`;
             console.log(`cross-team-claim-reaper: ${summary}`);

--- a/.github/workflows/cross-team-edit-warn.yml
+++ b/.github/workflows/cross-team-edit-warn.yml
@@ -70,7 +70,7 @@ jobs:
               if (labelNames.includes('coordinator:cross-team-needs-hand-off')) {
                 await github.rest.issues.removeLabel({
                   owner, repo, issue_number: issue.number, name: 'coordinator:cross-team-needs-hand-off'
-                }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
+                }).catch((err) => { if (err?.status !== 404) throw err; });
                 core.info(`#${issue.number}: stripped stale coordinator label (sibling-role conflict resolved) (#1830)`);
               }
               return core.info('no sibling role conflicts');
@@ -85,5 +85,5 @@ jobs:
             await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body: msg });
             await github.rest.issues.addLabels({
               owner, repo, issue_number: issue.number, labels: ['coordinator:cross-team-needs-hand-off']
-            }).catch(() => {}); // catch-empty: addLabels throws 422 if label already applied
+            }).catch((err) => { if (err?.status !== 422) throw err; });
             core.info('issues.labeled sibling-role warn posted');

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,3 +76,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: No unsuppressed empty catch in github-script blocks
         run: bash scripts/global/catch-empty-lint.sh .github/workflows
+      - name: Catch-empty suppression summary
+        shell: bash
+        run: |
+          count=$(grep -Rho '// catch-empty:' .github/workflows 2>/dev/null | wc -l | tr -d ' ')
+          {
+            echo '### catch-empty suppressions'
+            echo "Active suppressions in .github/workflows: $count"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ npm run deploy:both:apply
 | `auth:profile:context` | `node scripts/global/authorization-profile-context.js` |
 | `capability:probe` | `node scripts/global/capability-probe.js` |
 | `capability:show` | `node scripts/global/capability-show.js` |
+| `catch-empty` | `bash scripts/global/catch-empty-lint.sh .github/workflows` |
 | `cleanup:branches` | `node scripts/global/branch-cleanup-plan.js` |
 | `cost-report` | `node scripts/global/cost-report.js` |
 | `cost:baseline` | `node scripts/global/cost-baseline.js` |
@@ -131,7 +132,6 @@ npm run deploy:both:apply
 | `docs:compile` | `node scripts/docs-compile.js` |
 | `docs:exec` | `node scripts/global/docs-exec.js` |
 | `docs:lint` | `node scripts/docs-lint.js` |
-| `catch-empty` | `scripts/global/catch-empty-lint.sh .github/workflows` |
 | `epic:sync` | `node scripts/global/actuator-epic-sync.js` |
 | `format` | `prettier --write .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js` |
 | `format:check` | `prettier --check .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js` |

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ npm run deploy:both:apply
 | `docs:compile` | `node scripts/docs-compile.js` |
 | `docs:exec` | `node scripts/global/docs-exec.js` |
 | `docs:lint` | `node scripts/docs-lint.js` |
+| `catch-empty` | `scripts/global/catch-empty-lint.sh .github/workflows` |
 | `epic:sync` | `node scripts/global/actuator-epic-sync.js` |
 | `format` | `prettier --write .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js` |
 | `format:check` | `prettier --check .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js` |

--- a/instructions/workflow-resilience.instructions.md
+++ b/instructions/workflow-resilience.instructions.md
@@ -88,3 +88,9 @@ Run `docs-drift-maintenance` skill after any change to:
 - Configuration files, defaults, or environment variables.
 - Workflows, CI/CD pipelines, or automation scripts.
 - UX-visible behavior, user-facing features, or settings.
+
+## catch-empty suppression contract
+
+- `scripts/global/catch-empty-lint.sh` intentionally scans `.github/workflows/` only.
+- `scripts/global/` and `hooks/scripts/` may contain intentional non-empty catch handlers and are governed by code review plus unit tests instead of the workflow YAML lint.
+- Use `// catch-empty: <reason>` only for best-effort label/comment cleanup or equivalent known-safe GitHub API misses; if the handler can distinguish expected failures, prefer filtering the expected status code and rethrowing everything else.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "docs:compile": "node scripts/docs-compile.js",
     "docs:exec": "node scripts/global/docs-exec.js",
     "docs:lint": "node scripts/docs-lint.js",
+    "catch-empty": "bash scripts/global/catch-empty-lint.sh .github/workflows",
     "format": "prettier --write .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js",
     "format:check": "prettier --check .prettierrc.json package.json CONTRIBUTING.md .github/workflows/lint.yml lint-configs/README.md lint-configs/ci-lint.yml lint-configs/eslint.config.devenv.js scripts/lint-readability.js scripts/global/install-readability-toolchain.js",
     "governance:drift": "node scripts/global/governance-drift-classifier.js --json",

--- a/tests/catch-empty-lint.spec.js
+++ b/tests/catch-empty-lint.spec.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { test, expect } = require('@playwright/test');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const SCRIPT = path.join(REPO_ROOT, 'scripts/global/catch-empty-lint.sh');
+
+function tempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeWorkflow(root, relPath, body) {
+  const filePath = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, body);
+  return filePath;
+}
+
+function runLint(root) {
+  return spawnSync('bash', [SCRIPT, root], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+}
+
+test('catch-empty lint flags empty catches and counts suppressions', () => {
+  const root = tempDir('catch-empty-good-');
+  writeWorkflow(root, '.github/workflows/good.yml', `name: good
+on: [push]
+jobs:
+  ok:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({ owner: 'x', repo: 'y', issue_number: 1, name: 'z' })
+              .catch((err) => { if (err?.status !== 404) throw err; });
+`);
+  const r = runLint(root);
+  expect(r.status).toBe(0);
+  expect(r.stdout).toContain('OK: no unsuppressed empty catches found.');
+});
+
+test('catch-empty lint rejects bare empty catches', () => {
+  const root = tempDir('catch-empty-bad-');
+  writeWorkflow(root, '.github/workflows/bad.yml', `name: bad
+on: [push]
+jobs:
+  bad:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({ owner: 'x', repo: 'y', issue_number: 1, name: 'z' })
+              .catch(() => {})
+`);
+  const r = runLint(root);
+  expect(r.status).toBe(1);
+  expect(r.stdout + r.stderr).toContain('ERROR: unsuppressed empty catch block(s) found above.');
+});
+
+test('workflow call sites use status-specific catch handling and summary step exists', () => {
+  const claimReaper = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/cross-team-claim-reaper.yml'), 'utf8');
+  const editWarn = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/cross-team-edit-warn.yml'), 'utf8');
+  const lintWorkflow = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/lint.yml'), 'utf8');
+
+  expect(claimReaper).toContain('if (err?.status !== 404) throw err;');
+  expect(claimReaper).toContain('if (err?.status !== 422) throw err;');
+  expect(editWarn).toContain('if (err?.status !== 404) throw err;');
+  expect(editWarn).toContain('if (err?.status !== 422) throw err;');
+  expect(lintWorkflow).toContain('Catch-empty suppression summary');
+  expect(lintWorkflow).toContain('GITHUB_STEP_SUMMARY');
+});


### PR DESCRIPTION
Refs #2100

Summary:
- Tighten representative cross-team workflow catch handlers to rethrow non-404/422 errors.
- Add a lint job summary line for catch-empty suppressions in `.github/workflows`.
- Document the intentional workflow-only scope for the catch-empty gate.
- Add regression coverage for the script behavior and workflow summary wiring.

Validation:
- `npm run lint`
- `npx playwright test tests/catch-empty-lint.spec.js --reporter=line`