### PR TITLE
feat(governance): formalize 7-role taxonomy + cross-runtime sync #2321

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,10 +91,10 @@ AI-authored baton artifacts, PR evidence, and governance docs must include human
 
 All governed provider calls route through HAMR (`https://hamr.chf3198.workers.dev`). Activate per-checkout: `npm run hamr:activate`. Canonical contract: `instructions/hamr-routing.instructions.md`. The Global Task Router (lane selection) and HAMR (cost/observability mechanics) are complementary — HAMR does not duplicate lane policy.
 
-## Harness Goal Constitution (priority)
-Apply this decision order: Governance > Quality > Zero Cost > Privacy > Portability > Resilience > Throughput > Observability > Interoperability > Maintainability. Record rationale in ticket/PR evidence when a lower-priority goal wins.
+## Harness Goal Constitution — Governance > Quality > Zero Cost > Privacy > Portability > Resilience > Throughput > Observability > Interoperability > Maintainability. Record rationale in ticket/PR evidence when a lower-priority goal wins.
 ## Cross-Team Artifact-Write Contract — see `instructions/cross-team-artifact-write.instructions.md` (target-runtime team owns schema/contract test; required before manager-handoff on cross-runtime config writes).
 ## Hook Behavior Overrides — see `instructions/hook-behavior-overrides.instructions.md` (advisory-vs-blocking contract; Tier-2 self-anneal threshold).
 ## OWASP Agentic Security — see `instructions/owasp-agentic-mapping.instructions.md` (OA1-OA10 risk-to-goal mapping; G1-G10 coverage classification).
 ## Skill Index — auto-derived per `docs/skills-copilot.md`; regenerate via `node scripts/global/skill-views-derive.js`.
+## Role Taxonomy — 7-role canonical set: Manager / Collaborator / Admin / Consultant / IT / Red-Team / Client. Guest-Collaborator reserved. Operator is a meta-term (not a role). Canonical: `instructions/role-baton-routing.instructions.md` §"Role Taxonomy".
 ## Merge-evidence convention (cross-runtime, Epic #2295 P1.3) — PR bodies MUST include merge evidence: preferred `merge-evidence-deferred-final: #N` (no auto-close, Consultant retains terminal-finalize) or backward-compat `Closes #N`. Same marker across Claude Code / Codex / Copilot. Rationale: `governance-carve-outs/index.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,3 +87,10 @@ Preferred form: `merge-evidence-deferred-final: #N` — satisfies `merge-evidenc
 without triggering GitHub auto-close, preserving Consultant terminal-finalize authority.
 Backward-compat: `Closes #N` remains accepted. This convention applies to Claude Code,
 Codex, and Copilot team PRs equally. See `governance-carve-outs/index.md` for rationale.
+
+## Role Taxonomy
+
+The harness uses a 7-role canonical taxonomy: Manager / Collaborator / Admin /
+Consultant / IT / Red-Team / Client. Guest-Collaborator is reserved but not active.
+Operator is a meta-term for the AI agent — not a distinct role.
+Canonical definition: `instructions/role-baton-routing.instructions.md` §"Role Taxonomy".

--- a/instructions/operator-identity-context.instructions.md
+++ b/instructions/operator-identity-context.instructions.md
@@ -31,3 +31,18 @@ applyTo: "**"
    - Each role emits a named handoff artifact (`MANAGER_HANDOFF`, `COLLABORATOR_HANDOFF`, `ADMIN_HANDOFF`, `CONSULTANT_CLOSEOUT`) before the next role begins.
 
 6. **Self-anneal check:** If you catch yourself writing "you will need to…", "please manually…", or "the user must…" — stop, invoke the research protocol from the `operator-identity-context` skill, and find the automation path instead.
+
+## Role taxonomy disambiguation
+
+**Operator** is a meta-term for the AI agent (Claude Code, Codex, etc.) that executes
+the four baton roles (Manager, Collaborator, Admin, Consultant) in single-thread
+sequence. It is NOT a distinct role in the 7-role taxonomy.
+
+The canonical 7-role set is enumerated in
+`instructions/role-baton-routing.instructions.md` §"Role Taxonomy". The full list:
+Manager / Collaborator / Admin / Consultant / IT / Red-Team / Client.
+Guest-Collaborator is reserved but not active.
+
+When reading baton artifacts: "operator" in prose refers to the AI agent entity,
+never to a baton-step role. Use the exact role name (e.g. "the admin role") when
+referring to a specific baton position.

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -12,6 +12,34 @@ The GitHub issue **is** the baton. One active role at a time. Every state carrie
 Authoritative board: **Megingjord Harness Board** (GitHub Projects).
 Baton view filter: `status:triage,ready,in-progress,testing,review` (backlog/done/cancelled/dormant/deferred hidden from active baton view).
 
