### PR TITLE
fix(hamr): wire fleet-direct-block into pretool_guard #2236

### DIFF
--- a/.changes/unreleased/2236.md
+++ b/.changes/unreleased/2236.md
@@ -1,0 +1,3 @@
+### Added
+- `hooks/scripts/hamr_fleet_direct_block.py` (40 lines) — Python mirror of #2219 JS module.
+- `hooks/scripts/pretool_guard.py` Bash-tool branch now invokes `should_block` after `detect_bypass`. When `MEGINGJORD_FLEET_DIRECT_BLOCK=1` AND detection is `severity=fleet-bypass` (no override), pretool_guard emits DENY with redirect-to-`fleet-red-team-dispatch.js` message. 12 Python unittest + 6 JS parity tests. Epic #2029 wiring follow-on (3rd of 3 — completes the G3 enforcement loop). Refs #2236.

--- a/hooks/scripts/hamr_fleet_direct_block.py
+++ b/hooks/scripts/hamr_fleet_direct_block.py
@@ -1,0 +1,41 @@
+"""HAMR fleet-direct-block — env-gated enforcement for pretool_guard.
+
+Refs Epic #2029 #2236 wiring follow-on. Python mirror of
+scripts/global/hamr-fleet-direct-block.js (#2219). Consumes #2235
+detect_bypass output; returns block decision when
+MEGINGJORD_FLEET_DIRECT_BLOCK=1 AND severity='fleet-bypass'.
+"""
+
+from __future__ import annotations
+
+import os
+
+ENV_FLAG = "MEGINGJORD_FLEET_DIRECT_BLOCK"
+REDIRECT_MSG = (
+    "Direct fleet call blocked. Use scripts/global/fleet-red-team-dispatch.js "
+    "(Epic #2041 #2175) for HAMR-routed dispatch via tier=fleet-local."
+)
+
+
+def is_enabled(env=None):
+    env = env if env is not None else os.environ
+    return env.get(ENV_FLAG) == "1"
+
+
+def should_block(detection, env=None):
+    if not is_enabled(env):
+        return {"block": False, "reason": "env-flag-off"}
+    if not detection or not detection.get("detected"):
+        return {"block": False, "reason": "no-bypass-detected"}
+    if detection.get("suppressed"):
+        return {"block": False, "reason": "override-marker-suppresses"}
+    if detection.get("severity") == "fleet-bypass":
+        return {"block": True, "reason": "fleet-direct-blocked", "message": REDIRECT_MSG}
+    if detection.get("severity") == "paid-bypass":
+        return {"block": False, "reason": "paid-bypass-not-fleet-scope"}
+    return {"block": False, "reason": "unknown-severity"}
+
+
+def block_message(detection):
+    providers = ", ".join(p["name"] for p in (detection or {}).get("providers", [])) or "unknown"
+    return f"{REDIRECT_MSG} (detected providers: {providers})"

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -133,10 +133,15 @@ def main() -> int:
             return emit("deny","File edit blocked: no active ticket. Manager must reference a ticket (#N) before edits.")
     if tool in {"run_in_terminal","terminal","runTerminalCommand","Bash"}:
         # Refs #2235 — wire #2220 detector as ADVISORY (no deny; emit incident only).
+        # Refs #2236 — when MEGINGJORD_FLEET_DIRECT_BLOCK=1, enforce DENY on fleet-bypass.
         try:
             from hamr_bypass_detector import detect_bypass, emit_incident
+            from hamr_fleet_direct_block import should_block, block_message
             _det = detect_bypass("\n".join(values))
             emit_incident(_det)
+            _blk = should_block(_det)
+            if _blk.get("block"):
+                return emit("deny", block_message(_det))
         except Exception:
             pass  # detector failure must not break pre-tool flow
         result = check_terminal("\n".join(values), state, cwd)

--- a/tests/hamr-fleet-block-py-wiring.spec.js
+++ b/tests/hamr-fleet-block-py-wiring.spec.js
@@ -1,0 +1,61 @@
+// Refs #2236 — JS spec verifying py block module + pretool_guard wiring + parity.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PY_BLOCK = path.join(__dirname, '..', 'hooks', 'scripts', 'hamr_fleet_direct_block.py');
+const PRETOOL_GUARD = path.join(__dirname, '..', 'hooks', 'scripts', 'pretool_guard.py');
+
+test('Python block module exists at canonical path', () => {
+  assert.ok(fs.existsSync(PY_BLOCK));
+});
+
+test('pretool_guard.py imports should_block + block_message (#2236 wiring)', () => {
+  const src = fs.readFileSync(PRETOOL_GUARD, 'utf8');
+  assert.match(src, /from hamr_fleet_direct_block import should_block, block_message/);
+});
+
+test('pretool_guard.py invokes should_block AND emits deny on block:True', () => {
+  const src = fs.readFileSync(PRETOOL_GUARD, 'utf8');
+  assert.match(src, /should_block\(_det\)/);
+  assert.match(src, /emit\("deny", block_message/);
+});
+
+test('block module executable: env=1 + fleet-bypass = block', () => {
+  const result = spawnSync('python3', ['-c', `
+import sys, os
+sys.path.insert(0, '${path.dirname(PY_BLOCK)}')
+os.environ['MEGINGJORD_FLEET_DIRECT_BLOCK'] = '1'
+from hamr_fleet_direct_block import should_block
+r = should_block({'detected': True, 'severity': 'fleet-bypass'})
+print(r['block'], r.get('reason'))
+`], { encoding: 'utf8' });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /True fleet-direct-blocked/);
+});
+
+test('block module executable: env=0 = no block', () => {
+  const result = spawnSync('python3', ['-c', `
+import sys
+sys.path.insert(0, '${path.dirname(PY_BLOCK)}')
+from hamr_fleet_direct_block import should_block
+r = should_block({'detected': True, 'severity': 'fleet-bypass'}, env={})
+print(r['block'], r['reason'])
+`], { encoding: 'utf8' });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /False env-flag-off/);
+});
+
+test('JS-Python parity: ENV_FLAG names match', () => {
+  const js = require('../scripts/global/hamr-fleet-direct-block.js');
+  const result = spawnSync('python3', ['-c', `
+import sys
+sys.path.insert(0, '${path.dirname(PY_BLOCK)}')
+from hamr_fleet_direct_block import ENV_FLAG
+print(ENV_FLAG)
+`], { encoding: 'utf8' });
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout.trim(), js.ENV_FLAG);
+});

