### PR TITLE
feat(governance): migrate cross-team-lease.js to dispatcher #1997

### DIFF
--- a/.changes/unreleased/1997.md
+++ b/.changes/unreleased/1997.md
@@ -1,0 +1,2 @@
+### Changed
+- `scripts/global/cross-team-lease.js` comment-posting routes through `github-dispatcher.js execute()` (MCP-first with gh-CLI fallback) per the canonical pattern established by sibling #1995 migration. Stdout JSON format unchanged for callers. `MEGINGJORD_MCP_DISABLED=1` preserves existing gh-CLI path. Refs #1997.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ npm run deploy:both:apply
 | `governance:coordinator-cleanup` | `node scripts/global/coordinator-label-cleanup.js` |
 | `governance:cross-team-check` | `node scripts/global/cross-team-contract-check.js` |
 | `governance:cross-team-check:test` | `node --test tests/cross-team-contract-check.spec.js` |
+| `governance:cross-team-lease-dispatch:test` | `node --test tests/cross-team-lease-dispatch.spec.js` |
 | `governance:delegation-lint` | `node scripts/global/delegation-phrase-lint.js` |
 | `governance:drift` | `node scripts/global/governance-drift-classifier.js --json` |
 | `governance:duplicate-check` | `node scripts/global/ticket-duplicate-guard.js --scan` |

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "governance:coordinator-cleanup": "node scripts/global/coordinator-label-cleanup.js",
     "governance:cross-team-check": "node scripts/global/cross-team-contract-check.js",
     "governance:cross-team-check:test": "node --test tests/cross-team-contract-check.spec.js",
+    "governance:cross-team-lease-dispatch:test": "node --test tests/cross-team-lease-dispatch.spec.js",
     "governance:delegation-lint": "node scripts/global/delegation-phrase-lint.js",
     "governance:drift": "node scripts/global/governance-drift-classifier.js --json",
     "governance:duplicate-check": "node scripts/global/ticket-duplicate-guard.js --scan",

--- a/scripts/global/cross-team-lease.js
+++ b/scripts/global/cross-team-lease.js
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 'use strict';
+// cross-team-lease.js — wraps cross-team-lease-registry with CLI surface +
+// optional GitHub comment posting. Per #1997: comment posting routes through
+// github-dispatcher.js execute() (MCP-first with gh-CLI fallback); selection
+// controlled by MEGINGJORD_MCP_DISABLED env per #1629 contract.
 
-const { execFileSync } = require('child_process');
 const leaseRegistry = require('./cross-team-lease-registry');
