### PR TITLE
feat(governance): HAMR per-role lane preferences + matrix dispatch #2320

### DIFF
--- a/.changes/unreleased/2320.md
+++ b/.changes/unreleased/2320.md
@@ -1,0 +1,4 @@
+### Added
+- `model-routing-policy.json` gains `per_role_lane_preferences` block encoding preferred lane per role × complexity tier for 6 baton roles (manager, collaborator, admin, consultant, it, red-team), defaulting fleet-first per D3 (#2320).
+- `model-routing-engine.js` `resolveRouting()` now accepts `opts.role` or `route.role` and applies per-role lane preference; exports new `resolveRolePreference()` helper for direct runtime use; result carries `rolePrefApplied` and `activeRole` fields.
+- `instructions/hamr-routing.instructions.md` documents the per-role routing contract with usage example.

--- a/instructions/hamr-routing.instructions.md
+++ b/instructions/hamr-routing.instructions.md
@@ -122,7 +122,6 @@ Design intent per D3 (fleet-first for role-execution):
 - `manager`, `consultant`: haiku at mid; premium at high (scoping/critique require reasoning).
 - `red-team`: fleet at low+mid; haiku ceiling even at high (cross-family, not cloud-first).
 
-
 ## Override
 
 Repos that explicitly opt out (e.g., air-gapped) MUST set `MEGINGJORD_HAMR_DISABLED=1`.

--- a/instructions/hamr-routing.instructions.md
+++ b/instructions/hamr-routing.instructions.md
@@ -96,6 +96,33 @@ defaults to OpenAI-compatible activation and checks `OPENAI_API_KEY`.
 Provider-neutral, fleet, and Ollama activation modes do not require a cloud
 provider key at activation time. Set `HAMR_PROVIDER` to override the default.
 
+## Per-role lane preferences (Refs #2320)
+
+`model-routing-policy.json` now carries a `per_role_lane_preferences` block that
+encodes a preferred lane (free|fleet|haiku|premium) per role × complexity tier
+(low `[0,0.3)` / mid `[0.3,0.7)` / high `[0.7,1.0]`).
+
+When `resolveRouting(prompt, route, { role })` is called with an active baton role,
+the per-role preference overrides the base cascade lane — subject to rollback and
+budget governors. The preference is skipped when a rollback is in effect.
+
+Supported roles: `manager`, `collaborator`, `admin`, `consultant`, `it`, `red-team`.
+
+Usage from any runtime:
+
+```js
+const { resolveRouting } = require('./model-routing-engine');
+const resolved = resolveRouting(prompt, route, { role: 'collaborator' });
+// resolved.rolePrefApplied === true when preference was applied
+// resolved.activeRole === 'collaborator'
+```
+
+Design intent per D3 (fleet-first for role-execution):
+- `collaborator`, `admin`, `it`: fleet at low+mid complexity; haiku only at high.
+- `manager`, `consultant`: haiku at mid; premium at high (scoping/critique require reasoning).
+- `red-team`: fleet at low+mid; haiku ceiling even at high (cross-family, not cloud-first).
+
+
 ## Override
 
 Repos that explicitly opt out (e.g., air-gapped) MUST set `MEGINGJORD_HAMR_DISABLED=1`.

--- a/scripts/global/model-routing-engine.js
+++ b/scripts/global/model-routing-engine.js
@@ -30,8 +30,8 @@ function classifyTask(prompt, classes) {
   let best = keys[0] || 'routine';
   let top = -1;
   for (const k of keys) {
-    const scoreValue = score(text, classes[k]);
-    if (scoreValue > top) { top = scoreValue; best = k; }
+    const sv = score(text, classes[k]);
+    if (sv > top) { top = sv; best = k; }
   }
   return best;
 }
@@ -53,34 +53,51 @@ function applyComplexityThresholds(lane, complexity, thresholds) {
   return lane;
 }
 
-function resolveRouting(prompt, route) {
+// Refs #2320: resolve per-role preferred lane given complexity score.
+// Returns null when role is absent or not in policy, deferring to standard cascade.
+function resolveRolePreference(policy, role, complexity) {
+  const prefs = policy.per_role_lane_preferences;
+  if (!prefs || !role) return null;
+  const rolePref = prefs[String(role).toLowerCase()];
+  if (!rolePref) return null;
+  const thresh = policy.complexityThresholds || {};
+  if (complexity < (thresh.haiku ?? 0.3)) return rolePref.low || null;
+  if (complexity < (thresh.premium ?? 0.7)) return rolePref.mid || null;
+  return rolePref.high || null;
+}
+
+function buildRoutingResult(lane, cx, role, rolePrefLane, prompt, route, taskClass, policy) {
+  const premiumRationale = lane === 'premium'
+    ? normalizePremiumRationale(route, prompt, taskClass, cx) : null;
+  const budget = resolveBudget(policy, route, lane);
+  if (budget.downgraded) lane = 'haiku'; // eslint-disable-line no-param-reassign
+  const model = policy.models[lane] || policy.models.fallback;
+  const adapter = loadAdapters().lanes?.[lane] || {};
+  const overrides = loadOverrides();
+  return {
+    lane, modelId: adapter.capabilityTier || model.id,
+    providerModelId: adapter.defaultModelId || model.id,
+    providerPath: adapter.defaultProvider || model.endpoint || null,
+    adapterId: adapter.defaultAdapter || null,
+    multiplier: model.mult, taskClass,
+    complexity: cx, rolePrefApplied: rolePrefLane !== null, activeRole: role,
+    premiumRationale, premiumBudget: budget,
+    overridesApplied: overrides !== null, overridesStale: overrides?.stale ?? false,
+  };
+}
+
+function resolveRouting(prompt, route, opts) {
   const policy = loadPolicy();
   const rollbackApplied = route.disableRollback ? false : shouldRollback(policy);
   let lane = rollbackApplied ? policy.rollback.forceLane : route.lane;
   const cx = route.complexity ?? 0.5;
   lane = applyComplexityThresholds(lane, cx, policy.complexityThresholds);
+  const role = (opts && opts.role) || route.role || null;
+  const rolePrefLane = !rollbackApplied ? resolveRolePreference(policy, role, cx) : null;
+  if (rolePrefLane) lane = rolePrefLane;
   const taskClass = classifyTask(prompt, policy.taskClasses);
-  const premiumRationale = lane === 'premium' ? normalizePremiumRationale(route, prompt, taskClass, cx) : null;
-  const budget = resolveBudget(policy, route, lane);
-  if (budget.downgraded) lane = 'haiku';
-  const model = policy.models[lane] || policy.models.fallback;
-  const adapter = loadAdapters().lanes?.[lane] || {};
-  const overrides = loadOverrides();
-  return {
-    lane,
-    modelId: adapter.capabilityTier || model.id,
-    providerModelId: adapter.defaultModelId || model.id,
-    providerPath: adapter.defaultProvider || model.endpoint || null,
-    adapterId: adapter.defaultAdapter || null,
-    multiplier: model.mult,
-    taskClass,
-    rollbackApplied,
-    complexity: cx,
-    premiumRationale,
-    premiumBudget: budget,
-    overridesApplied: overrides !== null,
-    overridesStale: overrides?.stale ?? false,
-  };
+  return { rollbackApplied,
+    ...buildRoutingResult(lane, cx, role, rolePrefLane, prompt, route, taskClass, policy) };
 }
 
-module.exports = { resolveRouting, loadPolicy, loadAdapters, loadOverrides };
+module.exports = { resolveRouting, resolveRolePreference, loadPolicy, loadAdapters, loadOverrides };

--- a/scripts/global/model-routing-policy.json
+++ b/scripts/global/model-routing-policy.json
@@ -186,5 +186,45 @@
     "minFleetUtilizationShare": 0.85,
     "windowDays": 7,
     "violationEscalationReason": "fleet-bypass"
+  },
+  "per_role_lane_preferences": {
+    "_doc": "Per-role preferred lane by complexity tier. Consumed by resolveRouting when opts.role is set. Refs #2320.",
+    "_tiers": "low=[0,0.3) mid=[0.3,0.7) high=[0.7,1.0]",
+    "manager": {
+      "low": "fleet",
+      "mid": "haiku",
+      "high": "premium",
+      "_rationale": "Scoping novel work requires premium at high complexity; templatable tasks are fleet-eligible."
+    },
+    "collaborator": {
+      "low": "fleet",
+      "mid": "fleet",
+      "high": "haiku",
+      "_rationale": "Known-pattern implementation defaults fleet; multi-file novel work escalates to haiku."
+    },
+    "admin": {
+      "low": "fleet",
+      "mid": "fleet",
+      "high": "haiku",
+      "_rationale": "CI ops and deploy verification are templatable; git/release rarely needs above haiku."
+    },
+    "consultant": {
+      "low": "fleet",
+      "mid": "haiku",
+      "high": "premium",
+      "_rationale": "Critique needs independent reasoning; fleet for routine closeout; premium for novel G1-G9 rubric."
+    },
+    "it": {
+      "low": "fleet",
+      "mid": "fleet",
+      "high": "fleet",
+      "_rationale": "IT-ops maintenance fully fleet-eligible per D3. Escalate only on direct-to-premium trigger."
+    },
+    "red-team": {
+      "low": "fleet",
+      "mid": "fleet",
+      "high": "haiku",
+      "_rationale": "Cross-family adversarial review prefers fleet (qwen2.5-coder). Haiku ceiling for high-complexity exploit reasoning."
+    }
   }
 }

