### PR TITLE
feat(hamr): governance-context injection helper #2221

### DIFF
--- a/.changes/unreleased/2221.md
+++ b/.changes/unreleased/2221.md
@@ -1,0 +1,2 @@
+### Added
+- `scripts/global/governance-context.js` (51 LoC) — priority-sentence + goal-definition injection for governed provider calls. `injectGoalContext(opts)` returns `{systemPrefix, injected}`. Default-on; skips when `tier='diagnostic'`/`tier='test'` or `inject_goal_context:false`. Includes `estimateOverheadTokens()` reporting ~30 tokens priority-only or ~210 with full G1-G10 definitions. 15 unit tests. Phase-1 child P1-1 of Epic #2029. **G3 preservation**: <200 tokens absorbed by HAMR cache layer per Epic AC6. Refs #2221.

--- a/scripts/global/governance-context.js
+++ b/scripts/global/governance-context.js
@@ -1,0 +1,53 @@
+'use strict';
+// governance-context — inject canonical priority sentence + goal definitions
+// into governed provider calls via wrapProviderCall opts.
+// Refs Epic #2029 #2221. Mirrors goal_lens.py priority sentence at provider layer.
+
+const PRIORITY_SENTENCE = 'Goal priority: G1 Governance > G2 Quality > G3 Zero Cost > G4 Privacy > G5 Portability > G6 Resilience > G7 Throughput > G8 Observability > G9 Interoperability > G10 Maintainability.';
+const DECISION_CHECK = 'Decision check: justify any lower-priority override with explicit evidence.';
+
+const GOAL_DEFINITIONS = {
+  G1: 'Governance: policy, role, provenance, ticket controls non-negotiable.',
+  G2: 'Quality: maximize correctness and engineering value.',
+  G3: 'Zero Cost: prefer local/fleet/free lanes before paid providers.',
+  G4: 'Privacy: keep sensitive context local unless explicit override.',
+  G5: 'Portability: avoid user-specific coupling; settings-driven.',
+  G6: 'Resilience: graceful degradation; fallback paths.',
+  G7: 'Throughput: acceptable speed after higher-priority goals met.',
+  G8: 'Observability: decisions visible, auditable, attributable.',
+  G9: 'Interoperability: preserve compatibility across runtimes.',
+  G10: 'Maintainability: code clarity, low cognitive overhead, durable structure.',
+};
+
+function shouldInject(opts) {
+  if (!opts) return false;
+  if (opts.tier === 'diagnostic' || opts.tier === 'test') return false;
+  if (opts.inject_goal_context === false) return false;
+  return opts.inject_goal_context !== undefined ? Boolean(opts.inject_goal_context) : true;
+}
+
+function buildPrefix({ includeDefinitions } = {}) {
+  const lines = [PRIORITY_SENTENCE, DECISION_CHECK];
+  if (includeDefinitions) {
+    lines.push('Goal definitions:');
+    for (const [key, def] of Object.entries(GOAL_DEFINITIONS)) {
+      lines.push(`  ${key} ${def}`);
+    }
+  }
+  return lines.join(' ');
+}
+
+function injectGoalContext(opts) {
+  if (!shouldInject(opts)) return { systemPrefix: null, injected: false };
+  const includeDefinitions = Boolean(opts && opts.include_goal_definitions);
+  return { systemPrefix: buildPrefix({ includeDefinitions }), injected: true, includesDefinitions: includeDefinitions };
+}
+
+function estimateOverheadTokens({ includeDefinitions } = {}) {
+  const PRIORITY_LINE_TOKEN_EST = 30;
+  const DEFINITIONS_TOKEN_EST = 180;
+  return includeDefinitions ? PRIORITY_LINE_TOKEN_EST + DEFINITIONS_TOKEN_EST : PRIORITY_LINE_TOKEN_EST;
+}
+
+module.exports = { injectGoalContext, shouldInject, buildPrefix,
+  estimateOverheadTokens, PRIORITY_SENTENCE, DECISION_CHECK, GOAL_DEFINITIONS };

