### PR TITLE
fix: align workflow lightweight lanes with canonical lane-enum

### DIFF
--- a/.github/workflows/baton-gates.yml
+++ b/.github/workflows/baton-gates.yml
@@ -30,7 +30,7 @@ jobs:
               issue_number: linkedIssue,
             });
             const labels = issue.labels.map(l => l.name);
-            const lightweight = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:no-code-remediation'];
+            const lightweight = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research', 'lane:config-only', 'lane:no-code-remediation'];
             if (labels.some(l => lightweight.includes(l))) {
               console.log(`Issue #${linkedIssue}: lightweight lane; collaborator gate skipped.`);
               return;
@@ -69,7 +69,7 @@ jobs:
               issue_number: linkedIssue,
             });
             const labels = issue.labels.map(l => l.name);
-            const lightweight = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:no-code-remediation'];
+            const lightweight = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research', 'lane:config-only', 'lane:no-code-remediation'];
             if (labels.some(l => lightweight.includes(l))) {
               console.log(`Issue #${linkedIssue}: lightweight lane; admin gate skipped.`);
               return;

--- a/.github/workflows/evidence-completeness.yml
+++ b/.github/workflows/evidence-completeness.yml
@@ -65,7 +65,7 @@ jobs:
             if (labels.includes('type:epic')) {
               violations.push(`Issue #${linkedNum} is type:epic — PRs must link to child tickets, not epics`);
             }
-            const lightweight = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:no-code-remediation'];
+            const lightweight = ['lane:docs-research', 'lane:docs-only', 'lane:trivial', 'lane:research', 'lane:config-only', 'lane:no-code-remediation'];
             const requiresCollaborator = !labels.some(l => lightweight.includes(l));
 
             // 3. Branch-to-issue binding: N in branch name must equal N in Refs #N


### PR DESCRIPTION
## Summary
- fix drift between workflow gating lane lists and canonical lane-enum semantics
- add lane:research and lane:config-only to workflow lightweight arrays used by collaborator/admin/evidence gates
- preserve lane:no-code-remediation handling

## Validation
- npm run lint

Refs #2264
