### PR TITLE
feat: add lane:no-code-remediation coverage across governance gates

### DIFF
--- a/.github/workflows/baton-gates.yml
+++ b/.github/workflows/baton-gates.yml
@@ -30,7 +30,7 @@ jobs:
               issue_number: linkedIssue,
             });
             const labels = issue.labels.map(l => l.name);
-            const lightweight = ['lane:docs-research', 'lane:docs-only', 'lane:trivial'];
+            const lightweight = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:no-code-remediation'];
             if (labels.some(l => lightweight.includes(l))) {
               console.log(`Issue #${linkedIssue}: lightweight lane; collaborator gate skipped.`);
               return;
@@ -69,7 +69,7 @@ jobs:
               issue_number: linkedIssue,
             });
             const labels = issue.labels.map(l => l.name);
-            const lightweight = ['lane:docs-research', 'lane:docs-only', 'lane:trivial'];
+            const lightweight = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:no-code-remediation'];
             if (labels.some(l => lightweight.includes(l))) {
               console.log(`Issue #${linkedIssue}: lightweight lane; admin gate skipped.`);
               return;

--- a/.github/workflows/evidence-completeness.yml
+++ b/.github/workflows/evidence-completeness.yml
@@ -65,7 +65,7 @@ jobs:
             if (labels.includes('type:epic')) {
               violations.push(`Issue #${linkedNum} is type:epic — PRs must link to child tickets, not epics`);
             }
-            const lightweight = ['lane:docs-research', 'lane:docs-only', 'lane:trivial'];
+            const lightweight = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:no-code-remediation'];
             const requiresCollaborator = !labels.some(l => lightweight.includes(l));
 
             // 3. Branch-to-issue binding: N in branch name must equal N in Refs #N

--- a/instructions/test-methodology-matrix.instructions.md
+++ b/instructions/test-methodology-matrix.instructions.md
@@ -57,7 +57,7 @@ A surface does NOT require `stress-test` when ALL of:
 | `peer-review` | `CONSULTANT_CLOSEOUT` with rubric ≥7 per `role-consultant-critique` |
 | `manual-verify` | Before/after value + rationale in `ADMIN_HANDOFF` |
 | `stress-test` | One of: `tests/stress-*.spec.js` file in PR diff, OR `npm run stress:*` invocation cited in `COLLABORATOR_HANDOFF` Pre-handoff verification. Stress spec MUST assert: ≥1 chaos / fault-injection path (G6) AND ≥1 p99 latency budget (G7). Canonical examples: `tests/stress-{worktree-isolation,anneal-decision,rebase-discipline}.spec.js` from Epic #1871. |
-| `none` | Permitted only when lane ∈ {trivial, docs-research, docs-only, research, config-only} |
+| `none` | Permitted only when lane ∈ {trivial, docs-research, docs-only, research, config-only, no-code-remediation} |
 
 ## Stress promotion model (NO calendar threshold per Epic #1771 / #1827 lesson)
 

--- a/scripts/global/constitution-compressor.js
+++ b/scripts/global/constitution-compressor.js
@@ -28,7 +28,7 @@ const DEFAULT_KEYWORDS = [
   'MANAGER_HANDOFF', 'COLLABORATOR_HANDOFF', 'ADMIN_HANDOFF', 'CONSULTANT_CLOSEOUT',
   'role:manager', 'role:collaborator', 'role:admin', 'role:consultant',
   'status:backlog', 'status:triage', 'status:ready', 'status:in-progress', 'status:testing', 'status:review', 'status:done',
-  'lane:code-change', 'lane:docs-research', 'lane:config-only',
+  'lane:code-change', 'lane:docs-research', 'lane:config-only', 'lane:no-code-remediation',
   'Refs #', 'BLOCKER_NOTE', 'evidence-completeness', 'baton-gates',
   'Conventional Commits', 'GITHUB_TOKEN', 'AI-Signature', 'AI-Team-Model', 'AI-Role',
   'visual_qa', 'pr-title-required', 'collaborator-gate', 'admin-gate', 'consultant-gate',

--- a/scripts/global/consultant-checks-lib.js
+++ b/scripts/global/consultant-checks-lib.js
@@ -13,7 +13,7 @@ const decideGov003 = (fleetLog, eventLog) =>
 const decideGov005 = issueBody => !/- \[ \]/.test(issueBody);
 
 // #1615: lanes where no implementation branch or PR is expected
-const ISSUE_ONLY_LANES = /lane:docs-research|lane:trivial|type:epic/;
+const ISSUE_ONLY_LANES = /lane:docs-research|lane:trivial|lane:no-code-remediation|type:epic/;
 const isIssueOnlyLane = labels => ISSUE_ONLY_LANES.test(labels || '');
 
 // #1241: events.jsonl / fleet-health.jsonl are runtime artifacts written by

--- a/scripts/global/megalint/admin-handoff.js
+++ b/scripts/global/megalint/admin-handoff.js
@@ -4,7 +4,7 @@
 const path = require('path');
 const { roleIdentity } = require(path.join(__dirname, '..', 'baton-independence.js'));
 
-const LIGHTWEIGHT = ['lane:docs-research', 'lane:docs-only', 'lane:trivial'];
+const LIGHTWEIGHT = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:no-code-remediation'];
 
 function findAdminHandoff(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?ADMIN_HANDOFF\b/;

--- a/scripts/global/megalint/collaborator-handoff.js
+++ b/scripts/global/megalint/collaborator-handoff.js
@@ -4,7 +4,7 @@
 const path = require('path');
 const { roleIdentity } = require(path.join(__dirname, '..', 'baton-independence.js'));
 
-const LIGHTWEIGHT = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:config-only'];
+const LIGHTWEIGHT = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:config-only', 'lane:no-code-remediation'];
 
 function findCollaboratorHandoff(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?COLLABORATOR_HANDOFF\b/;

--- a/scripts/global/megalint/merge-evidence-pr-gate.js
+++ b/scripts/global/megalint/merge-evidence-pr-gate.js
@@ -6,7 +6,7 @@
 // the merge-evidence-override:approved label on the issue.
 
 const LIGHTWEIGHT_LANES = new Set([
-  'lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research',
+  'lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research', 'lane:no-code-remediation',
 ]);
 const OVERRIDE_LABEL = 'merge-evidence-override:approved';
 const CLOSE_KEYWORDS_RE = /\b(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+#(\d+)/gi;

--- a/scripts/global/megalint/merge-evidence.js
+++ b/scripts/global/megalint/merge-evidence.js
@@ -5,7 +5,7 @@
 // stays side-effect-free per existing megalint convention.
 
 const LIGHTWEIGHT_LANES = new Set([
-  'lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research',
+  'lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research', 'lane:no-code-remediation',
 ]);
 const OVERRIDE_LABEL = 'merge-evidence-override:approved';
 

--- a/scripts/global/test-strategy-enum.js
+++ b/scripts/global/test-strategy-enum.js
@@ -13,7 +13,7 @@ const ALLOWED_STRATEGIES = [
 
 const NONE_PERMITTED_LANES = [
   'lane:trivial', 'lane:docs-research', 'lane:docs-only',
-  'lane:research', 'lane:config-only',
+  'lane:research', 'lane:config-only', 'lane:no-code-remediation',
 ];
 
 const PEER_REVIEW_RUBRIC_THRESHOLD = 7;

--- a/tests/consultant-checks-lib.spec.js
+++ b/tests/consultant-checks-lib.spec.js
@@ -96,6 +96,10 @@ test('#1615 isIssueOnlyLane: lane:trivial → true (no PR expected)', () => {
   expect(lib.isIssueOnlyLane('lane:trivial\ntype:task')).toBe(true);
 });
 
+test('#2264 isIssueOnlyLane: lane:no-code-remediation → true (manager/consultant path)', () => {
+  expect(lib.isIssueOnlyLane('lane:no-code-remediation\ntype:task')).toBe(true);
+});
+
 test('#1615 isIssueOnlyLane: lane:code-change → false (branch check enforced)', () => {
   expect(lib.isIssueOnlyLane('lane:code-change\ntype:bug\npriority:P2')).toBe(false);
 });

--- a/tests/megalint-merge-evidence-pr-gate.spec.js
+++ b/tests/megalint-merge-evidence-pr-gate.spec.js
@@ -48,7 +48,7 @@ test('#1506 AC1: passes when PR closes multiple issues including the linked one'
 });
 
 test('#1506 AC3: lightweight lanes skip the gate', () => {
-  for (const lane of ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research']) {
+  for (const lane of ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research', 'lane:no-code-remediation']) {
     const result = gate.validate(ctx({ labels: ['type:task', lane], prBody: '' }));
     expect(result.ok, `lane=${lane}`).toBe(true);
     expect(result.skipped).toBe(`lightweight-lane:${lane}`);

--- a/tests/megalint-merge-evidence.spec.js
+++ b/tests/megalint-merge-evidence.spec.js
@@ -78,7 +78,7 @@ test('#1498 AC3: lightweight lanes skipped (docs-research)', () => {
 });
 
 test('#1498 AC3: lightweight lanes skipped (trivial, docs-only, research)', () => {
-  for (const lane of ['lane:trivial', 'lane:docs-only', 'lane:research']) {
+  for (const lane of ['lane:trivial', 'lane:docs-only', 'lane:research', 'lane:no-code-remediation']) {
     const result = rule.validate({
       state: 'closed', labels: ['status:done', 'type:task', lane], mergedPRRefs: [],
     });

--- a/tests/megalint/baton-handoffs.spec.js
+++ b/tests/megalint/baton-handoffs.spec.js
@@ -33,6 +33,12 @@ test('collaborator: lightweight lane skips check', () => {
   expect(r.reason).toBe('lightweight-lane-skip');
 });
 
+test('admin: no-code-remediation lane skips admin handoff requirement', () => {
+  const r = Adm.validate({ comments: [], lane: 'lane:no-code-remediation' });
+  expect(r.ok).toBe(true);
+  expect(r.reason).toBe('lightweight-lane-skip');
+});
+
 test('collaborator: missing handoff fails', () => {
   const r = Coll.validate({ comments: [{ body: 'no marker' }] });
   expect(r.ok).toBe(false);


### PR DESCRIPTION
## Summary
- extend lightweight/issue-only lane handling to include lane:no-code-remediation in governance gates and workflow checks
- align test-strategy lane enum and methodology matrix so strategy `none` is valid for no-code remediation lane
- add regression tests for issue-only detection and lightweight skip behavior

## Validation
- npx playwright test tests/consultant-checks-lib.spec.js tests/megalint/baton-handoffs.spec.js tests/megalint-merge-evidence.spec.js tests/megalint-merge-evidence-pr-gate.spec.js tests/test-evidence-validator.spec.js
- npm run lint

## Red-Team
- fleet adversarial review executed with fallback models
- qwen3:32b and qwen2.5-coder:32b unavailable by transport in this run; qwen2.5-coder:14b unavailable (404); qwen2.5-coder:7b completed with no critical blockers

Closes #2264
