### PR TITLE
feat(governance): hoist lane-enum to single source #2302

### DIFF
--- a/.changes/unreleased/2302.md
+++ b/.changes/unreleased/2302.md
@@ -1,0 +1,3 @@
+### Changed
+- `scripts/global/lane-enum.js` (new): single source-of-truth for canonical lane labels, exporting `LANES` (7 labels), `LANE_META` (severity per lane), `LIGHTWEIGHT`, `LIGHTWEIGHT_LANES`, `LIGHTWEIGHT_SET`, and helpers `isLightweight()`, `skipHandoff()`, `laneSeverity()` per #2302.
+- `scripts/global/megalint/merge-evidence-pr-gate.js`, `merge-evidence.js`, `admin-handoff.js`, `collaborator-handoff.js`: refactored to import `LIGHTWEIGHT`/`LIGHTWEIGHT_LANES` from `lane-enum.js`; all hardcoded arrays removed. Reconciles Conflict-4 (inter-validator lightweight-set drift) from Epic #2295.

--- a/scripts/global/lane-enum.js
+++ b/scripts/global/lane-enum.js
@@ -1,0 +1,104 @@
+'use strict';
+// lane-enum.js — single source-of-truth for canonical lane labels.
+// Refs #2302 / Epic #2295 P1.1 — reconciles inter-validator LIGHTWEIGHT drift.
+// CommonJS exports for cross-runtime portability (Node 14+, Cloudflare Workers).
+
+/**
+ * Severity tiers for lane labels.
+ * 'full'        = 4-role baton (code-change)
+ * 'lightweight' = reduced baton; COLLABORATOR_HANDOFF and/or ADMIN_HANDOFF N/A
+ * 'issue-only'  = no repo edits; Manager->Consultant only
+ */
+
+/** @type {ReadonlyArray<string>} Canonical set of lane labels. */
+const LANES = Object.freeze([
+  'lane:code-change',
+  'lane:docs-research',
+  'lane:docs-only',
+  'lane:config-only',
+  'lane:trivial',
+  'lane:research',
+  'lane:no-code-remediation',
+]);
+
+/**
+ * Per-lane severity metadata.
+ * @type {Record<string, {severity: string, collab: boolean, admin: boolean}>}
+ */
+const LANE_META = Object.freeze({
+  'lane:code-change':         { severity: 'full',       collab: true,  admin: true  },
+  'lane:docs-research':       { severity: 'lightweight', collab: false, admin: false },
+  'lane:docs-only':           { severity: 'lightweight', collab: false, admin: false },
+  'lane:config-only':         { severity: 'lightweight', collab: false, admin: true  },
+  'lane:trivial':             { severity: 'lightweight', collab: false, admin: false },
+  'lane:research':            { severity: 'lightweight', collab: false, admin: false },
+  'lane:no-code-remediation': { severity: 'issue-only', collab: false, admin: false },
+});
+
+/**
+ * LIGHTWEIGHT — lanes where COLLABORATOR_HANDOFF is N/A and/or skipped.
+ * Union of all prior per-validator sets to maximise backward compatibility.
+ *
+ * Carve-out registry (AC4):
+ *   lane:no-code-remediation — defined in instructions but absent from GitHub labels
+ *   as of 2026-05-27. Label creation tracked in Epic #2295. Included in LANES for
+ *   forward-compat; excluded from LIGHTWEIGHT because it is issue-only, not merely
+ *   lightweight. Validators skip on isLightweight() OR laneSeverity()==='issue-only'.
+ */
+const LIGHTWEIGHT = Object.freeze([
+  'lane:docs-research',
+  'lane:docs-only',
+  'lane:config-only',
+  'lane:trivial',
+  'lane:research',
+]);
+
+/** @type {ReadonlySet<string>} Set form of LIGHTWEIGHT for O(1) lookup. */
+const LIGHTWEIGHT_SET = new Set(LIGHTWEIGHT);
+
+/**
+ * LIGHTWEIGHT_LANES — Set alias used by merge-evidence validators.
+ * Identical to LIGHTWEIGHT_SET for backward compat.
+ * @type {ReadonlySet<string>}
+ */
+const LIGHTWEIGHT_LANES = LIGHTWEIGHT_SET;
+
+/**
+ * Returns true if the given lane label is in the lightweight set.
+ * @param {string} lane
+ * @returns {boolean}
+ */
+function isLightweight(lane) {
+  return LIGHTWEIGHT_SET.has(lane);
+}
+
+/**
+ * Returns true if the lane requires no collaborator or admin handoff.
+ * Covers both lightweight lanes and issue-only lanes (no-code-remediation).
+ * @param {string} lane
+ * @returns {boolean}
+ */
+function skipHandoff(lane) {
+  const meta = LANE_META[lane];
+  return meta ? (!meta.collab && !meta.admin) : false;
+}
+
+/**
+ * Returns the severity tier for a lane label, or null if unknown.
+ * @param {string} lane
+ * @returns {string|null}
+ */
+function laneSeverity(lane) {
+  return LANE_META[lane] ? LANE_META[lane].severity : null;
+}
+
+module.exports = {
+  LANES,
+  LANE_META,
+  LIGHTWEIGHT,
+  LIGHTWEIGHT_SET,
+  LIGHTWEIGHT_LANES,
+  isLightweight,
+  skipHandoff,
+  laneSeverity,
+};

