### PR TITLE
fix(1996): migrate anneal tier2 autofile create path to dispatcher

### DIFF
--- a/.changes/unreleased/1996.md
+++ b/.changes/unreleased/1996.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Migrate anneal auto-file ticket creation in `scripts/global/anneal-tier2-autofile.js` to dispatcher-backed GitHub MCP with CLI fallback when `MEGINGJORD_MCP_DISABLED=1`.
+- Add dispatcher `labels` array support for multi-label `create-issue` calls and targeted regression tests.

--- a/scripts/global/anneal-tier2-autofile.js
+++ b/scripts/global/anneal-tier2-autofile.js
@@ -8,6 +8,7 @@ const { classifyTier1 } = require('./anneal-severity-classifier');
 const { stepGate, patternRateGate, singleFlightGate, releaseSingleFlight } = require('./anneal-kill-switch');
 const { emitEvent, readEvents } = require('./anneal-event-schema');
 const { gateCandidate, markConfirmed } = require('./anneal-worker-confirmation');
+const { execute } = require('./github-dispatcher');
 
 const INCIDENTS = path.join(os.homedir(), '.megingjord', 'incidents.jsonl');
 const SUPPRESS_FILE = path.join(os.homedir(), '.megingjord', 'suppression-registry.json');
@@ -52,20 +53,31 @@ function buildBody(candidate, meta, nowIso) {
   return [
     'SELF_ANNEAL_PROPOSAL', `proposal_id: ${meta.proposal_id}`, `dedupe_key: ${meta.dedupe_key}`,
     `pattern_id: ${candidate.pattern_id}`, `severity: ${candidate.severity}`, `count_7d: ${candidate.count}`,
-    `threshold: >=2 in 7d`, `detected_at: ${nowIso}`, '', 'Evidence', ev, '',
+    'threshold: >=2 in 7d', `detected_at: ${nowIso}`, '', 'Evidence', ev, '',
     'Proposed remediation', '- run workflow-self-anneal with collected evidence',
     '- update instruction/guardrail only after review approval',
   ].join('\n');
 }
