### PR TITLE
fix(runtime): enforce env-backed Tavily credentials #2287

### DIFF
--- a/.changes/unreleased/2287.md
+++ b/.changes/unreleased/2287.md
@@ -1,0 +1,1 @@
+Added env-backed Tavily MCP guardrails for Codex runtime config and repository validation.

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ GOOGLE_AI_STUDIO_PROJECT_NUM=
 GROQ_API_KEY=gsk_...
 CEREBRAS_API_KEY=csk-...
 
+# --- Tavily AI Search ---
+TAVILY_API_KEY=tvly-...
+TAVILY_HUMAN_ID=
+TAVILY_DEFAULT_PARAMETERS={"search_depth":"basic","max_results":10}
+TAVILY_MCP_BASE_URL=https://mcp.tavily.com/mcp/
+
 # --- Cloudflare ---
 CLOUDFLARE_API_TOKEN=
 CLOUDFLARE_EMAIL=

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ npm run deploy:both:apply
 | `governance:coordinator-cleanup` | `node scripts/global/coordinator-label-cleanup.js` |
 | `governance:cross-team-check` | `node scripts/global/cross-team-contract-check.js` |
 | `governance:cross-team-check:test` | `node --test tests/cross-team-contract-check.spec.js` |
+| `governance:credentials-env` | `node scripts/global/credentials-env-guard.js` |
 | `governance:cross-team-lease-dispatch:test` | `node --test tests/cross-team-lease-dispatch.spec.js` |
 | `governance:delegation-lint` | `node scripts/global/delegation-phrase-lint.js` |
 | `governance:dispatcher-set-labels:test` | `node --test tests/github-dispatcher-set-labels.spec.js` |

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ npm test
 npm run deploy:both:apply
 ```
 
+## Env-backed credentials
+
+- Copy `.env.example` to `.env` for local resource credentials.
+- Tavily MCP must keep the secret only in `TAVILY_API_KEY`; do not inline Tavily keys in MCP URLs or tracked config.
+- Verify env-backed Tavily wiring with `npm run governance:credentials-env`.
+
 ## Research-first gate notes
 
 - Research-first Epic detection is label-first: `phase-gate:research-first` on `type:epic` tickets.

--- a/package.json
+++ b/package.json
@@ -243,7 +243,8 @@
     "wiki:reindex": "node scripts/wiki/reindex.js",
     "wiki:search": "node scripts/wiki/search.js",
     "worktree:bootstrap": "bash scripts/worktree-bootstrap-node-modules.sh",
-    "worktree:start": "bash scripts/worktree-session-start.sh"
+    "worktree:start": "bash scripts/worktree-session-start.sh",
+    "governance:credentials-env": "node scripts/global/credentials-env-guard.js"
   },
   "keywords": [
     "devops",

--- a/scripts/global/credentials-env-guard.js
+++ b/scripts/global/credentials-env-guard.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+function read(file) {
+  try { return fs.readFileSync(file, 'utf8'); } catch { return ''; }
+}
+
+function scan(root = path.resolve(__dirname, '..', '..')) {
+  const issues = [];
+  const envExample = read(path.join(root, '.env.example'));
+  const runtime = read(path.join(root, '.codex', 'runtime.config.toml'));
+  if (!/^TAVILY_API_KEY=/m.test(envExample)) issues.push('.env.example: missing TAVILY_API_KEY template');
+  if (!/^TAVILY_MCP_BASE_URL=https:\/\/mcp\.tavily\.com\/mcp\/$/m.test(envExample)) issues.push('.env.example: TAVILY_MCP_BASE_URL must be the static MCP base URL');
+  if (!/\[mcp_servers\.tavily\]/.test(runtime)) issues.push('.codex/runtime.config.toml: missing Tavily MCP server block');
+  if (!/bearer_token_env_var\s*=\s*"TAVILY_API_KEY"/.test(runtime)) issues.push('.codex/runtime.config.toml: Tavily must use bearer_token_env_var = "TAVILY_API_KEY"');
+  if (/tavilyApiKey=|tvly-[A-Za-z0-9_-]+/i.test(runtime)) issues.push('.codex/runtime.config.toml: inline Tavily credentials are forbidden');
+  if (!/url\s*=\s*"https:\/\/mcp\.tavily\.com\/mcp\/"/.test(runtime)) issues.push('.codex/runtime.config.toml: Tavily URL must stay on the static MCP base URL');
+  return { ok: issues.length === 0, issues };
+}
+
+if (require.main === module) {
+  const result = scan();
+  if (process.argv.includes('--json')) console.log(JSON.stringify(result, null, 2));
+  else if (result.ok) console.log('credentials-env-guard: PASS');
+  else result.issues.forEach((issue) => console.error(issue));
+  process.exit(result.ok ? 0 : 1);
+}
+
+module.exports = { scan };

--- a/tests/contract/credentials-env-contract.spec.js
+++ b/tests/contract/credentials-env-contract.spec.js
@@ -3,7 +3,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { scan } = require('../scripts/global/credentials-env-guard.js');
+const { scan } = require('../../scripts/global/credentials-env-guard.js');
 
 function fixture(files) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-env-'));

--- a/tests/credentials-env-guard.spec.js
+++ b/tests/credentials-env-guard.spec.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { scan } = require('../scripts/global/credentials-env-guard.js');
+
+function fixture(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-env-'));
+  for (const [name, body] of Object.entries(files)) {
+    const file = path.join(dir, name);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, body);
+  }
+  return dir;
+}
+
+test('passes when Tavily env template and runtime config are env-backed', () => {
+  const dir = fixture({
+    '.env.example': 'TAVILY_API_KEY=tvly-...\nTAVILY_MCP_BASE_URL=https://mcp.tavily.com/mcp/\n',
+    '.codex/runtime.config.toml': '[mcp_servers.tavily]\nurl = "https://mcp.tavily.com/mcp/"\nbearer_token_env_var = "TAVILY_API_KEY"\n',
+  });
+  assert.deepEqual(scan(dir), { ok: true, issues: [] });
+});
+
+test('fails when Tavily env template is missing', () => {
+  const dir = fixture({
+    '.env.example': 'OPENAI_API_KEY=sk-...\n',
+    '.codex/runtime.config.toml': '[mcp_servers.tavily]\nurl = "https://mcp.tavily.com/mcp/"\nbearer_token_env_var = "TAVILY_API_KEY"\n',
+  });
+  assert.match(scan(dir).issues.join('\n'), /missing TAVILY_API_KEY template/);
+});
+
+test('fails when runtime config inlines Tavily credentials', () => {
+  const dir = fixture({
+    '.env.example': 'TAVILY_API_KEY=tvly-...\nTAVILY_MCP_BASE_URL=https://mcp.tavily.com/mcp/\n',
+    '.codex/runtime.config.toml': '[mcp_servers.tavily]\nurl = "https://mcp.tavily.com/mcp/?tavilyApiKey=tvly-secret"\n',
+  });
+  const joined = scan(dir).issues.join('\n');
+  assert.match(joined, /inline Tavily credentials are forbidden/);
+  assert.match(joined, /bearer_token_env_var/);
+});


### PR DESCRIPTION
Refs #2287

## Summary
- add a deterministic Tavily env credential guard
- add Tavily env template entries for portable setup
- wire the guard into package scripts and regression tests

## Validation
- `npm run governance:credentials-env`
- `node --test tests/credentials-env-guard.spec.js`
- `npm run lint`
