### PR TITLE
docs(governance): document no-code remediation workflow #2268

### DIFF
--- a/.changes/unreleased/2268.md
+++ b/.changes/unreleased/2268.md
@@ -1,0 +1,2 @@
+### Changed
+- Documented the new `lane:no-code-remediation` governance flow across primary baton/ticket contracts, including eligibility, exclusions, required evidence markers, false positives, and escalation back to full baton. Added operator runbook at `docs/howto/no-code-remediation-workflow.md`. Refs #2268.

--- a/docs/howto/no-code-remediation-workflow.md
+++ b/docs/howto/no-code-remediation-workflow.md
@@ -1,0 +1,49 @@
+# HOWTO: No-Code Remediation Lane
+
+Refs #2258 #2268
+
+## Purpose
+
+Use `lane:no-code-remediation` when a ticket requires only issue-thread normalization (labels, artifacts, closeout evidence) and no repository changes.
+
+## Eligibility
+
+- Drift is limited to issue metadata/evidence state.
+- Corrective action can be completed without any branch diff.
+- Runtime sync checks are `N/A` because deployed runtime files are untouched.
+
+## Exclusions
+
+- Any edit under repository-tracked paths (`instructions/`, `scripts/`, `tests/`, docs, workflows, configs).
+- Any gate remediation that requires a commit or PR diff.
+- Any ambiguity about whether root cause is issue-only.
+
+When excluded, Manager reclassifies to `lane:code-change` and executes full baton.
+
+## Required Evidence Blocks
+
+Manager artifact must include:
+- `lane: lane:no-code-remediation`
+- explicit eligibility rationale
+- exact issue-only actions to run
+
+Consultant closeout must include:
+- verification that each issue-only action completed
+- `verdict`, `rubric_rating`, and `mid_flight_flaws` accounting
+
+Use explicit reduced markers:
+- `COLLABORATOR_HANDOFF: N/A - no-code remediation lane`
+- `ADMIN_HANDOFF: N/A - no-code remediation lane`
+
+## Common False Positives
+
+- Stale advisory label appears on a merged closed ticket.
+  - Valid no-code fix: remove stale advisory label after confirming merge evidence.
+- Missing merge evidence with uncertain state.
+  - Not no-code: escalate to full baton if evidence cannot be proven from issue/PR metadata.
+- Validator failure requests file edits.
+  - Not no-code: escalate to `lane:code-change`.
+
+## Escalation Rule
+
+If any step requires editing tracked files, stop no-code flow immediately and re-route to full baton with Manager correction comment.

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -101,8 +101,35 @@ Per v1.1 taxonomy, the active label is `role:collaborator` (not the older `role:
 | code-change  | Code, infra, deploy (default)  | Manager→Collab→Admin→Consultant   | none                           |
 | research     | Analysis, wiki — no git branch | Manager→Collab(analyst)→Admin→Consultant | Admin = doc reviewer, not CI |
 | config-only  | Single-value config, no design | Manager→Admin→Consultant          | COLLABORATOR_HANDOFF: N/A      |
+| no-code-remediation | Issue-only drift normalization (no repo edits) | Manager→Consultant | COLLABORATOR_HANDOFF: N/A, ADMIN_HANDOFF: N/A |
 
 Lane set at ticket creation via `lane:*` label and `Lane` Project field. Default: **code-change**.
+
+### No-code remediation lane contract (Refs #2258 #2268)
+
+Eligibility:
+- Ticket drift is limited to issue metadata/evidence normalization (labels, stale advisories, baton artifacts, or closeout evidence) with no source changes.
+- Corrective action is issue/thread state only; no PR diff is needed.
+- Runtime-deploy sync verification is `N/A` because deployed runtime artifacts are untouched.
+
+Exclusions (must escalate to normal baton lane):
+- Any tracked file edit, generated artifact edit, workflow/config change, or test change.
+- Any required CI or validator remediation that needs code/doc changes.
+- Any ambiguity about whether the incident is issue-only versus implementation drift.
+
+Required evidence blocks:
+- `MANAGER_HANDOFF` must state `lane: lane:no-code-remediation`, explicit eligibility rationale, and the exact issue-only actions.
+- `CONSULTANT_CLOSEOUT` must verify each issue-only action completed and include flaw-accounting (`mid_flight_flaws`) plus `verdict` and `rubric_rating`.
+
+False positives and escalation path:
+- If a no-code run reveals required repository edits, Manager posts a correction comment and routes to `lane:code-change` with the standard four-role baton.
+- If stale advisory labels conflict with merged evidence, clear the stale label as issue-only remediation; if merge evidence is absent, escalate to normal baton.
+
+Examples:
+- Valid: remove stale `governance:close-without-merge` on an already-merged closed ticket.
+- Invalid: changing `instructions/**` to satisfy a validator; this is `lane:code-change` (docs/code diff exists).
+
+Operator runbook: `docs/howto/no-code-remediation-workflow.md`.
 
 ## Archival
 
@@ -140,7 +167,7 @@ This decision must be cited in baton artifacts and summarized in `CONSULTANT_CLO
 
 Required fields on every `MANAGER_HANDOFF` comment:
 - `scope:` — what changes
-- `lane:` — `lane:code-change | lane:docs-research | lane:config-only | lane:trivial`
+- `lane:` — `lane:code-change | lane:docs-research | lane:config-only | lane:no-code-remediation | lane:trivial`
 - `test_strategy:` — one of `tdd-pyramid | tdd-trophy | contract-test | golden-file | eval-harness | visual-regression | drift-lint | peer-review | manual-verify | none`
 - `acceptance:` — AC checklist
 - `gates:` — CI/governance gates that must pass

--- a/instructions/ticket-driven-work.instructions.md
+++ b/instructions/ticket-driven-work.instructions.md
@@ -49,7 +49,12 @@ applyTo: "**"
 
 ## Valid owner × work-type matrix
 
-All work types use `role:collaborator`. Work types with CI gates (development, bug fix, infra/ops) include `testing`; all others skip it. Valid statuses: `triage` → `ready` → `in-progress` → [`testing`] → `review` → `done`.
+Default lanes use `role:collaborator`. Work types with CI gates (development, bug fix, infra/ops) include `testing`; docs/research may use reduced markers as defined in baton routing. Valid statuses: `triage` → `ready` → `in-progress` → [`testing`] → `review` → `done`.
+
+No-code remediation lane (`lane:no-code-remediation`) is issue-only and manager/consultant scoped:
+- Valid transitions: `triage` → `review` → `done`
+- Required markers: `COLLABORATOR_HANDOFF: N/A` and `ADMIN_HANDOFF: N/A`
+- Any repository diff, workflow edit, or validator fix requiring file changes must re-route to normal baton (`lane:code-change`).
 
 ## Forbidden combinations
 


### PR DESCRIPTION
## Summary
- Add explicit `lane:no-code-remediation` contract to primary baton governance docs.
- Extend ticket lifecycle doc with issue-only lane transitions and reroute rule.
- Add operator runbook covering eligibility, exclusions, evidence markers, false positives, and escalation.
- Add changelog fragment.

## Validation
- npm run lint
- npm run docs:lint
- npm run governance:verify
- cross-team conflict gate (clear)

Refs #2268
