### PR TITLE
feat(hamr): MEGINGJORD_FLEET_DIRECT_BLOCK env enforcement #2219

### DIFF
--- a/.changes/unreleased/2219.md
+++ b/.changes/unreleased/2219.md
@@ -1,0 +1,2 @@
+### Added
+- `scripts/global/hamr-fleet-direct-block.js` (24 LoC) — env-gated `MEGINGJORD_FLEET_DIRECT_BLOCK=1` enforcement that hard-fails direct fleet curls (consumes #2220 P1-2 detectBypass output). `shouldBlock({detection, env})` returns `{block, reason, message?}`. Override marker `# hamr-bypass-ok: <reason>` suppresses (per Phase-0 design). Redirect message cites `scripts/global/fleet-red-team-dispatch.js` (Epic #2041 #2175). 11 unit tests. Phase-1 child P1-3 of Epic #2029. **Direct G3 blocker**: forces routing through HAMR cost tracking. Refs #2219.

--- a/scripts/global/hamr-fleet-direct-block.js
+++ b/scripts/global/hamr-fleet-direct-block.js
@@ -1,0 +1,27 @@
+'use strict';
+// hamr-fleet-direct-block — env-gated enforcement that fails direct fleet curls
+// when MEGINGJORD_FLEET_DIRECT_BLOCK=1. Wraps detectBypass (#2220 P1-2).
+// Refs Epic #2029 #2219.
+
+const ENV_FLAG = 'MEGINGJORD_FLEET_DIRECT_BLOCK';
+const REDIRECT_MSG = 'Direct fleet call blocked. Use scripts/global/fleet-red-team-dispatch.js (Epic #2041 #2175) for HAMR-routed dispatch via tier=fleet-local.';
+
+function isEnabled(env) {
+  return (env || process.env)[ENV_FLAG] === '1';
+}
+
+function shouldBlock({ detection, env }) {
+  if (!isEnabled(env)) return { block: false, reason: 'env-flag-off' };
+  if (!detection || !detection.detected) return { block: false, reason: 'no-bypass-detected' };
+  if (detection.suppressed) return { block: false, reason: 'override-marker-suppresses' };
+  if (detection.severity === 'fleet-bypass') return { block: true, reason: 'fleet-direct-blocked', message: REDIRECT_MSG };
+  if (detection.severity === 'paid-bypass') return { block: false, reason: 'paid-bypass-not-fleet-scope' };
+  return { block: false, reason: 'unknown-severity' };
+}
+
+function blockMessage(detection) {
+  const providers = (detection && detection.providers) ? detection.providers.map(function (p) { return p.name; }).join(', ') : 'unknown';
+  return `${REDIRECT_MSG} (detected providers: ${providers})`;
+}
+
+module.exports = { shouldBlock, isEnabled, blockMessage, ENV_FLAG, REDIRECT_MSG };

--- a/tests/hamr-fleet-direct-block.spec.js
+++ b/tests/hamr-fleet-direct-block.spec.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { shouldBlock, isEnabled, blockMessage, ENV_FLAG, REDIRECT_MSG } = require('../scripts/global/hamr-fleet-direct-block.js');
+
+test('isEnabled: env=1 returns true', () => assert.equal(isEnabled({ MEGINGJORD_FLEET_DIRECT_BLOCK: '1' }), true));
+test('isEnabled: env=0 returns false', () => assert.equal(isEnabled({ MEGINGJORD_FLEET_DIRECT_BLOCK: '0' }), false));
+test('isEnabled: missing returns false', () => assert.equal(isEnabled({}), false));
+
+test('shouldBlock: env off + fleet-bypass = no block', () => {
+  const r = shouldBlock({ detection: { detected: true, severity: 'fleet-bypass' }, env: {} });
+  assert.equal(r.block, false);
+  assert.equal(r.reason, 'env-flag-off');
+});
+
+test('shouldBlock: env on + fleet-bypass = BLOCK', () => {
+  const r = shouldBlock({ detection: { detected: true, severity: 'fleet-bypass' }, env: { MEGINGJORD_FLEET_DIRECT_BLOCK: '1' } });
+  assert.equal(r.block, true);
+  assert.match(r.message, /Use scripts\/global\/fleet-red-team-dispatch/);
+});
+
+test('shouldBlock: env on + paid-bypass = NOT block (out of scope)', () => {
+  const r = shouldBlock({ detection: { detected: true, severity: 'paid-bypass' }, env: { MEGINGJORD_FLEET_DIRECT_BLOCK: '1' } });
+  assert.equal(r.block, false);
+  assert.equal(r.reason, 'paid-bypass-not-fleet-scope');
+});
+
+test('shouldBlock: env on + suppressed override = NOT block', () => {
+  const r = shouldBlock({ detection: { detected: true, suppressed: true }, env: { MEGINGJORD_FLEET_DIRECT_BLOCK: '1' } });
+  assert.equal(r.block, false);
+  assert.equal(r.reason, 'override-marker-suppresses');
+});
+
+test('shouldBlock: env on + no detection = NOT block', () => {
+  const r = shouldBlock({ detection: { detected: false }, env: { MEGINGJORD_FLEET_DIRECT_BLOCK: '1' } });
+  assert.equal(r.block, false);
+});
+
+test('blockMessage: includes detected provider names', () => {
+  const msg = blockMessage({ providers: [{ name: 'ollama-fleet' }, { name: 'ollama-local' }] });
+  assert.match(msg, /ollama-fleet, ollama-local/);
+});
+
+test('ENV_FLAG constant is MEGINGJORD_FLEET_DIRECT_BLOCK', () => {
+  assert.equal(ENV_FLAG, 'MEGINGJORD_FLEET_DIRECT_BLOCK');
+});
+
+test('REDIRECT_MSG cites dispatchRedTeam path', () => {
+  assert.match(REDIRECT_MSG, /fleet-red-team-dispatch/);
+});


### PR DESCRIPTION
## Summary

Phase-1 child P1-3 of Epic #2029. Direct G3 blocker.

- `scripts/global/hamr-fleet-direct-block.js` (24 LoC) — `MEGINGJORD_FLEET_DIRECT_BLOCK=1` env-gated enforcement
- Wraps detectBypass from #2220 P1-2
- 11 unit tests
- pretool_guard.py wiring deferred to follow-on

**G3 impact**: when env on, forces every fleet call through HAMR cost tracking (no more silent direct curls).

Refs #2219
Refs Epic #2029
Refs Phase-0 source #2218
Closes #2219

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2219#issuecomment-4550065780
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2219#issuecomment-4550074189
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2219#issuecomment-4550074314
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2219#issuecomment-4550074411 (rubric min 9/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
