### PR TITLE
fix(1995): route closeout-preflight reads through dispatcher

### DIFF
--- a/.changes/unreleased/1995.md
+++ b/.changes/unreleased/1995.md
@@ -1,0 +1,4 @@
+## #1995
+
+- Route `scripts/global/closeout-preflight.js` issue/PR reads through `scripts/global/github-dispatcher.js` operations so MCP routing can be used with CLI fallback.
+- Add dispatcher mapping for `get-pull-request` and tests for MCP-forced plus MCP-disabled fallback behavior.

--- a/scripts/global/closeout-preflight.js
+++ b/scripts/global/closeout-preflight.js
@@ -2,96 +2,78 @@
 
 const { execFileSync } = require('node:child_process');
 const megalint = require('./megalint');
+const { execute } = require('./github-dispatcher');
 
 function extractIssueFromBranch(branch) {
-  const match = String(branch || '').match(/(?:feat|fix|chore|docs|refactor|perf|hotfix)\/(\d+)-/i);
-  return match ? Number(match[1]) : null;
+  const m = String(branch || '').match(/(?:feat|fix|chore|docs|refactor|perf|hotfix)\/(\d+)-/i);
+  return m ? Number(m[1]) : null;
 }
-
 function currentBranch() {
   return (process.env.CLOSEOUT_PREFLIGHT_BRANCH || execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf8' })).trim();
 }
-
-function readIssue(issueNum) {
+async function readIssue(issueNum, opts = {}) {
   if (process.env.CLOSEOUT_PREFLIGHT_ISSUE_JSON) return JSON.parse(process.env.CLOSEOUT_PREFLIGHT_ISSUE_JSON);
-  return JSON.parse(execFileSync('gh', ['issue', 'view', String(issueNum), '--json', 'body,comments,title,labels,state'], { encoding: 'utf8' }));
+  const res = await execute('get-issue', { issue: issueNum, json: 'body,comments,title,labels,state' }, opts);
+  if (!res.ok) throw new Error(res.error || res.reason || 'issue lookup failed');
+  if (res.provider === 'gh-cli') return JSON.parse(res.stdout || '{}');
+  const payload = res.result?.issue || res.result;
+  if (!payload || typeof payload !== 'object') throw new Error('invalid MCP issue payload');
+  return payload;
 }
-
 function normalizeComments(comments) {
-  return (comments || []).map(comment => ({ body: comment.body || '', user: comment.user ? { login: comment.user.login } : undefined }));
+  return (comments || []).map((c) => ({ body: c.body || '', user: c.user ? { login: c.user.login } : undefined }));
 }
-
 function normalizeLabels(labels) {
-  return (labels || []).map(label => (typeof label === 'string' ? label : label.name)).filter(Boolean);
+  return (labels || []).map((l) => (typeof l === 'string' ? l : l.name)).filter(Boolean);
 }
-
 function deriveLaneFromLabels(labels) {
-  const laneLabel = (labels || []).find(l => typeof l === 'string' && l.startsWith('lane:'));
-  return laneLabel || 'lane:code-change';
+  return (labels || []).find((l) => typeof l === 'string' && l.startsWith('lane:')) || 'lane:code-change';
 }
-
 function toValidatorInput(issue, issueNum, branch) {
   const body = issue.body || '';
   const labels = normalizeLabels(issue.labels);
   return {
-    body,
-    comments: normalizeComments(issue.comments),
-    labels,
-    lane: deriveLaneFromLabels(labels),
-    prBody: '',
-    state: issue.state || 'open',
-    ticketRef: issueNum,
-    branch,
+    body, comments: normalizeComments(issue.comments), labels, lane: deriveLaneFromLabels(labels),
+    prBody: '', state: issue.state || 'open', ticketRef: issueNum, branch,
     isEpic: /\bEPIC\b/i.test(issue.title || '') || /##\s*Epic Summary/i.test(body),
   };
 }
-
-function fetchPrBody(branch) {
+async function fetchPrBody(branch, opts = {}) {
+  if (process.env.CLOSEOUT_PREFLIGHT_PR_BODY) return process.env.CLOSEOUT_PREFLIGHT_PR_BODY.trim();
   try {
-    return execFileSync(
-      'gh', ['pr', 'view', branch, '--json', 'body', '-q', '.body'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
-    ).trim();
+    const res = await execute('get-pull-request', { issue: branch, json: 'body' }, opts);
+    if (!res.ok) return null;
+    if (res.provider === 'gh-cli') return (JSON.parse(res.stdout || '{}').body || '').trim();
+    const payload = res.result?.pullRequest || res.result || {};
+    return typeof payload.body === 'string' ? payload.body.trim() : null;
   } catch { return null; }
 }
 
-function run() {
-  if (process.env.SKIP_CLOSEOUT_PREFLIGHT === '1') {
-    console.log('closeout-preflight: skipped (SKIP_CLOSEOUT_PREFLIGHT=1)');
-    return 0;
-  }
+async function run(opts = {}) {
+  if (process.env.SKIP_CLOSEOUT_PREFLIGHT === '1') { console.log('closeout-preflight: skipped (SKIP_CLOSEOUT_PREFLIGHT=1)'); return 0; }
   const branch = currentBranch();
   const issueNum = extractIssueFromBranch(branch);
-  if (!issueNum) {
-    console.log('closeout-preflight: skip (no ticket branch)');
-    return 0;
-  }
+  if (!issueNum) { console.log('closeout-preflight: skip (no ticket branch)'); return 0; }
   let issue;
-  try {
-    issue = readIssue(issueNum);
-  } catch (error) {
-    console.error(`closeout-preflight: unable to load issue #${issueNum}: ${error.message}`);
-    return 1;
-  }
+  try { issue = await readIssue(issueNum, opts); }
+  catch (error) { console.error(`closeout-preflight: unable to load issue #${issueNum}: ${error.message}`); return 1; }
   const input = toValidatorInput(issue, issueNum, branch);
-  const prBody = fetchPrBody(branch);
+  const prBody = await fetchPrBody(branch, opts);
   if (prBody !== null) input.prBody = prBody;
   const validators = ['manager-handoff', 'consultant-closeout'];
   if (prBody !== null) validators.push('merge-evidence-pr-gate');
   let failed = false;
   for (const name of validators) {
     const r = megalint.run(name, { ...input, issueNumber: issueNum });
-    if (!r.ok) {
-      failed = true;
-      console.error(`closeout-preflight: FAIL [${name}] #${issueNum}`);
-      for (const v of r.violations || []) console.error(`  - ${v.rule}: ${v.detail}`);
-    }
+    if (r.ok) continue;
+    failed = true; console.error(`closeout-preflight: FAIL [${name}] #${issueNum}`);
+    for (const v of r.violations || []) console.error(`  - ${v.rule}: ${v.detail}`);
   }
   if (failed) return 1;
   console.log(`closeout-preflight: PASS #${issueNum}`);
   return 0;
 }
 
-if (require.main === module) process.exit(run());
+if (require.main === module) run().then((code) => process.exit(code));
 
-module.exports = { extractIssueFromBranch, readIssue, toValidatorInput, run };
+module.exports = { extractIssueFromBranch, readIssue, fetchPrBody, toValidatorInput, run };

--- a/scripts/global/github-dispatcher.js
+++ b/scripts/global/github-dispatcher.js
@@ -1,7 +1,5 @@
 'use strict';
-// github-dispatcher (#1643 + #1710 execute layer) — MCP-vs-gh-CLI dispatcher.
-// dispatch() returns selection metadata; execute() actually invokes the chosen
-// provider. Per #1629 contract, fallback to gh CLI when MCP unavailable.
+// MCP-vs-gh-CLI dispatcher. Falls back to gh CLI when MCP is unavailable.
 
 const { execFile } = require('node:child_process');
 const { promisify } = require('node:util');
@@ -14,30 +12,28 @@ function provider(env = process.env) {
 }
 
 function toolName(operation, prov) {
-  const MAP = {
+  const map = {
     'create-issue': { mcp: 'mcp__github__create_issue', cli: 'gh issue create' },
     'add-comment': { mcp: 'mcp__github__create_issue_comment', cli: 'gh issue comment' },
     'get-issue': { mcp: 'mcp__github__get_issue', cli: 'gh issue view' },
     'list-issues': { mcp: 'mcp__github__list_issues', cli: 'gh issue list' },
     'update-issue': { mcp: 'mcp__github__update_issue', cli: 'gh issue edit' },
+    'get-pull-request': { mcp: 'mcp__github__get_pull_request', cli: 'gh pr view' },
     'update-project-v2-item-field': {
-      mcp: 'mcp__github__update_project_v2_item_field_value',
-      cli: 'gh api graphql -f query=...',
+      mcp: 'mcp__github__update_project_v2_item_field_value', cli: 'gh api graphql -f query=...',
     },
   };
-  if (!MAP[operation]) return null;
-  return prov === 'mcp' ? MAP[operation].mcp : MAP[operation].cli;
+  if (!map[operation]) return null;
+  return prov === 'mcp' ? map[operation].mcp : map[operation].cli;
 }
 
 function cliArgs(operation) {
-  const ARGS = {
-    'create-issue': ['issue', 'create'],
-    'add-comment': ['issue', 'comment'],
-    'get-issue': ['issue', 'view'],
-    'list-issues': ['issue', 'list'],
-    'update-issue': ['issue', 'edit'],
+  const map = {
+    'create-issue': ['issue', 'create'], 'add-comment': ['issue', 'comment'],
+    'get-issue': ['issue', 'view'], 'list-issues': ['issue', 'list'],
+    'update-issue': ['issue', 'edit'], 'get-pull-request': ['pr', 'view'],
   };
-  return ARGS[operation] || null;
+  return map[operation] || null;
 }
 
 function buildCliArgs(operation, params = {}) {
@@ -58,9 +54,7 @@ async function executeViaCli(operation, params = {}, runner = execFileAsync) {
   try {
     const { stdout, stderr } = await runner('gh', args);
     return { ok: true, provider: 'gh-cli', stdout, stderr };
-  } catch (error) {
-    return { ok: false, provider: 'gh-cli', error: error.message };
-  }
+  } catch (error) { return { ok: false, provider: 'gh-cli', error: error.message }; }
 }
 
 async function executeViaMcp(operation, params = {}, mcpClient) {
@@ -72,18 +66,14 @@ async function executeViaMcp(operation, params = {}, mcpClient) {
   try {
     const result = await mcpClient.invoke(tool, params);
     return { ok: true, provider: 'mcp', tool, result };
-  } catch (error) {
-    return { ok: false, provider: 'mcp', tool, error: error.message };
-  }
+  } catch (error) { return { ok: false, provider: 'mcp', tool, error: error.message }; }
 }
 
 async function execute(operation, params = {}, opts = {}) {
   const { env = process.env, mcpClient = null, cliRunner = execFileAsync } = opts;
-  const prov = provider(env);
-  if (prov === 'mcp') {
+  if (provider(env) === 'mcp') {
     const mcpResult = await executeViaMcp(operation, params, mcpClient);
     if (mcpResult.ok) return mcpResult;
-    return executeViaCli(operation, params, cliRunner);
   }
   return executeViaCli(operation, params, cliRunner);
 }

--- a/tests/closeout-preflight.spec.js
+++ b/tests/closeout-preflight.spec.js
@@ -5,6 +5,7 @@ const { spawnSync } = require('node:child_process');
 const path = require('path');
 
 const SCRIPT = path.resolve(__dirname, '..', 'scripts', 'global', 'closeout-preflight.js');
+const preflight = require('../scripts/global/closeout-preflight.js');
 
 function runWith(issueJson, branch) {
   return spawnSync(process.execPath, [SCRIPT], {
@@ -77,4 +78,37 @@ test('closeout-preflight skips when SKIP_CLOSEOUT_PREFLIGHT=1', () => {
   });
   expect(result.status).toBe(0);
   expect(result.stdout).toContain('skipped');
+});
+
+test('readIssue supports MCP path when forced', async () => {
+  let tool = '';
+  const issue = await preflight.readIssue(1995, {
+    env: { MEGINGJORD_MCP_FORCE_AVAILABLE: '1' },
+    mcpClient: { invoke: async (name) => { tool = name; return { issue: { title: 'T', body: '', comments: [], labels: [], state: 'open' } }; } },
+  });
+  expect(tool).toBe('mcp__github__get_issue');
+  expect(issue.title).toBe('T');
+});
+
+test('fetchPrBody supports MCP path when forced', async () => {
+  let tool = '';
+  const body = await preflight.fetchPrBody('fix/1995-closeout-preflight-mcp', {
+    env: { MEGINGJORD_MCP_FORCE_AVAILABLE: '1' },
+    mcpClient: { invoke: async (name) => { tool = name; return { pullRequest: { body: 'hello from mcp' } }; } },
+  });
+  expect(tool).toBe('mcp__github__get_pull_request');
+  expect(body).toBe('hello from mcp');
+});
+
+test('readIssue honors MCP-disabled CLI fallback', async () => {
+  let args = [];
+  const issue = await preflight.readIssue(1995, {
+    env: { MEGINGJORD_MCP_DISABLED: '1' },
+    cliRunner: async (_cmd, cliArgs) => {
+      args = cliArgs;
+      return { stdout: JSON.stringify({ title: 'CLI', body: '', comments: [], labels: [], state: 'open' }), stderr: '' };
+    },
+  });
+  expect(args.slice(0, 3)).toEqual(['issue', 'view', '1995']);
+  expect(issue.title).toBe('CLI');
 });

--- a/tests/github-dispatcher-execute.spec.js
+++ b/tests/github-dispatcher-execute.spec.js
@@ -13,6 +13,10 @@ test('cliArgs returns null for unknown operation', () => {
   expect(cliArgs('not-an-op')).toBe(null);
 });
 
+test('cliArgs maps get-pull-request to pr view', () => {
+  expect(cliArgs('get-pull-request')).toEqual(['pr', 'view']);
+});
+
 test('buildCliArgs appends --title and --body', () => {
   const args = buildCliArgs('create-issue', { title: 'T', body: 'B' });
   expect(args).toEqual(['issue', 'create', '--title', 'T', '--body', 'B']);

--- a/tests/mcp-integration.spec.js
+++ b/tests/mcp-integration.spec.js
@@ -23,6 +23,10 @@ test('toolName maps create-issue to gh CLI when provider=gh-cli', () => {
   expect(toolName('create-issue', 'gh-cli')).toBe('gh issue create');
 });
 
+test('toolName maps get-pull-request to MCP tool', () => {
+  expect(toolName('get-pull-request', 'mcp')).toBe('mcp__github__get_pull_request');
+});
+
 test('toolName maps update-project-v2-item-field to GraphQL CLI fallback', () => {
   expect(toolName('update-project-v2-item-field', 'gh-cli')).toContain('gh api graphql');
 });


### PR DESCRIPTION
Refs #1995

Summary:
- Migrate `closeout-preflight` issue/pr reads from direct `gh` shell calls to dispatcher operations.
- Add `get-pull-request` operation mapping in `github-dispatcher`.
- Add MCP-forced and MCP-disabled fallback coverage in focused tests.

Validation:
- `npx playwright test tests/closeout-preflight.spec.js tests/github-dispatcher-execute.spec.js tests/mcp-integration.spec.js --reporter=line`
- `npm run lint`