### PR TITLE
feat(governance): unify Conventional Commits enum across surfaces #2304

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -26,6 +26,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # Canonical 11-type set -- source of truth: scripts/global/conventional-commits-enum.js (#2304)
+          # CI sync guard: tests/conventional-commits-enum.spec.js asserts parity with JS module.
           types: |
             feat
             fix
@@ -36,6 +38,8 @@ jobs:
             docs
             style
             test
+            skill
+            hotfix
           requireScope: false
           subjectPattern: ^.{1,60}$
           subjectPatternError: >

--- a/hooks/scripts/validate-branch-name.sh
+++ b/hooks/scripts/validate-branch-name.sh
@@ -13,9 +13,11 @@ if echo "$BRANCH" | grep -qE "^sandbox/"; then
   exit 1
 fi
 
-# Allowed patterns (per #1336 AC1: add docs/content/perf/refactor/style/test
-# to match instructions/github-governance.instructions.md's published branch types)
-VALID="^(feat|fix|chore|skill|hotfix|docs|content|perf|refactor|style|test)/[a-z0-9][-a-z0-9]*$|^main$|^develop$"
+# Allowed type prefixes -- canonical 11-type set defined in #2304.
+# Source of truth: scripts/global/conventional-commits-enum.js
+# CI sync guard: tests/conventional-commits-enum.spec.js asserts this
+# literal matches the JS module's CONVENTIONAL_COMMIT_TYPES array.
+VALID="^(feat|fix|chore|content|perf|refactor|docs|style|test|skill|hotfix)/[a-z0-9][-a-z0-9]*$|^main$|^develop$"
 
 if ! echo "$BRANCH" | grep -qE "$VALID"; then
   echo "❌ Branch name '$BRANCH' violates naming convention."

--- a/instructions/github-governance.instructions.md
+++ b/instructions/github-governance.instructions.md
@@ -15,7 +15,7 @@ applyTo: "**"
 ## Commits and PR titles — Conventional Commits
 
 - Format: `type(scope): imperative description` ≤72 chars.