--- a/tests/hamr-per-role-routing.spec.js
+++ b/tests/hamr-per-role-routing.spec.js
@@ -1,0 +1,134 @@
+// HAMR per-role lane preference tests — #2320 (Epic #2299 Phase-1 child 4)
+// test_strategy: tdd-pyramid
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const {
+  resolveRouting,
+  resolveRolePreference,
+  loadPolicy,
+} = require(path.join(__dirname, '../scripts/global/model-routing-engine'));
+
+// ── AC1: per_role_lane_preferences block is present in policy ──────────────
+test('AC1: model-routing-policy has per_role_lane_preferences block', () => {
+  const policy = loadPolicy();
+  expect(typeof policy.per_role_lane_preferences).toBe('object');
+  const roles = ['manager', 'collaborator', 'admin', 'consultant', 'it', 'red-team'];
+  for (const r of roles) {
+    expect(policy.per_role_lane_preferences[r]).toBeDefined();
+    expect(typeof policy.per_role_lane_preferences[r].low).toBe('string');
+    expect(typeof policy.per_role_lane_preferences[r].mid).toBe('string');
+    expect(typeof policy.per_role_lane_preferences[r].high).toBe('string');
+  }
+});
+
+// ── AC2: resolveRolePreference returns correct lane per tier ───────────────
+test('AC2: collaborator low-complexity routes to fleet', () => {
+  const policy = loadPolicy();
+  expect(resolveRolePreference(policy, 'collaborator', 0.1)).toBe('fleet');
+});
+
+test('AC2: collaborator mid-complexity routes to fleet', () => {
+  const policy = loadPolicy();
+  expect(resolveRolePreference(policy, 'collaborator', 0.5)).toBe('fleet');
+});
+
+test('AC2: collaborator high-complexity routes to haiku', () => {
+  const policy = loadPolicy();
+  expect(resolveRolePreference(policy, 'collaborator', 0.8)).toBe('haiku');
+});
+
+test('AC2: manager low-complexity routes to fleet', () => {
+  const policy = loadPolicy();
+  expect(resolveRolePreference(policy, 'manager', 0.1)).toBe('fleet');
+});
+
+test('AC2: manager high-complexity routes to premium', () => {
+  const policy = loadPolicy();
+  expect(resolveRolePreference(policy, 'manager', 0.9)).toBe('premium');
+});
+
+test('AC2: consultant mid-complexity routes to haiku', () => {
+  const policy = loadPolicy();
+  expect(resolveRolePreference(policy, 'consultant', 0.5)).toBe('haiku');
+});
+
+test('AC2: consultant high-complexity routes to premium', () => {
+  const policy = loadPolicy();
+  expect(resolveRolePreference(policy, 'consultant', 0.75)).toBe('premium');
+});
+
+test('AC2: it role always routes to fleet across all tiers', () => {
+  const policy = loadPolicy();
+  expect(resolveRolePreference(policy, 'it', 0.1)).toBe('fleet');
+  expect(resolveRolePreference(policy, 'it', 0.5)).toBe('fleet');
+  expect(resolveRolePreference(policy, 'it', 0.9)).toBe('fleet');
+});
+
+test('AC2: red-team high-complexity routes to haiku (not premium)', () => {
+  const policy = loadPolicy();
+  expect(resolveRolePreference(policy, 'red-team', 0.8)).toBe('haiku');
+});
+
+// ── AC2: resolveRolePreference returns null for unknown/absent role ─────────
+test('AC2: resolveRolePreference returns null for unknown role', () => {
+  const policy = loadPolicy();
+  expect(resolveRolePreference(policy, 'unknown-role', 0.5)).toBeNull();
+});
+
+test('AC2: resolveRolePreference returns null when role is null', () => {
+  const policy = loadPolicy();
+  expect(resolveRolePreference(policy, null, 0.5)).toBeNull();
+});
+
+// ── AC2: resolveRouting applies per-role preference via opts.role ──────────
+test('AC2: resolveRouting applies collaborator preference via opts.role', () => {
+  const route = { lane: 'premium', complexity: 0.5 };
+  const resolved = resolveRouting('implement a function', route, { role: 'collaborator' });
+  expect(resolved.rolePrefApplied).toBe(true);
+  expect(resolved.activeRole).toBe('collaborator');
+  // collaborator mid → fleet
+  expect(resolved.lane).toBe('fleet');
+});
+
+test('AC2: resolveRouting applies manager high-complexity preference', () => {
+  const route = { lane: 'fleet', complexity: 0.85 };
+  const resolved = resolveRouting('architecture design for multi-team system', route, {
+    role: 'manager',
+  });
+  expect(resolved.rolePrefApplied).toBe(true);
+  expect(resolved.lane).toBe('premium');
+});
+
+test('AC2: resolveRouting sets rolePrefApplied false when no role given', () => {
+  const route = { lane: 'fleet', complexity: 0.5 };
+  const resolved = resolveRouting('search for files', route);
+  expect(resolved.rolePrefApplied).toBe(false);
+  expect(resolved.activeRole).toBeNull();
+});
+
+// ── AC2: route.role fallback when opts not provided ────────────────────────
+test('AC2: resolveRouting reads role from route.role when opts absent', () => {
+  const route = { lane: 'premium', complexity: 0.5, role: 'admin' };
+  const resolved = resolveRouting('run CI checks', route);
+  expect(resolved.rolePrefApplied).toBe(true);
+  expect(resolved.activeRole).toBe('admin');
+  // admin mid → fleet
+  expect(resolved.lane).toBe('fleet');
+});
+
+// ── AC4: policy is structurally valid JSON with required top-level keys ────
+test('AC4: policy JSON is structurally valid and cross-runtime consumable', () => {
+  const policy = loadPolicy();
+  expect(typeof policy.version).toBe('string');
+  expect(typeof policy.defaultLane).toBe('string');
+  expect(typeof policy.per_role_lane_preferences).toBe('object');
+  // All lane values are valid enum members
+  const validLanes = new Set(['free', 'fleet', 'haiku', 'premium']);
+  const prefs = policy.per_role_lane_preferences;
+  for (const role of Object.keys(prefs).filter(k => !k.startsWith('_'))) {
+    for (const tier of ['low', 'mid', 'high']) {
+      expect(validLanes.has(prefs[role][tier])).toBe(true);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- Add `per_role_lane_preferences` block to `scripts/global/model-routing-policy.json` with preferred lane per role × complexity tier for 6 roles (manager, collaborator, admin, consultant, it, red-team).
- Extend `resolveRouting()` in `scripts/global/model-routing-engine.js` to consume per-role preferences via `opts.role` or `route.role`; export `resolveRolePreference()` helper for all 4 runtimes.
- Document per-role routing contract in `instructions/hamr-routing.instructions.md`.
- Add `tests/hamr-per-role-routing.spec.js` — 17 tdd-pyramid tests, all green.

## Baton artifacts

MANAGER_HANDOFF posted on #2320
COLLABORATOR_HANDOFF posted on #2320
ADMIN_HANDOFF posted on #2320
CONSULTANT_CLOSEOUT posted on #2320

## Test plan

- [x] `npx playwright test tests/hamr-per-role-routing.spec.js` → 17/17 passed
- [x] `npx playwright test tests/routing-policy.spec.js tests/cascade-policy-overrides.spec.js` → 15/15 passed (no regressions)
- [x] `npm run lint` → 380 files, all within 100-line limit
- [x] `npm run lint:readability:ci` → 475 warnings (at baseline, no increase)
- [x] `npx markdownlint-cli2 'instructions/hamr-routing.instructions.md'` → 0 errors
- [x] All pre-push hooks green (megalint, lint-py, lint-line-cap, lint-readability, lint-sh, lint-md, lint-js)

Refs #2320
Refs Epic #2299
merge-evidence-deferred-final: #2320

🤖 Generated with [Claude Code](https://claude.com/claude-code)