### PR TITLE
feat(governance): land governance-rules.yaml registry + rule-card-extractor

### DIFF
--- a/.changes/unreleased/2301.md
+++ b/.changes/unreleased/2301.md
@@ -1,0 +1,14 @@
+## [Unreleased] — #2301
+
+### Added
+
+- `config/governance-rules.yaml`: v1 content-addressed registry of harness
+  governance rules with 10 seed rule-cards (lane enum, signer-fidelity,
+  single-status invariant, branch-name enum, test-strategy enum, and more).
+- `scripts/global/rule-card-extractor.js`: 8 typological adapters for
+  extracting rule-cards from instructions, templates, workflows, validators,
+  hooks, pre-commit config, config schemas, and live GitHub labels.
+- `npm run gov:extract`: idempotent CLI to dump all extracted rule-cards to
+  `/tmp/rule-cards.json`.
+- `docs/howto/rule-card-schema.md`: operator reference for the rule-card
+  schema and extractor usage.

--- a/.changes/unreleased/2301.md
+++ b/.changes/unreleased/2301.md
@@ -1,14 +1,13 @@
-## [Unreleased] — #2301
-
 ### Added
 
 - `config/governance-rules.yaml`: v1 content-addressed registry of harness
   governance rules with 10 seed rule-cards (lane enum, signer-fidelity,
   single-status invariant, branch-name enum, test-strategy enum, and more).
-- `scripts/global/rule-card-extractor.js`: 8 typological adapters for
-  extracting rule-cards from instructions, templates, workflows, validators,
-  hooks, pre-commit config, config schemas, and live GitHub labels.
+  Refs #2301.
+- `scripts/global/rule-card-extractor.js`: 8 typological adapters extracting
+  rule-cards from instructions, templates, workflows, validators, hooks,
+  pre-commit config, config schemas, and live GitHub labels. Refs #2301.
 - `npm run gov:extract`: idempotent CLI to dump all extracted rule-cards to
-  `/tmp/rule-cards.json`.
+  `/tmp/rule-cards.json`. Refs #2301.
 - `docs/howto/rule-card-schema.md`: operator reference for the rule-card
-  schema and extractor usage.
+  schema and extractor adapter usage. Refs #2301.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ npm run deploy:both:apply
 | `git:freshness-check` | `node scripts/global/git-freshness-check.js` |
 | `git:freshness-check:test` | `node --test tests/git-freshness-check.spec.js` |
 | `goals:regen` | `node scripts/global/goals-contract-generate.js` |
+| `gov:extract` | `node scripts/global/rule-card-extractor.js --all > /tmp/rule-cards.json` |
 | `governance:actuator-transitions:test` | `node --test tests/actuator-transitions.spec.js` |
 | `governance:adapters:emit` | `node scripts/global/governance-adapter-emit.js` |
 | `governance:adapters:test` | `node scripts/global/governance-adapter-emit.spec.js` |

--- a/config/governance-rules.yaml
+++ b/config/governance-rules.yaml
@@ -1,0 +1,195 @@
+# governance-rules.yaml — v1 content-addressed registry of harness governance rules
+# Refs #2301 (P1.2 of Epic #2295)
+#
+# Schema:
+#   rule_id:     unique kebab-case identifier
+#   class:       one of the 8 typological classes
+#   statement:   human-readable rule statement (one sentence)
+#   source:      file path (relative to repo root) + optional line reference
+#   enum_values: list of valid values (if class involves an enum)
+#   severity:    advisory | soft-mandatory | hard-mandatory
+#   cross_runtime_applicability: list of runtimes this rule applies to
+#
+# Classes:
+#   doc-vs-enforcement           — doc says X but no gate enforces X
+#   enforcement-vs-enforcement   — two gates enforce conflicting values
+#   enum-drift                   — enum in code differs from enum in docs
+#   doc-vs-no-enforcement        — rule documented but entirely unenforced
+#   authority-carve-out          — rule has explicit exception/carve-out path
+#   cross-runtime-fragmentation  — rule applies differently across runtimes
+#   maintenance-drift            — gate was once enforced but removed/relaxed
+#   context-substituting-for-guardrail — context substitutes for a hard gate
+
+version: 1
+generated_by: seed-rules-v1
+rules:
+
+  - rule_id: refs-not-closes-in-pr
+    class: doc-vs-enforcement
+    statement: >
+      PR bodies must use "Refs #N" (not "Closes #N") to link the issue;
+      issue closure is Consultant authority after CONSULTANT_CLOSEOUT.
+    source: instructions/github-governance.instructions.md
+    enum_values: []
+    severity: soft-mandatory
+    cross_runtime_applicability:
+      - claude-code
+      - codex
+      - copilot
+      - antigravity
+
+  - rule_id: lane-enum-values
+    class: enum-drift
+    statement: >
+      The lane field in MANAGER_HANDOFF must be one of the allowed lane
+      values; unknown lane values are rejected by the test-evidence gate.
+    source: instructions/role-baton-routing.instructions.md
+    enum_values:
+      - lane:code-change
+      - lane:docs-research
+      - lane:config-only
+      - lane:no-code-remediation
+      - lane:trivial
+    severity: hard-mandatory
+    cross_runtime_applicability:
+      - claude-code
+      - codex
+      - copilot
+      - antigravity
+
+  - rule_id: signer-independence-admin-vs-collaborator
+    class: enforcement-vs-enforcement
+    statement: >
+      The Admin signer alias must differ from the Collaborator signer alias;
+      identical aliases fail the signer-fidelity gate and block the
+      testing-to-review transition.
+    source: scripts/global/megalint/signer-fidelity.js
+    enum_values: []
+    severity: hard-mandatory
+    cross_runtime_applicability:
+      - claude-code
+      - codex
+      - copilot
+      - antigravity
+
+  - rule_id: single-status-invariant
+    class: enforcement-vs-enforcement
+    statement: >
+      Every ticket must carry exactly one status:* label at all times;
+      multi-status carriage is a Rule 1 violation enforced by label-lint.
+    source: instructions/role-baton-routing.instructions.md
+    enum_values:
+      - status:backlog
+      - status:queued
+      - status:triage
+      - status:ready
+      - status:in-progress
+      - status:testing
+      - status:review
+      - status:done
+      - status:cancelled
+      - status:dormant
+      - status:deferred
+    severity: hard-mandatory
+    cross_runtime_applicability:
+      - all
+
+  - rule_id: branch-name-prefix-enum
+    class: enum-drift
+    statement: >
+      Branch names must match one of the allowed prefix patterns; the
+      branch-name-required CI gate rejects branches not in the allowed set.
+    source: hooks/scripts/validate-branch-name.sh
+    enum_values:
+      - feat
+      - fix
+      - chore
+      - skill
+      - hotfix
+      - docs
+      - content
+      - perf
+      - refactor
+      - style
+      - test
+    severity: hard-mandatory
+    cross_runtime_applicability:
+      - claude-code
+      - codex
+      - copilot
+      - antigravity
+
+  - rule_id: test-strategy-enum-values
+    class: enum-drift
+    statement: >
+      The test_strategy field in MANAGER_HANDOFF must be one of the allowed
+      strategy values defined in test-strategy-enum.js; unknown values fail
+      the test-evidence gate.
+    source: scripts/global/test-strategy-enum.js
+    enum_values:
+      - tdd-pyramid
+      - tdd-trophy
+      - contract-test
+      - golden-file
+      - eval-harness
+      - visual-regression
+      - drift-lint
+      - peer-review
+      - manual-verify
+      - none
+    severity: hard-mandatory
+    cross_runtime_applicability:
+      - claude-code
+      - codex
+      - copilot
+      - antigravity
+
+  - rule_id: client-identity-never-signer
+    class: doc-vs-enforcement
+    statement: >
+      Client identity (Curtis Franks) must never appear in the Signed-by
+      field of any baton artifact; the signer-fidelity gate blocks such
+      artifacts.
+    source: scripts/global/megalint/signer-fidelity.js
+    enum_values: []
+    severity: hard-mandatory
+    cross_runtime_applicability:
+      - all
+
+  - rule_id: four-baton-artifacts-before-pr
+    class: doc-vs-enforcement
+    statement: >
+      All four baton artifacts must be posted on the linked issue before
+      gh pr create; the baton-gates CI fails when any artifact is absent.
+    source: instructions/role-baton-routing.instructions.md
+    enum_values: []
+    severity: hard-mandatory
+    cross_runtime_applicability:
+      - claude-code
+      - codex
+      - copilot
+      - antigravity
+
+  - rule_id: ticket-first-no-code-without-issue
+    class: doc-vs-no-enforcement
+    statement: >
+      No code or config work may begin without a linked GitHub issue; the
+      ticket-first gate requires every commit message to reference #N.
+    source: instructions/global-standards.instructions.md
+    enum_values: []
+    severity: hard-mandatory
+    cross_runtime_applicability:
+      - all
+
+  - rule_id: dormant-deferred-epic-only
+    class: authority-carve-out
+    statement: >
+      status:dormant and status:deferred are Epic-only states; non-Epic
+      tickets carrying these statuses violate Rule E5 enforced by label-lint.
+    source: instructions/ticket-driven-work.instructions.md
+    enum_values:
+      - status:dormant
+      - status:deferred
+    severity: hard-mandatory
+    cross_runtime_applicability:
+      - all

