### PR TITLE
feat(governance): hoist test-strategy enum + add stress-test to PR template #2305

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ Refs #<!-- issue number -->
 <!-- Per instructions/test-methodology-matrix.instructions.md.
      Must match MANAGER_HANDOFF.test_strategy on linked issue. -->
 
-- Strategy: <!-- tdd-pyramid|tdd-trophy|contract-test|golden-file|eval-harness|visual-regression|drift-lint|peer-review|manual-verify|none -->
+- Strategy: <!-- tdd-pyramid|tdd-trophy|contract-test|golden-file|eval-harness|visual-regression|drift-lint|peer-review|manual-verify|stress-test|none -->
 - Evidence artifact: <!-- spec file path / fixture path / VISUAL_QA_EVIDENCE link / "see linked issue MANAGER_HANDOFF" -->
 
 ## Validation

--- a/scripts/global/megalint/manager-handoff.js
+++ b/scripts/global/megalint/manager-handoff.js
@@ -2,6 +2,7 @@
 // manager-handoff — validates MANAGER_HANDOFF schema + crypto signature fields.
 
 const sig = require('../governance-artifact-signature');
+const { isValidStrategy } = require('../test-strategy-enum');
 const REQUIRED_FIELDS = ['scope', 'lane', 'test_strategy', 'acceptance', 'gates'];
 const PHASE_ONE_LABEL = process.env.PHASE_ONE_LABEL || 'phase-gate:phase-1';
 
