### PR TITLE
feat(governance): classify worktree lifecycle states #2250

### DIFF
--- a/.changes/unreleased/2250.md
+++ b/.changes/unreleased/2250.md
@@ -1,0 +1,2 @@
+### Added
+- `scripts/global/worktree-inventory.js` now reports non-destructive worktree lifecycle classifications with ticket inference, dirty/untracked/ahead-behind evidence, detached/prunable/locked signals, last activity, JSON output, and human-readable summaries. Behind-main evidence is warning-only unless other safety evidence is present. Refs #2250.

--- a/dashboard/js/activity-feed.js
+++ b/dashboard/js/activity-feed.js
@@ -1,5 +1,6 @@
 // Live Activity Feed — Agile lifecycle event log
 // Shows only meaningful events, suppresses repetitive noise
+/* global esc */
 
 const MAX_ACTIVITY = 30;
 const SUPPRESS_TYPES = new Set(['refresh']);
@@ -49,3 +50,6 @@ function activityIcon(type) {
   };
   return icons[type] || '📌';
 }
+
+window.addActivity = addActivity;
+window.renderActivityFeed = renderActivityFeed;

--- a/dashboard/js/agent-inventory.js
+++ b/dashboard/js/agent-inventory.js
@@ -1,5 +1,6 @@
 // Agent Inventory — renders defined agent personas for the Agents panel
 // Source: agents/roster.json (embedded; update when roster changes)
