### PR TITLE
test(worktree): add lifecycle regression coverage

### DIFF
--- a/.changes/unreleased/2255.md
+++ b/.changes/unreleased/2255.md
@@ -1,0 +1,3 @@
+### Fixed
+- Prevented automatic cleanup recommendations for merged worktrees that do not match governed ticket branch patterns; these now stay in manual review.
+- Added regression coverage for worktree lifecycle safety states and planner no-op defaults (ticket #2255).

--- a/scripts/global/worktree-cleanup-plan.js
+++ b/scripts/global/worktree-cleanup-plan.js
@@ -16,9 +16,11 @@ function leaseFor(entry, leases) {
 }
 
 function classify(entry, lease) {
+  const ticket = ticketFrom(entry.branch);
   if (lease) return 'active-lease';
   if (entry.locked) return 'keep-locked';
   if ((entry.branch || '').startsWith('sandbox/')) return 'keep-launcher';
+  if (entry.branch && entry.branch !== 'main' && ticket === null) return 'keep-review';
   if (entry.dirtyCount > 0 || entry.untrackedCount > 0 || entry.ahead > 0) return 'preserve-dirty';
   if (entry.openPr) return 'stale-open-pr';
   if (entry.mergedToMain) return 'merged-clean';

--- a/tests/worktree-lifecycle-regression-2255.spec.js
+++ b/tests/worktree-lifecycle-regression-2255.spec.js
@@ -1,0 +1,55 @@
+const { test, expect } = require('@playwright/test');
+const planner = require('../scripts/global/worktree-cleanup-plan');
+const inventory = require('../scripts/global/worktree-inventory');
+const checks = require('../scripts/global/consultant-checks-lib');
+
+function entry(overrides = {}) {
+  return {
+    path: '/tmp/wt-2255', branch: 'feat/2255-demo', dirtyCount: 0,
+    untrackedCount: 0, ahead: 0, mergedToMain: false, prunable: false,
+    locked: false, ...overrides,
+  };
+}
+
+test('#2255 AC1: clean merged linked worktrees are stale-safe and removable', () => {
+  expect(inventory.classify({ branch: 'feat/2255-demo', ticket: 2255, ahead: 0, mergedToMain: true })).toBe('stale-safe');
+  const state = planner.classify(entry({ mergedToMain: true }), null);
+  expect(state).toBe('merged-clean');
+});
+
+test('#2255 AC2: risky or ambiguous worktrees are never auto-removable', () => {
+  const cases = [
+    entry({ dirtyCount: 1 }),
+    entry({ untrackedCount: 1 }),
+    entry({ ahead: 1 }),
+    entry({ branch: undefined }),
+    entry({ branch: 'feat/2255-demo', locked: true }),
+    entry({ branch: 'feat/2255-demo', locked: true, lockReason: 'permanent' }),
+    entry({ branch: 'feature/no-ticket', mergedToMain: true }),
+    entry({ branch: 'wip/unknown', mergedToMain: true }),
+  ];
+  for (const wt of cases) {
+    const state = planner.classify(wt, null);
+    expect(state).not.toBe('merged-clean');
+    expect(planner.commands(wt, state).join(' ')).not.toContain('worktree remove');
+  }
+});
+
+test('#2255 AC3: prunable metadata is separated from real removal', () => {
+  const wt = entry({ branch: undefined, prunable: true });
+  const state = planner.classify(wt, null);
+  expect(state).toBe('prune-metadata');
+  expect(planner.commands(wt, state)).toEqual(['git worktree prune']);
+});
+
+test('#2255 AC4: issue-only lanes bypass branch-name gate paths', () => {
+  expect(checks.isIssueOnlyLane('lane:docs-research')).toBe(true);
+  expect(checks.isIssueOnlyLane('lane:trivial')).toBe(true);
+  expect(checks.isIssueOnlyLane('type:epic')).toBe(true);
+  expect(checks.isIssueOnlyLane('lane:code-change')).toBe(false);
+});
+
+test('#2255 AC5: planner defaults to dry-run/no-op report mode', () => {
+  const report = planner.plan({ inventory: { worktrees: [entry()] }, registry: { version: 1, leases: [] } });
+  expect(report.mode).toBe('plan-only');
+});


### PR DESCRIPTION
Refs #2255

## Summary
- prevent auto-removal of merged branches that do not match governed ticket branch patterns
- add focused regression suite covering AC1-AC5 for worktree lifecycle safety
- keep issue-only lane behavior explicitly covered to avoid branch-gate false positives

## Validation
- npx playwright test tests/worktree-lifecycle-regression-2255.spec.js tests/worktree-cleanup-plan.spec.js tests/consultant-checks-lib.spec.js
- node --test tests/worktree-inventory.test.js