--- a/scripts/global/megalint/admin-handoff.js
+++ b/scripts/global/megalint/admin-handoff.js
@@ -1,10 +1,11 @@
 'use strict';
 // admin-handoff — validates ADMIN_HANDOFF signer + independence vs Collaborator.
+// Refs #2302: LIGHTWEIGHT imported from lane-enum.js (single source of truth).
+// Updated to include lane:config-only and lane:research (were missing vs canonical set).
 
 const path = require('path');
 const { roleIdentity } = require(path.join(__dirname, '..', 'baton-independence.js'));
-
-const LIGHTWEIGHT = ['lane:docs-research', 'lane:docs-only', 'lane:trivial'];
+const { LIGHTWEIGHT } = require(path.join(__dirname, '..', 'lane-enum.js'));
 
 function findAdminHandoff(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?ADMIN_HANDOFF\b/;
@@ -23,9 +24,15 @@ function nameOnly(commentBody) {
 
 function checkSignerFields(body) {
   const violations = [];
-  if (!/Signed-by:/i.test(body)) violations.push({ rule: 'missing-signer', detail: 'ADMIN_HANDOFF missing Signed-by field' });
-  if (!/Team&Model:/i.test(body)) violations.push({ rule: 'missing-team-model', detail: 'ADMIN_HANDOFF missing Team&Model field' });
-  if (!/Role:\s*admin/i.test(body)) violations.push({ rule: 'missing-role-admin', detail: 'ADMIN_HANDOFF missing Role: admin field' });
+  if (!/Signed-by:/i.test(body)) {
+    violations.push({ rule: 'missing-signer', detail: 'ADMIN_HANDOFF missing Signed-by field' });
+  }
+  if (!/Team&Model:/i.test(body)) {
+    violations.push({ rule: 'missing-team-model', detail: 'ADMIN_HANDOFF missing Team&Model field' });
+  }
+  if (!/Role:\s*admin/i.test(body)) {
+    violations.push({ rule: 'missing-role-admin', detail: 'ADMIN_HANDOFF missing Role: admin field' });
+  }
   return violations;
 }
 
@@ -35,7 +42,8 @@ function checkIndependence(adminBody, collaboratorHandoff) {
   const adminName = nameOnly(adminBody);
   if (collabName && adminName && collabName === adminName) {
     return [{ rule: 'admin-signer-not-independent',
-      detail: `ADMIN_HANDOFF signer "${adminName}" matches COLLABORATOR_HANDOFF signer — independent verification requires a distinct identity` }];
+      detail: `ADMIN_HANDOFF signer "${adminName}" matches COLLABORATOR_HANDOFF signer`
+        + ` — independent verification requires a distinct identity` }];
   }
   return [];
 }

