### PR TITLE
fix(hamr): wire detectBypass advisory into pretool_guard.py #2235

### DIFF
--- a/.changes/unreleased/2235.md
+++ b/.changes/unreleased/2235.md
@@ -1,0 +1,3 @@
+### Added
+- `hooks/scripts/hamr_bypass_detector.py` (86 lines) — Python mirror of #2220 JS detector. Avoids subprocess overhead per Bash invocation.
+- `hooks/scripts/pretool_guard.py` PreToolUse hook now calls `detect_bypass` + `emit_incident` ADVISORY-ONLY for every Bash command. Direct curls to known paid/fleet provider endpoints surface as `pattern_id=hamr-bypass-detected` events in `~/.megingjord/incidents.jsonl`. No deny; #2236 wiring will add the env-gated block. 10 Python unittest cases mirror JS spec coverage. Epic #2029 wiring follow-on. Refs #2235.

--- a/hooks/scripts/hamr_bypass_detector.py
+++ b/hooks/scripts/hamr_bypass_detector.py
@@ -1,0 +1,86 @@
+"""HAMR bypass-detector for pretool_guard PreToolUse hook.
+
+Refs Epic #2029 #2235 wiring follow-on. Python mirror of
+scripts/global/hamr-bypass-detector.js (#2220) to avoid subprocess overhead
+on every Bash invocation. Detector logic kept minimal; canonical regex set
+matches the JS module per regression test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+FLEET_PORT = 11434
+LOOPBACK_IP_PARTS = (127, 0, 0, 1)
+DEFAULT_FLEET_IP_PARTS = (100, 91, 113, 16)
+
+PAID_PROVIDER_REGEXES = [
+    ("anthropic", re.compile(r"https?://api\.anthropic\.com", re.I)),
+    ("openai", re.compile(r"https?://api\.openai\.com", re.I)),
+    ("openrouter", re.compile(r"https?://openrouter\.ai", re.I)),
+    ("gemini", re.compile(r"https?://generativelanguage\.googleapis\.com", re.I)),
+    ("groq", re.compile(r"https?://api\.groq\.com", re.I)),
+    ("cerebras", re.compile(r"https?://api\.cerebras\.ai", re.I)),
+]
+
+OVERRIDE_MARKER_RE = re.compile(r"#\s*hamr-bypass-ok:\s*(.+?)(?:\n|$)", re.I)
+CURL_INVOKE_RE = re.compile(r"\b(?:curl|wget|http|httpie)\b", re.I)
+
+
+def _ip_from_parts(parts):
+    return ".".join(str(p) for p in parts)
+
+
+def _fleet_substrings():
+    fleet_ip = os.environ.get("FLEET_HOST_IP") or _ip_from_parts(DEFAULT_FLEET_IP_PARTS)
+    loopback = _ip_from_parts(LOOPBACK_IP_PARTS)
+    return [
+        ("ollama-fleet", f"{fleet_ip}:{FLEET_PORT}"),
+        ("ollama-local-ip", f"{loopback}:{FLEET_PORT}"),
+        ("ollama-local-name", f"localhost:{FLEET_PORT}"),
+    ]
+
+
+def detect_bypass(cmd_string):
+    text = str(cmd_string or "")
+    if not CURL_INVOKE_RE.search(text):
+        return {"detected": False, "reason": "not-http-invocation"}
+    matches = []
+    for name, regex in PAID_PROVIDER_REGEXES:
+        if regex.search(text):
+            matches.append({"name": name, "paid": True})
+    for name, literal in _fleet_substrings():
+        if literal in text:
+            matches.append({"name": name, "paid": False})
+    if not matches:
+        return {"detected": False, "reason": "no-known-provider-url"}
+    override_match = OVERRIDE_MARKER_RE.search(text)
+    if override_match:
+        return {"detected": True, "suppressed": True, "reason": "override-marker-present",
+                "override_reason": override_match.group(1).strip(), "providers": matches}
+    severity = "paid-bypass" if any(m["paid"] for m in matches) else "fleet-bypass"
+    return {"detected": True, "suppressed": False, "providers": matches, "severity": severity}
+
+
+def emit_incident(detection, incidents_path=None, now_ms=None):
+    if not detection or not detection.get("detected") or detection.get("suppressed"):
+        return None
+    incidents_path = incidents_path or str(Path.home() / ".megingjord" / "incidents.jsonl")
+    evt = {
+        "ts": now_ms or int(time.time() * 1000),
+        "version": 3,
+        "service": "megingjord-hamr-bypass-detector",
+        "env": "prod",
+        "event": "hamr-bypass-detected",
+        "pattern_id": "hamr-bypass-detected",
+        "severity": detection["severity"],
+        "providers": [p["name"] for p in detection["providers"]],
+    }
+    Path(incidents_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(incidents_path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(evt) + "\n")
+    return evt

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -132,6 +132,13 @@ def main() -> int:
         if not state.get("active_ticket"):
             return emit("deny","File edit blocked: no active ticket. Manager must reference a ticket (#N) before edits.")
     if tool in {"run_in_terminal","terminal","runTerminalCommand","Bash"}:
+        # Refs #2235 — wire #2220 detector as ADVISORY (no deny; emit incident only).
+        try:
+            from hamr_bypass_detector import detect_bypass, emit_incident
+            _det = detect_bypass("\n".join(values))
+            emit_incident(_det)
+        except Exception:
+            pass  # detector failure must not break pre-tool flow
         result = check_terminal("\n".join(values), state, cwd)
         if result is not None: return result
     suspicious = [v for v in values if "/" in v or "." in v]

--- a/tests/hamr-bypass-detector-py-wiring.spec.js
+++ b/tests/hamr-bypass-detector-py-wiring.spec.js
@@ -1,0 +1,64 @@
+// Refs #2235 — JS-side spec confirming pretool_guard wiring + Python detector parity.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PY_DETECTOR = path.join(__dirname, '..', 'hooks', 'scripts', 'hamr_bypass_detector.py');
+const PRETOOL_GUARD = path.join(__dirname, '..', 'hooks', 'scripts', 'pretool_guard.py');
+
+test('Python detector module exists at canonical path', () => {
+  assert.ok(fs.existsSync(PY_DETECTOR));
+});
+
+test('pretool_guard.py references hamr_bypass_detector (wiring landed)', () => {
+  const src = fs.readFileSync(PRETOOL_GUARD, 'utf8');
+  assert.match(src, /from hamr_bypass_detector import detect_bypass, emit_incident/);
+});
+
+test('pretool_guard wiring is wrapped in try/except (resilience)', () => {
+  const src = fs.readFileSync(PRETOOL_GUARD, 'utf8');
+  // Verify the detector invocation sits inside a try block
+  const wireIdx = src.indexOf('detect_bypass');
+  const preceding = src.slice(Math.max(0, wireIdx - 200), wireIdx);
+  assert.match(preceding, /try:/);
+});
+
+test('Python detector executable via python3 (sanity check)', () => {
+  const result = spawnSync('python3', ['-c', `
+import sys
+sys.path.insert(0, '${path.dirname(PY_DETECTOR)}')
+from hamr_bypass_detector import detect_bypass
+r = detect_bypass('curl https://api.anthropic.com/v1/messages')
+print(r['detected'], r.get('severity'))
+`], { encoding: 'utf8' });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /True paid-bypass/);
+});
+
+test('Python detector returns suppressed=True on override marker', () => {
+  const result = spawnSync('python3', ['-c', `
+import sys
+sys.path.insert(0, '${path.dirname(PY_DETECTOR)}')
+from hamr_bypass_detector import detect_bypass
+r = detect_bypass('curl http://localhost:11434 # hamr-bypass-ok: health-probe')
+print(r['suppressed'], r.get('override_reason'))
+`], { encoding: 'utf8' });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /True health-probe/);
+});
+
+test('JS-Python parity contract: PAID_PROVIDER_REGEXES set matches', () => {
+  const js = require('../scripts/global/hamr-bypass-detector.js');
+  const result = spawnSync('python3', ['-c', `
+import sys
+sys.path.insert(0, '${path.dirname(PY_DETECTOR)}')
+from hamr_bypass_detector import PAID_PROVIDER_REGEXES
+print(' '.join(name for name, _ in PAID_PROVIDER_REGEXES))
+`], { encoding: 'utf8' });
+  assert.equal(result.status, 0);
+  const pyNames = result.stdout.trim().split(' ').sort();
+  const jsNames = js.PAID_PROVIDER_REGEXES.map(p => p.name).sort();
+  assert.deepEqual(pyNames, jsNames, `Python ${pyNames.join(',')} vs JS ${jsNames.join(',')}`);
+});

--- a/tests/hamr_bypass_detector_python.py
+++ b/tests/hamr_bypass_detector_python.py
@@ -1,0 +1,72 @@
+"""Refs #2235 - Python detector tests; mirrors JS spec coverage."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks" / "scripts"))
+from hamr_bypass_detector import detect_bypass, emit_incident
+
+
+class TestDetectBypass(unittest.TestCase):
+    def test_anthropic_curl_paid_bypass(self):
+        r = detect_bypass('curl -X POST https://api.anthropic.com/v1/messages')
+        self.assertTrue(r["detected"])
+        self.assertEqual(r["severity"], "paid-bypass")
+
+    def test_fleet_curl_fleet_bypass(self):
+        r = detect_bypass('curl -X POST http://100.91.113.16:11434/api/generate')
+        self.assertTrue(r["detected"])
+        self.assertEqual(r["severity"], "fleet-bypass")
+
+    def test_localhost_ollama_fleet_bypass(self):
+        r = detect_bypass('curl http://localhost:11434/api/tags')
+        self.assertTrue(r["detected"])
+        self.assertEqual(r["severity"], "fleet-bypass")
+
+    def test_override_marker_suppresses(self):
+        r = detect_bypass('curl http://100.91.113.16:11434/api/tags # hamr-bypass-ok: health-probe')
+        self.assertTrue(r["detected"])
+        self.assertTrue(r["suppressed"])
+        self.assertEqual(r["override_reason"], "health-probe")
+
+    def test_non_curl_not_detected(self):
+        r = detect_bypass('node scripts/global/hamr-provider-wrapper.js')
+        self.assertFalse(r["detected"])
+
+    def test_unknown_url_not_detected(self):
+        r = detect_bypass('curl https://example.com/data.json')
+        self.assertFalse(r["detected"])
+
+    def test_empty_input(self):
+        self.assertFalse(detect_bypass("")["detected"])
+        self.assertFalse(detect_bypass(None)["detected"])
+
+    def test_multi_provider(self):
+        r = detect_bypass('curl https://api.anthropic.com; curl https://api.openai.com')
+        self.assertTrue(r["detected"])
+        self.assertGreaterEqual(len(r["providers"]), 2)
+
+
+class TestEmitIncident(unittest.TestCase):
+    def test_writes_jsonl(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "incidents.jsonl")
+            detection = detect_bypass('curl https://api.anthropic.com/v1/messages')
+            evt = emit_incident(detection, incidents_path=path)
+            self.assertIsNotNone(evt)
+            with open(path) as fh:
+                parsed = json.loads(fh.read().strip())
+            self.assertEqual(parsed["event"], "hamr-bypass-detected")
+            self.assertEqual(parsed["severity"], "paid-bypass")
+
+    def test_suppressed_returns_none(self):
+        detection = detect_bypass('curl http://localhost:11434 # hamr-bypass-ok: testing')
+        self.assertIsNone(emit_incident(detection, incidents_path="/tmp/should-not-write.jsonl"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Epic #2029 wiring follow-on (2nd of 3). Activates #2220 hamr-bypass-detector.js via Python mirror to avoid subprocess overhead per Bash invocation.

- `hooks/scripts/hamr_bypass_detector.py` (86 LoC) — Python mirror of JS detector
- `hooks/scripts/pretool_guard.py` Bash-tool branch invokes detector ADVISORY (try/except wrapped)
- Emits `pattern_id=hamr-bypass-detected` to `~/.megingjord/incidents.jsonl`
- No deny — #2236 wiring adds env-gated block
- 10 Python unittest cases mirror JS spec coverage

**G3 impact**: every direct curl to anthropic/openai/openrouter/gemini/groq/cerebras/ollama-fleet/ollama-local now logged for audit.

Refs #2235
Refs Epic #2029 (closed; wiring follow-on)
Closes #2235

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2235#issuecomment-4550699619
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2235#issuecomment-4550714079
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2235#issuecomment-4550714161
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2235#issuecomment-4550714233 (rubric min 9/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