--- a/tests/hamr_fleet_direct_block_python.py
+++ b/tests/hamr_fleet_direct_block_python.py
@@ -1,0 +1,68 @@
+"""Refs #2236 - Python fleet-direct-block tests."""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks" / "scripts"))
+from hamr_fleet_direct_block import should_block, is_enabled, block_message, ENV_FLAG, REDIRECT_MSG
+
+
+class TestIsEnabled(unittest.TestCase):
+    def test_env_1(self):
+        self.assertTrue(is_enabled({ENV_FLAG: "1"}))
+
+    def test_env_0(self):
+        self.assertFalse(is_enabled({ENV_FLAG: "0"}))
+
+    def test_missing(self):
+        self.assertFalse(is_enabled({}))
+
+
+class TestShouldBlock(unittest.TestCase):
+    def test_env_off_fleet_bypass_no_block(self):
+        r = should_block({"detected": True, "severity": "fleet-bypass"}, env={})
+        self.assertFalse(r["block"])
+        self.assertEqual(r["reason"], "env-flag-off")
+
+    def test_env_on_fleet_bypass_BLOCKS(self):
+        r = should_block({"detected": True, "severity": "fleet-bypass"}, env={ENV_FLAG: "1"})
+        self.assertTrue(r["block"])
+        self.assertIn("fleet-red-team-dispatch", r["message"])
+
+    def test_env_on_paid_bypass_NOT_block_out_of_scope(self):
+        r = should_block({"detected": True, "severity": "paid-bypass"}, env={ENV_FLAG: "1"})
+        self.assertFalse(r["block"])
+        self.assertEqual(r["reason"], "paid-bypass-not-fleet-scope")
+
+    def test_env_on_suppressed_no_block(self):
+        r = should_block({"detected": True, "suppressed": True}, env={ENV_FLAG: "1"})
+        self.assertFalse(r["block"])
+        self.assertEqual(r["reason"], "override-marker-suppresses")
+
+    def test_no_detection_no_block(self):
+        r = should_block({"detected": False}, env={ENV_FLAG: "1"})
+        self.assertFalse(r["block"])
+
+
+class TestBlockMessage(unittest.TestCase):
+    def test_includes_providers(self):
+        msg = block_message({"providers": [{"name": "ollama-fleet"}, {"name": "ollama-local-ip"}]})
+        self.assertIn("ollama-fleet, ollama-local-ip", msg)
+
+    def test_no_providers(self):
+        msg = block_message({})
+        self.assertIn("unknown", msg)
+
+
+class TestEnvConstants(unittest.TestCase):
+    def test_env_flag_name(self):
+        self.assertEqual(ENV_FLAG, "MEGINGJORD_FLEET_DIRECT_BLOCK")
+
+    def test_redirect_msg_cites_dispatcher(self):
+        self.assertIn("fleet-red-team-dispatch", REDIRECT_MSG)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Epic #2029 wiring follow-on (3rd of 3) — completes G3 enforcement loop. Detection (#2235) + block (#2236) + context-injection (#2234) all ACTIVE in pretool_guard.py / wrapProviderCall.

- `hooks/scripts/hamr_fleet_direct_block.py` (40 LoC) — Python mirror of #2219 JS module
- `hooks/scripts/pretool_guard.py` invokes `should_block` after `detect_bypass`
- `MEGINGJORD_FLEET_DIRECT_BLOCK=1` AND `severity=fleet-bypass` (no override) → DENY with redirect to `fleet-red-team-dispatch.js`
- 12 Python unittest + 6 JS parity tests

**G3 impact**: with env on (recommended for CI + governed sessions), no fleet calls escape HAMR cost tracking.

Refs #2236
Refs Epic #2029 (closed; wiring follow-on)
Closes #2236

## Baton trail

- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2236#issuecomment-4550745364
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2236#issuecomment-4550754065
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2236#issuecomment-4550754121
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2236#issuecomment-4550754170 (rubric min 10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