+## Role Taxonomy (7-role canonical set, Epic #2299)
+
+The harness recognizes seven named roles. Operator is a meta-term (see
+`instructions/operator-identity-context.instructions.md`), not an eighth role.
+
+| Role | Scope | GitHub baton label |
+|---|---|---|
+| Manager | Scope, AC authoring, baton routing, Epic oversight | `role:manager` |
+| Collaborator | Implementation, deliverable production, test authoring | `role:collaborator` |
+| Admin | Git/release ops, merge, runtime sync, publish | `role:admin` |
+| Consultant | Independent critique, rubric scoring, closeout authority | `role:consultant` |
+| IT | Fleet hardware + service setup/config (no GitHub workflow) | `role:it` |
+| Red-Team | Adversarial cross-family review; structured hallucination audit | `role:red-team` |
+| Client | Design direction + UAT confirmation; overrides Consultant carve-outs | `role:client` |
+
+**Guest-Collaborator (RESERVED)**: placeholder for non-adversarial external
+contributions (fleet-coding-local dispatch, cross-team feature contributions,
+external human wiki-ingest) that are NOT adversarial/critique-class. Not
+currently active; use Red-Team for all adversarial/review dispatches (D1,
+Epic #2299). Reserved to prevent taxonomy namespace collision.
+
+IT role note: IT scope covers fleet hardware (hosts, Tailscale mesh, Ollama
+models, MCP provisioning) and services (HAMR activation, cron, hook install).
+IT does NOT create tickets, push branches, commit, or comment on issues. The
+`[it-ops]` / `MEGINGJORD_IT_OPS=1` / `chore(it-ops):` bypass markers are the
+documented IT-role escape hatch for the rare tracked-file edit that does not
+warrant a full baton cycle.
+
 ## Status Workflow (11-state taxonomy v1.2, Epic #1828)
 
 ```

--- a/tests/role-taxonomy-cross-runtime-sync.spec.js
+++ b/tests/role-taxonomy-cross-runtime-sync.spec.js
@@ -1,0 +1,63 @@
+'use strict';
+// role-taxonomy-cross-runtime-sync — AC6 test for #2321 / Epic #2299
+// Verifies all 4 runtime config files reference the 7-role taxonomy.
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const ROLES = ['Manager', 'Collaborator', 'Admin', 'Consultant', 'IT', 'Red-Team', 'Client'];
+
+function readFile(rel) {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+// Files required to reference the 7-role taxonomy (AC6 cross-runtime requirement)
+const RUNTIME_FILES = [
+  'instructions/role-baton-routing.instructions.md',
+  'instructions/operator-identity-context.instructions.md',
+  'AGENTS.md',
+  '.github/copilot-instructions.md',
+];
+
+test.describe('Role taxonomy cross-runtime sync (#2321)', () => {
+  for (const file of RUNTIME_FILES) {
+    test(`${file} references 7-role taxonomy`, () => {
+      const content = readFile(file);
+      for (const role of ROLES) {
+        expect(
+          content,
+          `${file} must reference role "${role}"`
+        ).toContain(role);
+      }
+    });
+  }
+
+  test('role-baton-routing has Role Taxonomy section header', () => {
+    const content = readFile('instructions/role-baton-routing.instructions.md');
+    expect(content).toContain('## Role Taxonomy');
+    expect(content).toContain('Guest-Collaborator');
+    expect(content).toContain('RESERVED');
+  });
+
+  test('operator-identity-context has disambiguation section', () => {
+    const content = readFile('instructions/operator-identity-context.instructions.md');
+    expect(content).toContain('meta-term');
+    expect(content).toContain('7-role');
+    expect(content).toContain('role-baton-routing.instructions.md');
+  });
+
+  test('AGENTS.md has Role Taxonomy section', () => {
+    const content = readFile('AGENTS.md');
+    expect(content).toContain('## Role Taxonomy');
+    expect(content).toContain('role-baton-routing.instructions.md');
+  });
+
+  test('copilot-instructions within 100-line limit', () => {
+    const content = readFile('.github/copilot-instructions.md');
+    const lineCount = content.split('\n').filter((_, i, arr) =>
+      i < arr.length - 1 || arr[i] !== ''
+    ).length;
+    expect(lineCount).toBeLessThanOrEqual(100);
+  });
+});


### PR DESCRIPTION
Refs #2321
Refs Epic #2299
merge-evidence-deferred-final: #2321

## Summary

- Adds formal §"Role Taxonomy" section to `instructions/role-baton-routing.instructions.md` enumerating the 7-role canonical set (Manager / Collaborator / Admin / Consultant / IT / Red-Team / Client) with Guest-Collaborator as RESERVED footnote and IT-role scope note.
- Adds §"Role taxonomy disambiguation" to `instructions/operator-identity-context.instructions.md` clarifying Operator as a meta-term (not a distinct role) with cross-link to canonical taxonomy.
- Adds §"Role Taxonomy" reference to `AGENTS.md`.
- Adds compact Role Taxonomy reference line to `.github/copilot-instructions.md` (within 100-line budget by compressing Harness Goal Constitution header).
- Adds `tests/role-taxonomy-cross-runtime-sync.spec.js` — 8 tdd-pyramid tests verifying all 4 runtime config files reference the 7-role set.

## Baton artifacts

COLLABORATOR_HANDOFF: posted on #2321
ADMIN_HANDOFF: posted on #2321
CONSULTANT_CLOSEOUT: posted on #2321 (see below)

## Test evidence

`npx playwright test tests/role-taxonomy-cross-runtime-sync.spec.js` — 8/8 pass
`npm run lint` — PASS (380 files)
All pre-push hooks: PASS

## AC verification

- AC1 PASS: role-baton-routing has formal 7-role taxonomy section
- AC2 PASS: operator-identity-context disambiguates Operator meta-term
- AC3 PASS: AGENTS.md and copilot-instructions reference canonical taxonomy
- AC4 PASS: Guest-Collaborator listed as RESERVED with rationale
- AC5 PASS: courtesy notice posted on #2321
- AC6 PASS: all 4 runtime files reference 7-role taxonomy; 8 tests green