@@ -25,6 +26,19 @@ function checkRequiredFields(body) {
   if (!/Team&Model:/i.test(body)) violations.push({ rule: 'missing-team-model', detail: 'MANAGER_HANDOFF missing Team&Model field' });
   if (!/Role:\s*manager/i.test(body)) violations.push({ rule: 'missing-role-manager', detail: 'MANAGER_HANDOFF missing Role: manager field' });
   return violations;
+}
+function checkTestStrategy(body) {
+  const declared = extractField(body, 'test_strategy');
+  if (!declared) return []; // missing-field already caught by checkRequiredFields
+  if (!isValidStrategy(declared)) {
+    return [{
+      rule: 'lane:unknown-test-strategy',
+      detail: `MANAGER_HANDOFF test_strategy '${declared}' is not in the canonical enum. ` +
+        'See scripts/global/test-strategy-enum.js for valid values.',
+      severity: 'advisory',
+    }];
+  }
+  return [];
 }
 function checkLaneConsistency(body, expectedLane) {
   if (!expectedLane) return [];
@@ -70,6 +84,7 @@ function validate(input) {
   }
   const violations = [
     ...checkRequiredFields(handoff.body),
+    ...checkTestStrategy(handoff.body),
     ...checkLaneConsistency(handoff.body, input.lane),
     ...checkPhaseOneFields(handoff.body, input.labels),
     ...checkCrypto(handoff.body),

--- a/scripts/global/test-strategy-enum.js
+++ b/scripts/global/test-strategy-enum.js
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 'use strict';
-// #1236 — single source of truth for test_strategy enum.
-// Consumed by test-evidence-validator.js and drift-detection spec.
+// #1236 / #2305 — single source of truth for test_strategy enum.
+// Consumed by test-evidence-validator.js, manager-handoff.js, and drift-detection spec.
 // Adding a new strategy here requires updating instructions/test-methodology-matrix.instructions.md.
+//
+// Composability rule (Epic #1875): stress-test MAY appear as the second strategy
+// via '+' separator (e.g. 'tdd-pyramid+stress-test'). It is a valid standalone enum
+// value AND valid as a composed suffix. See isValidStrategy() below.
 
 const ALLOWED_STRATEGIES = [
   'tdd-pyramid', 'tdd-trophy', 'contract-test', 'golden-file',
   'eval-harness', 'visual-regression', 'drift-lint', 'peer-review',
-  'manual-verify', 'none',
-  // stress-test is composable (e.g. tdd-pyramid+stress-test); not a standalone strategy value.
+  'manual-verify', 'stress-test', 'none',
 ];
 
 const NONE_PERMITTED_LANES = [
@@ -18,4 +21,31 @@ const NONE_PERMITTED_LANES = [
 
 const PEER_REVIEW_RUBRIC_THRESHOLD = 7;
 
-module.exports = { ALLOWED_STRATEGIES, NONE_PERMITTED_LANES, PEER_REVIEW_RUBRIC_THRESHOLD };
+/**
+ * Returns true when the declared test_strategy value is valid.
+ * Accepts:
+ *   - any single value in ALLOWED_STRATEGIES
+ *   - a '+'-composed pair where both parts are in ALLOWED_STRATEGIES
+ *     and the second part is 'stress-test' (per Epic #1875 composability rule)
+ */
+function isValidStrategy(value) {
+  if (!value || typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (ALLOWED_STRATEGIES.includes(trimmed)) return true;
+  if (trimmed.includes('+')) {
+    const parts = trimmed.split('+').map(p => p.trim());
+    return (
+      parts.length === 2 &&
+      ALLOWED_STRATEGIES.includes(parts[0]) &&
+      parts[1] === 'stress-test'
+    );
+  }
+  return false;
+}
+
+module.exports = {
+  ALLOWED_STRATEGIES,
+  NONE_PERMITTED_LANES,
+  PEER_REVIEW_RUBRIC_THRESHOLD,
+  isValidStrategy,
+};

--- a/tests/test-strategy-enum.spec.js
+++ b/tests/test-strategy-enum.spec.js
@@ -1,0 +1,74 @@
+'use strict';
+// #2305 — test-strategy-enum: canonical 11 values, composability, manager-handoff advisory.
+const { test, expect } = require('@playwright/test');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const ENUM = require(path.resolve(__dirname, '../scripts/global/test-strategy-enum'));
+const { validate } = require(path.resolve(__dirname, '../scripts/global/megalint/manager-handoff'));
+const PR_TEMPLATE = path.resolve(__dirname, '../.github/PULL_REQUEST_TEMPLATE.md');
+
+const CANONICAL_11 = [
+  'tdd-pyramid', 'tdd-trophy', 'contract-test', 'golden-file', 'eval-harness',
+  'visual-regression', 'drift-lint', 'peer-review', 'manual-verify', 'stress-test', 'none',
+];
+
+test('#2305 ALLOWED_STRATEGIES is exactly the canonical 11 values', () => {
+  expect(ENUM.ALLOWED_STRATEGIES).toHaveLength(CANONICAL_11.length);
+  for (const s of CANONICAL_11) expect(ENUM.ALLOWED_STRATEGIES, `missing '${s}'`).toContain(s);
+});
+
+test('#2305 isValidStrategy accepts all 11 canonical values', () => {
+  for (const s of CANONICAL_11) expect(ENUM.isValidStrategy(s), `reject '${s}'`).toBe(true);
+});
+
+test('#2305 isValidStrategy accepts valid +-composed strategies', () => {
+  const primaryStrategies = CANONICAL_11.filter(s => s !== 'none' && s !== 'stress-test');
+  for (const p of primaryStrategies) {
+    expect(ENUM.isValidStrategy(`${p}+stress-test`), `reject '${p}+stress-test'`).toBe(true);
+  }
+});
+
+test('#2305 isValidStrategy rejects unknown and malformed values', () => {
+  const invalid = [
+    'unknown-strategy',
+    'tdd-pyramid+tdd-trophy',       // second part must be stress-test
+    'stress-test+tdd-pyramid',      // stress-test may only be SECOND part
+    'tdd-pyramid+stress-test+none', // three-part not allowed
+    '', null, undefined,
+  ];
+  for (const s of invalid) expect(ENUM.isValidStrategy(s), `accept '${String(s)}'`).toBe(false);
+});
+
+function makeHandoff(strategy) {
+  return [
+    'MANAGER_HANDOFF', 'scope: s', 'lane: lane:code-change',
+    `test_strategy: ${strategy}`, 'acceptance: AC1', 'gates: lint',
+    'Signed-by: Orla Mason', 'Team&Model: claude-code:opus@local', 'Role: manager',
+  ].join('\n');
+}
+
+test('#2305 manager-handoff emits advisory for unknown test_strategy', () => {
+  const result = validate({ comments: [{ body: makeHandoff('not-a-real-strategy') }] });
+  const adv = result.violations.find(v => v.rule === 'lane:unknown-test-strategy');
+  expect(adv, 'should emit lane:unknown-test-strategy advisory').toBeTruthy();
+  expect(adv.severity).toBe('advisory');
+});
+
+test('#2305 manager-handoff no advisory for valid composed strategy', () => {
+  const result = validate({ comments: [{ body: makeHandoff('tdd-pyramid+stress-test') }] });
+  const adv = result.violations.find(v => v.rule === 'lane:unknown-test-strategy');
+  expect(adv, 'should NOT emit advisory for valid composed strategy').toBeUndefined();
+});
+
+test('#2305 PR template Strategy line contains stress-test', () => {
+  const text = fs.readFileSync(PR_TEMPLATE, 'utf8');
+  const line = text.match(/- Strategy:.*\n/);
+  expect(line, 'PR template must have a Strategy: line').not.toBeNull();
+  expect(line[0]).toContain('stress-test');
+});
+
+test('#2305 PR template enum matches all ALLOWED_STRATEGIES values', () => {
+  const text = fs.readFileSync(PR_TEMPLATE, 'utf8');
+  for (const s of ENUM.ALLOWED_STRATEGIES) expect(text, `PR template missing '${s}'`).toContain(s);
+});


### PR DESCRIPTION
## Summary

- Adds `stress-test` to canonical 11-value `ALLOWED_STRATEGIES` in `scripts/global/test-strategy-enum.js`
- Exports `isValidStrategy()` with `+`-composability rule (Epic #1875)
- Refactors `scripts/global/megalint/manager-handoff.js` to import enum and emit advisory for unrecognised `test_strategy` values
- Updates `.github/PULL_REQUEST_TEMPLATE.md` to include `stress-test` in Strategy enum comment (Conflict-7 resolution)
- Adds `tests/test-strategy-enum.spec.js` with 8 cases covering all ACs

## Linked Issue

Refs #2305
Refs Epic #2295
Closes #2305

## Role Evidence

- **Manager**: see issue #2305 body (scope artifact)
- **Collaborator**: https://github.com/chf3198/megingjord-harness/issues/2305#issuecomment-4559230766
- **Admin**: https://github.com/chf3198/megingjord-harness/issues/2305#issuecomment-4559238256
- **Consultant**: https://github.com/chf3198/megingjord-harness/issues/2305#issuecomment-4559248320

## Test strategy

- Strategy: tdd-pyramid
- Evidence artifact: tests/test-strategy-enum.spec.js (8 tests), tests/test-strategy-enum-drift.spec.js (2 tests) — 10/10 pass

## Validation

- [x] `npm run lint` — clean (376 files, all ≤100 lines)
- [x] `npm test` — 10 passed
- [x] CHANGELOG — N/A (no user-visible behavior change; governance scripts only)
- [x] Docs synced — PR template updated; instructions/test-methodology-matrix.instructions.md is canonical source, JS module references it
- [x] `test-evidence` gate passes

## Risk

low — additive change only; all existing exports preserved; advisory is non-blocking