-function maybeCreateTicket(candidate, meta, nowIso, applyFlag) {
+function normalizeCreateResult(res) {
+  if (res.provider === 'gh-cli') return (res.stdout || '').trim();
+  const issue = res.result?.issue || res.result || {};
+  return issue.url || issue.html_url || (issue.number ? `#${issue.number}` : 'MCP-CREATED');
+}
+async function maybeCreateTicket(candidate, meta, nowIso, applyFlag, opts = {}) {
   const body = buildBody(candidate, meta, nowIso);
   if (!applyFlag) return 'DRY-RUN';
-  const existing = dedupeHit(meta.dedupe_key); if (existing) return existing;
-  const args = ['issue', 'create', '--title', `Anneal Proposal: ${candidate.pattern_id}`,
-    '--label', 'type:task', '--label', 'area:governance', '--label', 'status:backlog', '--body', body];
-  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+  const dedupeLookup = opts.dedupeLookup || dedupeHit;
+  const existing = dedupeLookup(meta.dedupe_key);
+  if (existing) return existing;
+  const res = await execute('create-issue', {
+    title: `Anneal Proposal: ${candidate.pattern_id}`,
+    body,
+    labels: ['type:task', 'area:governance', 'status:backlog'],
+  }, opts.dispatcherOpts || {});
+  if (!res.ok) throw new Error(res.error || res.reason || 'issue create failed');
+  return normalizeCreateResult(res);
 }
-function processOneCandidate(candidate, ctx, out) {
+async function processOneCandidate(candidate, ctx, out) {
   if (!stepGate(out.length + Number('1')).ok) {
     emitKillSwitch('step-counter', candidate.pattern_id, ctx.sessionId, ctx.nowIso);
     return 'break';
@@ -78,7 +90,10 @@ function processOneCandidate(candidate, ctx, out) {
     out.push({ pattern_id: candidate.pattern_id, severity: candidate.severity, proposal_id: meta.proposal_id, dedupe_key: meta.dedupe_key, ticket_ref: `PENDING-CONFIRMATION:${confirmGate.reason}` });
     return 'continue';
   }
-  const ticketRef = maybeCreateTicket(candidate, meta, ctx.nowIso, ctx.applyFlag);
+  const ticketRef = await maybeCreateTicket(candidate, meta, ctx.nowIso, ctx.applyFlag, {
+    dedupeLookup: ctx.dedupeLookup,
+    dispatcherOpts: ctx.dispatcherOpts,
+  });
   emitEvent({ version: TWO, timestamp: ctx.nowIso, tier: TWO, trigger_role: 'system', trigger_type: 'sensor-driven',
     pattern_id: candidate.pattern_id, severity: candidate.severity, evidence: [`count=${candidate.count}`],
     ticket_ref: ticketRef, epic_ref: '#1308', proposal_id: meta.proposal_id, dedupe_key: meta.dedupe_key, session_id: ctx.sessionId,
@@ -87,7 +102,7 @@ function processOneCandidate(candidate, ctx, out) {
   return 'next';
 }
 
-function run(argv) {
+async function run(argv, opts = {}) {
   const applyFlag = argv.includes('--apply');
   const confirmIdx = argv.indexOf('--apply-confirmed');
   if (confirmIdx >= 0 && argv[confirmIdx + 1]) markConfirmed(argv[confirmIdx + 1]);
@@ -101,10 +116,10 @@ function run(argv) {
   const flight = singleFlightGate(sessionId); if (!flight.ok) return emitKillSwitch(flight.reason, '', sessionId, nowIso);
   const candidates = buildCandidates(tier1).filter((item) => !isSuppressed(item.pattern_id, suppressions));
   const out = [];
-  const ctx = { applyFlag, nowIso, sessionId, tier2 };
+  const ctx = { applyFlag, nowIso, sessionId, tier2, dispatcherOpts: opts.dispatcherOpts || {}, dedupeLookup: opts.dedupeLookup };
   try {
     for (const candidate of candidates) {
-      const decision = processOneCandidate(candidate, ctx, out);
+      const decision = await processOneCandidate(candidate, ctx, out);
       if (decision === 'break') break;
     }
   } finally {
@@ -112,5 +127,7 @@ function run(argv) {
   }
   process.stdout.write(JSON.stringify({ created: out.length, records: out }, null, TWO) + '\n');
 }
-if (require.main === module) run(process.argv.slice(TWO));
-module.exports = { buildCandidates, isSuppressed, proposalMeta, loadSuppressions, run };
+if (require.main === module) {
+  run(process.argv.slice(TWO)).catch((error) => { console.error(error.message); process.exit(1); });
+}
+module.exports = { buildCandidates, isSuppressed, proposalMeta, loadSuppressions, maybeCreateTicket, run };

--- a/scripts/global/github-dispatcher.js
+++ b/scripts/global/github-dispatcher.js
@@ -43,6 +43,9 @@ function buildCliArgs(operation, params = {}) {
   if (params.issue !== undefined) args.push(String(params.issue));
   if (params.title) args.push('--title', params.title);
   if (params.body) args.push('--body', params.body);
+  if (Array.isArray(params.labels)) {
+    for (const label of params.labels) args.push('--label', label);
+  }
   if (params.label) args.push('--add-label', params.label);
   if (params.json) args.push('--json', params.json);
   return args;

--- a/tests/anneal-tier2-autofile.spec.js
+++ b/tests/anneal-tier2-autofile.spec.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { maybeCreateTicket } = require('../scripts/global/anneal-tier2-autofile');
+
+const candidate = { pattern_id: 'stall-loop', severity: 'high', count: 3, events: [] };
+const meta = { dedupe_key: 'anneal:stall-loop:high', proposal_id: 'anneal:stall-loop:high:2026-05-26' };
+
+test('maybeCreateTicket returns DRY-RUN when applyFlag is false', async () => {
+  const ref = await maybeCreateTicket(candidate, meta, '2026-05-26T00:00:00Z', false);
+  expect(ref).toBe('DRY-RUN');
+});
+
+test('maybeCreateTicket uses MCP path when forced', async () => {
+  let seenTool = '';
+  let seenLabels = [];
+  const ref = await maybeCreateTicket(candidate, meta, '2026-05-26T00:00:00Z', true, {
+    dedupeLookup: () => '',
+    dispatcherOpts: {
+      env: { MEGINGJORD_MCP_FORCE_AVAILABLE: '1' },
+      mcpClient: {
+        invoke: async (tool, params) => {
+          seenTool = tool;
+          seenLabels = params.labels || [];
+          return { issue: { url: 'https://github.com/chf3198/megingjord-harness/issues/9999' } };
+        },
+      },
+    },
+  });
+  expect(seenTool).toBe('mcp__github__create_issue');
+  expect(seenLabels).toEqual(['type:task', 'area:governance', 'status:backlog']);
+  expect(ref).toContain('/issues/9999');
+});
+
+test('maybeCreateTicket honors MCP-disabled CLI fallback', async () => {
+  let cliArgs = [];
+  const ref = await maybeCreateTicket(candidate, meta, '2026-05-26T00:00:00Z', true, {
+    dedupeLookup: () => '',
+    dispatcherOpts: {
+      env: { MEGINGJORD_MCP_DISABLED: '1' },
+      cliRunner: async (_cmd, args) => {
+        cliArgs = args;
+        return { stdout: 'https://github.com/chf3198/megingjord-harness/issues/7777\n', stderr: '' };
+      },
+    },
+  });
+  expect(cliArgs.slice(0, 2)).toEqual(['issue', 'create']);
+  expect(cliArgs.filter((a) => a === '--label').length).toBe(3);
+  expect(ref).toContain('/issues/7777');
+});
+
+test('maybeCreateTicket short-circuits on dedupe hit', async () => {
+  let invoked = false;
+  const ref = await maybeCreateTicket(candidate, meta, '2026-05-26T00:00:00Z', true, {
+    dedupeLookup: () => 'https://github.com/chf3198/megingjord-harness/issues/1234',
+    dispatcherOpts: {
+      env: { MEGINGJORD_MCP_DISABLED: '1' },
+      cliRunner: async () => {
+        invoked = true;
+        return { stdout: '', stderr: '' };
+      },
+    },
+  });
+  expect(invoked).toBe(false);
+  expect(ref).toContain('/issues/1234');
+});

--- a/tests/github-dispatcher-execute.spec.js
+++ b/tests/github-dispatcher-execute.spec.js
@@ -31,6 +31,11 @@ test('buildCliArgs returns null for unknown operation', () => {
   expect(buildCliArgs('not-an-op', {})).toBe(null);
 });
 
+test('buildCliArgs appends repeated labels for create-issue', () => {
+  const args = buildCliArgs('create-issue', { labels: ['one', 'two'] });
+  expect(args).toEqual(['issue', 'create', '--label', 'one', '--label', 'two']);
+});
+
 test('executeViaCli returns ok=true when runner succeeds', async () => {
   let captured = null;
   const fakeRunner = async (cmd, args) => { captured = { cmd, args }; return { stdout: 'OUT', stderr: '' }; };


### PR DESCRIPTION
Refs #1996

Summary:
- Migrate `scripts/global/anneal-tier2-autofile.js` issue creation path from direct `gh issue create` to dispatcher-backed MCP/CLI execution.
- Preserve dedupe lookup behavior while introducing MCP-first create path.
- Add dispatcher `labels` array support for repeated create labels.
- Add focused tests and changelog fragment `.changes/unreleased/1996.md`.

Validation:
- `npx playwright test tests/anneal-tier2-autofile.spec.js tests/github-dispatcher-execute.spec.js tests/mcp-integration.spec.js --reporter=line`
- `npm run lint`