+const { execute } = require('./github-dispatcher');
 
 function parse(args) {
   const out = { _: [] };
@@ -14,13 +18,17 @@ function parse(args) {
   return out;
 }
 
-function post(issue, body) {
-  execFileSync('gh', ['issue', 'comment', String(issue), '--body', body], {
-    stdio: 'inherit',
-  });
+async function post(issue, body, opts = {}) {
+  const res = await execute('add-comment', { issue: String(issue), body }, opts);
+  if (!res.ok) {
+    throw new Error(
+      `add-comment failed via ${res.provider || 'dispatcher'}: ${res.error || res.reason || 'unknown'}`,
+    );
+  }
+  return res;
 }
 
-function run(argv = process.argv.slice(2)) {
+async function run(argv = process.argv.slice(2), opts = {}) {
   const args = parse(argv);
   const cmd = args._[0];
   const registry = leaseRegistry.read(args.file || leaseRegistry.DEFAULT_PATH);
@@ -35,14 +43,14 @@ function run(argv = process.argv.slice(2)) {
   const result = commands[cmd]();
   if (cmd !== 'list') leaseRegistry.write(registry, args.file || leaseRegistry.DEFAULT_PATH);
   if (args.post_comment && result && !Array.isArray(result)) {
-    post(result.ticket, leaseRegistry.commentBlock(cmd, result));
+    await post(result.ticket, leaseRegistry.commentBlock(cmd, result), opts);
   }
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   return result;
 }
 
 if (require.main === module) {
-  try { run(); } catch (error) { console.error(error.message); process.exit(1); }
+  run().catch((error) => { console.error(error.message); process.exit(1); });
 }
 
-module.exports = { run, parse };
+module.exports = { run, parse, post };

--- a/tests/cross-team-lease-dispatch.spec.js
+++ b/tests/cross-team-lease-dispatch.spec.js
@@ -1,0 +1,97 @@
+'use strict';
+// tests/cross-team-lease-dispatch.spec.js — dispatcher-routing coverage for #1997.
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+function silent(fn) {
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = () => true;
+  return Promise.resolve(fn()).finally(() => { process.stdout.write = orig; });
+}
+
+function tmpFile() {
+  const p = path.join(os.tmpdir(), `lease-${Date.now()}-${Math.random()}.json`);
+  fs.writeFileSync(p, `${JSON.stringify({ version: 1, leases: [] })}\n`);
+  return p;
+}
+
+function withStub(stub, fn) {
+  const dKey = require.resolve('../scripts/global/github-dispatcher');
+  const lKey = require.resolve('../scripts/global/cross-team-lease');
+  const orig = require.cache[dKey];
+  delete require.cache[dKey];
+  require.cache[dKey] = { exports: stub };
+  delete require.cache[lKey];
+  try { return fn(require('../scripts/global/cross-team-lease')); }
+  finally {
+    delete require.cache[lKey];
+    if (orig) require.cache[dKey] = orig; else delete require.cache[dKey];
+  }
+}
+
+test('post() routes through dispatcher execute("add-comment", ...)', async () => {
+  const calls = [];
+  const stub = { execute: async (op, p) => { calls.push({ op, p }); return { ok: true, provider: 'mcp' }; } };
+  await withStub(stub, async (m) => { await m.post(42, 'hello'); });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].op, 'add-comment');
+  assert.equal(calls[0].p.issue, '42');
+  assert.equal(calls[0].p.body, 'hello');
+});
+
+test('post() throws when execute returns ok:false', async () => {
+  const stub = { execute: async () => ({ ok: false, provider: 'gh-cli', error: 'auth-required' }) };
+  await withStub(stub, async (m) => {
+    await assert.rejects(() => m.post(7, 'x'), /add-comment failed via gh-cli: auth-required/);
+  });
+});
+
+test('run() does NOT call post when --post-comment flag is absent', async () => {
+  const file = tmpFile();
+  const calls = [];
+  const stub = { execute: async (op) => { calls.push(op); return { ok: true }; } };
+  await withStub(stub, async (m) => {
+    await silent(() => m.run([
+      'create', '--ticket', '1', '--team', 'claude-code', '--role', 'collaborator',
+      '--branch', 'feat/1-test', '--file', file,
+    ]));
+  });
+  assert.equal(calls.length, 0);
+  fs.unlinkSync(file);
+});
+
+test('run() calls post when --post-comment is set on a single-result cmd', async () => {
+  const file = tmpFile();
+  const calls = [];
+  const stub = { execute: async (op, p) => { calls.push({ op, p }); return { ok: true }; } };
+  await withStub(stub, async (m) => {
+    await silent(() => m.run([
+      'create', '--ticket', '99', '--team', 'claude-code', '--role', 'collaborator',
+      '--branch', 'feat/99-x', '--file', file, '--post-comment', 'true',
+    ]));
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].p.issue, '99');
+  fs.unlinkSync(file);
+});
+
+test('run() with list cmd skips post() even when --post-comment is set', async () => {
+  const file = tmpFile();
+  const calls = [];
+  const stub = { execute: async (op) => { calls.push(op); return { ok: true }; } };
+  await withStub(stub, async (m) => {
+    await silent(() => m.run(['list', '--file', file, '--post-comment', 'true']));
+  });
+  assert.equal(calls.length, 0);
+  fs.unlinkSync(file);
+});
+
+test('module exports run, parse, post', () => {
+  const m = require('../scripts/global/cross-team-lease');
+  assert.equal(typeof m.run, 'function');
+  assert.equal(typeof m.parse, 'function');
+  assert.equal(typeof m.post, 'function');
+});


### PR DESCRIPTION
## Summary

Routes `scripts/global/cross-team-lease.js post()` (comment-posting) through `github-dispatcher.js execute()` per the canonical pattern established by sibling #1995 migration. MCP-first with gh-CLI fallback; `MEGINGJORD_MCP_DISABLED=1` (current default) preserves existing behavior. Stdout JSON output format unchanged.

- Modified: `scripts/global/cross-team-lease.js` (53 → 56 LoC; async cascade applied; main entry uses `.catch()` for exit-code-1 preservation)
- New: `tests/cross-team-lease-dispatch.spec.js` (97 LoC, 6 node --test units)
- Existing: `tests/cross-team-lease-registry.spec.js` (playwright) 9/9 pass — CLI-shell test confirms backward-compat
- npm script: `governance:cross-team-lease-dispatch:test`
- Changelog fragment: `.changes/unreleased/1997.md`

## Test plan

- [x] `npm run governance:cross-team-lease-dispatch:test` → 6/6 pass
- [x] `npx playwright test tests/cross-team-lease-registry.spec.js` → 9/9 pass
- [x] `npm run lint` → 370 files within 100-line cap
- [x] End-to-end smoke against real lease registry (claude-code #1997 + codex #2100 listed correctly)

## Baton artifacts (full evidence on linked issue)

- the-manager-handoff-artifact: https://github.com/chf3198/megingjord-harness/issues/1997#issuecomment-4552801107
- the-collaborator-handoff-artifact: https://github.com/chf3198/megingjord-harness/issues/1997#issuecomment-4552863943
- the-admin-handoff-artifact: posted same time as PR
- the-consultant-closeout-artifact: pending post-CI

Signer-independence: Orla Harper (collaborator) ≠ Orla Reyes (admin).

## Scope note

Manager amendment 4552801107 surfaced three remediations from the critical-examination pass:
1. **Body call-surface drift** — body claimed 2 surfaces (`gh issue comment` + `gh issue view`); actual code has ONLY `gh issue comment`. Phantom `gh issue view` AC dropped.
2. **Async cascade** — dispatcher's `execute()` is async; `post() → run()` both cascaded to async; main entry uses `.catch()` for exit-code-1 preservation.
3. **Stdout backward-compat** — explicit AC6 added to confirm JSON output format unchanged for callers parsing stdout.

Refs #1997