--- a/docs/howto/rule-card-schema.md
+++ b/docs/howto/rule-card-schema.md
@@ -1,0 +1,67 @@
+# Rule-Card Schema
+
+## Purpose
+
+`config/governance-rules.yaml` is a content-addressed registry of harness
+governance rules. Each entry is a **rule-card** that captures where a rule
+lives, its typological class, its severity, and (for enum-typed rules) its
+allowed values.
+
+Refs #2301 (Epic #2295 Phase-1 P1.2).
+
+## Rule-card fields
+
+| Field | Type | Description |
+|---|---|---|
+| `rule_id` | string | Unique kebab-case identifier |
+| `class` | enum | One of 8 typological classes (see below) |
+| `statement` | string | One-sentence rule statement |
+| `source` | string | Repo-relative path to the authoritative source |
+| `enum_values` | list | Allowed values for enum-typed rules; empty otherwise |
+| `severity` | enum | `advisory`, `soft-mandatory`, or `hard-mandatory` |
+| `cross_runtime_applicability` | list | Runtimes this rule applies to |
+
+## Typological classes
+
+| Class | Meaning |
+|---|---|
+| `doc-vs-enforcement` | Doc says X but gate enforces something different |
+| `enforcement-vs-enforcement` | Two gates enforce conflicting values |
+| `enum-drift` | Enum in code differs from enum in docs |
+| `doc-vs-no-enforcement` | Rule documented but entirely unenforced by any gate |
+| `authority-carve-out` | Rule has an explicit exception/carve-out path |
+| `cross-runtime-fragmentation` | Rule applies differently across runtimes |
+| `maintenance-drift` | Gate was once enforced but removed or relaxed |
+| `context-substituting-for-guardrail` | Context substitutes for a hard gate |
+
+## Severity levels
+
+- `advisory` — violation produces a warning; no gate blocks.
+- `soft-mandatory` — violation produces a blocking advisory; easy to override.
+- `hard-mandatory` — violation produces a CI-blocking gate failure.
+
+## Extraction
+
+The extractor in `scripts/global/rule-card-extractor.js` implements eight
+typological adapters that walk the harness file tree and emit rule-cards:
+
+1. `extractFromInstructions` — parses `instructions/*.md` for HTML-comment
+   blocks and fenced ` ```rule-card ``` ` blocks.
+2. `extractFromTemplate` — parses `.github/` templates for annotated enums.
+3. `extractFromWorkflow` — parses `.github/workflows/*.yml` for `types:` enums.
+4. `extractFromValidator` — extracts `const NAME = [...]` arrays from
+   `scripts/global/megalint/*.js` and `scripts/global/*.js`.
+5. `extractFromHook` — extracts `NAME = [...]` from `hooks/scripts/*.py`.
+6. `extractFromPrecommit` — extracts command names from `lefthook.yml`.
+7. `extractFromConfigSchema` — extracts `enum:` arrays from
+   `config/*.schema.json`.
+8. `extractFromLabels` — queries live GitHub label list (best-effort).
+
+Run extraction: `npm run gov:extract` — writes to `/tmp/rule-cards.json`.
+
+## Adding a new rule-card
+
+Append to `config/governance-rules.yaml` following the existing schema.
+Run `node scripts/global/rule-card-extractor.js --all` to verify the new
+card is well-formed. Tests in `tests/rule-card-extractor.spec.js` validate
+schema invariants automatically.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "megingjord-harness",
   "version": "3.3.8",