--- a/tests/governance-context.spec.js
+++ b/tests/governance-context.spec.js
@@ -1,0 +1,70 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { injectGoalContext, shouldInject, buildPrefix, estimateOverheadTokens, PRIORITY_SENTENCE, DECISION_CHECK, GOAL_DEFINITIONS } = require('../scripts/global/governance-context.js');
+
+test('PRIORITY_SENTENCE contains all 10 goal labels', () => {
+  for (let i = 1; i <= 10; i++) assert.match(PRIORITY_SENTENCE, new RegExp(`G${i}\\b`));
+});
+
+test('DECISION_CHECK mirrors goal_lens.py', () => {
+  assert.match(DECISION_CHECK, /justify any lower-priority override/);
+});
+
+test('GOAL_DEFINITIONS has 10 entries G1-G10', () => {
+  for (let i = 1; i <= 10; i++) assert.ok(GOAL_DEFINITIONS[`G${i}`], `G${i} missing`);
+});
+
+test('shouldInject: default true', () => {
+  assert.equal(shouldInject({}), true);
+});
+
+test('shouldInject: tier=diagnostic skips', () => {
+  assert.equal(shouldInject({ tier: 'diagnostic' }), false);
+});
+
+test('shouldInject: tier=test skips', () => {
+  assert.equal(shouldInject({ tier: 'test' }), false);
+});
+
+test('shouldInject: explicit inject_goal_context=false skips', () => {
+  assert.equal(shouldInject({ inject_goal_context: false }), false);
+});
+
+test('shouldInject: explicit inject_goal_context=true honors', () => {
+  assert.equal(shouldInject({ inject_goal_context: true, tier: 'fleet-local' }), true);
+});
+
+test('shouldInject: null opts returns false', () => {
+  assert.equal(shouldInject(null), false);
+});
+
+test('buildPrefix: default omits definitions', () => {
+  const p = buildPrefix();
+  assert.match(p, /G1 Governance/);
+  assert.equal(p.includes('G1 Governance:'), false);  // definitions header
+});
+
+test('buildPrefix: includeDefinitions=true adds all 10 definitions', () => {
+  const p = buildPrefix({ includeDefinitions: true });
+  for (let i = 1; i <= 10; i++) assert.match(p, new RegExp(`G${i} `));
+});
+
+test('injectGoalContext: returns {systemPrefix, injected:true} when shouldInject', () => {
+  const r = injectGoalContext({});
+  assert.equal(r.injected, true);
+  assert.ok(r.systemPrefix);
+});
+
+test('injectGoalContext: diagnostic tier returns null systemPrefix', () => {
+  const r = injectGoalContext({ tier: 'diagnostic' });
+  assert.equal(r.injected, false);
+  assert.equal(r.systemPrefix, null);
+});
+
+test('estimateOverheadTokens: priority-only ~30 tokens', () => {
+  assert.equal(estimateOverheadTokens(), 30);
+});
+
+test('estimateOverheadTokens: with definitions ~210 tokens', () => {
+  assert.equal(estimateOverheadTokens({ includeDefinitions: true }), 210);
+});


### PR DESCRIPTION
## Summary

Phase-1 child P1-1 of Epic #2029. Foundational helper for goal-aware governed calls.

- `scripts/global/governance-context.js` (51 LoC) — `injectGoalContext(opts)` returns `{systemPrefix, injected}`
- Mirrors `goal_lens.py` priority sentence at provider layer
- Default-on; skips `tier='diagnostic'/'test'` or explicit opt-out
- Two modes: priority-only (~30 tokens) or with-definitions (~210 tokens)
- 15 unit tests
- wrapProviderCall integration deferred to follow-on

Refs #2221
Refs Epic #2029
Refs Phase-0 source #2218
Closes #2221

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2221#issuecomment-4550083317
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2221#issuecomment-4550092428
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2221#issuecomment-4550092597
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2221#issuecomment-4550092725 (rubric min 9/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
