### PR TITLE
feat(governance): Option C carve-out for Refs-vs-Closes #2303

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,16 @@
 ## Linked Issue
 
 Refs #<!-- issue number -->
-<!-- Note: Consultant closes the issue explicitly via gh issue close after CONSULTANT_CLOSEOUT. Do NOT use "Closes #N" — it auto-closes the issue before Consultant review. -->
+
+## Merge Evidence
+
+<!-- PREFERRED: deferred-finalize marker — satisfies merge-evidence gate WITHOUT auto-closing
+     the issue on merge. Consultant retains explicit terminal-finalize authority and closes
+     the issue manually via `gh issue close #N` after CONSULTANT_CLOSEOUT is posted. -->
+merge-evidence-deferred-final: #<!-- issue number -->
+
+<!-- BACKWARD COMPAT: `Closes #N` remains accepted by merge-evidence-pr-gate and triggers
+     GitHub auto-close on merge. Use only when Consultant-explicit-close is not required. -->
 
 ## Changes
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,9 +92,9 @@ AI-authored baton artifacts, PR evidence, and governance docs must include human
 All governed provider calls route through HAMR (`https://hamr.chf3198.workers.dev`). Activate per-checkout: `npm run hamr:activate`. Canonical contract: `instructions/hamr-routing.instructions.md`. The Global Task Router (lane selection) and HAMR (cost/observability mechanics) are complementary — HAMR does not duplicate lane policy.
 
 ## Harness Goal Constitution (priority)
-
 Apply this decision order: Governance > Quality > Zero Cost > Privacy > Portability > Resilience > Throughput > Observability > Interoperability > Maintainability. Record rationale in ticket/PR evidence when a lower-priority goal wins.
 ## Cross-Team Artifact-Write Contract — see `instructions/cross-team-artifact-write.instructions.md` (target-runtime team owns schema/contract test; required before manager-handoff on cross-runtime config writes).
 ## Hook Behavior Overrides — see `instructions/hook-behavior-overrides.instructions.md` (advisory-vs-blocking contract; Tier-2 self-anneal threshold).
 ## OWASP Agentic Security — see `instructions/owasp-agentic-mapping.instructions.md` (OA1-OA10 risk-to-goal mapping; G1-G10 coverage classification).
 ## Skill Index — auto-derived per `docs/skills-copilot.md`; regenerate via `node scripts/global/skill-views-derive.js`.
+## Merge-evidence convention (cross-runtime, Epic #2295 P1.3) — PR bodies MUST include merge evidence: preferred `merge-evidence-deferred-final: #N` (no auto-close, Consultant retains terminal-finalize) or backward-compat `Closes #N`. Same marker across Claude Code / Codex / Copilot. Rationale: `governance-carve-outs/index.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,3 +79,11 @@ Auto-derived from `skills/<name>/SKILL.md` frontmatter — see [`docs/skills-age
 - Alpine.js for state, vanilla JS for logic
 - No build step — static files served directly
 - Cloudflare Pages for production deployment
+
+## Merge-evidence convention (cross-runtime, Epic #2295 P1.3)
+
+PR bodies targeting this harness MUST include merge evidence for their linked issue.
+Preferred form: `merge-evidence-deferred-final: #N` — satisfies `merge-evidence-pr-gate`
+without triggering GitHub auto-close, preserving Consultant terminal-finalize authority.
+Backward-compat: `Closes #N` remains accepted. This convention applies to Claude Code,
+Codex, and Copilot team PRs equally. See `governance-carve-outs/index.md` for rationale.

