### PR TITLE
fix(codex): wire Tavily MCP runtime config #2269

### DIFF
--- a/.changes/unreleased/2269.md
+++ b/.changes/unreleased/2269.md
@@ -1,0 +1,2 @@
+### Fixed
+- Wired Tavily MCP into managed Codex runtime config using environment-based bearer auth and added HAMR activation-time drift warning when TAVILY_API_KEY is present but Tavily MCP config is missing. Refs #2269.

--- a/.codex/runtime.config.toml
+++ b/.codex/runtime.config.toml
@@ -5,3 +5,7 @@ codex_hooks = true
 
 [mcp_servers.openaiDeveloperDocs]
 url = "https://developers.openai.com/mcp"
+
+[mcp_servers.tavily]
+url = "https://mcp.tavily.com/mcp/"
+bearer_token_env_var = "TAVILY_API_KEY"

--- a/scripts/global/hamr-activate.sh
+++ b/scripts/global/hamr-activate.sh
@@ -43,6 +43,9 @@ case "$provider" in
   ollama|fleet|provider-neutral) ;;
   *) echo "⚠ unknown HAMR_PROVIDER=$provider; provider key check skipped" ;;
 esac
+if [ -n "${TAVILY_API_KEY:-}" ] && ! grep -q "^\[mcp_servers\.tavily\]" "$repo_root/.codex/runtime.config.toml" 2>/dev/null; then
+  echo "⚠ TAVILY_API_KEY detected but [mcp_servers.tavily] is missing from .codex/runtime.config.toml"
+fi
 if [ "${#missing[@]}" -eq 0 ]; then
   echo "✅ all required env present"
 else

--- a/tests/hamr-activate-contract.spec.js
+++ b/tests/hamr-activate-contract.spec.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const CFG = path.join(ROOT, '.codex', 'runtime.config.toml');
+const ACT = path.join(ROOT, 'scripts', 'global', 'hamr-activate.sh');
+
+test('contract: Tavily MCP config wiring is present', () => {
+  const cfg = fs.readFileSync(CFG, 'utf8');
+  assert.match(cfg, /\[mcp_servers\.tavily\]/);
+  assert.match(cfg, /bearer_token_env_var = "TAVILY_API_KEY"/);
+});
+
+test('contract: hamr-activate contains Tavily drift warning', () => {
+  const script = fs.readFileSync(ACT, 'utf8');
+  assert.match(script, /TAVILY_API_KEY detected but \[mcp_servers\.tavily\] is missing/);
+});

--- a/tests/hamr-activate.spec.js
+++ b/tests/hamr-activate.spec.js
@@ -6,6 +6,9 @@ const { spawnSync } = require('child_process');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const ACTIVATE = path.join(REPO_ROOT, 'scripts', 'global', 'hamr-activate.sh');
+const CODEX_RUNTIME_CONFIG = path.join(REPO_ROOT, '.codex', 'runtime.config.toml');
+
+test.describe.configure({ mode: 'serial' });
 
 test('hamr-activate.sh exists and is executable', () => {
   expect(fs.existsSync(ACTIVATE)).toBe(true);
@@ -24,4 +27,32 @@ test('hamr-activate.sh runs all 5 steps and exits 0', () => {
 test('hamr-activate.sh reports Worker reachability check', () => {
   const result = spawnSync('bash', [ACTIVATE], { cwd: REPO_ROOT, encoding: 'utf8' });
   expect(result.stdout + result.stderr).toMatch(/Worker (\/healthz reachable|unreachable)/);
+});
+
+test('managed Codex runtime config includes Tavily MCP env-auth server', () => {
+  const cfg = fs.readFileSync(CODEX_RUNTIME_CONFIG, 'utf8');
+  expect(cfg).toContain('[mcp_servers.tavily]');
+  expect(cfg).toContain('url = "https://mcp.tavily.com/mcp/"');
+  expect(cfg).toContain('bearer_token_env_var = "TAVILY_API_KEY"');
+});
+
+test('hamr-activate.sh warns on Tavily key/config drift', () => {
+  const original = fs.readFileSync(CODEX_RUNTIME_CONFIG, 'utf8');
+  const stripped = original
+    .split('\n')
+    .filter(line => !line.includes('mcp_servers.tavily'))
+    .filter(line => !line.includes('mcp.tavily.com'))
+    .filter(line => !line.includes('TAVILY_API_KEY'))
+    .join('\n');
+  fs.writeFileSync(CODEX_RUNTIME_CONFIG, stripped);
+  try {
+    const result = spawnSync('bash', [ACTIVATE], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, TAVILY_API_KEY: 'test-key' }
+    });
+    expect(result.stdout).toContain('TAVILY_API_KEY detected but [mcp_servers.tavily] is missing');
+  } finally {
+    fs.writeFileSync(CODEX_RUNTIME_CONFIG, original);
+  }
 });


### PR DESCRIPTION
## Summary
- Add Tavily MCP server wiring in managed Codex runtime config using env-based bearer token auth.
- Add HAMR activation drift warning when TAVILY_API_KEY exists but Tavily MCP config is missing.
- Add regression coverage for Tavily wiring/drift warning and changelog fragment.

## Validation
- npm run lint
- npm run deploy:codex
- npm run sync:codex:dry
- Runtime drift-warning behavior check via temporary config mutation and restore
- npx playwright test tests/hamr-activate.spec.js (blocked locally in this worktree: missing @playwright/test)

Refs #2269
