### PR TITLE
feat(governance): codify Red-Team as first-class skill + matrix #2317

### DIFF
--- a/.claude/agents/red-team.md
+++ b/.claude/agents/red-team.md
@@ -1,0 +1,60 @@
+---
+name: Red-Team Reviewer
+description: >
+  Adversarial cross-family critic. Routes governance artifacts and PR diffs to a
+  non-Anthropic fleet model (Qwen via Ollama) for independent adversarial review.
+  Returns structured ACCEPT/REJECT/PARTIAL findings with hallucination-risk
+  classification. Does not modify implementation; advisory output only.
+model: claude-sonnet-4-6
+tools:
+  - Bash
+  - Read
+---
+
+# Red-Team Reviewer
+
+You are the adversarial reviewer. Your job is to find problems, not validate work.
+Route all review calls to a non-Anthropic fleet model. Never use a Claude model
+as the reviewer — that defeats the cross-family invariant.
+
+## Activation
+
+Invoke when asked to red-team a baton artifact, PR diff, or governance document.
+Use `scripts/global/fleet-red-team-dispatch.js` to dispatch to Ollama.
+
+## Dispatch Steps
+
+1. Identify artifact type: `epic-scope | child-implementation | collaborator-handoff |
+   admin-handoff | pr-diff | instruction-edit | consultant-closeout`
+2. Select model via `selectModel()` in `fleet-red-team-dispatch.js` using
+   `config/red-team-model-matrix.yml`. Default: `qwen2.5-coder:32b` for high-stakes,
+   `qwen2.5-coder:7b` for fast fallback.
+3. Dispatch: `node scripts/global/fleet-red-team-dispatch.js --artifact-type <type>
+   --ticket <N> --model <model>`
+4. Post findings to the GitHub issue using
+   `scripts/global/baton-fleet-review-comment.js` output format.
+5. Classify each finding: ACCEPT (valid) / REJECT (false positive) /
+   PARTIAL (needs clarification).
+6. Assign `hallucination_risk: low | medium | high` per finding.
+   Discard `high` findings without independent verification.
+
+## Output Contract
+
+Every review comment must include:
+- Iteration number (1, 2, or 3 max)
+- Per-finding table: # | Verdict | Finding | Hallucination Risk
+- Summary rubric: G1-G10 scores with `boxes_checked/boxes_total`
+- Warning block if fleet returned empty, short, or refused response
+
+## Score Honesty
+
+Do NOT produce uniform high scores. A 9+ across all orthogonal goals on a
+non-trivial change is evidence of non-adversarial engagement. If that happens,
+re-run with the 32B model or flag `hallucination_risk: high` on the rubric.
+
+## Constraints
+
+- Max 3 iterations per artifact.
+- Cross-family invariant: dispatched model must not be Anthropic/Claude.
+- Do not block the baton — unresolved partials become follow-up tickets.
+- Fleet host: `100.91.113.16:11434` (Tailscale). Offline fallback: skip with note.

--- a/.claude/commands/role-red-team-critique.md
+++ b/.claude/commands/role-red-team-critique.md
@@ -1,0 +1,38 @@
+---
+description: "Dispatch adversarial cross-family fleet review of baton artifacts, PR diffs, or governance docs."
+argument-hint: "[artifact-type] [ticket:#N] [--stakes high|medium|low] [--model qwen2.5-coder:32b|7b]"
+---
+
+# Role: Red-Team Critique
+
+Invoke this command to run an adversarial review using a non-Anthropic fleet model.
+See `skills/role-red-team-critique/SKILL.md` for the full skill contract.
+
+## Dispatch
+
+```bash
+node scripts/global/fleet-red-team-dispatch.js \
+  --artifact-type <type> \
+  --ticket <N> \
+  [--stakes high|medium|low] \
+  [--model qwen2.5-coder:32b|qwen2.5-coder:7b]
+```
+
+Artifact types: `epic-scope | child-implementation | collaborator-handoff |
+admin-handoff | pr-diff | instruction-edit | consultant-closeout`
+
+Model selection uses `config/red-team-model-matrix.yml` automatically.
+Pass `--stakes high` to force 32B; omit for auto-selection (defaults to 7B).
+
+## Output
+
+Post findings to the linked GitHub issue using `baton-fleet-review-comment.js`.
+Classify each finding: ACCEPT / REJECT / PARTIAL.
+Assign `hallucination_risk: low | medium | high` per finding.
+
+## Constraints
+
+- Cross-family invariant: dispatched model must NOT be Anthropic/Claude family.
+- Max 3 iterations per artifact. Unresolved partials become follow-up tickets.
+- Fleet host: `100.91.113.16:11434` (Tailscale). Skip with note if offline.
+- Do not block the baton on red-team findings — advisory only.