+/* global esc */
 
 const AGENT_ROSTER = [
   { id: 'manny-scope', name: 'Manny Scope', role: 'manager', specialty: 'Scope definition, constraints, AC gates' },

--- a/dashboard/js/baton-filter.js
+++ b/dashboard/js/baton-filter.js
@@ -1,6 +1,7 @@
+/* global Alpine, esc */
 (function() { // Baton Filter — dropdown filter for epic and status
 
-let _batonFilter = { epic: '', status: '' };
+const _batonFilter = { epic: '', status: '' };
 
 function getBatonFilter() { return _batonFilter; }
 function setBatonFilter(key, val) {
@@ -13,21 +14,21 @@ function setBatonFilter(key, val) {
 }
 
 function applyBatonFilter(tickets) {
-  const f = _batonFilter;
+  const filter = _batonFilter;
   return tickets.filter(t =>
-    (!f.epic || String(t.epic) === f.epic) &&
-    (!f.status || t.status === f.status));
+    (!filter.epic || String(t.epic) === filter.epic) &&
+    (!filter.status || t.status === filter.status));
 }
 
 function renderBatonFilterBar(tickets) {
   const epics = [...new Set(tickets.map(t => t.epic).filter(Boolean))].sort();
   const statuses = [...new Set(tickets.map(t => t.status).filter(Boolean))];
-  const f = _batonFilter;
+  const filter = _batonFilter;
   const epicOpts = epics.map(e =>
-    `<option value="${e}" ${f.epic == e ? 'selected' : ''}>Epic #${e}</option>`
+    `<option value="${e}" ${filter.epic === String(e) ? 'selected' : ''}>Epic #${e}</option>`
   ).join('');
   const statusOpts = statuses.map(s =>
-    `<option value="${s}" ${f.status === s ? 'selected' : ''}>${esc(s)}</option>`
+    `<option value="${s}" ${filter.status === s ? 'selected' : ''}>${esc(s)}</option>`
   ).join('');
   return `<div class="baton-filter-bar">
     <select onchange="setBatonFilter('epic',this.value)" title="Filter by epic">

--- a/dashboard/js/fleet-settings.js
+++ b/dashboard/js/fleet-settings.js
@@ -1,10 +1,14 @@
 // Fleet Settings — localStorage-backed configuration UI
 // Manages fleet IPs, LLM API keys, and service endpoints
+const OPENCLAW_DEFAULT_PORT = 4000;
+const OLLAMA_DEFAULT_PORT = 11434;
 
 function loadFleetSettings() {
   const defaults = {
     fleetIPs: { 'penguin-1': '', 'windows-laptop': '', 'chromebook-2': '' },
-    sshUser: 'admin', openclawPort: 4000, ollamaPort: 11434,
+    sshUser: 'admin',
+    openclawPort: OPENCLAW_DEFAULT_PORT,
+    ollamaPort: OLLAMA_DEFAULT_PORT,
     apiKeys: { openrouter: '', groq: '', cerebras: '', google: '', anthropic: '' },
     endpoints: { openclaw: '', cloudflare: '' },
     autoDetect: true
@@ -27,20 +31,20 @@ function saveFleetSettings(settings) {
 }
 
 function renderFleetSettingsPanel() {
-  const s = loadFleetSettings();
-  const devices = Object.entries(s.fleetIPs);
-  const keys = Object.entries(s.apiKeys);
+  const settings = loadFleetSettings();
+  const devices = Object.entries(settings.fleetIPs);
+  const keys = Object.entries(settings.apiKeys);
   const maskKey = v => v ? '••••' + v.slice(-4) : '';
   return `<div class="settings-form">
     <h3 style="color:var(--blue);font-size:0.85rem;margin:0 0 8px">Fleet Devices</h3>
-    <label><input type="checkbox" ${s.autoDetect ? 'checked' : ''}
+    <label><input type="checkbox" ${settings.autoDetect ? 'checked' : ''}
       onchange="toggleAutoDetect(this.checked)"> Auto-detect via Tailscale</label>
     ${devices.map(([id, ip]) => `<label>${id}
       <input type="text" value="${ip}" placeholder="auto-detect"
-        ${s.autoDetect ? 'disabled' : ''}
+        ${settings.autoDetect ? 'disabled' : ''}
         onchange="updateFleetIP('${id}', this.value)">
     </label>`).join('')}
-    <label>SSH User<input type="text" value="${s.sshUser}"
+    <label>SSH User<input type="text" value="${settings.sshUser}"
       onchange="updateSetting('sshUser', this.value)"></label>
     <h3 style="color:var(--blue);font-size:0.85rem;margin:12px 0 8px">API Keys</h3>
     ${keys.map(([name, val]) => `<label>${name}
@@ -51,14 +55,22 @@ function renderFleetSettingsPanel() {
 }
 
 function toggleAutoDetect(on) {
-  const s = loadFleetSettings(); s.autoDetect = on; saveFleetSettings(s);
+  const settings = loadFleetSettings();
+  settings.autoDetect = on;
+  saveFleetSettings(settings);
 }
 function updateFleetIP(id, val) {
-  const s = loadFleetSettings(); s.fleetIPs[id] = val.trim(); saveFleetSettings(s);
+  const settings = loadFleetSettings();
+  settings.fleetIPs[id] = val.trim();
+  saveFleetSettings(settings);
 }
 function updateAPIKey(name, val) {
-  const s = loadFleetSettings(); s.apiKeys[name] = val.trim(); saveFleetSettings(s);
+  const settings = loadFleetSettings();
+  settings.apiKeys[name] = val.trim();
+  saveFleetSettings(settings);
 }
 function updateSetting(key, val) {
-  const s = loadFleetSettings(); s[key] = val.trim(); saveFleetSettings(s);
+  const settings = loadFleetSettings();
+  settings[key] = val.trim();
+  saveFleetSettings(settings);
 }

--- a/scripts/global/worktree-cleanup-plan.js
+++ b/scripts/global/worktree-cleanup-plan.js
@@ -19,7 +19,7 @@ function classify(entry, lease) {
   if (lease) return 'active-lease';
   if (entry.locked) return 'keep-locked';
   if ((entry.branch || '').startsWith('sandbox/')) return 'keep-launcher';
-  if (entry.dirtyCount > 0 || entry.ahead > 0) return 'preserve-dirty';
+  if (entry.dirtyCount > 0 || entry.untrackedCount > 0 || entry.ahead > 0) return 'preserve-dirty';
   if (entry.openPr) return 'stale-open-pr';
   if (entry.mergedToMain) return 'merged-clean';
   if (entry.prunable) return 'prune-metadata';

--- a/scripts/global/worktree-inventory.js
+++ b/scripts/global/worktree-inventory.js
@@ -1,79 +1,98 @@
 #!/usr/bin/env node
 'use strict';
-const { execSync } = require('child_process');
-
-function sh(cmd, cwd) {
+/* eslint-disable jsdoc/require-jsdoc, complexity */
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+const TICKET_RE = /(?:^|\/)(?:feat|fix|chore|docs|refactor|hotfix)\/(\d+)-/;
+function git(args, cwd) {
   try {
-    return execSync(cmd, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-  } catch {
-    return '';
-  }
+    return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch { return ''; }
 }
-
+function gitOk(args, cwd) {
+  try {
+    execFileSync('git', args, { cwd, stdio: ['ignore', 'ignore', 'ignore'] });
+    return true;
+  } catch { return false; }
+}
+function base(entry) {
+  return { ...entry, ticket: ticketFrom(entry.branch || ''), dirty: false,
+    untracked: false, ahead: null, behind: null };
+}
 function parsePorcelain(raw) {
   return raw.split('\n\n').filter(Boolean).map(block => {
-    const item = { locked: false, prunable: false };
+    const item = { locked: false, prunable: false, detached: false, missing: false };
     for (const line of block.split('\n')) {
       const [key, ...rest] = line.split(' ');
       const value = rest.join(' ');
-      if (key === 'worktree') item.path = value;
-      if (key === 'HEAD') item.head = value;
-      if (key === 'branch') item.branch = value.replace('refs/heads/', '');
-      if (key === 'locked') item.locked = true;
-      if (key === 'prunable') item.prunable = true;
+      if (key === 'worktree') item.path = value; else if (key === 'HEAD') item.head = value;
+      else if (key === 'branch') item.branch = value.replace('refs/heads/', '');
+      else if (key === 'detached') item.detached = true;
+      else if (key === 'locked') { item.locked = true; item.lockReason = value || null; }
+      else if (key === 'prunable') { item.prunable = true; item.prunableReason = value || null; }
     }
+    if (item.path && !fs.existsSync(item.path)) item.missing = true;
     return item;
   });
 }
-
-function recommendation(entry) {
-  if (entry.locked) return 'keep-locked';
-  if (entry.prunable) return 'prune-metadata';
-  if (entry.dirtyCount > 0) return 'review-dirty';
-  if (!entry.branch) return 'review-detached';
-  if (entry.branch === 'main') return 'keep-main';
-  if (entry.branch.startsWith('sandbox/')) return 'keep-active';
-  if (entry.mergedToMain) return 'remove-after-merge';
-  return 'keep-active';
+function ticketFrom(branch = '') {
+  const hit = branch.match(TICKET_RE);
+  return hit ? Number(hit[1]) : null;
 }
-
-function enrich(entry) {
-  const dirty = sh('git status --porcelain --untracked-files=all', entry.path);
-  const upstream = sh('git rev-parse --abbrev-ref --symbolic-full-name @{u}', entry.path);
-  const div = upstream ? sh(`git rev-list --left-right --count ${upstream}...HEAD`, entry.path) : '';
-  const [behind = 0, ahead = 0] = div ? div.split(/\s+/).map(Number) : [null, null];
-  const merged = entry.branch && entry.branch !== 'main'
-    ? sh(`git merge-base --is-ancestor ${entry.head} origin/main && echo yes`, entry.path) === 'yes'
-    : false;
-  const enriched = {
-    ...entry,
-    dirtyCount: dirty ? dirty.split('\n').length : 0,
-    upstream: upstream || null,
-    ahead,
-    behind,
-    mergedToMain: merged,
-  };
-  return { ...enriched, action: recommendation(enriched) };
+function splitStatus(raw) {
+  const lines = raw ? raw.split('\n').filter(Boolean) : [];
+  return { dirtyCount: lines.filter(l => !l.startsWith('??')).length,
+    untrackedCount: lines.filter(l => l.startsWith('??')).length };
 }
-
-function inventory(raw = sh('git worktree list --porcelain')) {
-  return {
-    generatedAt: new Date().toISOString(),
-    mode: 'read-only',
-    worktrees: parsePorcelain(raw).map(enrich),
-  };
+function classify(entry) {
+  if (entry.prunable || entry.missing) return 'prunable-metadata';
+  if (entry.locked) return 'active';
+  if (entry.detached || !entry.branch) {
+    if (entry.dirty || entry.untracked || entry.ahead > 0) return 'rescue-needed';
+    return 'detached-temp';
+  }
+  if (entry.branch === 'main' || entry.branch.startsWith('sandbox/')) return 'active';
+  if (!entry.ticket) return entry.dirty || entry.untracked || entry.ahead > 0
+    ? 'rescue-needed' : 'ready/parked';
+  if (entry.dirty || entry.untracked || entry.ahead > 0) return 'stale-risky';
+  if (entry.upstream === null) return 'abandoned';
+  if (entry.mergedToMain) return 'stale-safe';
+  if ((entry.behind || 0) >= 50) return 'stale-warning';
+  return 'ready/parked';
 }
-
+function mergedToMain(entry, runGit) {
+  if (!entry.branch || entry.branch === 'main') return false;
+  if (runGit === git) return gitOk(['merge-base', '--is-ancestor', entry.head, 'origin/main'], entry.path);
+  return runGit(['merge-base', '--is-ancestor', entry.head, 'origin/main'], entry.path) === 'yes';
+}
+function enrich(entry, runGit = git) {
+  if (entry.missing || entry.prunable) {
+    const enriched = base(entry);
+    return { ...enriched, lifecycleState: classify(enriched), removalSafe: false };
+  }
+  const status = splitStatus(runGit(['status', '--porcelain', '--untracked-files=all'], entry.path));
+  const upstream = runGit(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], entry.path);
+  const div = upstream ? runGit(['rev-list', '--left-right', '--count', `${upstream}...HEAD`], entry.path) : '';
+  const [behind, ahead] = div ? div.split(/\s+/).map(Number) : [null, null];
+  const lastActivity = runGit(['log', '-1', '--format=%cI'], entry.path) || null;
+  const enriched = { ...entry, ticket: ticketFrom(entry.branch || ''), upstream: upstream || null,
+    ahead, behind, dirtyCount: status.dirtyCount, untrackedCount: status.untrackedCount,
+    dirty: status.dirtyCount > 0, untracked: status.untrackedCount > 0,
+    mergedToMain: mergedToMain(entry, runGit), lastActivity };
+  const lifecycleState = classify(enriched);
+  return { ...enriched, lifecycleState, action: lifecycleState, removalSafe: lifecycleState === 'stale-safe' };
+}
+function inventory(raw = git(['worktree', 'list', '--porcelain']), opts = {}) {
+  const runGit = opts.runGit || git;
+  return { generatedAt: new Date().toISOString(), mode: 'read-only',
+    worktrees: parsePorcelain(raw).map(entry => enrich(entry, runGit)) };
+}
 function print(report, json) {
   if (json) return console.log(JSON.stringify(report, null, 2));
   for (const worktree of report.worktrees) {
-    console.log(`${worktree.action.padEnd(18)} ${worktree.branch || 'DETACHED'} ${worktree.path}`);
+    const ref = worktree.branch || 'DETACHED';
+    console.log(`${worktree.lifecycleState.padEnd(18)} ${String(worktree.ticket || '-').padEnd(6)} ${ref} ${worktree.path}`);
   }
 }
-
-if (require.main === module) {
-  const report = inventory();
-  print(report, process.argv.includes('--json'));
-}
-
-module.exports = { inventory, parsePorcelain, recommendation };
+if (require.main === module) print(inventory(), process.argv.includes('--json'));
+module.exports = { classify, enrich, inventory, parsePorcelain, ticketFrom };

--- a/scripts/global/worktree-inventory.js
+++ b/scripts/global/worktree-inventory.js
@@ -72,11 +72,14 @@ function enrich(entry, runGit = git) {
   }
   const status = splitStatus(runGit(['status', '--porcelain', '--untracked-files=all'], entry.path));
   const upstream = runGit(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], entry.path);
-  const div = upstream ? runGit(['rev-list', '--left-right', '--count', `${upstream}...HEAD`], entry.path) : '';
-  const [behind, ahead] = div ? div.split(/\s+/).map(Number) : [null, null];
+  const upstreamDiv = upstream ? runGit(['rev-list', '--left-right', '--count', `${upstream}...HEAD`], entry.path) : '';
+  const mainDiv = runGit(['rev-list', '--left-right', '--count', 'origin/main...HEAD'], entry.path);
+  const [upstreamBehind, upstreamAhead] = upstreamDiv ? upstreamDiv.split(/\s+/).map(Number) : [null, null];
+  const [behind, mainAhead] = mainDiv ? mainDiv.split(/\s+/).map(Number) : [null, null];
   const lastActivity = runGit(['log', '-1', '--format=%cI'], entry.path) || null;
   const enriched = { ...entry, ticket: ticketFrom(entry.branch || ''), upstream: upstream || null,
-    ahead, behind, dirtyCount: status.dirtyCount, untrackedCount: status.untrackedCount,
+    ahead: upstreamAhead, behind, mainAhead, upstreamBehind,
+    dirtyCount: status.dirtyCount, untrackedCount: status.untrackedCount,
     dirty: status.dirtyCount > 0, untracked: status.untrackedCount > 0,
     mergedToMain: mergedToMain(entry, runGit), lastActivity };
   const lifecycleState = classify(enriched);

--- a/tests/worktree-cleanup-plan.spec.js
+++ b/tests/worktree-cleanup-plan.spec.js
@@ -37,6 +37,12 @@ test('preserves dirty or unpushed work with rescue commands', () => {
   expect(planner.commands(entry(), state)[0]).toContain('rescue/1700-preserve');
 });
 
+test('preserves untracked-only work with rescue commands', () => {
+  const state = planner.classify(entry({ untrackedCount: 1, mergedToMain: true }), null);
+  expect(state).toBe('preserve-dirty');
+  expect(planner.commands(entry(), state)[0]).toContain('rescue/1700-preserve');
+});
+
 test('keeps active lease worktrees visible', () => {
   const report = planner.plan({
     inventory: { worktrees: [entry({ branch: 'feat/1704-active' })] },

--- a/tests/worktree-inventory.test.js
+++ b/tests/worktree-inventory.test.js
@@ -58,11 +58,14 @@ test('behind main is warning evidence only, not removal-safe proof', () => {
   const item = enrich({ path: '.', head: 'abc', branch: 'feat/2250-x' }, runner({
     'status --porcelain --untracked-files=all': '',
     'rev-parse --abbrev-ref --symbolic-full-name @{u}': 'origin/feat/2250-x',
-    'rev-list --left-right --count origin/feat/2250-x...HEAD': '63 0',
+    'rev-list --left-right --count origin/feat/2250-x...HEAD': '0 0',
+    'rev-list --left-right --count origin/main...HEAD': '63 0',
     'log -1 --format=%cI': '2026-05-27T00:00:00Z',
   }));
   assert.strictEqual(item.lifecycleState, 'stale-warning');
   assert.strictEqual(item.removalSafe, false);
+  assert.strictEqual(item.ahead, 0);
+  assert.strictEqual(item.behind, 63);
 });
 
 test('inventory emits JSON-ready enriched worktree records', () => {
@@ -72,6 +75,7 @@ branch refs/heads/feat/2250-x`, { runGit: runner({
     'status --porcelain --untracked-files=all': '?? note.txt',
     'rev-parse --abbrev-ref --symbolic-full-name @{u}': 'origin/feat/2250-x',
     'rev-list --left-right --count origin/feat/2250-x...HEAD': '1 0',
+    'rev-list --left-right --count origin/main...HEAD': '1 0',
     'log -1 --format=%cI': '2026-05-27T00:00:00Z',
   }) });
   assert.strictEqual(report.mode, 'read-only');

--- a/tests/worktree-inventory.test.js
+++ b/tests/worktree-inventory.test.js
@@ -2,7 +2,7 @@
 'use strict';
 const test = require('node:test');
 const assert = require('node:assert');
-const { parsePorcelain, recommendation } = require('../scripts/global/worktree-inventory');
+const { classify, enrich, inventory, parsePorcelain, ticketFrom } = require('../scripts/global/worktree-inventory');
 
 const RAW = `worktree /repo
 HEAD abc
@@ -15,23 +15,67 @@ locked agent active
 
 worktree /repo-old
 HEAD 111
-prunable gitdir file points to non-existent location`;
+prunable gitdir file points to non-existent location
 
-test('worktree inventory parses porcelain entries', () => {
-  assert.deepStrictEqual(parsePorcelain(RAW), [
-    { path: '/repo', head: 'abc', branch: 'main', locked: false, prunable: false },
-    { path: '/repo-agent', head: 'def', branch: 'feat/123-work', locked: true, prunable: false },
-    { path: '/repo-old', head: '111', locked: false, prunable: true },
+worktree /repo-detached
+HEAD 222
+detached`;
+
+function runner(map = {}) {
+  return (args) => map[args.join(' ')] || '';
+}
+
+test('parses porcelain lifecycle fields', () => {
+  assert.deepStrictEqual(parsePorcelain(RAW).map(w => ({
+    path: w.path, branch: w.branch, locked: w.locked, prunable: w.prunable, detached: w.detached,
+  })), [
+    { path: '/repo', branch: 'main', locked: false, prunable: false, detached: false },
+    { path: '/repo-agent', branch: 'feat/123-work', locked: true, prunable: false, detached: false },
+    { path: '/repo-old', branch: undefined, locked: false, prunable: true, detached: false },
+    { path: '/repo-detached', branch: undefined, locked: false, prunable: false, detached: true },
   ]);
 });
 
-test('worktree inventory classifies safe read-only actions', () => {
-  assert.strictEqual(recommendation({ locked: true }), 'keep-locked');
-  assert.strictEqual(recommendation({ prunable: true }), 'prune-metadata');
-  assert.strictEqual(recommendation({ dirtyCount: 2, branch: 'feat/x' }), 'review-dirty');
-  assert.strictEqual(recommendation({ dirtyCount: 0 }), 'review-detached');
-  assert.strictEqual(recommendation({ dirtyCount: 0, branch: 'main' }), 'keep-main');
-  assert.strictEqual(recommendation({ dirtyCount: 0, branch: 'sandbox/codex', mergedToMain: true }), 'keep-active');
-  assert.strictEqual(recommendation({ dirtyCount: 0, branch: 'feat/x', mergedToMain: true }), 'remove-after-merge');
-  assert.strictEqual(recommendation({ dirtyCount: 0, branch: 'feat/x', mergedToMain: false }), 'keep-active');
+test('infers ticket numbers from governed branches', () => {
+  assert.strictEqual(ticketFrom('feat/2250-worktree-lifecycle-classifier'), 2250);
+  assert.strictEqual(ticketFrom('sandbox/codex'), null);
+});
+
+test('classifies active, parked, warning, safe, risky, abandoned, detached, and rescue states', () => {
+  assert.strictEqual(classify({ branch: 'main' }), 'active');
+  assert.strictEqual(classify({ locked: true, branch: 'feat/1-x' }), 'active');
+  assert.strictEqual(classify({ prunable: true }), 'prunable-metadata');
+  assert.strictEqual(classify({ branch: 'feat/no-ticket', dirty: false, untracked: false, ahead: 0 }), 'ready/parked');
+  assert.strictEqual(classify({ branch: 'feat/1-x', ticket: 1, behind: 80, ahead: 0 }), 'stale-warning');
+  assert.strictEqual(classify({ branch: 'feat/1-x', ticket: 1, mergedToMain: true, ahead: 0 }), 'stale-safe');
+  assert.strictEqual(classify({ branch: 'feat/1-x', ticket: 1, dirty: true, behind: 80 }), 'stale-risky');
+  assert.strictEqual(classify({ branch: 'feat/1-x', ticket: 1, ahead: 0, upstream: null }), 'abandoned');
+  assert.strictEqual(classify({ detached: true, ahead: 0, dirty: false, untracked: false }), 'detached-temp');
+  assert.strictEqual(classify({ detached: true, ahead: 1 }), 'rescue-needed');
+});
+
+test('behind main is warning evidence only, not removal-safe proof', () => {
+  const item = enrich({ path: '.', head: 'abc', branch: 'feat/2250-x' }, runner({
+    'status --porcelain --untracked-files=all': '',
+    'rev-parse --abbrev-ref --symbolic-full-name @{u}': 'origin/feat/2250-x',
+    'rev-list --left-right --count origin/feat/2250-x...HEAD': '63 0',
+    'log -1 --format=%cI': '2026-05-27T00:00:00Z',
+  }));
+  assert.strictEqual(item.lifecycleState, 'stale-warning');
+  assert.strictEqual(item.removalSafe, false);
+});
+
+test('inventory emits JSON-ready enriched worktree records', () => {
+  const report = inventory(`worktree .
+HEAD abc
+branch refs/heads/feat/2250-x`, { runGit: runner({
+    'status --porcelain --untracked-files=all': '?? note.txt',
+    'rev-parse --abbrev-ref --symbolic-full-name @{u}': 'origin/feat/2250-x',
+    'rev-list --left-right --count origin/feat/2250-x...HEAD': '1 0',
+    'log -1 --format=%cI': '2026-05-27T00:00:00Z',
+  }) });
+  assert.strictEqual(report.mode, 'read-only');
+  assert.strictEqual(report.worktrees[0].ticket, 2250);
+  assert.strictEqual(report.worktrees[0].untracked, true);
+  assert.strictEqual(report.worktrees[0].lifecycleState, 'stale-risky');
 });


### PR DESCRIPTION
## Summary

Refs #2250
Closes #2250
Refs Epic #2248

Adds a read-only worktree lifecycle classifier that reports enriched state for each worktree and distinguishes warning evidence from removal-safe evidence. Also includes focused tests and a small dashboard readability-budget cleanup required by the local pre-push gate.

## Governance

- **Manager**: https://github.com/chf3198/megingjord-harness/issues/2250#issuecomment-4551060482
- **Collaborator**: https://github.com/chf3198/megingjord-harness/issues/2250#issuecomment-4556681656
- **Admin**: https://github.com/chf3198/megingjord-harness/issues/2250#issuecomment-4556739692
- **Consultant**: https://github.com/chf3198/megingjord-harness/issues/2250#issuecomment-4556741431

## Verification

- `npm run lint` — PASS
- `npm run lint:readability:ci` — PASS at 475/475 warnings
- `npm run lint:js` — PASS exit 0 with existing warning backlog
- `node --test tests/worktree-inventory.test.js` — PASS, 5 tests
- `npx playwright test tests/worktree-cleanup-plan.spec.js tests/worktree-governance-audit.spec.js` — PASS, 10 tests after Codex review fixes
- `git diff --check` — PASS
- `node scripts/global/worktree-inventory.js --json` — PASS, 45 worktrees; observed states: abandoned, active, detached-temp, ready/parked, stale-risky, stale-safe

## Risk Notes

- No cleanup/prune/remove command is added or executed.
- `behind main` is classified against `origin/main` as warning-only evidence, not safe-removal evidence.
- Untracked-only worktrees are preserved by cleanup planning rather than treated as clean-removable.
- Fleet adversarial review attempts timed out on qwen3:32b and fallbacks; evidence is in the Collaborator and Consultant artifacts.