### PR TITLE
feat(wiki): add Wiki B work-log guardrails

### DIFF
--- a/scripts/wiki/health-contract.js
+++ b/scripts/wiki/health-contract.js
@@ -6,25 +6,14 @@ const path = require('node:path');
 const { listPages, parseFrontmatter, WIKI_DIR } = require('./wiki-io');
 
 const REQUIRED_FIELDS = ['title', 'type', 'created', 'status'];
-const CATS = ['entities', 'concepts', 'sources', 'syntheses'];
+const CATS = ['entities', 'concepts', 'sources', 'syntheses', 'work-log/tickets', 'work-log/prs'];
 
 function links(content) {
   return [...String(content).matchAll(/\[\[([^\]]+)\]\]/g)].map(m => m[1]);
 }
 
-function listPagesFrom(dir) {
-  const pages = [];
-  for (const d of CATS) {
-    const dp = path.join(dir, d);
-    if (!fs.existsSync(dp)) continue;
-    for (const f of fs.readdirSync(dp).filter(x => x.endsWith('.md')))
-      pages.push({ slug: f.replace('.md', ''), type: d, path: path.join(dp, f) });
-  }
-  return pages;
-}
-
 function computeWikiHealth(pages = null, wikiDir = WIKI_DIR) {
-  const set = pages || listPages();
+  const set = pages || listPages(wikiDir);
   const allSlugs = new Set(set.map(p => p.slug));
   const broken = []; const orphans = []; const frontmatter = []; const indexSync = [];
   const inbound = new Set();
@@ -53,7 +42,7 @@ function computeWikiHealth(pages = null, wikiDir = WIKI_DIR) {
 }
 
 function scanHealth(wikiDir = WIKI_DIR) {
-  const pages = listPagesFrom(wikiDir);
+  const pages = listPages(wikiDir);
   const h = computeWikiHealth(pages, wikiDir);
   const score = h.pages === 0 ? 100 : Math.max(0, 100 - Math.round(h.issues / h.pages * 100));
   const grade = score >= 90 ? 'A' : score >= 75 ? 'B' : score >= 60 ? 'C' : 'D';

--- a/scripts/wiki/wiki-io.js
+++ b/scripts/wiki/wiki-io.js
@@ -5,18 +5,23 @@ const matter = require('gray-matter');
 const WIKI_DIR = path.join(__dirname, '../../wiki');
 const DATE_TOLERANCE_DAYS = 1;
 const CATS = ['entities', 'concepts', 'sources', 'syntheses', 'skills'];
+const WORK_LOG_DIRS = [{ dir: 'work-log/tickets', type: 'ticket' }, { dir: 'work-log/prs', type: 'pr' }];
 const TYPE_DIR = {
   entity: 'entities', entities: 'entities',
   concept: 'concepts', concepts: 'concepts',
   source: 'sources', sources: 'sources',
   synthesis: 'syntheses', syntheses: 'syntheses',
   skill: 'skills', skills: 'skills',
+  ticket: 'work-log/tickets', tickets: 'work-log/tickets',
+  pr: 'work-log/prs', prs: 'work-log/prs',
 };
 const SECTION_MAP = {
   entity: '## Entities', entities: '## Entities',
   concept: '## Concepts', concepts: '## Concepts',
   source: '## Source Summaries', sources: '## Source Summaries',
   synthesis: '## Syntheses', syntheses: '## Syntheses',
+  ticket: '## Work Log', tickets: '## Work Log',
+  pr: '## Work Log', prs: '## Work Log',
 };
 
 function parseFrontmatter(content) {
@@ -28,8 +33,8 @@ function parseFrontmatter(content) {
   }
 }
 
-function updateIndex(slug, title, type) {
-  const indexPath = path.join(WIKI_DIR, 'index.md');
+function updateIndex(slug, title, type, wikiDir = WIKI_DIR) {
+  const indexPath = path.join(wikiDir, 'index.md');
   let content = fs.readFileSync(indexPath, 'utf-8');
   const section = SECTION_MAP[type] || '## Source Summaries';
   const entry = `- [[${slug}]] — ${title}`;
@@ -41,7 +46,7 @@ function updateIndex(slug, title, type) {
   content = insertAt === -1
     ? `${content}\n${entry}\n`
     : `${content.slice(0, insertAt)}\n${entry}\n${content.slice(insertAt)}`;
-  const pages = countPages();
+  const pages = countPages(wikiDir);
   content = content.replace(
     /\*\*Pages\*\*:.*$/m,
     `**Pages**: ${pages} | **Last updated**: ${new Date().toISOString().split('T')[0]}`
@@ -49,46 +54,45 @@ function updateIndex(slug, title, type) {
   fs.writeFileSync(indexPath, content);
 }
 
-function writePage(slug, type, content) {
+function writePage(slug, type, content, wikiDir = WIKI_DIR) {
   const dir = TYPE_DIR[type] || 'sources';
-  const pagePath = path.join(WIKI_DIR, dir, `${slug}.md`);
+  const pagePath = path.join(wikiDir, dir, `${slug}.md`);
   fs.mkdirSync(path.dirname(pagePath), { recursive: true });
   fs.writeFileSync(pagePath, content);
   const { frontmatter } = parseFrontmatter(content);
-  updateIndex(slug, frontmatter.title || slug, type);
+  updateIndex(slug, frontmatter.title || slug, type, wikiDir);
   return pagePath;
 }
 
-function appendLog(date, operation, subject) {
+function appendLog(date, operation, subject, wikiDir = WIKI_DIR) {
   const now = Date.now();
   const maxFutureMs = now + DATE_TOLERANCE_DAYS * 86400000;
   const parsedDate = Date.parse(`${date}T00:00:00Z`);
   if (!Number.isFinite(parsedDate)) throw new Error(`Invalid wiki log date: ${date}`);
   if (parsedDate > maxFutureMs) throw new Error(`Refusing future wiki log date '${date}' (tolerance ${DATE_TOLERANCE_DAYS} day).`);
-  const logPath = path.join(WIKI_DIR, 'log.md');
+  const logPath = path.join(wikiDir, 'log.md');
   fs.appendFileSync(logPath, `\n## [${date}] ${operation} | ${subject}\n`);
 }
-function countPages() {
-  let count = 0;
-  for (const d of CATS) {
-    const dp = path.join(WIKI_DIR, d);
-    if (!fs.existsSync(dp)) continue;
-    count += fs.readdirSync(dp).filter((f) => f.endsWith('.md')).length;
-  }
-  return count;
-}
-function listPages() {
+
+function listPages(wikiDir = WIKI_DIR) {
   const pages = [];
   for (const d of CATS) {
-    const dp = path.join(WIKI_DIR, d);
+    const dp = path.join(wikiDir, d);
     if (!fs.existsSync(dp)) continue;
     for (const f of fs.readdirSync(dp).filter((x) => x.endsWith('.md')))
       pages.push({ slug: f.replace('.md', ''), type: d, path: path.join(dp, f) });
   }
+  for (const { dir, type } of WORK_LOG_DIRS) {
+    const dp = path.join(wikiDir, dir);
+    if (!fs.existsSync(dp)) continue;
+    for (const f of fs.readdirSync(dp).filter((x) => x.endsWith('.md')))
+      pages.push({ slug: f.replace('.md', ''), type, path: path.join(dp, f) });
+  }
   return pages;
 }
 
-module.exports = {
-  parseFrontmatter, updateIndex, writePage, appendLog,
-  countPages, listPages, WIKI_DIR, DATE_TOLERANCE_DAYS,
-};
+function countPages(wikiDir = WIKI_DIR) {
+  return listPages(wikiDir).length;
+}
+
+module.exports = { parseFrontmatter, updateIndex, writePage, appendLog, countPages, listPages, WIKI_DIR, DATE_TOLERANCE_DAYS, CATS, WORK_LOG_DIRS, TYPE_DIR, SECTION_MAP };

--- a/tests/wiki-hygiene-eval.spec.js
+++ b/tests/wiki-hygiene-eval.spec.js
@@ -1,9 +1,16 @@
 // Wiki hygiene scanner + eval harness tests (#870 + #872).
 const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const H = require(path.resolve(__dirname, '..', 'scripts', 'wiki', 'hygiene.js'));
 const E = require(path.resolve(__dirname, '..', 'scripts', 'wiki', 'eval-harness.js'));
 const HC = require(path.resolve(__dirname, '..', 'scripts', 'wiki', 'health-contract.js'));
+const W = require(path.resolve(__dirname, '..', 'scripts', 'wiki', 'wiki-io.js'));
+
+function tmpWikiDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'wiki-health-'));
+}
 
 test('hygiene tokens lowercases and drops short tokens', () => {
   const t = H.tokens('Hello World HAMR_test xy');
@@ -41,6 +48,32 @@ test('hygiene orphans/frontmatter match unified health contract', () => {
   const health = HC.computeWikiHealth();
   expect(scan.orphans.sort()).toEqual(health.orphans.sort());
   expect(scan.frontmatter.sort()).toEqual(health.frontmatter.sort());
+});
+
+test('health contract recognizes Wiki B work-log pages', () => {
+  const wikiDir = tmpWikiDir();
+  fs.mkdirSync(path.join(wikiDir, 'entities'), { recursive: true });
+  fs.mkdirSync(path.join(wikiDir, 'work-log', 'tickets'), { recursive: true });
+  fs.mkdirSync(path.join(wikiDir, 'work-log', 'prs'), { recursive: true });
+  fs.writeFileSync(path.join(wikiDir, 'index.md'), [
+    '# Wiki Index',
+    '',
+    '## Work Log',
+    '- [[2054]] — Wiki B mirror',
+    '- [[2101]] — Wiki B PR',
+    '',
+    '## Entities',
+    '- [[openclaw]] — OpenClaw',
+  ].join('\n'));
+  fs.writeFileSync(path.join(wikiDir, 'entities', 'openclaw.md'), '---\ntitle: OpenClaw\ntype: entity\ncreated: 2026-05-27\nstatus: draft\n---\n');
+  fs.writeFileSync(path.join(wikiDir, 'work-log', 'tickets', '2054.md'), '---\ntitle: Wiki B mirror\ntype: ticket\ncreated: 2026-05-27\nstatus: draft\n---\n');
+  fs.writeFileSync(path.join(wikiDir, 'work-log', 'prs', '2101.md'), '---\ntitle: Wiki B PR\ntype: pr\ncreated: 2026-05-27\nstatus: draft\n---\n');
+
+  const health = HC.computeWikiHealth(W.listPages(wikiDir), wikiDir);
+  expect(health.pages).toBe(3);
+  expect(health.indexSync).toEqual([]);
+  expect(health.orphans).toEqual([]);
+  expect(health.frontmatter).toEqual([]);
 });
 
 test('eval precisionAtK returns hits/k', () => {

--- a/tests/wiki-io.spec.js
+++ b/tests/wiki-io.spec.js
@@ -1,37 +1,12 @@
 const { test, expect } = require('@playwright/test');
-const path = require('path');
+const fs = require('fs'); const os = require('os'); const path = require('path');
 const W = require(path.resolve(__dirname, '..', 'scripts', 'wiki', 'wiki-io.js'));
+const tmpWikiDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'wiki-io-'));
 
-test('parseFrontmatter preserves colon values via gray-matter', () => {
-  const doc = [
-    '---',
-    'title: "Routing: Anthropic Batch"',
-    'type: source',
-    'created: 2026-05-16',
-    'status: draft',
-    '---',
-    '',
-    'body here',
-  ].join('\n');
-  const { frontmatter, body } = W.parseFrontmatter(doc);
-  expect(frontmatter.title).toBe('Routing: Anthropic Batch');
-  expect(frontmatter.type).toBe('source');
-  expect(body.trim()).toBe('body here');
-});
-
-test('appendLog rejects far future dates', () => {
-  expect(() => W.appendLog('2099-01-01', 'test', 'future guard')).toThrow(/Refusing future wiki log date/);
-});
-
-test('appendLog rejects dates 2 days in the future (boundary precision per #1681)', () => {
-  const twoDaysAhead = new Date(Date.now() + 2 * 86400000).toISOString().slice(0, 10);
-  expect(() => W.appendLog(twoDaysAhead, 'test', 'two-day boundary')).toThrow(/Refusing future wiki log date/);
-});
-
-test('appendLog rejects malformed date strings (Invalid wiki log date)', () => {
-  expect(() => W.appendLog('not-a-date', 'test', 'invalid input')).toThrow(/Invalid wiki log date/);
-});
-
-test('appendLog date tolerance constant remains 1 day', () => {
-  expect(W.DATE_TOLERANCE_DAYS).toBe(1);
-});
+test('parseFrontmatter preserves colon values via gray-matter', () => { const doc = ['---','title: "Routing: Anthropic Batch"','type: source','created: 2026-05-16','status: draft','---','','body here'].join('\n'); const { frontmatter, body } = W.parseFrontmatter(doc); expect(frontmatter.title).toBe('Routing: Anthropic Batch'); expect(frontmatter.type).toBe('source'); expect(body.trim()).toBe('body here'); });
+test('appendLog rejects far future dates', () => { expect(() => W.appendLog('2099-01-01', 'test', 'future guard')).toThrow(/Refusing future wiki log date/); });
+test('appendLog rejects dates 2 days in the future (boundary precision per #1681)', () => { const twoDaysAhead = new Date(Date.now() + 2 * 86400000).toISOString().slice(0, 10); expect(() => W.appendLog(twoDaysAhead, 'test', 'two-day boundary')).toThrow(/Refusing future wiki log date/); });
+test('appendLog rejects malformed date strings (Invalid wiki log date)', () => { expect(() => W.appendLog('not-a-date', 'test', 'invalid input')).toThrow(/Invalid wiki log date/); });
+test('appendLog date tolerance constant remains 1 day', () => { expect(W.DATE_TOLERANCE_DAYS).toBe(1); });
+test('listPages includes Wiki B ticket and PR pages', () => { const wikiDir = tmpWikiDir(); fs.mkdirSync(path.join(wikiDir, 'entities'), { recursive: true }); fs.mkdirSync(path.join(wikiDir, 'work-log', 'tickets'), { recursive: true }); fs.mkdirSync(path.join(wikiDir, 'work-log', 'prs'), { recursive: true }); fs.writeFileSync(path.join(wikiDir, 'entities', 'openclaw.md'), '---\ntitle: OpenClaw\n---\n'); fs.writeFileSync(path.join(wikiDir, 'work-log', 'tickets', '2054.md'), '---\ntitle: Wiki B mirror\n---\n'); fs.writeFileSync(path.join(wikiDir, 'work-log', 'prs', '2101.md'), '---\ntitle: Wiki B PR\n---\n'); const pages = W.listPages(wikiDir); expect(pages).toEqual(expect.arrayContaining([expect.objectContaining({ slug: 'openclaw', type: 'entities' }), expect.objectContaining({ slug: '2054', type: 'ticket' }), expect.objectContaining({ slug: '2101', type: 'pr' })])); });
+test('writePage routes ticket pages into work-log/tickets and updates index', () => { const wikiDir = tmpWikiDir(); fs.mkdirSync(path.join(wikiDir, 'work-log', 'tickets'), { recursive: true }); fs.mkdirSync(path.join(wikiDir, 'work-log', 'prs'), { recursive: true }); fs.writeFileSync(path.join(wikiDir, 'index.md'), ['# Wiki Index','','## Work Log','','## Concepts',''].join('\n')); const pagePath = W.writePage('2054', 'ticket', ['---','title: Wiki B mirror','type: ticket','created: 2026-05-27','status: draft','---','','body here'].join('\n'), wikiDir); expect(pagePath).toBe(path.join(wikiDir, 'work-log', 'tickets', '2054.md')); expect(fs.readFileSync(pagePath, 'utf8')).toContain('Wiki B mirror'); expect(fs.readFileSync(path.join(wikiDir, 'index.md'), 'utf8')).toContain('[[2054]]'); });

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -20,6 +20,10 @@ Per `research/three-wiki-typology-synthesis-1943.md`, the wiki is organized into
 - **`wiki/wisdom/global/`** (Wiki C scope=global) — Cross-project wisdom (committed in this repo, distributed to operator-global `~/.copilot/wiki/`). Currently EMPTY — the legacy paths `wiki/concepts/`, `wiki/entities/`, `wiki/sources/`, `wiki/syntheses/`, `wiki/skills/` ARE conceptually this scope but live at their pre-migration paths. Physical migration is queued as a follow-on to #2051.
 
 Each subtree has a README.md documenting its purpose.
+## Work Log
+
+Mirror of GitHub tickets + PRs. Wiki B pages are written here by the shared wiki I/O layer and keep the work-log catalog distinct from the legacy research pages below.
+
 
 ### Legacy paths (still in use)
 


### PR DESCRIPTION
## Summary
- extend shared wiki path model so Wiki B pages in work-log/tickets and work-log/prs are first-class surfaces
- route health-contract scanning through shared listPages(wikiDir) to keep lint/health/index behavior consistent
- add targeted tests for Wiki B discovery and index routing, plus health-contract coverage for work-log pages
- add an explicit Work Log section in wiki/index.md so ticket/PR inserts have a stable anchor

## Validation
- npm run lint
- npm test -- tests/wiki-io.spec.js tests/wiki-hygiene-eval.spec.js

Refs #2054
Refs #1942