-- Allowed types: `feat` `fix` `chore` `content` `perf` `refactor` `docs` `style` `test`.
+- Allowed types: `feat` `fix` `chore` `content` `perf` `refactor` `docs` `style` `test` `skill` `hotfix`. (Canonical 11-type set; source of truth: `scripts/global/conventional-commits-enum.js` per #2304.)
 - Branch naming: `<type>/<issue-number>-<short-slug>` (e.g. `fix/5-nav-contrast`).
 
 ## Ticket lifecycle gates

--- a/scripts/global/conventional-commits-enum.js
+++ b/scripts/global/conventional-commits-enum.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+'use strict';
+// #2304 -- single source of truth for Conventional Commits type enum.
+// Consumed by validate-branch-name.sh (CI guard test asserts parity),
+// .github/workflows/pr-title.yml (updated to match), and
+// instructions/github-governance.instructions.md (updated to match).
+// Adding a new type here requires updating all three surfaces.
+
+const CONVENTIONAL_COMMIT_TYPES = [
+  'feat',
+  'fix',
+  'chore',
+  'content',
+  'perf',
+  'refactor',
+  'docs',
+  'style',
+  'test',
+  'skill',
+  'hotfix',
+];
+
+// Regex alternation string -- suitable for use in grep -E or RegExp constructor.
+// Example: "^(feat|fix|chore|...)/<rest>"
+const regexPattern = `(${CONVENTIONAL_COMMIT_TYPES.join('|')})`;
+
+// Full branch-prefix regex -- matches <type>/<slug> where slug is lowercase alnum+dash.
+const branchPrefixRegex = new RegExp(
+  `^${regexPattern}/[a-z0-9][-a-z0-9]*$`
+);
+
+// PR title regex -- matches type(optional-scope): subject
+const prTitleRegex = new RegExp(
+  `^${regexPattern}(\\([^)]+\\))?!?:\\s.+`
+);
+
+module.exports = {
+  CONVENTIONAL_COMMIT_TYPES,
+  regexPattern,
+  branchPrefixRegex,
+  prTitleRegex,
+};

--- a/tests/conventional-commits-enum.spec.js
+++ b/tests/conventional-commits-enum.spec.js
@@ -1,0 +1,100 @@
+'use strict';
+// #2304 -- drift-detection spec: verify conventional-commits-enum module stays
+// in sync with validate-branch-name.sh, pr-title.yml, and the instructions doc.
+const { test, expect } = require('@playwright/test');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const ENUM_MODULE = path.resolve(__dirname, '../scripts/global/conventional-commits-enum');
+const BRANCH_SCRIPT = path.resolve(__dirname, '../hooks/scripts/validate-branch-name.sh');
+const PR_TITLE_WF = path.resolve(__dirname, '../.github/workflows/pr-title.yml');
+const INST_DOC = path.resolve(__dirname, '../instructions/github-governance.instructions.md');
+
+const EXPECTED_TYPES = [
+  'feat', 'fix', 'chore', 'content', 'perf',
+  'refactor', 'docs', 'style', 'test', 'skill', 'hotfix',
+];
+
+test('#2304 module exports required constants', () => {
+  const { CONVENTIONAL_COMMIT_TYPES, regexPattern, branchPrefixRegex, prTitleRegex } =
+    require(ENUM_MODULE);
+  expect(Array.isArray(CONVENTIONAL_COMMIT_TYPES)).toBe(true);
+  expect(CONVENTIONAL_COMMIT_TYPES).toHaveLength(11);
+  for (const t of EXPECTED_TYPES) {
+    expect(CONVENTIONAL_COMMIT_TYPES).toContain(t);
+  }
+  expect(typeof regexPattern).toBe('string');
+  expect(regexPattern).toContain('skill');
+  expect(regexPattern).toContain('hotfix');
+  expect(branchPrefixRegex).toBeInstanceOf(RegExp);
+  expect(prTitleRegex).toBeInstanceOf(RegExp);
+});
+
+test('#2304 branchPrefixRegex: all 11 types accepted', () => {
+  const { branchPrefixRegex } = require(ENUM_MODULE);
+  for (const t of EXPECTED_TYPES) {
+    const branch = `${t}/some-slug`;
+    expect(branchPrefixRegex.test(branch),
+      `branchPrefixRegex should accept '${branch}'`).toBe(true);
+  }
+});
+
+test('#2304 branchPrefixRegex: skill/<name> and hotfix/<N>-slug accepted', () => {
+  const { branchPrefixRegex } = require(ENUM_MODULE);
+  expect(branchPrefixRegex.test('skill/my-new-skill')).toBe(true);
+  expect(branchPrefixRegex.test('hotfix/99-critical-fix')).toBe(true);
+  expect(branchPrefixRegex.test('unknown/some-slug')).toBe(false);
+});
+
+test('#2304 prTitleRegex: all 11 types accepted in PR title form', () => {
+  const { prTitleRegex } = require(ENUM_MODULE);
+  for (const t of EXPECTED_TYPES) {
+    const title = `${t}: do something useful`;
+    expect(prTitleRegex.test(title),
+      `prTitleRegex should accept '${title}'`).toBe(true);
+  }
+});
+
+test('#2304 prTitleRegex: skill(scope) and hotfix(scope) forms accepted', () => {
+  const { prTitleRegex } = require(ENUM_MODULE);
+  expect(prTitleRegex.test('skill(governance): add new skill #2304')).toBe(true);
+  expect(prTitleRegex.test('hotfix(auth): fix token expiry #2304')).toBe(true);
+});
+
+test('#2304 drift: validate-branch-name.sh VALID pattern contains all 11 types', () => {
+  const script = fs.readFileSync(BRANCH_SCRIPT, 'utf8');
+  const validMatch = script.match(/^VALID="([^"]+)"/m);
+  expect(validMatch, 'Could not find VALID= line in validate-branch-name.sh').not.toBeNull();
+  const validLine = validMatch[1];
+  for (const t of EXPECTED_TYPES) {
+    expect(validLine,
+      `Type '${t}' missing from VALID pattern in validate-branch-name.sh`
+    ).toContain(t);
+  }
+});
+
+test('#2304 drift: pr-title.yml types block contains all 11 types', () => {
+  const wf = fs.readFileSync(PR_TITLE_WF, 'utf8');
+  const typesMatch = wf.match(/types:\s*\|([\s\S]+?)requireScope/);
+  expect(typesMatch, 'Could not find types block in pr-title.yml').not.toBeNull();
+  const typesBlock = typesMatch[1];
+  for (const t of EXPECTED_TYPES) {
+    expect(typesBlock,
+      `Type '${t}' missing from types block in pr-title.yml`
+    ).toContain(t);
+  }
+});
+
+test('#2304 drift: instructions doc Allowed types line contains all 11 types', () => {
+  const doc = fs.readFileSync(INST_DOC, 'utf8');
+  const allowedMatch = doc.match(/Allowed types:([^\n]+)/);
+  expect(allowedMatch,
+    'Could not find "Allowed types:" line in github-governance.instructions.md'
+  ).not.toBeNull();
+  const allowedLine = allowedMatch[1];
+  for (const t of EXPECTED_TYPES) {
+    expect(allowedLine,
+      `Type '${t}' missing from Allowed types line in github-governance.instructions.md`
+    ).toContain(t);
+  }
+});


### PR DESCRIPTION
## Summary

- Add `scripts/global/conventional-commits-enum.js` as the canonical 11-type source of truth (`feat fix chore content perf refactor docs style test skill hotfix`).
- Update `hooks/scripts/validate-branch-name.sh`: literal updated to canonical 11-type set; comment points to JS module and CI guard test.
- Update `.github/workflows/pr-title.yml`: add `skill` and `hotfix` to the `types:` block (was 9 types, now 11).
- Update `instructions/github-governance.instructions.md`: Allowed types line extended to all 11 types with source-of-truth reference.
- Add `tests/conventional-commits-enum.spec.js`: 8 tdd-pyramid tests asserting module exports, regex behaviour, and drift parity across all three surfaces.

Resolves Conflict-2 + Conflict-8 from Epic #2295 Phase-0 research (#2296).

## Baton artifacts

- COLLABORATOR_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2304#issuecomment-4559225045
- ADMIN_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2304#issuecomment-4559230580
- CONSULTANT_CLOSEOUT: https://github.com/chf3198/megingjord-harness/issues/2304#issuecomment-4559232315

## AC verification

- AC1 PASS: all three surfaces express the same 11-type enum
- AC2 PASS: `skill/<name>` branch accepted by all three surfaces
- AC3 PASS: `hotfix/<name>` branch accepted by all three surfaces
- AC4 PASS: enum module follows `test-strategy-enum.js` lane-enum-style import pattern
- AC5 PASS: this PR title uses `feat(governance):` — in the 11-type set
- AC6 PASS: CommonJS module, no external dependencies, portable across runtimes

## Test plan

- [x] `tests/conventional-commits-enum.spec.js` — 8/8 passed locally
- [x] `npm run lint` — 376 files scanned, all within 100-line limit
- [x] All pre-push hooks green (branch-name-regex, git-freshness, lint-line-cap, lint-py, lint-readability, lint-sh, lint-md, lint-js, closeout-preflight)

Refs #2304
Refs Epic #2295
Closes #2304