--- a/governance-carve-outs/index.md
+++ b/governance-carve-outs/index.md
@@ -1,0 +1,39 @@
+# Governance Carve-Outs Registry
+
+Carve-outs are documented exceptions or extensions to baseline governance rules.
+Each entry records the rule being relaxed or extended, the rationale, scope, and
+originating decision artifact so future operators can audit intent.
+
+| rule_id | description | scope | originating_decision |
+|---|---|---|---|
+| `closes-vs-refs-deferred-final-carveout` | Deferred-finalize marker accepted as merge-evidence alternative to Closes-keyword | All PRs; cross-runtime (Claude Code, Codex, Copilot) | Epic #2295 Phase-1 P1.3 (#2303) |
+
+---
+
+## closes-vs-refs-deferred-final-carveout
+
+**rule_id**: `closes-vs-refs-deferred-final-carveout`
+
+**conflict resolved**: PR template instructs authors to use `Refs #N` (not `Closes #N`) to
+preserve Consultant terminal-finalize authority. The `merge-evidence-pr-gate` previously
+required a `Closes #N` (or `Fixes`/`Resolves`) keyword to confirm the PR commits to closing
+its linked issue. These two rules created an irreconcilable conflict for authors following
+the template.
+
+**resolution (Option C)**: `merge-evidence-pr-gate` now accepts EITHER:
+1. `merge-evidence-deferred-final: #N` — **preferred new form**. Not a GitHub auto-close
+   keyword; GitHub will NOT close the issue on merge. Satisfies the harness gate. Consultant
+   closes explicitly via `gh issue close #N` after `CONSULTANT_CLOSEOUT`.
+2. `Closes #N` / `Fixes #N` / `Resolves #N` — **backward-compat**. GitHub auto-closes on
+   merge. Accepted indefinitely for PRs that pre-date this carve-out or that intentionally
+   want auto-close behavior.
+
+**scope**: All governed PRs in the Megingjord harness. Cross-runtime portable — Claude Code,
+Codex, and Copilot teams may all emit `merge-evidence-deferred-final: #N` in PR bodies.
+
+**originating_decision**: Epic #2295 (Origin Conflict Resolution), Phase-1 child #2303.
+Design rationale in issue #2303 body and Phase-0 research child #2296.
+
+**validator**: `scripts/global/megalint/merge-evidence-pr-gate.js` — exports `DEFERRED_FINAL_RE`.
+
+**effective_date**: 2026-05-27

--- a/instructions/github-governance.instructions.md
+++ b/instructions/github-governance.instructions.md
@@ -21,7 +21,13 @@ applyTo: "**"
 ## Ticket lifecycle gates
 
 - Every change needs a linked issue with taxonomy label (`type:*`), priority label, domain label, milestone, and project assignment before coding starts.