--- a/config/red-team-model-matrix.yml
+++ b/config/red-team-model-matrix.yml
@@ -1,0 +1,90 @@
+# Red-Team Model Selection Matrix — A1 selection function
+# Refs #2317 (Phase-1 P1.1 of Epic #2299)
+# Consumed by: scripts/global/fleet-red-team-dispatch.js selectModel()
+#
+# A1 selection function: choose the first model where all factor requirements
+# are satisfied, evaluated top-to-bottom. Caller passes taskContext + opts.
+
+cross_family_required: true
+fleet_host_default: "http://100.91.113.16:11434"
+
+# Factors evaluated per model:
+#   availability  — is the model reachable on the fleet host?
+#   capability    — is the model capable for this task complexity?
+#   cost          — GPU-hours / request (relative: low | medium | high)
+#   throughput    — requests/hour estimate (fleet-local)
+#   cross_family  — model family must differ from primary authoring family
+
+models:
+  - id: "qwen2.5-coder:32b"
+    family: "qwen"
+    cross_family_ok: true
+    availability: "conditional"
+    availability_note: >
+      Host 36gbwinresource (100.91.113.16) via Tailscale. Requires ~24 GB VRAM.
+      Spills to CPU on low-resource if VRAM insufficient (Epic #2295 P1 finding).
+      Check host health before dispatch; fall back to 7b if unavailable.
+    capability_vs_task:
+      governance_artifacts: high
+      pr_diff_large: high
+      instruction_edit: high
+      pr_diff_small: high
+      epic_scope: high
+    cost: medium
+    throughput_rph: 12
+    stakes_threshold: high
+    default_for_stakes: ["high", "medium"]
+    notes: "Preferred for high-stakes and medium-stakes reviews. ~3-5 min/call."
+
+  - id: "qwen2.5-coder:7b"
+    family: "qwen"
+    cross_family_ok: true
+    availability: "generally_available"
+    availability_note: >
+      Same fleet host; fits in 8 GB VRAM. Reliable fast path.
+    capability_vs_task:
+      governance_artifacts: medium
+      pr_diff_large: medium
+      instruction_edit: medium
+      pr_diff_small: high
+      epic_scope: low
+    cost: low
+    throughput_rph: 60
+    stakes_threshold: low
+    default_for_stakes: ["low"]
+    notes: "Fast fallback. Use when 32b unavailable or stakes=low. ~30-60 sec."
+
+  - id: "qwen3:32b"
+    family: "qwen"
+    cross_family_ok: true
+    availability: "untested"
+    availability_note: >
+      Untested on fleet host as of Epic #2295 P1. Host-resource-spilled during
+      trial run. Do not use as default until host-fit confirmed.
+    capability_vs_task:
+      governance_artifacts: unknown
+      pr_diff_large: unknown
+      instruction_edit: unknown
+      pr_diff_small: unknown
+      epic_scope: unknown
+    cost: high
+    throughput_rph: 6
+    stakes_threshold: high
+    notes: "Blocked pending host-fit verification. Not in default selection path."
+    blocked: true
+
+# Selection algorithm (implemented in fleet-red-team-dispatch.js selectModel()):
+#
+#   1. Filter to models where blocked != true
+#   2. Filter to models where cross_family_ok == true (always required)
+#   3. If opts.model explicitly set, use that model (bypasses matrix)
+#   4. If taskContext.stakes == 'high' or 'medium':
+#        select first model where 'high' or 'medium' in default_for_stakes
+#   5. If taskContext.stakes == 'low' or unset:
+#        select first model where 'low' in default_for_stakes
+#   6. Verify availability != 'untested'; warn if 'conditional'
+#   7. Return { modelId, rationale, warningIfConditional }
+
+selection_defaults:
+  stakes_when_unset: "low"
+  fallback_chain: ["qwen2.5-coder:32b", "qwen2.5-coder:7b"]

--- a/scripts/global/baton-fleet-review-comment.js
+++ b/scripts/global/baton-fleet-review-comment.js
@@ -1,5 +1,5 @@
 'use strict';
-// baton-fleet-review-comment — canonical guest-collaborator comment formatter
+// baton-fleet-review-comment — canonical red-team comment formatter
 // Refs #2179 (Phase-1 P1-2 of Epic #2041). Consumes dispatchRedTeam output (#2175 P1-1).
 // Per Phase-0 dog-food finding: per-iteration table = aggregation primitive.
 

--- a/scripts/global/fleet-red-team-dispatch.js
+++ b/scripts/global/fleet-red-team-dispatch.js
@@ -2,6 +2,7 @@
 // fleet-red-team-dispatch — HAMR-wrapped Ollama dispatcher for adversarial review.
 // Refs #2175 (Phase-1 P1-1 of Epic #2041). Consumes templates from #2181 P1-3.
 // Uses tier='fleet-local' (per #2178 P1-7) so cache-stats records ollama provider correctly.
+// selectModel() added by #2317 (Phase-1 P1.1 of Epic #2299): reads matrix at dispatch time.
 
 'use strict';
 const fs = require('node:fs');
@@ -14,10 +15,62 @@ const TIER = 'fleet-local';
 const RETRY_DELAYS_MS = [1000, 4000];
 const REQUEST_TIMEOUT_MS = 600_000;
 const TEMPLATES_PATH = path.join(__dirname, '..', '..', 'config', 'fleet-red-team-prompts.json');
+const MATRIX_PATH = path.join(__dirname, '..', '..', 'config', 'red-team-model-matrix.yml');
 const TOKEN_BUDGET_HEADROOM = 200;
 const MAX_NUM_PREDICT = 2000;
 const REFUSAL_PATTERNS = [/^i cannot help with/i, /^i'm sorry, but i cannot/i, /^i am unable to/i];
 const ARXIV_HALLUCINATION_RE = /arxiv\.org\/abs\/[0-9]{4}\.[0-9]{4,5}/gi;
+
+// Minimal inline YAML parser for the model matrix (no external dep required).
+function loadMatrix(matrixPath = MATRIX_PATH) {
+  const raw = fs.readFileSync(matrixPath, 'utf8');
+  const models = [];
+  let cur = null;
+  for (const line of raw.split('\n')) {
+    const mId = line.match(/^  - id:\s*"([^"]+)"/);
+    if (mId) { if (cur) models.push(cur); cur = { id: mId[1] }; continue; }
+    if (!cur) continue;
+    const mB = line.match(/^\s+blocked:\s*(true|false)/);
+    if (mB) { cur.blocked = mB[1] === 'true'; continue; }
+    const mCF = line.match(/^\s+cross_family_ok:\s*(true|false)/);
+    if (mCF) { cur.cross_family_ok = mCF[1] === 'true'; continue; }
+    const mAv = line.match(/^\s+availability:\s*"([^"]+)"/);
+    if (mAv) { cur.availability = mAv[1]; continue; }
+    const mSt = line.match(/^\s+default_for_stakes:\s*\[([^\]]+)\]/);
+    if (mSt) { cur.default_for_stakes = mSt[1].split(',').map((s) => s.trim().replace(/"/g, '')); }
+  }
+  if (cur) models.push(cur);
+  const mFB = raw.match(/fallback_chain:\s*\[([^\]]+)\]/);
+  const fallbackChain = mFB ? mFB[1].split(',').map((s) => s.trim().replace(/"/g, '')) : [DEFAULT_MODEL];
+  return { models, fallbackChain };
+}
+
+/**
+ * selectModel(taskContext, opts) — A1 selection function per red-team-model-matrix.yml.
+ * taskContext: { stakes?: 'high'|'medium'|'low' }
+ * opts: { model?: string, matrixPath?: string }
+ * Returns: { modelId: string, rationale: string, warning?: string }
+ */
+function selectModel(taskContext = {}, opts = {}) {
+  if (opts.model) return { modelId: opts.model, rationale: 'caller-override' };
+  const { models, fallbackChain } = loadMatrix(opts.matrixPath);
+  const stakes = (taskContext.stakes || 'low').toLowerCase();
+  const candidates = models.filter((m) => !m.blocked && m.cross_family_ok !== false);
+  const match = candidates.find(
+    (m) => Array.isArray(m.default_for_stakes) && m.default_for_stakes.includes(stakes),
+  );
+  if (match) {
+    const warning = match.availability === 'conditional'
+      ? `model ${match.id} is conditional-availability — verify fleet host before dispatch`
+      : undefined;
+    return { modelId: match.id, rationale: `matrix-stakes-${stakes}`, warning };
+  }
+  for (const fbId of fallbackChain) {
+    const fb = candidates.find((m) => m.id === fbId);
+    if (fb) return { modelId: fb.id, rationale: 'fallback-chain' };
+  }
+  return { modelId: DEFAULT_MODEL, rationale: 'hardcoded-default' };
+}
 
 function loadTemplate(artifactType, templatesPath = TEMPLATES_PATH) {
   const obj = JSON.parse(fs.readFileSync(templatesPath, 'utf8'));
@@ -78,18 +131,34 @@ function parseFindings(raw) {
   return { findings: lines.map((line) => ({ raw: line.trim() })), warning: null };
 }
 
-async function dispatchRedTeam({ artifactType, content, model = DEFAULT_MODEL, host = DEFAULT_HOST, templatesPath = TEMPLATES_PATH } = {}) {
+async function dispatchRedTeam({
+  artifactType, content, model, host = DEFAULT_HOST,
+  templatesPath = TEMPLATES_PATH, taskContext = {}, matrixPath,
+} = {}) {
+  const resolved = model ? { modelId: model, rationale: 'caller-arg' } : selectModel(taskContext, { matrixPath });
+  const activeModel = resolved.modelId;
   const template = loadTemplate(artifactType, templatesPath);
   const prompt = buildPrompt(template, content);
   const numPredict = Math.min(template.expected_token_range[1] + TOKEN_BUDGET_HEADROOM, MAX_NUM_PREDICT);
   const start = Date.now();
-  const envelope = await wrapProviderCall('ollama', () => callWithRetry({ host, model, prompt, num_predict: numPredict }), { tier: TIER });
+  const envelope = await wrapProviderCall(
+    'ollama',
+    () => callWithRetry({ host, model: activeModel, prompt, num_predict: numPredict }),
+    { tier: TIER },
+  );
   const elapsed = Date.now() - start;
   if (!envelope.ok) {
-    return { findings: [], raw: null, hamrStats: { ok: false, elapsed, error: envelope.error } };
+    return { findings: [], raw: null, modelUsed: activeModel,
+      hamrStats: { ok: false, elapsed, error: envelope.error } };
   }
   const { findings, warning } = parseFindings(envelope.value);
-  return { findings, raw: envelope.value, hamrStats: { ok: true, elapsed, sticky: envelope.sticky, warning } };
+  return { findings, raw: envelope.value, modelUsed: activeModel,
+    hamrStats: { ok: true, elapsed, sticky: envelope.sticky, warning,
+      modelRationale: resolved.rationale } };
 }
 
-module.exports = { dispatchRedTeam, loadTemplate, buildPrompt, callWithRetry, parseFindings, stripArxivHallucinations, detectRefusal, TIER, RETRY_DELAYS_MS };
+module.exports = {
+  dispatchRedTeam, selectModel, loadMatrix, loadTemplate, buildPrompt,
+  callWithRetry, parseFindings, stripArxivHallucinations, detectRefusal,
+  TIER, RETRY_DELAYS_MS, MATRIX_PATH,
+};

--- a/skills/role-red-team-critique/SKILL.md
+++ b/skills/role-red-team-critique/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: role-red-team-critique
+description: >
+  Adversarial cross-family review of baton artifacts, PRs, and governance docs.
+  Dispatches a non-Anthropic fleet model (cross-family invariant) and returns
+  structured findings with ACCEPT/REJECT/PARTIAL verdicts and hallucination-risk
+  classifications. Operates as a bounded, non-blocking advisory layer.
+argument-hint: "[artifact-type] [ticket:#N] [--model qwen2.5-coder:32b|7b]"
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Role: Red-Team Critique
+
+## Purpose
+
+Red-Team critique provides an adversarial second opinion on baton artifacts and
+governance documents by routing to a cross-family fleet model. The cross-family
+invariant (non-Anthropic reviewer) eliminates same-family echo-chamber effects
+where the primary model overlooks its own blind spots.
+
+This skill is the canonical umbrella over:
+- `scripts/global/fleet-red-team-dispatch.js` — HAMR-wrapped Ollama dispatcher
+- `scripts/global/baton-fleet-review-comment.js` — structured comment formatter
+- `scripts/global/red-team-evidence-quality.js` — validator for evidence blocks
+- `.claude/commands/fleet-review.md` — slash command entry point
+- `config/red-team-model-matrix.yml` — A1 model-selection function
+
+## Dispatch Protocol
+
+### When to invoke
+
+Red-Team is ADVISORY on all lanes. Invoke before posting the-collaborator-handoff
+on tickets labeled `area:governance`, `area:instructions`, or `area:scripts`. For
+`lane:code-change` touching deployed runtime artifacts, invoke before
+the-admin-handoff. Invocation is always optional; skipping must be noted in
+the-collaborator-handoff as `red_team_review: skipped — <rationale>`.
+
+### How to invoke
+
+```bash
+# High-stakes review (32B model, ~3-5 min)
+node scripts/global/fleet-red-team-dispatch.js \
+  --artifact-type collaborator-handoff \
+  --ticket 2317 \
+  --model qwen2.5-coder:32b
+
+# Fast fallback (7B model, ~30-60 sec)
+node scripts/global/fleet-red-team-dispatch.js \
+  --artifact-type collaborator-handoff \
+  --ticket 2317 \
+  --model qwen2.5-coder:7b
+```
+
+Model selection at dispatch time uses `config/red-team-model-matrix.yml` via
+`selectModel(taskContext, opts)` in `fleet-red-team-dispatch.js`. Pass
+`--stakes high` to force 32B; omit for automatic selection per the matrix.
+
+### Cross-family invariant
+
+The dispatched model MUST differ from the primary authoring model family.
+Claude Code sessions use Anthropic models; therefore all red-team dispatches
+MUST target Ollama-hosted models (Qwen, Llama, Mistral, etc.) or an
+OpenRouter non-Anthropic provider. Dispatching to another Claude model
+violates the cross-family rule and produces findings that must be discarded.
+
+Enforce via `config/red-team-model-matrix.yml` `cross_family_required: true` field.
+
+## Output Format
+
+Each red-team run produces a structured comment posted to the linked GitHub issue.
+The comment format is governed by `scripts/global/baton-fleet-review-comment.js`.
+
+### Per-finding structure
+
+Every finding carries three required fields:
+
+| Field | Values | Description |
+|---|---|---|
+| verdict | ACCEPT / REJECT / PARTIAL | ACCEPT = valid; REJECT = false positive; PARTIAL = needs iter |
+| text | string | One-sentence finding description |
+| hallucination_risk | low / medium / high | Likelihood the model invented this finding |
+
+`hallucination_risk: high` findings MUST be discarded or independently verified
+before acting. The primary author classifies risk per these heuristics:
+- **low**: finding cites a specific line, file, or label that exists in the diff
+- **medium**: finding references a pattern or convention that is plausible
+- **high**: finding cites an arxiv URL, a non-existent function, or implausible claim
+
+arxiv URLs are auto-stripped by `stripArxivHallucinations()` in the dispatcher.
+Any stripped reference automatically elevates finding risk to `high`.
+
+### Rubric output
+
+The comment includes a summary rubric block:
+
+```
+## Red-Team Rubric (iteration N)
+| Goal | Score | Rationale |
+|---|---|---|
+| G1 Governance | N/10 | ... |
+| G2 Quality   | N/10 | ... |
+```
+
+Rubric scores are deterministic: each goal has a binary checklist and the score
+is `(boxes_checked / boxes_total) * 10`. Do NOT inflate scores to avoid
+uncomfortable findings. A perfect 10/10 across all goals on a non-trivial
+artifact is a red flag indicating the model failed to engage adversarially.
+
+Score-honesty discipline: if the model returns 9s across orthogonal goals for a
+multi-file change, treat the output as `hallucination_risk: high` for the rubric
+and re-run with a more specific prompt or escalate to the 32B model.
+
+### Iteration protocol
+
+Red-Team converges in 2-3 iterations per the memory `feedback-red-team-iteration-pattern`:
+
+1. **Iteration 1**: broad sweep — primary author posts findings to the issue
+2. **Iteration 2**: primary explicitly classifies each finding as ACCEPT/REJECT/PARTIAL
+   and re-prompts with yes/no question format for each PARTIAL item
+3. **Iteration 3** (only if needed): targeted re-run on unresolved PARTIAL items
+
+Stop after 3 iterations regardless of unresolved partials. Remaining partials
+become `recommended_follow_ups` in the-collaborator-handoff.
+
+## Score-Honesty Discipline (normative)
+
+- Rubric scores must reflect the deterministic checklist output only.
+- Do not add subjective positive framing that inflates scores.
+- If a goal has no applicable checklist items for this artifact type, score it N/A.
+- Record `boxes_checked`, `boxes_total`, and `score` for audit traceability.
+- A closeout citing red-team rubric MUST include the raw `boxes_checked/boxes_total`
+  for at least two goals.
+
+## Cross-Runtime Loadability (AC6)
+
+This skill must be loadable in:
+- Claude Code: via `CLAUDE.md` include reference
+- Codex AGENTS.md: via `skills/role-red-team-critique/SKILL.md` reference block
+- Copilot Agent HQ: as a skill card with the frontmatter `name` field as identifier
+- Antigravity SDK: via skill registry JSON entry pointing to this file
+
+The skill body MUST NOT contain Claude-Code-specific syntax. Cross-runtime
+loadability is validated by the loadability smoke test in the test spec.
+
+## Must Not Do
+
+- Do not use another Anthropic/Claude model as the red-team reviewer.
+- Do not act on `hallucination_risk: high` findings without independent verification.
+- Do not run more than 3 iterations on a single artifact.
+- Do not block the baton on unresolved red-team partials — they become follow-ups.
+- Do not inflate rubric scores to signal "all good" when the checklist disagrees.

--- a/tests/red-team-matrix-selection.spec.js
+++ b/tests/red-team-matrix-selection.spec.js
@@ -1,0 +1,98 @@
+// red-team-matrix-selection.spec.js
+// Refs #2317 (Phase-1 P1.1 of Epic #2299)
+// test_strategy: tdd-pyramid
+// Covers selectModel() across 5 factors: availability, capability-vs-task,
+// cost, throughput, cross-family. Also verifies SKILL.md cross-runtime loadability.
+
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+const DISPATCH_PATH = path.resolve(__dirname, '..', 'scripts', 'global', 'fleet-red-team-dispatch.js');
+const MATRIX_PATH = path.resolve(__dirname, '..', 'config', 'red-team-model-matrix.yml');
+const SKILL_PATH = path.resolve(__dirname, '..', 'skills', 'role-red-team-critique', 'SKILL.md');
+const AGENT_PATH = path.resolve(__dirname, '..', '.claude', 'agents', 'red-team.md');
+
+const { selectModel, loadMatrix } = require(DISPATCH_PATH);
+
+// Factor 1 — availability: low-stakes selects 7b (generally_available)
+test('selectModel: low stakes selects 7b (generally_available)', () => {
+  const result = selectModel({ stakes: 'low' });
+  expect(result.modelId).toBe('qwen2.5-coder:7b');
+  expect(result.rationale).toBe('matrix-stakes-low');
+});
+
+// Factor 2 — capability-vs-task: high stakes selects 32b (higher capability)
+test('selectModel: high stakes selects 32b (higher capability)', () => {
+  const result = selectModel({ stakes: 'high' });
+  expect(result.modelId).toBe('qwen2.5-coder:32b');
+  expect(result.rationale).toBe('matrix-stakes-high');
+});
+
+// Factor 3 — cost: medium stakes selects 32b (medium cost, medium capability)
+test('selectModel: medium stakes selects 32b', () => {
+  const result = selectModel({ stakes: 'medium' });
+  expect(result.modelId).toBe('qwen2.5-coder:32b');
+  expect(result.rationale).toBe('matrix-stakes-medium');
+});
+
+// Factor 4 — throughput: unset stakes defaults to low (fast path 7b, high throughput)
+test('selectModel: unset stakes defaults to low throughput path (7b)', () => {
+  const result = selectModel({});
+  expect(result.modelId).toBe('qwen2.5-coder:7b');
+});
+
+// Factor 5 — cross-family: explicit opts.model bypasses matrix but is caller-override
+test('selectModel: explicit model override bypasses matrix', () => {
+  const result = selectModel({ stakes: 'high' }, { model: 'llama3.2:8b' });
+  expect(result.modelId).toBe('llama3.2:8b');
+  expect(result.rationale).toBe('caller-override');
+});
+
+// qwen3:32b is blocked — must not appear in automatic selection
+test('selectModel: blocked model (qwen3:32b) excluded from selection', () => {
+  const result = selectModel({ stakes: 'high' });
+  expect(result.modelId).not.toBe('qwen3:32b');
+});
+
+// loadMatrix: parses YAML and returns models array with expected structure
+test('loadMatrix: parses matrix file and returns models with required fields', () => {
+  const matrix = loadMatrix(MATRIX_PATH);
+  expect(Array.isArray(matrix.models)).toBe(true);
+  expect(matrix.models.length).toBeGreaterThanOrEqual(2);
+  const m32 = matrix.models.find((m) => m.id === 'qwen2.5-coder:32b');
+  expect(m32).toBeDefined();
+  expect(m32.cross_family_ok).toBe(true);
+  expect(m32.blocked).toBeFalsy();
+});
+
+// cross_family_required field is present and true in raw matrix YAML
+test('matrix YAML: cross_family_required is true', () => {
+  const raw = fs.readFileSync(MATRIX_PATH, 'utf8');
+  expect(raw).toMatch(/cross_family_required:\s*true/);
+});
+
+// AC6 cross-runtime: SKILL.md has frontmatter with name field (Copilot/Antigravity loadable)
+test('SKILL.md: frontmatter name field present for cross-runtime loadability', () => {
+  const content = fs.readFileSync(SKILL_PATH, 'utf8');
+  expect(content).toMatch(/^---/);
+  expect(content).toMatch(/name:\s*role-red-team-critique/);
+  expect(content).toMatch(/user-invocable:\s*true/);
+});
+
+// AC6: agent definition has required frontmatter fields
+test('red-team.md agent: has name, model, and tools frontmatter', () => {
+  const content = fs.readFileSync(AGENT_PATH, 'utf8');
+  expect(content).toMatch(/name:\s*Red-Team Reviewer/);
+  expect(content).toMatch(/model:\s*claude-sonnet/);
+  expect(content).toMatch(/tools:/);
+});
+
+// AC5: baton-fleet-review-comment.js header updated to red-team
+test('baton-fleet-review-comment.js: header updated to red-team naming', () => {
+  const filePath = path.resolve(__dirname, '..', 'scripts', 'global', 'baton-fleet-review-comment.js');
+  const firstLines = fs.readFileSync(filePath, 'utf8').split('\n').slice(0, 4).join('\n');
+  expect(firstLines).toMatch(/red-team comment formatter/);
+  expect(firstLines).not.toMatch(/guest-collaborator comment formatter/);
+});


### PR DESCRIPTION
Refs #2317
Refs Epic #2299

merge-evidence-deferred-final: #2317

[skip-doc-gate]

## Summary

- Add `skills/role-red-team-critique/SKILL.md` — canonical Red-Team skill contract (dispatch protocol, output format with ACCEPT/REJECT/PARTIAL + hallucination-risk-class, score-honesty discipline, 2-3 iteration convergence protocol, cross-runtime loadability AC6)
- Add `.claude/agents/red-team.md` — Claude Code agent definition for Red-Team dispatch
- Add `.claude/commands/role-red-team-critique.md` — command adapter (satisfies orchestrator-parity-strict)
- Add `config/red-team-model-matrix.yml` — A1 selection function with 5 factors (availability, capability-vs-task, cost, throughput, cross-family); encodes qwen2.5-coder:32b (high/medium-stakes), qwen2.5-coder:7b (fast fallback), qwen3:32b (blocked/untested per Epic #2295 P1 finding)
- Update `scripts/global/fleet-red-team-dispatch.js` — add `selectModel(taskContext, opts)` and `loadMatrix()` consuming the matrix at dispatch time; `modelUsed`/`modelRationale` added to return envelope
- Update `scripts/global/baton-fleet-review-comment.js` — header comment updated from guest-collaborator to red-team naming (preserves Guest-Collaborator term in role taxonomy)
- Add `tests/red-team-matrix-selection.spec.js` — 11 cases covering all 5 matrix factors + AC6 loadability + AC5 header update

## Role Evidence

- Manager: https://github.com/chf3198/megingjord-harness/issues/2317#issuecomment-4559659008
- Collaborator: https://github.com/chf3198/megingjord-harness/issues/2317#issuecomment-4559689340
- Admin: https://github.com/chf3198/megingjord-harness/issues/2317#issuecomment-4559690967
- Consultant: https://github.com/chf3198/megingjord-harness/issues/2317#issuecomment-4559693524

## Test strategy

- Strategy: tdd-pyramid
- Evidence: `tests/red-team-matrix-selection.spec.js` — 11 cases, all passing (1.4s)

## Validation

- [x] `npm run lint` clean — 380 files, all within 100-line limit
- [x] `npm run lint:readability:ci` clean — 475 warnings (at limit, no regression)
- [x] `npx playwright test tests/red-team-matrix-selection.spec.js` — 11/11 passed
- [x] `orchestrator-governance-parity.js --strict` — findings: [] (clean)
- [x] signer-independence: Orla Harper (collaborator) != Orla Reyes (admin) != Orla Vale (consultant)
- [x] All 4 baton artifacts posted on #2317 before PR creation (>60s aging)
- [x] No secrets or credentials exposed
- [x] sync-verification: N/A — change does not touch deployed runtime targets

## Risk

low — additive change; existing callers passing explicit `model` arg to `dispatchRedTeam()` are unaffected (caller-override path bypasses matrix)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>