### PR TITLE
fix(governance): require source artifact remediation

### DIFF
--- a/.changes/unreleased/2257.md
+++ b/.changes/unreleased/2257.md
@@ -1,0 +1,2 @@
+### Changed
+- Consultant baton artifact checks now mark fixable signer-role and canonical signature defects as source-edit-first remediations, directing agents to edit the offending artifact in place before adding audit notes. Canonical signer parsing also ignores prose `role:` mentions before the `Team&Model` block so future governance reruns do not keep rediscovering fully remediable defects. Refs #2257.

--- a/scripts/global/baton-artifact-governance.js
+++ b/scripts/global/baton-artifact-governance.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { validateArtifactAlias } = require('./megalint/signer-registry-check');
+const { extractArtifactFields, validateArtifactAlias } = require('./megalint/signer-registry-check');
 
 const ARTIFACT_ROLE = {
   MANAGER_HANDOFF: 'manager',
@@ -20,8 +20,7 @@ function isEpic(labels) {
 }
 
 function roleFromBody(body) {
-  const m = String(body || '').match(/Role\s*:\s*(\w+)/i);
-  return m ? m[1].toLowerCase() : null;
+  return extractArtifactFields(body).role;
 }
 
 function entries(comments) {
@@ -33,6 +32,25 @@ function entries(comments) {
     }
   }
   return out;
+}
+
+function fixable(rule) {
+  return [
+    'artifact-role-mismatch',
+    'signer-alias-not-registry-derived',
+    'signer-fields-invalid',
+  ].includes(rule);
+}
+
+function violation(artifact, rule, detail) {
+  const v = { artifact, rule, detail };
+  if (fixable(rule)) {
+    v.remediation = {
+      mode: 'source-edit-first',
+      suggestedFix: 'Edit the offending issue comment/artifact in place, then rerun consultant checks. Use additive audit comments only when the source artifact cannot be edited.',
+    };
+  }
+  return v;
 }
 
 function analyzeComments(comments, opts = {}) {
@@ -48,16 +66,17 @@ function analyzeComments(comments, opts = {}) {
     }
     const actualRole = roleFromBody(entry.body);
     if (!actualRole || actualRole !== entry.role) {
-      violations.push({ artifact: entry.artifact, rule: 'artifact-role-mismatch',
-        detail: `Expected Role: ${entry.role} for ${entry.artifact}.` });
+      violations.push(violation(entry.artifact, 'artifact-role-mismatch',
+        `Expected Role: ${entry.role} for ${entry.artifact}.`));
     }
     const alias = validateArtifactAlias(entry.body, opts);
     if (alias.ok) continue;
-    if (alias.violation) violations.push({ artifact: entry.artifact, ...alias.violation });
-    else violations.push({ artifact: entry.artifact, rule: 'signer-fields-invalid',
-      detail: alias.skipped || 'invalid signer fields' });
+    if (alias.violation) violations.push(violation(entry.artifact,
+      alias.violation.rule, alias.violation.detail));
+    else violations.push(violation(entry.artifact, 'signer-fields-invalid',
+      alias.skipped || 'invalid signer fields'));
   }
   return { ok: violations.length === 0, count: entries(comments).length, violations };
 }
 
-module.exports = { analyzeComments, ARTIFACT_ROLE, isEpic, EPIC_FORBIDDEN_ARTIFACTS };
+module.exports = { analyzeComments, ARTIFACT_ROLE, isEpic, EPIC_FORBIDDEN_ARTIFACTS, violation };

--- a/scripts/global/consultant-checks.js
+++ b/scripts/global/consultant-checks.js
@@ -70,7 +70,8 @@ const checks = [
       id('gov', 7), 'governance', result.ok,
       result.ok ? `${result.count} baton artifact comments validated` : `${first?.artifact || 'artifact'} ${first?.rule || 'unknown'}`,
       'signer-role-consistency',
-      'rebuild artifact via baton-comment-build.js or agent-signature.js and correct role fields'
+      first?.remediation?.suggestedFix ||
+        'rebuild artifact via baton-comment-build.js or agent-signature.js and correct role fields'
     );
   }],
   [id('tool', 1), 'tools', () => ok(id('tool', 1), 'tools', exists('wiki/index.md') && exists('wiki/log.md'), 'wiki index/log presence', 'wiki-growth-ready', 'maintain wiki index/log updates')],