-  "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex \u2014 multi-runtime skills, hooks, agents, wiki, and install tooling",
+  "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex — multi-runtime skills, hooks, agents, wiki, and install tooling",
   "private": true,
   "scripts": {
     "adr:build": "log4brains build",
@@ -203,7 +203,7 @@
     "routing:refresh": "node scripts/global/routing-refresh.js --update-matrix",
     "routing:report": "node scripts/global/routing-baseline-report.js --days 7",
     "routing:telemetry": "node scripts/global/token-telemetry-report.js --json",
-    "setup": "npm install && echo '\u2705 megingjord ready \u2014 run: npm start'",
+    "setup": "npm install && echo '✅ megingjord ready — run: npm start'",
     "signing:bootstrap": "node scripts/global/crypto-signing-bootstrap.js",
     "start": "node scripts/dashboard-server.js",
     "state:offload": "node scripts/global/state-offload-client.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "megingjord-harness",
   "version": "3.3.8",
-  "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex — multi-runtime skills, hooks, agents, wiki, and install tooling",
+  "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex \u2014 multi-runtime skills, hooks, agents, wiki, and install tooling",
   "private": true,
   "scripts": {
     "adr:build": "log4brains build",
@@ -203,7 +203,7 @@
     "routing:refresh": "node scripts/global/routing-refresh.js --update-matrix",
     "routing:report": "node scripts/global/routing-baseline-report.js --days 7",
     "routing:telemetry": "node scripts/global/token-telemetry-report.js --json",
-    "setup": "npm install && echo '✅ megingjord ready — run: npm start'",
+    "setup": "npm install && echo '\u2705 megingjord ready \u2014 run: npm start'",
     "signing:bootstrap": "node scripts/global/crypto-signing-bootstrap.js",
     "start": "node scripts/dashboard-server.js",
     "state:offload": "node scripts/global/state-offload-client.js",
@@ -247,7 +247,8 @@
     "worktree:bootstrap": "bash scripts/worktree-bootstrap-node-modules.sh",
     "worktree:start": "bash scripts/worktree-session-start.sh",
     "governance:rule-parity": "node scripts/global/governance-rule-parity.js",
-    "governance:rule-parity:test": "node --test tests/governance-rule-parity.spec.js"
+    "governance:rule-parity:test": "node --test tests/governance-rule-parity.spec.js",
+    "gov:extract": "node scripts/global/rule-card-extractor.js --all > /tmp/rule-cards.json"
   },
   "keywords": [
     "devops",

--- a/scripts/global/rule-card-extractor.js
+++ b/scripts/global/rule-card-extractor.js
@@ -1,0 +1,438 @@
+#!/usr/bin/env node
+// rule-card-extractor.js — 8 typological adapters for governance rule-card
+// extraction. Refs #2301 (Epic #2295 Phase-1 child P1.2).
+// CommonJS for max cross-runtime portability (Claude Code/Codex/Copilot/Antigravity).
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const cp = require('node:child_process');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const VALID_CLASSES = [
+  'doc-vs-enforcement', 'enforcement-vs-enforcement', 'enum-drift',
+  'doc-vs-no-enforcement', 'authority-carve-out',
+  'cross-runtime-fragmentation', 'maintenance-drift',
+  'context-substituting-for-guardrail',
+];
+const VALID_SEVERITIES = ['advisory', 'soft-mandatory', 'hard-mandatory'];
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function rel(absPath) {
+  return path.relative(ROOT, absPath).replace(/\\/g, '/');
+}
+
+function makeCard(fields) {
+  return {
+    rule_id: fields.rule_id || '',
+    class: fields.class || 'doc-vs-no-enforcement',
+    statement: (fields.statement || '').trim(),
+    source: fields.source || '',
+    enum_values: Array.isArray(fields.enum_values) ? fields.enum_values : [],
+    severity: VALID_SEVERITIES.includes(fields.severity)
+      ? fields.severity : 'advisory',
+    cross_runtime_applicability: fields.cross_runtime_applicability || ['all'],
+  };
+}
+
+function parseKV(raw) {
+  const out = {};
+  // Multi-line form: one key=value per line (fenced blocks)
+  for (const line of raw.split(/\r?\n/)) {
+    const ml = line.match(/^\s*([\w_]+)\s*=\s*"?([^"]*)"?\s*$/);
+    if (ml) { out[ml[1]] = ml[2]; continue; }
+  }
+  // Single-line form: key=value key2="quoted value" (HTML comments)
+  const singleRe = /([\w_]+)=(?:"([^"]*)"|([\S]+))/g;
+  let sm;
+  while ((sm = singleRe.exec(raw)) !== null) {
+    if (!out[sm[1]]) out[sm[1]] = sm[2] !== undefined ? sm[2] : sm[3];
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 1: instructions/*.md — HTML comment blocks + fenced rule-card blocks
+// ---------------------------------------------------------------------------
+function extractFromInstructions(filePath) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  const cards = [];
+  const srcRel = rel(filePath);
+
+  // HTML-comment form: <!-- rule-card: rule_id=foo class=bar statement="..." -->
+  const htmlRe = /<!--\s*rule-card:\s*([\s\S]*?)-->/g;
+  let m;
+  while ((m = htmlRe.exec(src)) !== null) {
+    const kv = parseKV(m[1]);
+    if (kv.rule_id) {
+      cards.push(makeCard({ ...kv, source: srcRel,
+        enum_values: kv.enum_values ? kv.enum_values.split(',').map(s => s.trim()) : [],
+      }));
+    }
+  }
+
+  // Fenced ```rule-card``` blocks
+  const fenceRe = /```rule-card\r?\n([\s\S]*?)```/g;
+  while ((m = fenceRe.exec(src)) !== null) {
+    const kv = parseKV(m[1]);
+    if (kv.rule_id) {
+      cards.push(makeCard({ ...kv, source: srcRel,
+        enum_values: kv.enum_values ? kv.enum_values.split(',').map(s => s.trim()) : [],
+      }));
+    }
+  }
+  return cards;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 2: .github templates — HTML-comment-annotated enum lists
+// ---------------------------------------------------------------------------
+function extractFromTemplate(filePath) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  const cards = [];
+  const srcRel = rel(filePath);
+  const re = /<!--\s*rule-card:\s*([\s\S]*?)-->/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const kv = parseKV(m[1]);
+    if (kv.rule_id) {
+      cards.push(makeCard({ ...kv, source: srcRel,
+        enum_values: kv.enum_values ? kv.enum_values.split(',').map(s => s.trim()) : [],
+      }));
+    }
+  }
+  return cards;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 3: .github/workflows/*.yml — types: enum blocks in with: sections
+// ---------------------------------------------------------------------------
+function extractFromWorkflow(filePath) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  const srcRel = rel(filePath);
+  const cards = [];
+  // Capture `types: [a, b, c]` or multi-line `types:\n  - a\n  - b`
+  const inlineRe = /types\s*:\s*\[([^\]]+)\]/g;
+  let m;
+  while ((m = inlineRe.exec(src)) !== null) {
+    const vals = m[1].split(',').map(s => s.trim().replace(/^['"]|['"]$/g, ''));
+    if (vals.length > 1) {
+      cards.push(makeCard({
+        rule_id: `workflow-types-enum-${path.basename(filePath, '.yml')}`,
+        class: 'enum-drift',
+        statement: `Workflow ${path.basename(filePath)} constrains event types to a fixed enum.`,
+        source: srcRel,
+        enum_values: vals,
+        severity: 'soft-mandatory',
+        cross_runtime_applicability: ['all'],
+      }));
+    }
+  }
+  // Multi-line `types:` list
+  const mlRe = /\btypes\s*:\s*\n((?:\s+-[^\n]+\n)+)/g;
+  while ((m = mlRe.exec(src)) !== null) {
+    const vals = m[1].split('\n')
+      .map(l => l.replace(/^\s+-\s*/, '').trim())
+      .filter(Boolean);
+    if (vals.length > 1) {
+      cards.push(makeCard({
+        rule_id: `workflow-types-multiline-${path.basename(filePath, '.yml')}`,
+        class: 'enum-drift',
+        statement: `Workflow ${path.basename(filePath)} constrains event types to a fixed enum.`,
+        source: srcRel,
+        enum_values: vals,
+        severity: 'soft-mandatory',
+        cross_runtime_applicability: ['all'],
+      }));
+    }
+  }
+  return cards;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 4: scripts/global/megalint/*.js — hardcoded const arrays
+// ---------------------------------------------------------------------------
+function extractFromValidator(filePath) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  const srcRel = rel(filePath);
+  const cards = [];
+  // Match: const NAME = ['a', 'b', ...]  or  const NAME = ["a","b",...]
+  const re = /const\s+([A-Z_][A-Z0-9_]*)\s*=\s*\[([^\]]+)\]/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const vals = m[2].split(',')
+      .map(s => s.trim().replace(/^['"`]|['"`]$/g, ''))
+      .filter(Boolean);
+    if (vals.length > 1) {
+      const constName = m[1];
+      cards.push(makeCard({
+        rule_id: `validator-const-${constName.toLowerCase().replace(/_/g, '-')}`
+          + `-${path.basename(filePath, '.js')}`,
+        class: 'enum-drift',
+        statement: `Validator ${path.basename(filePath)} enforces ${constName} as a fixed set.`,
+        source: srcRel,
+        enum_values: vals,
+        severity: 'hard-mandatory',
+        cross_runtime_applicability: ['all'],
+      }));
+    }
+  }
+  return cards;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 5: hooks/scripts/*.py — Python enum constants
+// ---------------------------------------------------------------------------
+function extractFromHook(filePath) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  const srcRel = rel(filePath);
+  const cards = [];
+  // Match: NAME = ['a', 'b', ...] or NAME = ("a", "b", ...)
+  const re = /([A-Z_][A-Z0-9_]*)\s*=\s*[\[(]([^)\]]+)[\])]/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const vals = m[2].split(',')
+      .map(s => s.trim().replace(/^['"]|['"]$/g, ''))
+      .filter(s => s.length > 0 && !s.startsWith('#'));
+    if (vals.length > 1) {
+      cards.push(makeCard({
+        rule_id: `hook-const-${m[1].toLowerCase().replace(/_/g, '-')}`
+          + `-${path.basename(filePath, '.py')}`,
+        class: 'enum-drift',
+        statement: `Hook ${path.basename(filePath)} enforces ${m[1]} as a fixed set.`,
+        source: srcRel,
+        enum_values: vals,
+        severity: 'soft-mandatory',
+        cross_runtime_applicability: ['all'],
+      }));
+    }
+  }
+  return cards;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 6: lefthook.yml — commands keys + run values
+// ---------------------------------------------------------------------------
+function extractFromPrecommit(filePath) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  const srcRel = rel(filePath);
+  const cards = [];
+  // Extract command names from `commands:` blocks
+  const cmdNames = [];
+  const cmdRe = /^\s{4}([a-z][a-z0-9_-]+)\s*:/gm;
+  let m;
+  while ((m = cmdRe.exec(src)) !== null) {
+    cmdNames.push(m[1]);
+  }
+  if (cmdNames.length > 0) {
+    cards.push(makeCard({
+      rule_id: 'lefthook-pre-commit-commands',
+      class: 'enforcement-vs-enforcement',
+      statement: 'lefthook.yml defines the set of pre-commit/pre-push gates '
+        + 'that must all pass before a push is accepted.',
+      source: srcRel,
+      enum_values: cmdNames,
+      severity: 'hard-mandatory',
+      cross_runtime_applicability: ['claude-code', 'codex', 'copilot', 'antigravity'],
+    }));
+  }
+  return cards;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 7: config/*.schema.json — enum arrays
+// ---------------------------------------------------------------------------
+function extractFromConfigSchema(filePath) {
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return [];
+  }
+  const srcRel = rel(filePath);
+  const cards = [];
+
+  function walk(obj, pathParts) {
+    if (!obj || typeof obj !== 'object') return;
+    if (Array.isArray(obj.enum) && obj.enum.length > 1) {
+      const propName = pathParts[pathParts.length - 1] || 'root';
+      cards.push(makeCard({
+        rule_id: `schema-enum-${path.basename(filePath, '.json')}-${propName}`
+          .replace(/[^a-z0-9-]/gi, '-').toLowerCase(),
+        class: 'enum-drift',
+        statement: `Schema ${path.basename(filePath)} constrains `
+          + `${pathParts.join('.')} to an enum.`,
+        source: srcRel,
+        enum_values: obj.enum.map(String),
+        severity: 'soft-mandatory',
+        cross_runtime_applicability: ['all'],
+      }));
+    }
+    for (const [k, v] of Object.entries(obj)) {
+      if (k !== 'enum' && v && typeof v === 'object') walk(v, [...pathParts, k]);
+    }
+  }
+  walk(data, []);
+  return cards;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 8: gh label list — best-effort live label enum
+// ---------------------------------------------------------------------------
+function extractFromLabels() {
+  try {
+    const out = cp.execFileSync('gh', ['label', 'list', '--json', 'name', '--limit', '200'],
+      { stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 });
+    const labels = JSON.parse(out.toString()).map(l => l.name);
+    if (labels.length === 0) return [];
+    const statusVals = labels.filter(l => l.startsWith('status:'));
+    const roleVals = labels.filter(l => l.startsWith('role:'));
+    const laneVals = labels.filter(l => l.startsWith('lane:'));
+    const cards = [];
+    if (statusVals.length > 0) {
+      cards.push(makeCard({
+        rule_id: 'live-labels-status-enum',
+        class: 'enum-drift',
+        statement: 'Live GitHub label set defines the allowed status:* values.',
+        source: 'gh:label-list',
+        enum_values: statusVals,
+        severity: 'hard-mandatory',
+        cross_runtime_applicability: ['all'],
+      }));
+    }
+    if (roleVals.length > 0) {
+      cards.push(makeCard({
+        rule_id: 'live-labels-role-enum',
+        class: 'enum-drift',
+        statement: 'Live GitHub label set defines the allowed role:* values.',
+        source: 'gh:label-list',
+        enum_values: roleVals,
+        severity: 'hard-mandatory',
+        cross_runtime_applicability: ['all'],
+      }));
+    }
+    if (laneVals.length > 0) {
+      cards.push(makeCard({
+        rule_id: 'live-labels-lane-enum',
+        class: 'enum-drift',
+        statement: 'Live GitHub label set defines the allowed lane:* values.',
+        source: 'gh:label-list',
+        enum_values: laneVals,
+        severity: 'hard-mandatory',
+        cross_runtime_applicability: ['all'],
+      }));
+    }
+    return cards;
+  } catch {
+    return []; // best-effort; no gh or no auth
+  }
+}
+
+// ---------------------------------------------------------------------------
+// extractAll — walks harness file tree, unions all adapter outputs
+// ---------------------------------------------------------------------------
+function extractAll(opts) {
+  const rootDir = (opts && opts.root) || ROOT;
+  const cards = [];
+
+  function globSync(dir, ext, maxDepth) {
+    const results = [];
+    function recurse(cur, depth) {
+      if (depth > maxDepth) return;
+      let entries;
+      try { entries = fs.readdirSync(cur, { withFileTypes: true }); } catch { return; }
+      for (const e of entries) {
+        if (e.name === 'node_modules' || e.name.startsWith('.')) continue;
+        const full = path.join(cur, e.name);
+        if (e.isDirectory()) { recurse(full, depth + 1); }
+        else if (e.name.endsWith(ext)) results.push(full);
+      }
+    }
+    recurse(dir, 0);
+    return results;
+  }
+
+  // Adapter 1: instructions
+  for (const f of globSync(path.join(rootDir, 'instructions'), '.md', 1)) {
+    try { cards.push(...extractFromInstructions(f)); } catch { /* skip */ }
+  }
+
+  // Adapter 2: .github templates
+  for (const f of [
+    path.join(rootDir, '.github', 'PULL_REQUEST_TEMPLATE.md'),
+    ...globSync(path.join(rootDir, '.github', 'ISSUE_TEMPLATE'), '.md', 1),
+  ]) {
+    if (fs.existsSync(f)) {
+      try { cards.push(...extractFromTemplate(f)); } catch { /* skip */ }
+    }
+  }
+
+  // Adapter 3: workflows
+  for (const f of globSync(path.join(rootDir, '.github', 'workflows'), '.yml', 1)) {
+    try { cards.push(...extractFromWorkflow(f)); } catch { /* skip */ }
+  }
+
+  // Adapter 4: megalint validators
+  for (const f of globSync(path.join(rootDir, 'scripts', 'global', 'megalint'), '.js', 1)) {
+    try { cards.push(...extractFromValidator(f)); } catch { /* skip */ }
+  }
+  // Also scan scripts/global/*.js for top-level const enums
+  for (const f of globSync(path.join(rootDir, 'scripts', 'global'), '.js', 0)) {
+    try { cards.push(...extractFromValidator(f)); } catch { /* skip */ }
+  }
+
+  // Adapter 5: python hooks
+  for (const f of globSync(path.join(rootDir, 'hooks', 'scripts'), '.py', 1)) {
+    try { cards.push(...extractFromHook(f)); } catch { /* skip */ }
+  }
+
+  // Adapter 6: lefthook
+  const lefthook = path.join(rootDir, 'lefthook.yml');
+  if (fs.existsSync(lefthook)) {
+    try { cards.push(...extractFromPrecommit(lefthook)); } catch { /* skip */ }
+  }
+
+  // Adapter 7: config schemas
+  for (const f of globSync(path.join(rootDir, 'config'), '.json', 1)) {
+    if (f.endsWith('.schema.json')) {
+      try { cards.push(...extractFromConfigSchema(f)); } catch { /* skip */ }
+    }
+  }
+
+  // Adapter 8: live labels (best-effort)
+  cards.push(...extractFromLabels());
+
+  return cards;
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry-point
+// ---------------------------------------------------------------------------
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.includes('--all')) {
+    const cards = extractAll();
+    process.stdout.write(JSON.stringify(cards, null, 2) + '\n');
+  } else {
+    console.error('Usage: node rule-card-extractor.js --all');
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  extractFromInstructions,
+  extractFromTemplate,
+  extractFromWorkflow,
+  extractFromValidator,
+  extractFromHook,
+  extractFromPrecommit,
+  extractFromConfigSchema,
+  extractFromLabels,
+  extractAll,
+  VALID_CLASSES,
+  VALID_SEVERITIES,
+  makeCard,
+};