-- PR requires `Refs #N`, milestone, labels, and gate-suite evidence. Use `Refs` not `Closes` — issue close is Consultant authority via `gh issue close` after CONSULTANT_CLOSEOUT.
+- PR body MUST include `Refs #N` for issue linkage AND one of the following merge-evidence
+  forms (per Epic #2295 Phase-1 P1.3):
+  - **Preferred**: `merge-evidence-deferred-final: #N` — satisfies `merge-evidence-pr-gate`
+    without auto-closing the issue on merge. Consultant retains explicit terminal-finalize
+    authority and closes via `gh issue close #N` after `CONSULTANT_CLOSEOUT`.
+  - **Backward-compat**: `Closes #N` (or `Fixes #N` / `Resolves #N`) — still accepted;
+    triggers GitHub auto-close on merge.
 - Issues must include: problem/objective, expected outcome, acceptance criteria.
 - Large work is decomposed with sub-issues and `blocked by` / `blocking` dependencies.
 - Templates required: at minimum bug, task, and epic forms. `blank_issues_enabled: false` in config.yml.

--- a/instructions/global-standards.instructions.md
+++ b/instructions/global-standards.instructions.md
@@ -28,6 +28,20 @@ applyTo: "**"
 - Use deterministic checks and objective pass/fail gates whenever possible.
 - If evidence is incomplete, state uncertainty and gather missing evidence.
 
+## Deferred-finalize merge-evidence contract (Epic #2295 P1.3)
+
+PR bodies MUST include merge evidence for their linked issue. Two accepted forms:
+
+- **Preferred** — `merge-evidence-deferred-final: #N`: satisfies `merge-evidence-pr-gate`
+  WITHOUT triggering GitHub auto-close on merge. Consultant retains explicit terminal-finalize
+  authority and closes the issue via `gh issue close #N` after posting `CONSULTANT_CLOSEOUT`.
+- **Backward-compat** — `Closes #N` (or `Fixes #N` / `Resolves #N`): still accepted; triggers
+  GitHub auto-close on merge. Use only when Consultant-explicit-close is not required.
+
+Carve-out rationale: the deferred-finalize form resolves the PR-template vs merge-evidence-gate
+conflict (template says "use Refs, not Closes"; gate previously required Closes). Registry entry:
+`governance-carve-outs/index.md` entry `closes-vs-refs-deferred-final-carveout`.
+
 ## Goal-lens decision lint (required)
 
 - Apply this priority order to all governed decisions:

--- a/scripts/global/megalint/merge-evidence-pr-gate.js
+++ b/scripts/global/megalint/merge-evidence-pr-gate.js
@@ -3,18 +3,24 @@
 // that promotes merge-evidence from advisory to required. Ensures every
 // non-lightweight, non-epic PR commits to atomically closing its linked
 // issue via GitHub auto-close keywords (Closes/Fixes/Resolves), or carries
+// a deferred-finalize marker (merge-evidence-deferred-final: #N), or carries
 // the merge-evidence-override:approved label on the issue.
 // Refs #2302: LIGHTWEIGHT_LANES imported from lane-enum.js (single source of truth).
+// Refs #2303: deferred-finalize marker (Option C carve-out) preserves Consultant
+// terminal-finalize authority — the marker satisfies merge-evidence WITHOUT
+// triggering GitHub auto-close, so Consultant explicitly closes via gh issue close.
 
 const path = require('path');
 const { LIGHTWEIGHT_LANES } = require(path.join(__dirname, '..', 'lane-enum.js'));
 const OVERRIDE_LABEL = 'merge-evidence-override:approved';
 const CLOSE_KEYWORDS_RE = /\b(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+#(\d+)/gi;
+const DEFERRED_FINAL_RE = /\bmerge-evidence-deferred-final:\s*#(\d+)/gi;
 
 function findCloseTargets(prBody) {
   const out = new Set();
   if (!prBody) return out;
   for (const m of prBody.matchAll(CLOSE_KEYWORDS_RE)) out.add(parseInt(m[3], 10));
+  for (const m of prBody.matchAll(DEFERRED_FINAL_RE)) out.add(parseInt(m[1], 10));
   return out;
 }
 
@@ -42,10 +48,11 @@ function validate(input) {
     ok: false,
     violations: [{
       rule: 'merge-evidence-pr-gate-missing',
-      detail: `PR body must include a GitHub auto-close keyword for issue #${issueNumber} `
-        + `(e.g. "Closes #${issueNumber}"). This commits the PR to closing the issue on merge, `
-        + `which is the merge evidence the harness will then validate. Override via `
-        + `\`${OVERRIDE_LABEL}\` on the issue if closure-without-merge is intentional.`,
+      detail: `PR body must include merge evidence for issue #${issueNumber}. `
+        + `Preferred: "merge-evidence-deferred-final: #${issueNumber}" (preserves Consultant `
+        + `terminal-finalize authority; does NOT auto-close on merge). `
+        + `Backward-compat: a GitHub auto-close keyword (e.g. "Closes #${issueNumber}"). `
+        + `Override via \`${OVERRIDE_LABEL}\` on the issue if closure-without-merge is intentional.`,
       issueNumber, closeTargetsFound: [...closeTargets],
     }],
   };
@@ -53,5 +60,5 @@ function validate(input) {
 
 module.exports = {
   validate, findCloseTargets, shouldSkip,
-  LIGHTWEIGHT_LANES, OVERRIDE_LABEL, CLOSE_KEYWORDS_RE,
+  LIGHTWEIGHT_LANES, OVERRIDE_LABEL, CLOSE_KEYWORDS_RE, DEFERRED_FINAL_RE,
 };

--- a/tests/refs-vs-closes-carveout.spec.js
+++ b/tests/refs-vs-closes-carveout.spec.js
@@ -1,0 +1,109 @@
+// Tests for Option C deferred-finalize carve-out (Epic #2295 P1.3, #2303).
+// Covers: deferred-finalize marker accepted, Closes-keyword backward-compat,
+// both markers together, neither present (fail), lightweight-lane skip.
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const gate = require('../scripts/global/megalint/merge-evidence-pr-gate');
+
+const ctx = (overrides = {}) => ({
+  labels: ['type:task', 'lane:code-change'],
+  issueNumber: 2303,
+  prBody: '',
+  ...overrides,
+});
+
+// --- deferred-finalize marker (new preferred form) ---
+
+test('#2303 AC1: deferred-finalize marker alone passes the gate', () => {
+  const result = gate.validate(ctx({
+    prBody: 'Refs #2303\n\nmerge-evidence-deferred-final: #2303',
+  }));
+  expect(result.ok).toBe(true);
+  expect(result.closeTargets).toContain(2303);
+});
+
+test('#2303 AC1: deferred-finalize marker is case-insensitive for the keyword', () => {
+  const result = gate.validate(ctx({
+    prBody: 'MERGE-EVIDENCE-DEFERRED-FINAL: #2303',
+  }));
+  expect(result.ok).toBe(true);
+});
+
+test('#2303 AC1: deferred-finalize with extra whitespace around # passes', () => {
+  const result = gate.validate(ctx({
+    prBody: 'merge-evidence-deferred-final:  #2303',
+  }));
+  expect(result.ok).toBe(true);
+});
+
+test('#2303 AC1: deferred-finalize for wrong issue does not satisfy linked issue', () => {
+  const result = gate.validate(ctx({
+    prBody: 'merge-evidence-deferred-final: #9999',
+  }));
+  expect(result.ok).toBe(false);
+  expect(result.violations[0].rule).toBe('merge-evidence-pr-gate-missing');
+});
+
+// --- Closes-keyword backward compat ---
+
+test('#2303 AC5 (backward-compat): Closes #N alone still passes', () => {
+  const result = gate.validate(ctx({ prBody: 'Refs #2303\nCloses #2303' }));
+  expect(result.ok).toBe(true);
+});
+
+test('#2303 AC5 (backward-compat): Fixes / Resolves variants still pass', () => {
+  for (const kw of ['Fixes', 'Fixed', 'Resolves', 'Resolved']) {
+    expect(gate.validate(ctx({ prBody: `${kw} #2303` })).ok).toBe(true);
+  }
+});
+
+// --- Both markers together ---
+
+test('#2303 AC1+AC5: both deferred-finalize and Closes present passes', () => {
+  const result = gate.validate(ctx({
+    prBody: 'merge-evidence-deferred-final: #2303\nCloses #2303',
+  }));
+  expect(result.ok).toBe(true);
+  expect(result.closeTargets).toContain(2303);
+});
+
+// --- Neither marker present (must fail with updated message) ---
+
+test('#2303 AC1: neither marker present fails with message citing both options', () => {
+  const result = gate.validate(ctx({ prBody: 'Refs #2303\n\nNo evidence marker here.' }));
+  expect(result.ok).toBe(false);
+  const detail = result.violations[0].detail;
+  expect(detail).toMatch(/merge-evidence-deferred-final/);
+  expect(detail).toMatch(/Closes #2303/);
+  expect(result.violations[0].issueNumber).toBe(2303);
+});
+
+// --- Lightweight-lane labels still skip gate ---
+
+test('#2303: lightweight lanes skip the gate regardless of body', () => {
+  for (const lane of ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research']) {
+    const result = gate.validate(ctx({ labels: ['type:task', lane], prBody: '' }));
+    expect(result.ok, `lane=${lane}`).toBe(true);
+    expect(result.skipped).toBe(`lightweight-lane:${lane}`);
+  }
+});
+
+// --- DEFERRED_FINAL_RE exported for consumers ---
+
+test('#2303: DEFERRED_FINAL_RE is exported and matches the marker pattern', () => {
+  expect(gate.DEFERRED_FINAL_RE).toBeDefined();
+  const re = new RegExp(gate.DEFERRED_FINAL_RE.source, gate.DEFERRED_FINAL_RE.flags);
+  expect('merge-evidence-deferred-final: #42'.match(re)).not.toBeNull();
+  expect('Closes #42'.match(re)).toBeNull();
+});
+
+// --- findCloseTargets combines both sources ---
+
+test('#2303: findCloseTargets returns union of Closes-keyword and deferred-finalize targets', () => {
+  const targets = gate.findCloseTargets(
+    'Closes #100\nmerge-evidence-deferred-final: #200',
+  );
+  expect(targets.has(100)).toBe(true);
+  expect(targets.has(200)).toBe(true);
+});


### PR DESCRIPTION
## Summary

- Adds `merge-evidence-deferred-final: #N` marker as alternative to GitHub auto-close keywords
- Preserves Consultant terminal-finalize authority
- Keeps `Closes #N` backward-compat
- Registers carve-out in `governance-carve-outs/index.md` (NEW directory)
- Updates PR template + 2 instructions + AGENTS.md + .github/copilot-instructions.md for cross-runtime portability
- **PR uses the new marker** — first dogfood

## Linked Issue

Refs #2303
merge-evidence-deferred-final: #2303

Refs Epic #2295

## Role Evidence

- Manager: https://github.com/chf3198/megingjord-harness/issues/2303#issuecomment-4559317511
- Collaborator: https://github.com/chf3198/megingjord-harness/issues/2303#issuecomment-4559445686
- Admin: https://github.com/chf3198/megingjord-harness/issues/2303#issuecomment-4559446090
- Consultant: post-merge atomic with `gh issue close` (demonstrates deferred-finalize semantics)

## Test strategy

- Strategy: tdd-pyramid
- Evidence: `tests/refs-vs-closes-carveout.spec.js` — 11 cases passing

## Validation

- [x] `npm run lint` — clean
- [x] `npx playwright test tests/refs-vs-closes-carveout.spec.js` — 11/11 pass
- [x] Docs synced inline

## Risk

low — additive change; Closes-keyword path unchanged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>