--- a/scripts/global/megalint/signer-registry-check.js
+++ b/scripts/global/megalint/signer-registry-check.js
@@ -47,9 +47,14 @@ function expectedAliasFor({ team, model, role, device, registryOverride }) {
 
 function extractArtifactFields(body) {
   const text = body || '';
-  const signedBy = (text.match(/Signed-by\s*:\s*([^·,\n]+?)(?=\s*[·,\n]|$)/i) || [])[1];
-  const teamModel = (text.match(/Team&Model\s*:\s*(\S+)/i) || [])[1];
-  const role = (text.match(/Role\s*:\s*(\w+)/i) || [])[1];
+  const field = (label, value) => {
+    const pattern = new RegExp(`(?:^|[·,\\n])\\s*${label}\\s*:\\s*(${value})`, 'gm');
+    const matches = [...text.matchAll(pattern)];
+    return matches.length ? matches[matches.length - 1][1] : null;
+  };
+  const signedBy = field('Signed-by', '[^·,\\n]+');
+  const teamModel = field('Team&Model', '\\S+');
+  const role = field('Role', '\\w+');
   return {
     signedBy: signedBy ? signedBy.trim() : null,
     teamModel,

--- a/tests/baton-artifact-governance.spec.js
+++ b/tests/baton-artifact-governance.spec.js
@@ -36,3 +36,19 @@ test('fails on artifact-role mismatch', () => {
   expect(r.ok).toBe(false);
   expect(r.violations.some(v => v.rule === 'artifact-role-mismatch')).toBe(true);
 });
+
+test('source-fixable role mismatch carries source-edit-first guidance', () => {
+  const comments = [{
+    body: [
+      'role: collaborator',
+      '## COLLABORATOR_HANDOFF',
+      'Signed-by: Nova Mason',
+      'Team&Model: codex:gpt-5.4@codex-cli',
+      'Role: manager',
+    ].join('\n'),
+  }];
+  const r = G.analyzeComments(comments);
+  const v = r.violations.find(x => x.rule === 'artifact-role-mismatch');
+  expect(v.remediation.mode).toBe('source-edit-first');
+  expect(v.remediation.suggestedFix).toContain('Edit the offending issue comment');
+});

--- a/tests/megalint/signer-registry-check.spec.js
+++ b/tests/megalint/signer-registry-check.spec.js
@@ -64,6 +64,18 @@ test('extractArtifactFields: pulls Signed-by / Team&Model / Role', () => {
   expect(fields.role).toBe('manager');
 });
 
+test('extractArtifactFields: ignores prose lowercase role before signature', () => {
+  const body = [
+    'role: collaborator',
+    'notes: prose field should not be treated as signer role',
+    'Signed-by: Orla Mason',
+    'Team&Model: claude-code:opus-4-7@anthropic',
+    'Role: manager',
+  ].join('\n');
+  const fields = R.extractArtifactFields(body);
+  expect(fields.role).toBe('manager');
+});
+
 test('validateArtifactAlias: drift "Cole Mason" on claude-code:opus → violation with expected="Orla Mason"', () => {
   const file = makeRegistry();
   const body = 'Signed-by: Cole Mason\nTeam&Model: claude-code:opus-4-7@anthropic\nRole: manager';


### PR DESCRIPTION
Refs #2257
Closes #2257

## Summary

- Tightens canonical baton signature parsing so prose `role:` fields do not poison `Role:` extraction.
- Adds `source-edit-first` remediation metadata for fixable baton artifact defects.
- Surfaces source-remediation guidance in Consultant gov-007 output.
- Adds regression coverage for source-fixable role mismatch and lowercase prose `role:` parsing.
- Records the governance behavior change in `.changes/unreleased/2257.md`.

## Validation

- `npm run lint`
- `npx playwright test tests/baton-artifact-governance.spec.js tests/megalint/signer-registry-check.spec.js`
- `git diff --check`
- Live gov-007 check against #2249 passed after editing the source Manager artifact in place.

## Notes

Pre-push reported unrelated existing lint warnings and initially flagged the #2257 Manager handoff schema; the Manager handoff source comment was updated with lane, test_strategy, and gates before PR creation.

Team&Model:
- Human alias: Curtis Franks
- Team runtime: Codex
- Model: GPT-5
- Role: Admin