--- a/scripts/global/rule-card-extractor.js
+++ b/scripts/global/rule-card-extractor.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // rule-card-extractor.js — 8 typological adapters for governance rule-card
 // extraction. Refs #2301 (Epic #2295 Phase-1 child P1.2).
-// CommonJS for max cross-runtime portability (Claude Code/Codex/Copilot/Antigravity).
+// CommonJS for max cross-runtime portability (Claude Code/Codex/Copilot).
 'use strict';
 
 const fs = require('node:fs');
@@ -9,6 +9,9 @@ const path = require('node:path');
 const cp = require('node:child_process');
 
 const ROOT = path.resolve(__dirname, '..', '..');
+const GH_LABEL_LIMIT = 200;
+const GH_TIMEOUT_MS = 10000;
+
 const VALID_CLASSES = [
   'doc-vs-enforcement', 'enforcement-vs-enforcement', 'enum-drift',
   'doc-vs-no-enforcement', 'authority-carve-out',
@@ -46,7 +49,7 @@ function parseKV(raw) {
     if (ml) { out[ml[1]] = ml[2]; continue; }
   }
   // Single-line form: key=value key2="quoted value" (HTML comments)
-  const singleRe = /([\w_]+)=(?:"([^"]*)"|([\S]+))/g;
+  const singleRe = /([\w_]+)=(?:"([^"]*)"|(\S+))/g;
   let sm;
   while ((sm = singleRe.exec(raw)) !== null) {
     if (!out[sm[1]]) out[sm[1]] = sm[2] !== undefined ? sm[2] : sm[3];
@@ -54,128 +57,129 @@ function parseKV(raw) {
   return out;
 }
 
+function splitEnum(raw) {
+  return (raw || '').split(',').map(s => s.trim()).filter(Boolean);
+}
+
+function htmlCommentCards(src, srcRel) {
+  const cards = [];
+  const htmlRe = /<!--\s*rule-card:\s*([\s\S]*?)-->/g;
+  let match;
+  while ((match = htmlRe.exec(src)) !== null) {
+    const kv = parseKV(match[1]);
+    if (kv.rule_id) {
+      cards.push(makeCard({ ...kv, source: srcRel,
+        enum_values: splitEnum(kv.enum_values) }));
+    }
+  }
+  return cards;
+}
+
+function fencedCards(src, srcRel) {
+  const cards = [];
+  const fenceRe = /```rule-card\r?\n([\s\S]*?)```/g;
+  let match;
+  while ((match = fenceRe.exec(src)) !== null) {
+    const kv = parseKV(match[1]);
+    if (kv.rule_id) {
+      cards.push(makeCard({ ...kv, source: srcRel,
+        enum_values: splitEnum(kv.enum_values) }));
+    }
+  }
+  return cards;
+}
+
 // ---------------------------------------------------------------------------
-// Adapter 1: instructions/*.md — HTML comment blocks + fenced rule-card blocks
+// Adapter 1: instructions/*.md
 // ---------------------------------------------------------------------------
 function extractFromInstructions(filePath) {
   const src = fs.readFileSync(filePath, 'utf8');
-  const cards = [];
   const srcRel = rel(filePath);
-
-  // HTML-comment form: <!-- rule-card: rule_id=foo class=bar statement="..." -->
-  const htmlRe = /<!--\s*rule-card:\s*([\s\S]*?)-->/g;
-  let m;
-  while ((m = htmlRe.exec(src)) !== null) {
-    const kv = parseKV(m[1]);
-    if (kv.rule_id) {
-      cards.push(makeCard({ ...kv, source: srcRel,
-        enum_values: kv.enum_values ? kv.enum_values.split(',').map(s => s.trim()) : [],
-      }));
-    }
-  }
-
-  // Fenced ```rule-card``` blocks
-  const fenceRe = /```rule-card\r?\n([\s\S]*?)```/g;
-  while ((m = fenceRe.exec(src)) !== null) {
-    const kv = parseKV(m[1]);
-    if (kv.rule_id) {
-      cards.push(makeCard({ ...kv, source: srcRel,
-        enum_values: kv.enum_values ? kv.enum_values.split(',').map(s => s.trim()) : [],
-      }));
-    }
-  }
-  return cards;
+  return [...htmlCommentCards(src, srcRel), ...fencedCards(src, srcRel)];
 }
 
 // ---------------------------------------------------------------------------
-// Adapter 2: .github templates — HTML-comment-annotated enum lists
+// Adapter 2: .github templates
 // ---------------------------------------------------------------------------
 function extractFromTemplate(filePath) {
   const src = fs.readFileSync(filePath, 'utf8');
+  return htmlCommentCards(src, rel(filePath));
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 3: .github/workflows/*.yml — types: enum blocks
+// ---------------------------------------------------------------------------
+function workflowInlineCards(src, srcRel, baseName) {
   const cards = [];
-  const srcRel = rel(filePath);
-  const re = /<!--\s*rule-card:\s*([\s\S]*?)-->/g;
-  let m;
-  while ((m = re.exec(src)) !== null) {
-    const kv = parseKV(m[1]);
-    if (kv.rule_id) {
-      cards.push(makeCard({ ...kv, source: srcRel,
-        enum_values: kv.enum_values ? kv.enum_values.split(',').map(s => s.trim()) : [],
+  const inlineRe = /types\s*:\s*\[([^\]]+)\]/g;
+  let match;
+  while ((match = inlineRe.exec(src)) !== null) {
+    const vals = match[1].split(',')
+      .map(s => s.trim().replace(/^['"]|['"]$/g, ''));
+    if (vals.length > 1) {
+      cards.push(makeCard({
+        rule_id: `workflow-types-enum-${baseName}`,
+        class: 'enum-drift',
+        statement: `Workflow ${baseName}.yml constrains event types to a fixed enum.`,
+        source: srcRel, enum_values: vals, severity: 'soft-mandatory',
+        cross_runtime_applicability: ['all'],
       }));
     }
   }
   return cards;
 }
 
-// ---------------------------------------------------------------------------
-// Adapter 3: .github/workflows/*.yml — types: enum blocks in with: sections
-// ---------------------------------------------------------------------------
+function workflowMultilineCards(src, srcRel, baseName) {
+  const cards = [];
+  const mlRe = /\btypes\s*:\s*\n((?:\s+-[^\n]+\n)+)/g;
+  let match;
+  while ((match = mlRe.exec(src)) !== null) {
+    const vals = match[1].split('\n')
+      .map(l => l.replace(/^\s+-\s*/, '').trim()).filter(Boolean);
+    if (vals.length > 1) {
+      cards.push(makeCard({
+        rule_id: `workflow-types-multiline-${baseName}`,
+        class: 'enum-drift',
+        statement: `Workflow ${baseName}.yml constrains event types to a fixed enum.`,
+        source: srcRel, enum_values: vals, severity: 'soft-mandatory',
+        cross_runtime_applicability: ['all'],
+      }));
+    }
+  }
+  return cards;
+}
+
 function extractFromWorkflow(filePath) {
   const src = fs.readFileSync(filePath, 'utf8');
   const srcRel = rel(filePath);
-  const cards = [];
-  // Capture `types: [a, b, c]` or multi-line `types:\n  - a\n  - b`
-  const inlineRe = /types\s*:\s*\[([^\]]+)\]/g;
-  let m;
-  while ((m = inlineRe.exec(src)) !== null) {
-    const vals = m[1].split(',').map(s => s.trim().replace(/^['"]|['"]$/g, ''));
-    if (vals.length > 1) {
-      cards.push(makeCard({
-        rule_id: `workflow-types-enum-${path.basename(filePath, '.yml')}`,
-        class: 'enum-drift',
-        statement: `Workflow ${path.basename(filePath)} constrains event types to a fixed enum.`,
-        source: srcRel,
-        enum_values: vals,
-        severity: 'soft-mandatory',
-        cross_runtime_applicability: ['all'],
-      }));
-    }
-  }
-  // Multi-line `types:` list
-  const mlRe = /\btypes\s*:\s*\n((?:\s+-[^\n]+\n)+)/g;
-  while ((m = mlRe.exec(src)) !== null) {
-    const vals = m[1].split('\n')
-      .map(l => l.replace(/^\s+-\s*/, '').trim())
-      .filter(Boolean);
-    if (vals.length > 1) {
-      cards.push(makeCard({
-        rule_id: `workflow-types-multiline-${path.basename(filePath, '.yml')}`,
-        class: 'enum-drift',
-        statement: `Workflow ${path.basename(filePath)} constrains event types to a fixed enum.`,
-        source: srcRel,
-        enum_values: vals,
-        severity: 'soft-mandatory',
-        cross_runtime_applicability: ['all'],
-      }));
-    }
-  }
-  return cards;
+  const baseName = path.basename(filePath, '.yml');
+  return [
+    ...workflowInlineCards(src, srcRel, baseName),
+    ...workflowMultilineCards(src, srcRel, baseName),
+  ];
 }
 
 // ---------------------------------------------------------------------------
-// Adapter 4: scripts/global/megalint/*.js — hardcoded const arrays
+// Adapter 4: scripts/global/megalint/*.js and scripts/global/*.js
 // ---------------------------------------------------------------------------
 function extractFromValidator(filePath) {
   const src = fs.readFileSync(filePath, 'utf8');
   const srcRel = rel(filePath);
   const cards = [];
-  // Match: const NAME = ['a', 'b', ...]  or  const NAME = ["a","b",...]
   const re = /const\s+([A-Z_][A-Z0-9_]*)\s*=\s*\[([^\]]+)\]/g;
-  let m;
-  while ((m = re.exec(src)) !== null) {
-    const vals = m[2].split(',')
-      .map(s => s.trim().replace(/^['"`]|['"`]$/g, ''))
-      .filter(Boolean);
+  let match;
+  while ((match = re.exec(src)) !== null) {
+    const vals = match[2].split(',')
+      .map(s => s.trim().replace(/^['"`]|['"`]$/g, '')).filter(Boolean);
     if (vals.length > 1) {
-      const constName = m[1];
+      const constName = match[1];
+      const slug = constName.toLowerCase().replace(/_/g, '-');
+      const base = path.basename(filePath, '.js');
       cards.push(makeCard({
-        rule_id: `validator-const-${constName.toLowerCase().replace(/_/g, '-')}`
-          + `-${path.basename(filePath, '.js')}`,
+        rule_id: `validator-const-${slug}-${base}`,
         class: 'enum-drift',
-        statement: `Validator ${path.basename(filePath)} enforces ${constName} as a fixed set.`,
-        source: srcRel,
-        enum_values: vals,
-        severity: 'hard-mandatory',
+        statement: `Validator ${base}.js enforces ${constName} as a fixed set.`,
+        source: srcRel, enum_values: vals, severity: 'hard-mandatory',
         cross_runtime_applicability: ['all'],
       }));
     }
@@ -184,28 +188,26 @@ function extractFromValidator(filePath) {
 }
 
 // ---------------------------------------------------------------------------
-// Adapter 5: hooks/scripts/*.py — Python enum constants
+// Adapter 5: hooks/scripts/*.py
 // ---------------------------------------------------------------------------
 function extractFromHook(filePath) {
   const src = fs.readFileSync(filePath, 'utf8');
   const srcRel = rel(filePath);
   const cards = [];
-  // Match: NAME = ['a', 'b', ...] or NAME = ("a", "b", ...)
   const re = /([A-Z_][A-Z0-9_]*)\s*=\s*[\[(]([^)\]]+)[\])]/g;
-  let m;
-  while ((m = re.exec(src)) !== null) {
-    const vals = m[2].split(',')
+  let match;
+  while ((match = re.exec(src)) !== null) {
+    const vals = match[2].split(',')
       .map(s => s.trim().replace(/^['"]|['"]$/g, ''))
       .filter(s => s.length > 0 && !s.startsWith('#'));
     if (vals.length > 1) {
+      const slug = match[1].toLowerCase().replace(/_/g, '-');
+      const base = path.basename(filePath, '.py');
       cards.push(makeCard({
-        rule_id: `hook-const-${m[1].toLowerCase().replace(/_/g, '-')}`
-          + `-${path.basename(filePath, '.py')}`,
+        rule_id: `hook-const-${slug}-${base}`,
         class: 'enum-drift',
-        statement: `Hook ${path.basename(filePath)} enforces ${m[1]} as a fixed set.`,
-        source: srcRel,
-        enum_values: vals,
-        severity: 'soft-mandatory',
+        statement: `Hook ${base}.py enforces ${match[1]} as a fixed set.`,
+        source: srcRel, enum_values: vals, severity: 'soft-mandatory',
         cross_runtime_applicability: ['all'],
       }));
     }
@@ -214,197 +216,157 @@ function extractFromHook(filePath) {
 }
 
 // ---------------------------------------------------------------------------
-// Adapter 6: lefthook.yml — commands keys + run values
+// Adapter 6: lefthook.yml
 // ---------------------------------------------------------------------------
 function extractFromPrecommit(filePath) {
   const src = fs.readFileSync(filePath, 'utf8');
-  const srcRel = rel(filePath);
-  const cards = [];
-  // Extract command names from `commands:` blocks
   const cmdNames = [];
   const cmdRe = /^\s{4}([a-z][a-z0-9_-]+)\s*:/gm;
-  let m;
-  while ((m = cmdRe.exec(src)) !== null) {
-    cmdNames.push(m[1]);
-  }
-  if (cmdNames.length > 0) {
+  let match;
+  while ((match = cmdRe.exec(src)) !== null) cmdNames.push(match[1]);
+  if (cmdNames.length === 0) return [];
+  return [makeCard({
+    rule_id: 'lefthook-pre-commit-commands',
+    class: 'enforcement-vs-enforcement',
+    statement: 'lefthook.yml defines the set of pre-commit/pre-push gates '
+      + 'that must all pass before a push is accepted.',
+    source: rel(filePath), enum_values: cmdNames, severity: 'hard-mandatory',
+    cross_runtime_applicability: ['claude-code', 'codex', 'copilot', 'antigravity'],
+  })];
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 7: config/*.schema.json
+// ---------------------------------------------------------------------------
+function walkSchemaEnums(obj, pathParts, srcRel, baseName, cards) {
+  if (!obj || typeof obj !== 'object') return;
+  if (Array.isArray(obj.enum) && obj.enum.length > 1) {
+    const propName = pathParts[pathParts.length - 1] || 'root';
+    const slug = `schema-enum-${baseName}-${propName}`
+      .replace(/[^a-z0-9-]/gi, '-').toLowerCase();
     cards.push(makeCard({
-      rule_id: 'lefthook-pre-commit-commands',
-      class: 'enforcement-vs-enforcement',
-      statement: 'lefthook.yml defines the set of pre-commit/pre-push gates '
-        + 'that must all pass before a push is accepted.',
-      source: srcRel,
-      enum_values: cmdNames,
-      severity: 'hard-mandatory',
-      cross_runtime_applicability: ['claude-code', 'codex', 'copilot', 'antigravity'],
+      rule_id: slug, class: 'enum-drift',
+      statement: `Schema ${baseName}.json constrains ${pathParts.join('.')} to an enum.`,
+      source: srcRel, enum_values: obj.enum.map(String), severity: 'soft-mandatory',
+      cross_runtime_applicability: ['all'],
     }));
   }
-  return cards;
+  for (const [key, val] of Object.entries(obj)) {
+    if (key !== 'enum' && val && typeof val === 'object') {
+      walkSchemaEnums(val, [...pathParts, key], srcRel, baseName, cards);
+    }
+  }
 }
 
-// ---------------------------------------------------------------------------
-// Adapter 7: config/*.schema.json — enum arrays
-// ---------------------------------------------------------------------------
 function extractFromConfigSchema(filePath) {
   let data;
-  try {
-    data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch {
-    return [];
-  }
-  const srcRel = rel(filePath);
+  try { data = JSON.parse(fs.readFileSync(filePath, 'utf8')); } catch { return []; }
   const cards = [];
-
-  function walk(obj, pathParts) {
-    if (!obj || typeof obj !== 'object') return;
-    if (Array.isArray(obj.enum) && obj.enum.length > 1) {
-      const propName = pathParts[pathParts.length - 1] || 'root';
-      cards.push(makeCard({
-        rule_id: `schema-enum-${path.basename(filePath, '.json')}-${propName}`
-          .replace(/[^a-z0-9-]/gi, '-').toLowerCase(),
-        class: 'enum-drift',
-        statement: `Schema ${path.basename(filePath)} constrains `
-          + `${pathParts.join('.')} to an enum.`,
-        source: srcRel,
-        enum_values: obj.enum.map(String),
-        severity: 'soft-mandatory',
-        cross_runtime_applicability: ['all'],
-      }));
-    }
-    for (const [k, v] of Object.entries(obj)) {
-      if (k !== 'enum' && v && typeof v === 'object') walk(v, [...pathParts, k]);
-    }
-  }
-  walk(data, []);
+  walkSchemaEnums(data, [], rel(filePath), path.basename(filePath, '.json'), cards);
   return cards;
 }
 
 // ---------------------------------------------------------------------------
-// Adapter 8: gh label list — best-effort live label enum
+// Adapter 8: gh label list (best-effort)
 // ---------------------------------------------------------------------------
+function labelsToCards(labels) {
+  const cards = [];
+  const statusVals = labels.filter(l => l.startsWith('status:'));
+  const roleVals = labels.filter(l => l.startsWith('role:'));
+  const laneVals = labels.filter(l => l.startsWith('lane:'));
+  if (statusVals.length > 0) {
+    cards.push(makeCard({ rule_id: 'live-labels-status-enum', class: 'enum-drift',
+      statement: 'Live GitHub label set defines the allowed status:* values.',
+      source: 'gh:label-list', enum_values: statusVals, severity: 'hard-mandatory',
+      cross_runtime_applicability: ['all'] }));
+  }
+  if (roleVals.length > 0) {
+    cards.push(makeCard({ rule_id: 'live-labels-role-enum', class: 'enum-drift',
+      statement: 'Live GitHub label set defines the allowed role:* values.',
+      source: 'gh:label-list', enum_values: roleVals, severity: 'hard-mandatory',
+      cross_runtime_applicability: ['all'] }));
+  }
+  if (laneVals.length > 0) {
+    cards.push(makeCard({ rule_id: 'live-labels-lane-enum', class: 'enum-drift',
+      statement: 'Live GitHub label set defines the allowed lane:* values.',
+      source: 'gh:label-list', enum_values: laneVals, severity: 'hard-mandatory',
+      cross_runtime_applicability: ['all'] }));
+  }
+  return cards;
+}
+
 function extractFromLabels() {
   try {
-    const out = cp.execFileSync('gh', ['label', 'list', '--json', 'name', '--limit', '200'],
-      { stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 });
+    const out = cp.execFileSync(
+      'gh', ['label', 'list', '--json', 'name', '--limit', String(GH_LABEL_LIMIT)],
+      { stdio: ['pipe', 'pipe', 'pipe'], timeout: GH_TIMEOUT_MS });
     const labels = JSON.parse(out.toString()).map(l => l.name);
-    if (labels.length === 0) return [];
-    const statusVals = labels.filter(l => l.startsWith('status:'));
-    const roleVals = labels.filter(l => l.startsWith('role:'));
-    const laneVals = labels.filter(l => l.startsWith('lane:'));
-    const cards = [];
-    if (statusVals.length > 0) {
-      cards.push(makeCard({
-        rule_id: 'live-labels-status-enum',
-        class: 'enum-drift',
-        statement: 'Live GitHub label set defines the allowed status:* values.',
-        source: 'gh:label-list',
-        enum_values: statusVals,
-        severity: 'hard-mandatory',
-        cross_runtime_applicability: ['all'],
-      }));
-    }
-    if (roleVals.length > 0) {
-      cards.push(makeCard({
-        rule_id: 'live-labels-role-enum',
-        class: 'enum-drift',
-        statement: 'Live GitHub label set defines the allowed role:* values.',
-        source: 'gh:label-list',
-        enum_values: roleVals,
-        severity: 'hard-mandatory',
-        cross_runtime_applicability: ['all'],
-      }));
-    }
-    if (laneVals.length > 0) {
-      cards.push(makeCard({
-        rule_id: 'live-labels-lane-enum',
-        class: 'enum-drift',
-        statement: 'Live GitHub label set defines the allowed lane:* values.',
-        source: 'gh:label-list',
-        enum_values: laneVals,
-        severity: 'hard-mandatory',
-        cross_runtime_applicability: ['all'],
-      }));
-    }
-    return cards;
-  } catch {
-    return []; // best-effort; no gh or no auth
-  }
+    return labels.length === 0 ? [] : labelsToCards(labels);
+  } catch { return []; }
 }
 
 // ---------------------------------------------------------------------------
 // extractAll — walks harness file tree, unions all adapter outputs
 // ---------------------------------------------------------------------------
-function extractAll(opts) {
-  const rootDir = (opts && opts.root) || ROOT;
-  const cards = [];
-
-  function globSync(dir, ext, maxDepth) {
-    const results = [];
-    function recurse(cur, depth) {
-      if (depth > maxDepth) return;
-      let entries;
-      try { entries = fs.readdirSync(cur, { withFileTypes: true }); } catch { return; }
-      for (const e of entries) {
-        if (e.name === 'node_modules' || e.name.startsWith('.')) continue;
-        const full = path.join(cur, e.name);
-        if (e.isDirectory()) { recurse(full, depth + 1); }
-        else if (e.name.endsWith(ext)) results.push(full);
-      }
+function globSync(dir, ext, maxDepth) {
+  const results = [];
+  function recurse(cur, depth) {
+    if (depth > maxDepth) return;
+    let entries;
+    try { entries = fs.readdirSync(cur, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+      const full = path.join(cur, entry.name);
+      if (entry.isDirectory()) recurse(full, depth + 1);
+      else if (entry.name.endsWith(ext)) results.push(full);
     }
-    recurse(dir, 0);
-    return results;
   }
+  recurse(dir, 0);
+  return results;
+}
 
-  // Adapter 1: instructions
-  for (const f of globSync(path.join(rootDir, 'instructions'), '.md', 1)) {
-    try { cards.push(...extractFromInstructions(f)); } catch { /* skip */ }
+function collectAdapter(files, fn, cards) {
+  for (const filePath of files) {
+    try { cards.push(...fn(filePath)); } catch { /* skip unreadable */ }
   }
+}
 
-  // Adapter 2: .github templates
-  for (const f of [
+function collectFromTree(rootDir, cards) {
+  collectAdapter(
+    globSync(path.join(rootDir, 'instructions'), '.md', 1),
+    extractFromInstructions, cards);
+  const templateFiles = [
     path.join(rootDir, '.github', 'PULL_REQUEST_TEMPLATE.md'),
     ...globSync(path.join(rootDir, '.github', 'ISSUE_TEMPLATE'), '.md', 1),
-  ]) {
-    if (fs.existsSync(f)) {
-      try { cards.push(...extractFromTemplate(f)); } catch { /* skip */ }
-    }
-  }
-
-  // Adapter 3: workflows
-  for (const f of globSync(path.join(rootDir, '.github', 'workflows'), '.yml', 1)) {
-    try { cards.push(...extractFromWorkflow(f)); } catch { /* skip */ }
-  }
-
-  // Adapter 4: megalint validators
-  for (const f of globSync(path.join(rootDir, 'scripts', 'global', 'megalint'), '.js', 1)) {
-    try { cards.push(...extractFromValidator(f)); } catch { /* skip */ }
-  }
-  // Also scan scripts/global/*.js for top-level const enums
-  for (const f of globSync(path.join(rootDir, 'scripts', 'global'), '.js', 0)) {
-    try { cards.push(...extractFromValidator(f)); } catch { /* skip */ }
-  }
-
-  // Adapter 5: python hooks
-  for (const f of globSync(path.join(rootDir, 'hooks', 'scripts'), '.py', 1)) {
-    try { cards.push(...extractFromHook(f)); } catch { /* skip */ }
-  }
-
-  // Adapter 6: lefthook
+  ].filter(fp => fs.existsSync(fp));
+  collectAdapter(templateFiles, extractFromTemplate, cards);
+  collectAdapter(
+    globSync(path.join(rootDir, '.github', 'workflows'), '.yml', 1),
+    extractFromWorkflow, cards);
+  collectAdapter(
+    globSync(path.join(rootDir, 'scripts', 'global', 'megalint'), '.js', 1),
+    extractFromValidator, cards);
+  collectAdapter(
+    globSync(path.join(rootDir, 'scripts', 'global'), '.js', 0),
+    extractFromValidator, cards);
+  collectAdapter(
+    globSync(path.join(rootDir, 'hooks', 'scripts'), '.py', 1),
+    extractFromHook, cards);
   const lefthook = path.join(rootDir, 'lefthook.yml');
   if (fs.existsSync(lefthook)) {
     try { cards.push(...extractFromPrecommit(lefthook)); } catch { /* skip */ }
   }
+  collectAdapter(
+    globSync(path.join(rootDir, 'config'), '.json', 1)
+      .filter(fp => fp.endsWith('.schema.json')),
+    extractFromConfigSchema, cards);
+}
 
-  // Adapter 7: config schemas
-  for (const f of globSync(path.join(rootDir, 'config'), '.json', 1)) {
-    if (f.endsWith('.schema.json')) {
-      try { cards.push(...extractFromConfigSchema(f)); } catch { /* skip */ }
-    }
-  }
-
-  // Adapter 8: live labels (best-effort)
+function extractAll(opts) {
+  const rootDir = (opts && opts.root) || ROOT;
+  const cards = [];
+  collectFromTree(rootDir, cards);
   cards.push(...extractFromLabels());
-
   return cards;
 }
 
@@ -423,16 +385,8 @@ if (require.main === module) {
 }
 
 module.exports = {
-  extractFromInstructions,
-  extractFromTemplate,
-  extractFromWorkflow,
-  extractFromValidator,
-  extractFromHook,
-  extractFromPrecommit,
-  extractFromConfigSchema,
-  extractFromLabels,
-  extractAll,
-  VALID_CLASSES,
-  VALID_SEVERITIES,
-  makeCard,
+  extractFromInstructions, extractFromTemplate, extractFromWorkflow,
+  extractFromValidator, extractFromHook, extractFromPrecommit,
+  extractFromConfigSchema, extractFromLabels, extractAll,
+  VALID_CLASSES, VALID_SEVERITIES, makeCard,
 };

--- a/tests/fixtures/rule-card-extractor/sample-hook.py
+++ b/tests/fixtures/rule-card-extractor/sample-hook.py
@@ -1,0 +1,2 @@
+ALLOWED_LANES = ['lane:code-change', 'lane:trivial', 'lane:config-only']
+TERMINAL_STATES = ('status:done', 'status:cancelled')

--- a/tests/fixtures/rule-card-extractor/sample-instruction.md
+++ b/tests/fixtures/rule-card-extractor/sample-instruction.md
@@ -1,0 +1,13 @@
+# Sample Instruction Fixture
+
+<!-- rule-card: rule_id=test-html-comment class=doc-vs-enforcement statement="Test rule from HTML comment" severity=hard-mandatory -->
+
+Regular instruction text here.
+
+```rule-card
+rule_id=test-fenced-block
+class=enum-drift
+statement=Test rule from fenced block
+severity=soft-mandatory
+enum_values=val-a,val-b,val-c
+```

--- a/tests/fixtures/rule-card-extractor/sample-lefthook.yml
+++ b/tests/fixtures/rule-card-extractor/sample-lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+  parallel: false
+  commands:
+    docs-check:
+      run: node scripts/check.js
+    lint-check:
+      run: npm run lint
+
+pre-push:
+  parallel: true
+  commands:
+    branch-name-regex:
+      run: hooks/scripts/validate-branch-name.sh
+    lint-line-cap:
+      run: npm run lint

--- a/tests/fixtures/rule-card-extractor/sample-schema.json
+++ b/tests/fixtures/rule-card-extractor/sample-schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "lane": {
+      "type": "string",
+      "enum": ["lane:code-change", "lane:trivial", "lane:config-only"]
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["advisory", "soft-mandatory", "hard-mandatory"]
+    }
+  }
+}

--- a/tests/fixtures/rule-card-extractor/sample-template.md
+++ b/tests/fixtures/rule-card-extractor/sample-template.md
@@ -1,0 +1,7 @@
+# Sample Template Fixture
+
+<!-- rule-card: rule_id=test-template-enum class=enum-drift statement="Template enforces a fixed enum" severity=soft-mandatory enum_values=option-a,option-b,option-c -->
+
+- option-a
+- option-b
+- option-c

--- a/tests/fixtures/rule-card-extractor/sample-validator.js
+++ b/tests/fixtures/rule-card-extractor/sample-validator.js
@@ -1,0 +1,3 @@
+'use strict';
+const ALLOWED_STRATEGIES = ['tdd-pyramid', 'tdd-trophy', 'peer-review', 'none'];
+const LIGHTWEIGHT = ['lane:trivial', 'lane:config-only', 'lane:docs-only'];

--- a/tests/fixtures/rule-card-extractor/sample-workflow.yml
+++ b/tests/fixtures/rule-card-extractor/sample-workflow.yml
@@ -1,0 +1,8 @@
+on:
+  issues:
+    types: [opened, edited, labeled, unlabeled]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - closed

--- a/tests/rule-card-extractor.spec.js
+++ b/tests/rule-card-extractor.spec.js
@@ -1,0 +1,358 @@
+// tests/rule-card-extractor.spec.js — tdd-pyramid tests for rule-card-extractor
+// Refs #2301 (Epic #2295 Phase-1 P1.2). test_strategy: tdd-pyramid
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const path = require('node:path');
+const fs = require('node:fs');
+const yaml = require('js-yaml');
+
+const {
+  extractFromInstructions,
+  extractFromTemplate,
+  extractFromWorkflow,
+  extractFromValidator,
+  extractFromHook,
+  extractFromPrecommit,
+  extractFromConfigSchema,
+  extractAll,
+  VALID_CLASSES,
+  VALID_SEVERITIES,
+  makeCard,
+} = require('../scripts/global/rule-card-extractor.js');
+
+const FIXTURES = path.resolve(__dirname, 'fixtures', 'rule-card-extractor');
+const ROOT = path.resolve(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// makeCard defaults
+// ---------------------------------------------------------------------------
+test('makeCard returns all required fields', () => {
+  const card = makeCard({ rule_id: 'test-id', statement: 'A statement.' });
+  expect(card).toHaveProperty('rule_id', 'test-id');
+  expect(card).toHaveProperty('class', 'doc-vs-no-enforcement');
+  expect(card).toHaveProperty('statement', 'A statement.');
+  expect(card).toHaveProperty('enum_values');
+  expect(Array.isArray(card.enum_values)).toBe(true);
+  expect(card).toHaveProperty('severity', 'advisory');
+  expect(card).toHaveProperty('cross_runtime_applicability');
+});
+
+test('makeCard rejects invalid severity — falls back to advisory', () => {
+  const card = makeCard({ rule_id: 'x', severity: 'ultra-critical' });
+  expect(card.severity).toBe('advisory');
+});
+
+test('makeCard preserves valid severity values', () => {
+  for (const sev of VALID_SEVERITIES) {
+    expect(makeCard({ rule_id: 'x', severity: sev }).severity).toBe(sev);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Adapter 1: extractFromInstructions
+// ---------------------------------------------------------------------------
+test.describe('extractFromInstructions', () => {
+  const fixture = path.join(FIXTURES, 'sample-instruction.md');
+
+  test('extracts HTML-comment rule-card', () => {
+    const cards = extractFromInstructions(fixture);
+    const htmlCard = cards.find(c => c.rule_id === 'test-html-comment');
+    expect(htmlCard).toBeTruthy();
+    expect(htmlCard.class).toBe('doc-vs-enforcement');
+    expect(htmlCard.severity).toBe('hard-mandatory');
+  });
+
+  test('extracts fenced rule-card block', () => {
+    const cards = extractFromInstructions(fixture);
+    const fenced = cards.find(c => c.rule_id === 'test-fenced-block');
+    expect(fenced).toBeTruthy();
+    expect(fenced.class).toBe('enum-drift');
+    expect(fenced.enum_values).toContain('val-a');
+    expect(fenced.enum_values).toContain('val-b');
+  });
+
+  test('source field is relative repo path', () => {
+    const cards = extractFromInstructions(fixture);
+    for (const card of cards) {
+      expect(card.source).not.toContain(ROOT);
+      expect(card.source).toMatch(/fixtures\/rule-card-extractor/);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter 2: extractFromTemplate
+// ---------------------------------------------------------------------------
+test.describe('extractFromTemplate', () => {
+  const fixture = path.join(FIXTURES, 'sample-template.md');
+
+  test('extracts HTML-comment rule-card from template', () => {
+    const cards = extractFromTemplate(fixture);
+    expect(cards.length).toBeGreaterThanOrEqual(1);
+    const card = cards.find(c => c.rule_id === 'test-template-enum');
+    expect(card).toBeTruthy();
+    expect(card.enum_values).toContain('option-a');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter 3: extractFromWorkflow
+// ---------------------------------------------------------------------------
+test.describe('extractFromWorkflow', () => {
+  const fixture = path.join(FIXTURES, 'sample-workflow.yml');
+
+  test('extracts inline types enum', () => {
+    const cards = extractFromWorkflow(fixture);
+    const inline = cards.find(c => c.rule_id.includes('sample-workflow'));
+    expect(inline).toBeTruthy();
+    expect(inline.enum_values).toContain('opened');
+    expect(inline.enum_values).toContain('labeled');
+  });
+
+  test('extracts multi-line types list', () => {
+    const cards = extractFromWorkflow(fixture);
+    const ml = cards.find(c => c.rule_id.includes('multiline'));
+    expect(ml).toBeTruthy();
+    expect(ml.enum_values).toContain('synchronize');
+    expect(ml.enum_values).toContain('closed');
+  });
+
+  test('emitted cards have valid class', () => {
+    const cards = extractFromWorkflow(fixture);
+    for (const card of cards) {
+      expect(VALID_CLASSES).toContain(card.class);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter 4: extractFromValidator
+// ---------------------------------------------------------------------------
+test.describe('extractFromValidator', () => {
+  const fixture = path.join(FIXTURES, 'sample-validator.js');
+
+  test('extracts ALLOWED_STRATEGIES constant', () => {
+    const cards = extractFromValidator(fixture);
+    const card = cards.find(c => c.rule_id.includes('allowed-strategies'));
+    expect(card).toBeTruthy();
+    expect(card.enum_values).toContain('tdd-pyramid');
+    expect(card.enum_values).toContain('peer-review');
+  });
+
+  test('extracts LIGHTWEIGHT constant', () => {
+    const cards = extractFromValidator(fixture);
+    const card = cards.find(c => c.rule_id.includes('lightweight'));
+    expect(card).toBeTruthy();
+    expect(card.enum_values).toContain('lane:trivial');
+  });
+
+  test('severity is hard-mandatory for validator consts', () => {
+    const cards = extractFromValidator(fixture);
+    for (const card of cards) {
+      expect(card.severity).toBe('hard-mandatory');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter 5: extractFromHook
+// ---------------------------------------------------------------------------
+test.describe('extractFromHook', () => {
+  const fixture = path.join(FIXTURES, 'sample-hook.py');
+
+  test('extracts Python list constant', () => {
+    const cards = extractFromHook(fixture);
+    const card = cards.find(c => c.rule_id.includes('allowed-lanes'));
+    expect(card).toBeTruthy();
+    expect(card.enum_values).toContain('lane:code-change');
+  });
+
+  test('extracts Python tuple constant', () => {
+    const cards = extractFromHook(fixture);
+    const card = cards.find(c => c.rule_id.includes('terminal-states'));
+    expect(card).toBeTruthy();
+    expect(card.enum_values).toContain('status:done');
+    expect(card.enum_values).toContain('status:cancelled');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter 6: extractFromPrecommit
+// ---------------------------------------------------------------------------
+test.describe('extractFromPrecommit', () => {
+  const fixture = path.join(FIXTURES, 'sample-lefthook.yml');
+
+  test('extracts command names as enum_values', () => {
+    const cards = extractFromPrecommit(fixture);
+    expect(cards.length).toBeGreaterThanOrEqual(1);
+    const card = cards[0];
+    expect(card.enum_values).toContain('docs-check');
+    expect(card.enum_values).toContain('lint-check');
+  });
+
+  test('rule_id is lefthook-pre-commit-commands', () => {
+    const cards = extractFromPrecommit(fixture);
+    expect(cards[0].rule_id).toBe('lefthook-pre-commit-commands');
+  });
+
+  test('severity is hard-mandatory', () => {
+    const cards = extractFromPrecommit(fixture);
+    expect(cards[0].severity).toBe('hard-mandatory');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter 7: extractFromConfigSchema
+// ---------------------------------------------------------------------------
+test.describe('extractFromConfigSchema', () => {
+  const fixture = path.join(FIXTURES, 'sample-schema.json');
+
+  test('extracts enum arrays from JSON schema', () => {
+    const cards = extractFromConfigSchema(fixture);
+    expect(cards.length).toBeGreaterThanOrEqual(1);
+    const laneCard = cards.find(c => c.rule_id.includes('lane'));
+    expect(laneCard).toBeTruthy();
+    expect(laneCard.enum_values).toContain('lane:code-change');
+  });
+
+  test('returns empty array for invalid JSON', () => {
+    const tmpFile = path.join(FIXTURES, '_bad.json');
+    fs.writeFileSync(tmpFile, '{ invalid json !!');
+    const cards = extractFromConfigSchema(tmpFile);
+    expect(cards).toEqual([]);
+    fs.unlinkSync(tmpFile);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip: extract → serialize → parse yields bit-identical cards
+// ---------------------------------------------------------------------------
+test.describe('round-trip serialization', () => {
+  const fixture = path.join(FIXTURES, 'sample-validator.js');
+
+  test('JSON round-trip is bit-identical for validator cards', () => {
+    const original = extractFromValidator(fixture);
+    const serialized = JSON.stringify(original);
+    const parsed = JSON.parse(serialized);
+    expect(parsed).toEqual(original);
+  });
+
+  test('JSON round-trip is bit-identical for instruction cards', () => {
+    const fixture2 = path.join(FIXTURES, 'sample-instruction.md');
+    const original = extractFromInstructions(fixture2);
+    const serialized = JSON.stringify(original);
+    const parsed = JSON.parse(serialized);
+    expect(parsed).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// governance-rules.yaml schema validation
+// ---------------------------------------------------------------------------
+test.describe('governance-rules.yaml schema', () => {
+  const yamlPath = path.join(ROOT, 'config', 'governance-rules.yaml');
+
+  test('governance-rules.yaml parses without error', () => {
+    expect(() => yaml.load(fs.readFileSync(yamlPath, 'utf8'))).not.toThrow();
+  });
+
+  test('has version: 1', () => {
+    const doc = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+    expect(doc.version).toBe(1);
+  });
+
+  test('has at least 5 seed rules', () => {
+    const doc = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+    expect(doc.rules.length).toBeGreaterThanOrEqual(5);
+  });
+
+  test('each rule has required fields', () => {
+    const doc = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+    for (const rule of doc.rules) {
+      expect(typeof rule.rule_id).toBe('string');
+      expect(rule.rule_id.length).toBeGreaterThan(0);
+      expect(VALID_CLASSES).toContain(rule.class);
+      expect(typeof rule.statement).toBe('string');
+      expect(rule.statement.trim().length).toBeGreaterThan(0);
+      expect(VALID_SEVERITIES).toContain(rule.severity);
+      expect(Array.isArray(rule.enum_values)).toBe(true);
+      expect(Array.isArray(rule.cross_runtime_applicability)).toBe(true);
+    }
+  });
+
+  test('rule_ids are unique', () => {
+    const doc = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+    const ids = doc.rules.map(r => r.rule_id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractAll — integration: finds seed rules from governance-rules.yaml
+// ---------------------------------------------------------------------------
+test.describe('extractAll integration', () => {
+  test('returns at least 10 cards from the live harness', () => {
+    const cards = extractAll({ root: ROOT });
+    expect(cards.length).toBeGreaterThanOrEqual(10);
+  });
+
+  test('all emitted cards have the 7 required fields', () => {
+    const cards = extractAll({ root: ROOT });
+    const REQUIRED = [
+      'rule_id', 'class', 'statement', 'source',
+      'enum_values', 'severity', 'cross_runtime_applicability',
+    ];
+    for (const card of cards) {
+      for (const field of REQUIRED) {
+        expect(card).toHaveProperty(field);
+      }
+    }
+  });
+
+  test('finds at least 5 seed rule_ids from governance-rules.yaml via extractAll', () => {
+    const yamlPath = path.join(ROOT, 'config', 'governance-rules.yaml');
+    const doc = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+    const seedIds = doc.rules.map(r => r.rule_id);
+
+    // extractAll finds cards from validators + workflows which include values
+    // from seed rules (lane-enum, test-strategy-enum, single-status, branch-name).
+    // We verify coverage by checking that lane and test-strategy enums appear.
+    const cards = extractAll({ root: ROOT });
+    const allEnumValues = cards.flatMap(c => c.enum_values);
+
+    // lane-enum-values seed: at least 3 lane values present in extracted enums
+    const laneVals = ['lane:code-change', 'lane:trivial', 'lane:config-only'];
+    const foundLanes = laneVals.filter(v => allEnumValues.includes(v));
+    expect(foundLanes.length).toBeGreaterThanOrEqual(3);
+
+    // test-strategy-enum-values seed: tdd-pyramid must appear
+    expect(allEnumValues).toContain('tdd-pyramid');
+
+    // single-status-invariant seed: status values must appear
+    expect(allEnumValues).toContain('status:done');
+    expect(allEnumValues).toContain('status:in-progress');
+
+    // branch-name-prefix-enum seed: feat and fix must appear
+    expect(allEnumValues).toContain('feat');
+    expect(allEnumValues).toContain('fix');
+
+    // Confirm at least 5 distinct seed rule ids have evidence
+    const matchedSeeds = seedIds.filter(id => {
+      const enumsFromSeed = doc.rules.find(r => r.rule_id === id).enum_values;
+      if (enumsFromSeed.length === 0) return false;
+      return enumsFromSeed.some(v => allEnumValues.includes(v));
+    });
+    expect(matchedSeeds.length).toBeGreaterThanOrEqual(5);
+  });
+
+  test('cards with class=enum-drift have at least one enum_value', () => {
+    const cards = extractAll({ root: ROOT });
+    const enumDrift = cards.filter(c => c.class === 'enum-drift');
+    expect(enumDrift.length).toBeGreaterThan(0);
+    for (const card of enumDrift) {
+      expect(card.enum_values.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- \`config/governance-rules.yaml\`: v1 content-addressed registry with 10 seed rules (Refs-vs-Closes, lane enum, signer-fidelity, single-status invariant, branch-name enum, test-strategy enum, client-identity gate, four-baton-artifacts-before-pr, ticket-first, dormant/deferred epic-only)
- \`scripts/global/rule-card-extractor.js\`: 8 typological adapters (instructions, template, workflow, validator, hook, precommit, config-schema, labels) + \`extractAll()\` tree-walker; CommonJS for cross-runtime portability
- \`tests/rule-card-extractor.spec.js\`: 31 tdd-pyramid tests, all passing
- \`tests/fixtures/rule-card-extractor/\`: isolated adapter fixture files
- \`docs/howto/rule-card-schema.md\`: rule-card schema reference
- \`package.json\` + \`README.md\`: \`gov:extract\` script added

## Linked issues

Refs #2301
Refs Epic #2295
Closes #2301

## Role evidence

- **Manager**: https://github.com/chf3198/megingjord-harness/issues/2301 (body)
- **Collaborator**: https://github.com/chf3198/megingjord-harness/issues/2301#issuecomment-4559273036
- **Admin**: https://github.com/chf3198/megingjord-harness/issues/2301#issuecomment-4559274245
- **Consultant**: https://github.com/chf3198/megingjord-harness/issues/2301#issuecomment-4559276903

## Test strategy

- Strategy: tdd-pyramid
- Evidence artifact: \`tests/rule-card-extractor.spec.js\` (31 tests, all pass)

## Validation

- [x] \`npm run lint\` — clean (376 files, all within 100-line limit)
- [x] \`npm run lint:readability:ci\` — 475/475 (at cap, no new violations)
- [x] \`npm run lint:md\` — 0 errors
- [x] \`npx playwright test tests/rule-card-extractor.spec.js\` — 31/31 pass
- [x] \`npm run gov:extract\` — idempotent, writes /tmp/rule-cards.json
- [x] All pre-push gates green (megalint, branch-name, git-freshness, closeout-preflight, lint-*)
- [x] Rebased onto origin/main (package.json conflict resolved)

## Risk

Low. New files only — no modification to existing governance scripts or validators. The extractor is read-only over the harness tree. The YAML registry is additive config. No deployed-runtime artifacts touched.