--- a/scripts/global/megalint/collaborator-handoff.js
+++ b/scripts/global/megalint/collaborator-handoff.js
@@ -1,10 +1,11 @@
 'use strict';
 // collaborator-handoff — validates COLLABORATOR_HANDOFF signer + content.
+// Refs #2302: LIGHTWEIGHT imported from lane-enum.js (single source of truth).
+// Updated to include lane:research (was missing vs canonical set).
 
 const path = require('path');
 const { roleIdentity } = require(path.join(__dirname, '..', 'baton-independence.js'));
-
-const LIGHTWEIGHT = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:config-only'];
+const { LIGHTWEIGHT } = require(path.join(__dirname, '..', 'lane-enum.js'));
 
 function findCollaboratorHandoff(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?COLLABORATOR_HANDOFF\b/;

--- a/scripts/global/megalint/merge-evidence-pr-gate.js
+++ b/scripts/global/megalint/merge-evidence-pr-gate.js
@@ -4,10 +4,10 @@
 // non-lightweight, non-epic PR commits to atomically closing its linked
 // issue via GitHub auto-close keywords (Closes/Fixes/Resolves), or carries
 // the merge-evidence-override:approved label on the issue.
+// Refs #2302: LIGHTWEIGHT_LANES imported from lane-enum.js (single source of truth).
 
-const LIGHTWEIGHT_LANES = new Set([
-  'lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research',
-]);
+const path = require('path');
+const { LIGHTWEIGHT_LANES } = require(path.join(__dirname, '..', 'lane-enum.js'));
 const OVERRIDE_LABEL = 'merge-evidence-override:approved';
 const CLOSE_KEYWORDS_RE = /\b(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+#(\d+)/gi;
 

--- a/scripts/global/megalint/merge-evidence.js
+++ b/scripts/global/megalint/merge-evidence.js
@@ -3,10 +3,10 @@
 // closed as status:done with no merged PR referencing them on main. Caller
 // supplies mergedPRRefs (already filtered to merged-to-main); this rule
 // stays side-effect-free per existing megalint convention.
+// Refs #2302: LIGHTWEIGHT_LANES imported from lane-enum.js (single source of truth).
 
-const LIGHTWEIGHT_LANES = new Set([
-  'lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research',
-]);
+const path = require('path');
+const { LIGHTWEIGHT_LANES } = require(path.join(__dirname, '..', 'lane-enum.js'));
 const OVERRIDE_LABEL = 'merge-evidence-override:approved';
 
 function shouldSkip(labels, state) {

--- a/tests/lane-enum.spec.js
+++ b/tests/lane-enum.spec.js
@@ -1,0 +1,168 @@
+'use strict';
+// tests/lane-enum.spec.js — Refs #2302 / Epic #2295 P1.1
+// Verifies lane-enum.js single source of truth + validator consistency.
+
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const laneEnum = require(path.join(__dirname, '..', 'scripts', 'global', 'lane-enum.js'));
+const collabHandoff = require(path.join(
+  __dirname, '..', 'scripts', 'global', 'megalint', 'collaborator-handoff.js'));
+const adminHandoff = require(path.join(
+  __dirname, '..', 'scripts', 'global', 'megalint', 'admin-handoff.js'));
+const mergeGate = require(path.join(
+  __dirname, '..', 'scripts', 'global', 'megalint', 'merge-evidence-pr-gate.js'));
+const mergeEvidence = require(path.join(
+  __dirname, '..', 'scripts', 'global', 'megalint', 'merge-evidence.js'));
+
+// --- AC1: canonical lane set membership ---
+
+test('LANES exports all 7 canonical lane labels', () => {
+  const expected = [
+    'lane:code-change', 'lane:docs-research', 'lane:docs-only',
+    'lane:config-only', 'lane:trivial', 'lane:research', 'lane:no-code-remediation',
+  ];
+  expect(laneEnum.LANES).toEqual(expected);
+});
+
+test('LANES is frozen (immutable)', () => {
+  expect(Object.isFrozen(laneEnum.LANES)).toBe(true);
+});
+
+test('LANE_META has an entry for every lane in LANES', () => {
+  for (const lane of laneEnum.LANES) {
+    expect(laneEnum.LANE_META[lane]).toBeDefined();
+    expect(typeof laneEnum.LANE_META[lane].severity).toBe('string');
+  }
+});
+
+test('lane:code-change has severity full and both handoffs required', () => {
+  const meta = laneEnum.LANE_META['lane:code-change'];
+  expect(meta.severity).toBe('full');
+  expect(meta.collab).toBe(true);
+  expect(meta.admin).toBe(true);
+});
+
+test('lane:no-code-remediation has severity issue-only and no handoffs', () => {
+  const meta = laneEnum.LANE_META['lane:no-code-remediation'];
+  expect(meta.severity).toBe('issue-only');
+  expect(meta.collab).toBe(false);
+  expect(meta.admin).toBe(false);
+});
+
+// --- AC2/AC5: LIGHTWEIGHT set semantics ---
+
+test('LIGHTWEIGHT contains exactly 5 reduced-baton lanes', () => {
+  const expected = new Set([
+    'lane:docs-research', 'lane:docs-only', 'lane:config-only',
+    'lane:trivial', 'lane:research',
+  ]);
+  expect(new Set(laneEnum.LIGHTWEIGHT)).toEqual(expected);
+});
+
+test('LIGHTWEIGHT does not include lane:code-change', () => {
+  expect(laneEnum.LIGHTWEIGHT).not.toContain('lane:code-change');
+});
+
+test('LIGHTWEIGHT does not include lane:no-code-remediation', () => {
+  expect(laneEnum.LIGHTWEIGHT).not.toContain('lane:no-code-remediation');
+});
+
+test('LIGHTWEIGHT_LANES Set has same membership as LIGHTWEIGHT array', () => {
+  for (const lane of laneEnum.LIGHTWEIGHT) {
+    expect(laneEnum.LIGHTWEIGHT_LANES.has(lane)).toBe(true);
+  }
+  expect(laneEnum.LIGHTWEIGHT_LANES.size).toBe(laneEnum.LIGHTWEIGHT.length);
+});
+
+test('isLightweight() returns true for all lightweight lanes', () => {
+  for (const lane of laneEnum.LIGHTWEIGHT) {
+    expect(laneEnum.isLightweight(lane)).toBe(true);
+  }
+});
+
+test('isLightweight() returns false for lane:code-change', () => {
+  expect(laneEnum.isLightweight('lane:code-change')).toBe(false);
+});
+
+test('skipHandoff() returns true for no-collab+no-admin lanes', () => {
+  // lanes where both collab and admin are false
+  const noHandoffLanes = laneEnum.LANES.filter(l => {
+    const meta = laneEnum.LANE_META[l];
+    return !meta.collab && !meta.admin;
+  });
+  for (const lane of noHandoffLanes) {
+    expect(laneEnum.skipHandoff(lane)).toBe(true);
+  }
+});
+
+test('skipHandoff() returns false for lane:code-change', () => {
+  expect(laneEnum.skipHandoff('lane:code-change')).toBe(false);
+});
+
+test('skipHandoff() returns false for lane:config-only (requires admin)', () => {
+  // config-only needs admin handoff even though collab is skipped
+  expect(laneEnum.skipHandoff('lane:config-only')).toBe(false);
+});
+
+test('skipHandoff() returns true for lane:no-code-remediation', () => {
+  expect(laneEnum.skipHandoff('lane:no-code-remediation')).toBe(true);
+});
+
+test('laneSeverity() returns expected values', () => {
+  expect(laneEnum.laneSeverity('lane:code-change')).toBe('full');
+  expect(laneEnum.laneSeverity('lane:trivial')).toBe('lightweight');
+  expect(laneEnum.laneSeverity('lane:no-code-remediation')).toBe('issue-only');
+  expect(laneEnum.laneSeverity('lane:unknown')).toBeNull();
+});
+
+// --- AC5: all three validators recognise the same lightweight set ---
+
+test('collaborator-handoff skips all LIGHTWEIGHT lanes', () => {
+  for (const lane of laneEnum.LIGHTWEIGHT) {
+    const result = collabHandoff.validate({ lane, comments: [] });
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe('lightweight-lane-skip');
+  }
+  // lane:code-change does NOT skip — requires COLLABORATOR_HANDOFF
+  const codeChange = collabHandoff.validate({ lane: 'lane:code-change', comments: [] });
+  expect(codeChange.ok).toBe(false);
+  expect(codeChange.violations[0].rule).toBe('missing-collaborator-handoff');
+});
+
+test('admin-handoff skips all LIGHTWEIGHT lanes', () => {
+  for (const lane of laneEnum.LIGHTWEIGHT) {
+    const result = adminHandoff.validate({ lane, comments: [] });
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe('lightweight-lane-skip');
+  }
+  // lane:code-change requires ADMIN_HANDOFF
+  const codeChange = adminHandoff.validate({ lane: 'lane:code-change', comments: [] });
+  expect(codeChange.ok).toBe(false);
+  expect(codeChange.violations[0].rule).toBe('missing-admin-handoff');
+});
+
+test('merge-evidence-pr-gate skips all LIGHTWEIGHT_LANES', () => {
+  for (const lane of laneEnum.LIGHTWEIGHT) {
+    const result = mergeGate.validate({ labels: [lane], issueNumber: 42, prBody: '' });
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toMatch(/^lightweight-lane:/);
+  }
+});
+
+test('merge-evidence skips all LIGHTWEIGHT_LANES', () => {
+  for (const lane of laneEnum.LIGHTWEIGHT) {
+    const result = mergeEvidence.validate({
+      labels: ['status:done', lane], state: 'closed', mergedPRRefs: [],
+    });
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toMatch(/^lightweight-lane:/);
+  }
+});
+
+test('all validators use identical lightweight set from lane-enum', () => {
+  const enumSet = new Set(laneEnum.LIGHTWEIGHT);
+  // merge-evidence validators export LIGHTWEIGHT_LANES — verify Set identity
+  expect(mergeGate.LIGHTWEIGHT_LANES).toEqual(enumSet);
+  expect(mergeEvidence.LIGHTWEIGHT_LANES).toEqual(enumSet);
+});


### PR DESCRIPTION
## Summary

- Add `scripts/global/lane-enum.js` as single source-of-truth for canonical lane labels, exporting `LANES` (7 labels), `LANE_META` (severity per lane), `LIGHTWEIGHT`, `LIGHTWEIGHT_LANES`, `LIGHTWEIGHT_SET`, and helpers `isLightweight()`, `skipHandoff()`, `laneSeverity()`.
- Refactor `merge-evidence-pr-gate.js`, `merge-evidence.js`, `admin-handoff.js`, `collaborator-handoff.js` to import from `lane-enum.js`; delete all hardcoded `LIGHTWEIGHT` arrays.
- Add `tests/lane-enum.spec.js` (21 tests) verifying canonical membership, frozen invariants, and all-validators-agree assertion.
- Reconciles Conflict-4 (inter-validator lightweight-set drift) from Epic #2295.

## Baton artifacts

COLLABORATOR_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2302#issuecomment-4559244002
ADMIN_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2302#issuecomment-4559245926

## Test plan

- [x] `npx playwright test tests/lane-enum.spec.js` — 21/21 PASS
- [x] `npx playwright test tests/merge-evidence*.spec.js tests/baton-independence.spec.js` — 38/38 PASS (no regressions)
- [x] `npx playwright test tests/batch-evidence.spec.js tests/collaborator-handoff-doc-coverage.spec.js` — 16/16 PASS
- [x] `npm run lint` — PASS
- [x] All pre-push hooks green (closeout-preflight PASS)

Refs #2302
Refs Epic #2295
Closes #2302

commit: ba2c084

🤖 Generated with [Claude Code](https://claude.com/claude-code)