### PR TITLE
fix(governance): block open terminal ticket states

### DIFF
--- a/scripts/global/label-rules.js
+++ b/scripts/global/label-rules.js
@@ -8,6 +8,7 @@ const STATUS_ROLE_REQUIRED = {
   'status:review':      'role:consultant',
 };
 const EPIC_ONLY_STATES = ['status:dormant', 'status:deferred'];
+const TERMINAL_STATES = ['status:done', 'status:cancelled'];
 
 function evaluate(issue) {
   const labels = (issue.labels || []).map(l => typeof l === 'string' ? l : l.name);
@@ -33,6 +34,8 @@ function evaluate(issue) {
     if (!statusLabels.some(s => s === 'status:done' || s === 'status:cancelled')) {
       violations.push('Rule 7b: closed issue must have status:done or status:cancelled');
     }
+  } else if (statusLabels.some(s => TERMINAL_STATES.includes(s))) {
+    violations.push('Rule 12: open issue must not carry terminal status:done or status:cancelled');
   }
 
   if (isEpic) {

--- a/tests/label-rules.spec.js
+++ b/tests/label-rules.spec.js
@@ -94,3 +94,7 @@ test('Rule 11: either label alone is OK', () => {
   expect(v1.filter(x => x.includes('Rule 11'))).toEqual([]);
   expect(v2.filter(x => x.includes('Rule 11'))).toEqual([]);
 });
+
+test('Rule 12: open issues cannot carry terminal statuses', () => { for (const terminal of ['status:done', 'status:cancelled']) {
+  const v = R.evaluate(mk(['type:task', terminal, 'area:governance'])); expect(v.some(x => x.includes('Rule 12'))).toBe(true); }
+});


### PR DESCRIPTION
Refs #2197
merge-evidence-deferred-final: #2197

## Summary
- block open issues from carrying terminal statuses in the shared label-rules evaluator
- add regression coverage for open status:done and status:cancelled
- close the last concrete AC2 gap identified by Epic #2197 and research child #2198

## Validation
- npx playwright test tests/label-rules.spec.js tests/label-lint-status-cardinality.spec.js
- npx playwright test tests/governance-drift.spec.js
- npm run lint

## Notes
- Fleet red-team dispatch was attempted via HAMR-routed Ollama with strongest-model fallback, then direct qwen2.5-coder:7b fallback; dispatch remained slow/stalled, so consultant closeout will record that as residual review risk rather than fabricate findings.
- Sync verification: N/A — change does not touch deployed runtime targets.
