### PR TITLE
feat(governance): router enforcement gate for fleet-eligible tasks #2205

### DIFF
--- a/.changes/unreleased/2205.md
+++ b/.changes/unreleased/2205.md
@@ -1,0 +1,2 @@
+### Added
+- `scripts/global/router-enforcement.js` (58 LoC) — deterministic gate that fails governed runs when fleet-eligible tasks bypass HAMR without an approved override artifact. Override tiers: diagnostic / test / smoke (per Epic #1155 carve-out pattern). 15 unit tests. Coordinates API with Epic #2192 router-bypass detection. Phase-1 child P1-4 of Epic #2150. Refs #2205.

--- a/scripts/global/router-enforcement.js
+++ b/scripts/global/router-enforcement.js
@@ -1,0 +1,58 @@
+'use strict';
+// router-enforcement — deterministic gate: fail governed runs that bypass fleet/HAMR
+// without an approved override artifact. Refs Epic #2150 #2205.
+// Coordinates API surface with Epic #2192 router-bypass detection.
+
+const FLEET_ELIGIBLE_HINTS = [
+  'fleet', 'qwen', 'ollama', 'redteam', 'red-team', 'adversarial', 'dispatchRedTeam',
+];
+
+const OVERRIDE_TIERS = ['diagnostic', 'test', 'smoke'];
+
+function isFleetEligible(task) {
+  if (!task || typeof task !== 'object') return false;
+  const lane = task.lane || '';
+  const desc = String(task.description || '').toLowerCase();
+  const artifact = String(task.artifactType || '').toLowerCase();
+  if (lane.includes('lane:trivial') || lane.includes('lane:config-only')) return false;
+  if (artifact.includes('redteam') || artifact.includes('red-team')) return true;
+  return FLEET_ELIGIBLE_HINTS.some((hint) => desc.includes(hint));
+}
+
+function validateOverride(override) {
+  if (!override) return { ok: false, reason: 'no-override' };
+  if (typeof override !== 'object') return { ok: false, reason: 'override-not-object' };
+  if (!override.tier) return { ok: false, reason: 'override-missing-tier' };
+  if (!OVERRIDE_TIERS.includes(override.tier)) {
+    return { ok: false, reason: `override-tier-not-allowed: '${override.tier}' (allowed: ${OVERRIDE_TIERS.join(', ')})` };
+  }
+  if (!override.reason || override.reason.length < 8) {
+    return { ok: false, reason: 'override-reason-too-short (min 8 chars)' };
+  }
+  return { ok: true, tier: override.tier };
+}
+
+function enforceRouter({ task, override, usedHamr } = {}) {
+  if (!isFleetEligible(task)) {
+    return { ok: true, reason: 'not-fleet-eligible' };
+  }
+  if (usedHamr === true) {
+    return { ok: true, reason: 'hamr-used' };
+  }
+  const overrideCheck = validateOverride(override);
+  if (overrideCheck.ok) {
+    return { ok: true, reason: `override-approved: ${overrideCheck.tier}` };
+  }
+  return {
+    ok: false,
+    reason: `fleet-eligible task bypassed HAMR without approved override: ${overrideCheck.reason}`,
+  };
+}
+
+module.exports = {
+  enforceRouter,
+  isFleetEligible,
+  validateOverride,
+  FLEET_ELIGIBLE_HINTS,
+  OVERRIDE_TIERS,
+};

--- a/tests/router-enforcement.spec.js
+++ b/tests/router-enforcement.spec.js
@@ -1,0 +1,79 @@
+// Refs #2205 - tests for router enforcement gate
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { enforceRouter, isFleetEligible, validateOverride, FLEET_ELIGIBLE_HINTS, OVERRIDE_TIERS } = require('../scripts/global/router-enforcement.js');
+
+test('isFleetEligible: fleet-keyword task is eligible', () => {
+  assert.equal(isFleetEligible({ description: 'dispatch to fleet model qwen2.5-coder:32b' }), true);
+});
+
+test('isFleetEligible: redteam artifact is eligible', () => {
+  assert.equal(isFleetEligible({ artifactType: 'redteam-review' }), true);
+});
+
+test('isFleetEligible: lane:trivial is not eligible', () => {
+  assert.equal(isFleetEligible({ lane: 'lane:trivial', description: 'fleet' }), false);
+});
+
+test('isFleetEligible: plain code task is not eligible', () => {
+  assert.equal(isFleetEligible({ description: 'add unit test' }), false);
+});
+
+test('isFleetEligible: null returns false', () => {
+  assert.equal(isFleetEligible(null), false);
+});
+
+test('validateOverride: well-formed override passes', () => {
+  assert.equal(validateOverride({ tier: 'diagnostic', reason: 'health-check-probe' }).ok, true);
+});
+
+test('validateOverride: missing override fails', () => {
+  assert.equal(validateOverride(null).ok, false);
+});
+
+test('validateOverride: unknown tier rejected', () => {
+  const r = validateOverride({ tier: 'bogus', reason: 'whatever-long-enough' });
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /not-allowed/);
+});
+
+test('validateOverride: short reason rejected', () => {
+  const r = validateOverride({ tier: 'diagnostic', reason: 'no' });
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /too-short/);
+});
+
+test('enforceRouter: non-fleet-eligible task passes', () => {
+  const r = enforceRouter({ task: { description: 'add comment' } });
+  assert.equal(r.ok, true);
+});
+
+test('enforceRouter: fleet-eligible + HAMR used = pass', () => {
+  const r = enforceRouter({ task: { description: 'dispatch to fleet' }, usedHamr: true });
+  assert.equal(r.ok, true);
+  assert.equal(r.reason, 'hamr-used');
+});
+
+test('enforceRouter: fleet-eligible + valid override = pass', () => {
+  const r = enforceRouter({
+    task: { description: 'fleet probe' },
+    override: { tier: 'diagnostic', reason: 'health-probe-via-cli' },
+  });
+  assert.equal(r.ok, true);
+  assert.match(r.reason, /override-approved/);
+});
+
+test('enforceRouter: fleet-eligible bypass = fail', () => {
+  const r = enforceRouter({ task: { description: 'dispatch ollama fleet model' } });
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /bypassed HAMR/);
+});
+
+test('FLEET_ELIGIBLE_HINTS exported', () => {
+  assert.ok(FLEET_ELIGIBLE_HINTS.includes('fleet'));
+  assert.ok(FLEET_ELIGIBLE_HINTS.includes('ollama'));
+});
+
+test('OVERRIDE_TIERS exported includes diagnostic', () => {
+  assert.ok(OVERRIDE_TIERS.includes('diagnostic'));
+});


### PR DESCRIPTION
## Summary

Phase-1 child P1-4 of Epic #2150 (AC1). Router enforcement gate that fails governed runs when fleet-eligible tasks bypass HAMR without an approved override.

- `scripts/global/router-enforcement.js` (58 LoC) exports `enforceRouter({task, override, usedHamr})`
- Override pattern: `{tier:'diagnostic'|'test'|'smoke', reason:>=8chars}` per Epic #1155 carve-out
- 15 unit tests
- Coordinates API with Epic #2192 router-bypass detection

Refs #2205
Refs Epic #2150
Refs Phase-0 source #2200
Closes #2205

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2205#issuecomment-4549864149
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2205#issuecomment-4549870551
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2205#issuecomment-4549870667
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2205#issuecomment-4549870758 (rubric min 9/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
