### PR TITLE
feat(governance): wire validate-config-schemas to CI #1957

### DIFF
--- a/.changes/unreleased/1957.md
+++ b/.changes/unreleased/1957.md
@@ -1,0 +1,2 @@
+### Added
+- CI workflow `.github/workflows/validate-config-schemas.yml` wires `scripts/global/validate-config-schemas.js` to `pull_request` + `push` to main (Refs #1957). Runs Python `jsonschema` (Draft 2020-12 compatible) against `.claude/settings.json` per `config/claude-code-settings.schema.json` and asserts the flat-hook-entry regression fixture FAILS validation. Closes #1957 AC4 (the missing CI wiring on a 4/5-met ticket). Phase-2 follow-on for Epic #1956 close.

--- a/.github/workflows/validate-config-schemas.yml
+++ b/.github/workflows/validate-config-schemas.yml
@@ -1,0 +1,42 @@
+# validate-config-schemas — JSON-schema validation gate for cross-runtime
+# config files. Refs #1957 / Epic #1956. Validates .claude/settings.json
+# against config/claude-code-settings.schema.json using Python jsonschema
+# (Draft 2020-12 compatible). Codex equivalent is advisory until a schema
+# is published. Fails on the flat-hook-entry regression that broke #1917.
+name: validate-config-schemas
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.claude/**'
+      - '.codex/**'
+      - 'config/**'
+      - 'scripts/global/validate-config-schemas.js'
+      - 'tests/fixtures/flat_hook_settings.json'
+      - 'tests/validate-config-schemas.spec.js'
+      - '.github/workflows/validate-config-schemas.yml'
+  push:
+    branches: [main]
+permissions:
+  contents: read
+concurrency:
+  group: validate-config-schemas-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  validate-config-schemas:
+    name: validate-config-schemas
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install jsonschema (Draft 2020-12)
+        run: python3 -m pip install jsonschema
+      - name: Validate cross-runtime config files
+        run: node scripts/global/validate-config-schemas.js
+      - name: Run regression-fixture assertion (flat-hook-entry must FAIL validation)
+        run: node --test tests/validate-config-schemas.spec.js

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ npm run deploy:both:apply
 | `governance:sync-check` | `node scripts/global/governance-sync-check.js` |
 | `governance:ticket-redundancy:test` | `node --test tests/validate-ticket-redundancy.spec.js` |
 | `governance:tokens` | `node scripts/global/governance-token-lint.js` |
+| `governance:validate-config-schemas-workflow:test` | `node --test tests/validate-config-schemas-workflow.spec.js` |
 | `governance:verify` | `node scripts/global/governance-verify.js --json` |
 | `governance:weekly` | `node scripts/global/governance-weekly-report.js` |
 | `governance:wiki-catalog:test` | `node --test tests/validate-wiki-catalog.spec.js` |

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "governance:sync-check": "node scripts/global/governance-sync-check.js",
     "governance:ticket-redundancy:test": "node --test tests/validate-ticket-redundancy.spec.js",
     "governance:tokens": "node scripts/global/governance-token-lint.js",
+    "governance:validate-config-schemas-workflow:test": "node --test tests/validate-config-schemas-workflow.spec.js",
     "governance:verify": "node scripts/global/governance-verify.js --json",
     "governance:weekly": "node scripts/global/governance-weekly-report.js",
     "governance:wiki-catalog:test": "node --test tests/validate-wiki-catalog.spec.js",

--- a/tests/fixtures/validate-config-schemas-workflow.yml
+++ b/tests/fixtures/validate-config-schemas-workflow.yml
@@ -1,0 +1,42 @@
+# validate-config-schemas — JSON-schema validation gate for cross-runtime
+# config files. Refs #1957 / Epic #1956. Validates .claude/settings.json
+# against config/claude-code-settings.schema.json using Python jsonschema
+# (Draft 2020-12 compatible). Codex equivalent is advisory until a schema
+# is published. Fails on the flat-hook-entry regression that broke #1917.
+name: validate-config-schemas
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.claude/**'
+      - '.codex/**'
+      - 'config/**'
+      - 'scripts/global/validate-config-schemas.js'
+      - 'tests/fixtures/flat_hook_settings.json'
+      - 'tests/validate-config-schemas.spec.js'
+      - '.github/workflows/validate-config-schemas.yml'
+  push:
+    branches: [main]
+permissions:
+  contents: read
+concurrency:
+  group: validate-config-schemas-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  validate-config-schemas:
+    name: validate-config-schemas
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install jsonschema (Draft 2020-12)
+        run: python3 -m pip install jsonschema
+      - name: Validate cross-runtime config files
+        run: node scripts/global/validate-config-schemas.js
+      - name: Run regression-fixture assertion (flat-hook-entry must FAIL validation)
+        run: node --test tests/validate-config-schemas.spec.js

--- a/tests/validate-config-schemas-workflow.spec.js
+++ b/tests/validate-config-schemas-workflow.spec.js
@@ -1,0 +1,63 @@
+'use strict';
+// tests/validate-config-schemas-workflow.spec.js — golden-file + structural assertions for #1957 AC4.
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const WF = path.resolve(__dirname, '..', '.github/workflows/validate-config-schemas.yml');
+const FIX = path.resolve(__dirname, 'fixtures/validate-config-schemas-workflow.yml');
+const read = () => fs.readFileSync(WF, 'utf8');
+
+test('golden-file byte-equality: workflow matches fixture snapshot', () => {
+  assert.equal(fs.readFileSync(WF, 'utf8'), fs.readFileSync(FIX, 'utf8'));
+});
+
+test('workflow triggers on pull_request to main (AC4 trigger #1)', () => {
+  const y = read();
+  assert.match(y, /pull_request:\s*\n\s+branches:\s+\[main\]/);
+});
+
+test('workflow triggers on push to main (AC4 trigger #2)', () => {
+  const y = read();
+  assert.match(y, /push:\s*\n\s+branches:\s+\[main\]/);
+});
+
+test('workflow runs the validator script (AC1 binding)', () => {
+  const y = read();
+  assert.match(y, /node scripts\/global\/validate-config-schemas\.js/);
+});
+
+test('workflow runs the regression-fixture assertion (AC3 binding)', () => {
+  const y = read();
+  assert.match(y, /node --test tests\/validate-config-schemas\.spec\.js/);
+});
+
+test('workflow installs Python jsonschema (Draft 2020-12 compatible)', () => {
+  const y = read();
+  assert.match(y, /python3 -m pip install jsonschema/);
+});
+
+test('workflow has minimal contents:read permissions (no write surfaces)', () => {
+  const y = read();
+  assert.match(y, /permissions:\s*\n\s+contents:\s+read/);
+  assert.doesNotMatch(y, /contents:\s+write/);
+  assert.doesNotMatch(y, /issues:\s+write/);
+});
+
+test('workflow has concurrency group keyed by ref (re-run safety)', () => {
+  const y = read();
+  assert.match(y, /concurrency:\s*\n\s+group:\s+validate-config-schemas-\$\{\{ github\.ref \}\}/);
+});
+
+test('workflow paths include all cross-runtime config surfaces', () => {
+  const y = read();
+  for (const p of ['\\.claude/\\*\\*', '\\.codex/\\*\\*', 'config/\\*\\*']) {
+    assert.match(y, new RegExp(`-\\s+'${p}'`), `missing path: ${p}`);
+  }
+});
+
+test('job name matches expected required-status-check identifier', () => {
+  const y = read();
+  assert.match(y, /^\s*name:\s+validate-config-schemas\s*$/m);
+});


### PR DESCRIPTION
## Summary

Ships AC4 of #1957 (CI workflow wiring) — completes the 4-of-5-met ticket. Validator + tests + fixture already shipped in prior unmerged work; this PR adds `.github/workflows/validate-config-schemas.yml` so the gate actually blocks PRs that would introduce the #1917-class flat-hook-entry regression.

- New: `.github/workflows/validate-config-schemas.yml` (42 LoC) — runs on PR + push to main, paths `.claude/**`, `.codex/**`, `config/**` + validator/test/fixture/workflow self
- New: `tests/fixtures/validate-config-schemas-workflow.yml` (42 LoC golden-file snapshot)
- New: `tests/validate-config-schemas-workflow.spec.js` (63 LoC, 10 golden-file structural tests)
- npm script: `governance:validate-config-schemas-workflow:test`
- Changelog fragment: `.changes/unreleased/1957.md`

## Test plan

- [x] 10 new golden-file structural tests pass
- [x] 2 pre-existing validate-config-schemas tests still pass
- [x] `npm run lint` → 375 files within 100-line cap
- [x] Smoke: live validator returns `✅ Claude settings parsed correctly against schema`
- [x] Fixture assertion: flat-hook-entry regression FAILS validation as expected

## Baton artifacts

- the-manager-handoff-artifact: #1957#issuecomment-4556751130
- the-collaborator-handoff-artifact: #1957#issuecomment-4556763646
- the-admin-handoff-artifact: posted alongside this PR
- the-consultant-closeout-artifact: pending post-CI (includes qwen2.5-coder:32b red-team)

## Scope note

Manager amendment 4556751130 documented that 4/5 ACs were already substantively met. AC4 (CI wiring) is the missing piece this PR ships. AC3 (add to required-status-checks via gh api PATCH) happens post-merge in Admin phase per the #1157 cycle pattern.

Refs #1957
Refs Epic #1956 (chain-unblocker)
