### PR TITLE
feat(wiki): frontmatter schema, bounded trust_score, Ed25519 #2052

### DIFF
--- a/config/wiki-frontmatter.schema.json
+++ b/config/wiki-frontmatter.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://megingjord.internal/schemas/wiki-frontmatter.json",
+  "title": "Wiki Page Frontmatter",
+  "description": "Contract for wiki page YAML frontmatter. Loadable by all runtimes. Refs #2052",
+  "type": "object",
+  "required": ["title", "type", "content_trust_score", "created", "updated"],
+  "additionalProperties": true,
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable page title."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["code", "work-log", "wisdom-global", "wisdom-project"],
+      "description": "Wiki typology class (Three-Wiki typology, Epic #1942)."
+    },
+    "content_trust_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Bounded [0, 1] trust score for page content quality."
+    },
+    "trust_attestation": {
+      "type": "object",
+      "description": "Optional Ed25519 attestation. When present all sub-fields are required.",
+      "required": ["algorithm", "signer", "signature_b64", "signed_payload_hash"],
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "const": "ed25519"
+        },
+        "signer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "signature_b64": {
+          "type": "string",
+          "minLength": 1
+        },
+        "signed_payload_hash": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "created": {
+      "description": "ISO 8601 creation date (string or Date object after YAML parse).",
+      "oneOf": [
+        { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}" },
+        { "type": "object" }
+      ]
+    },
+    "updated": {
+      "description": "ISO 8601 last-updated date (string or Date object after YAML parse).",
+      "oneOf": [
+        { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}" },
+        { "type": "object" }
+      ]
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "related": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "status": {
+      "type": "string"
+    }
+  }
+}

--- a/scripts/wiki/sign-frontmatter.js
+++ b/scripts/wiki/sign-frontmatter.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// scripts/wiki/sign-frontmatter.js — Attach Ed25519 trust_attestation to wiki page.
+// Generates ephemeral key pair, signs body hash, writes trust_attestation block.
+// For production use, supply --key-file <private-key.pem> to use a persistent key.
+// CommonJS; Refs #2052
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const matter = require('gray-matter');
+
+/**
+ * Compute SHA-256 hex digest of a string.
+ * @param {string} text - input text
+ * @returns {string} hex digest
+ */
+function sha256Hex(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+/**
+ * Sign the body of a wiki page and return the attestation object.
+ * @param {string} body - markdown body (post-frontmatter content)
+ * @param {crypto.KeyObject} privateKey - Ed25519 private key
+ * @param {string} signer - signer identity string
+ * @returns {{ algorithm: string, signer: string, signature_b64: string, signed_payload_hash: string }}
+ */
+function buildAttestation(body, privateKey, signer) {
+  const signed_payload_hash = sha256Hex(body);
+  const payloadBuf = Buffer.from(signed_payload_hash, 'hex');
+  const sigBuf = crypto.sign(null, payloadBuf, privateKey);
+  return {
+    algorithm: 'ed25519',
+    signer,
+    signature_b64: sigBuf.toString('base64'),
+    signed_payload_hash,
+  };
+}
+
+/**
+ * Load an Ed25519 private key from a PEM file.
+ * @param {string} keyPath - path to PEM file
+ * @returns {crypto.KeyObject}
+ */
+function loadPrivateKey(keyPath) {
+  const pem = fs.readFileSync(keyPath, 'utf-8');
+  return crypto.createPrivateKey(pem);
+}
+
+/**
+ * Sign a wiki markdown file in-place with an Ed25519 trust_attestation block.
+ * @param {string} filePath - path to markdown file
+ * @param {{ keyFile?: string, signer?: string }} [opts] - options
+ * @returns {{ filePath: string, signed_payload_hash: string, signer: string }}
+ */
+function signFile(filePath, opts = {}) {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const { data: fm, content: body } = matter(raw);
+
+  let privateKey;
+  let signerIdentity;
+  if (opts.keyFile) {
+    privateKey = loadPrivateKey(opts.keyFile);
+    const pubKey = crypto.createPublicKey(privateKey);
+    const rawPub = pubKey.export({ format: 'der', type: 'spki' }).slice(12).toString('hex');
+    signerIdentity = opts.signer || rawPub;
+  } else {
+    const kp = crypto.generateKeyPairSync('ed25519');
+    privateKey = kp.privateKey;
+    const rawPub = kp.publicKey.export({ format: 'der', type: 'spki' }).slice(12).toString('hex');
+    signerIdentity = opts.signer || rawPub;
+  }
+
+  fm.trust_attestation = buildAttestation(body, privateKey, signerIdentity);
+  const updated = matter.stringify(body, fm);
+  fs.writeFileSync(filePath, updated);
+  return { filePath, signed_payload_hash: fm.trust_attestation.signed_payload_hash, signer: signerIdentity };
+}
+
+module.exports = { signFile, buildAttestation, loadPrivateKey, sha256Hex };
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const target = args.find((a) => !a.startsWith('--'));
+  const keyFlag = args.indexOf('--key-file');
+  const signerFlag = args.indexOf('--signer');
+  if (!target) { console.error('Usage: sign-frontmatter.js <file.md> [--key-file <pem>] [--signer <id>]'); process.exit(1); }
+  const opts = {};
+  if (keyFlag !== -1) opts.keyFile = args[keyFlag + 1];
+  if (signerFlag !== -1) opts.signer = args[signerFlag + 1];
+  const result = signFile(path.resolve(target), opts);
+  console.log(`✅ Signed ${result.filePath}`);
+  console.log(`   signer: ${result.signer}`);
+  console.log(`   payload_hash: ${result.signed_payload_hash}`);
+}

--- a/scripts/wiki/validate-frontmatter.js
+++ b/scripts/wiki/validate-frontmatter.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// scripts/wiki/validate-frontmatter.js — Wiki frontmatter schema validator
+// Validates YAML frontmatter against config/wiki-frontmatter.schema.json.
+// Optionally verifies Ed25519 trust_attestation when signature present.
+// CommonJS; loadable by Claude Code, Codex, Copilot, Antigravity. Refs #2052
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const matter = require('gray-matter');
+const Ajv = require('ajv');
+
+const SCHEMA_PATH = path.join(__dirname, '../../config/wiki-frontmatter.schema.json');
+
+/**
+ * Load and compile the frontmatter JSON Schema via Ajv.
+ * @returns {import('ajv').ValidateFunction} compiled validator
+ */
+function loadValidator() {
+  const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf-8'));
+  const ajv = new Ajv({ allErrors: true });
+  return ajv.compile(schema);
+}
+
+/**
+ * Verify Ed25519 trust_attestation block against body content.
+ * @param {object} attestation - trust_attestation object from frontmatter
+ * @param {string} body - markdown body (post-frontmatter content)
+ * @returns {{ ok: boolean, error?: string }}
+ */
+function verifyAttestation(attestation, body) {
+  try {
+    const { signature_b64, signed_payload_hash } = attestation;
+    const actualHash = crypto.createHash('sha256').update(body).digest('hex');
+    if (actualHash !== signed_payload_hash) {
+      return { ok: false, error: `payload hash mismatch: expected ${signed_payload_hash}` };
+    }
+    const sigBuf = Buffer.from(signature_b64, 'base64');
+    const payloadBuf = Buffer.from(signed_payload_hash, 'hex');
+    // Reconstruct public key from signer field if it is a raw hex public key;
+    // otherwise attestation is treated as structurally valid (hash verified).
+    const { signer } = attestation;
+    if (signer && signer.length === 64 && /^[0-9a-f]+$/i.test(signer)) {
+      const pubKey = crypto.createPublicKey({
+        key: Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), Buffer.from(signer, 'hex')]),
+        format: 'der',
+        type: 'spki',
+      });
+      const valid = crypto.verify(null, payloadBuf, pubKey, sigBuf);
+      if (!valid) return { ok: false, error: 'Ed25519 signature verification failed' };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: `attestation verification error: ${err.message}` };
+  }
+}
+
+/**
+ * Validate a wiki markdown file's frontmatter.
+ * @param {string} filePath - absolute or relative path to markdown file
+ * @param {{ verifySignature?: boolean }} [opts] - options
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateFile(filePath, opts = {}) {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  return validateContent(raw, opts);
+}
+
+/**
+ * Validate raw markdown string frontmatter.
+ * @param {string} raw - full markdown content including frontmatter fences
+ * @param {{ verifySignature?: boolean }} [opts] - options
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateContent(raw, opts = {}) {
+  const { data: fm, content: body } = matter(String(raw));
+  const validate = loadValidator();
+  const schemaValid = validate(fm);
+  const errors = schemaValid ? [] : validate.errors.map((e) => `${e.dataPath} ${e.message}`);
+
+  if (schemaValid && fm.trust_attestation && opts.verifySignature !== false) {
+    const result = verifyAttestation(fm.trust_attestation, body);
+    if (!result.ok) errors.push(`trust_attestation: ${result.error}`);
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+module.exports = { validateFile, validateContent, verifyAttestation, loadValidator };
+
+if (require.main === module) {
+  const [, , target] = process.argv;
+  if (!target) { console.error('Usage: validate-frontmatter.js <file.md>'); process.exit(1); }
+  const result = validateFile(path.resolve(target), { verifySignature: true });
+  if (result.valid) { console.log('✅ Frontmatter valid'); process.exit(0); }
+  result.errors.forEach((e) => console.error(`  ✗ ${e}`));
+  process.exit(1);
+}

--- a/tests/fixtures/wiki-frontmatter/invalid-missing-title.md
+++ b/tests/fixtures/wiki-frontmatter/invalid-missing-title.md
@@ -1,0 +1,8 @@
+---
+type: work-log
+content_trust_score: 0.5
+created: "2026-01-01"
+updated: "2026-01-01"
+---
+
+No title field here.

--- a/tests/fixtures/wiki-frontmatter/invalid-score-above-one.md
+++ b/tests/fixtures/wiki-frontmatter/invalid-score-above-one.md
@@ -1,0 +1,9 @@
+---
+title: "Bad Score Above One"
+type: wisdom-project
+content_trust_score: 1.5
+created: "2026-01-01"
+updated: "2026-01-01"
+---
+
+Body content.

--- a/tests/fixtures/wiki-frontmatter/invalid-score-negative.md
+++ b/tests/fixtures/wiki-frontmatter/invalid-score-negative.md
@@ -1,0 +1,9 @@
+---
+title: "Bad Score Negative"
+type: code
+content_trust_score: -0.1
+created: "2026-01-01"
+updated: "2026-01-01"
+---
+
+Body content.

--- a/tests/fixtures/wiki-frontmatter/invalid-score-string.md
+++ b/tests/fixtures/wiki-frontmatter/invalid-score-string.md
@@ -1,0 +1,9 @@
+---
+title: "Bad Score String"
+type: code
+content_trust_score: "high"
+created: "2026-01-01"
+updated: "2026-01-01"
+---
+
+Body content.

--- a/tests/fixtures/wiki-frontmatter/invalid-type-enum.md
+++ b/tests/fixtures/wiki-frontmatter/invalid-type-enum.md
@@ -1,0 +1,9 @@
+---
+title: "Wrong Type"
+type: unknown-wiki-type
+content_trust_score: 0.5
+created: "2026-01-01"
+updated: "2026-01-01"
+---
+
+Body content.

--- a/tests/fixtures/wiki-frontmatter/valid-code.md
+++ b/tests/fixtures/wiki-frontmatter/valid-code.md
@@ -1,0 +1,14 @@
+---
+title: "Validator Architecture"
+type: code
+content_trust_score: 0.9
+created: "2026-01-15"
+updated: "2026-05-01"
+tags: [architecture, validator]
+related: [schema-contract]
+status: published
+---
+
+# Validator Architecture
+
+Describes the wiki frontmatter validator design.

--- a/tests/fixtures/wiki-frontmatter/valid-wisdom-global.md
+++ b/tests/fixtures/wiki-frontmatter/valid-wisdom-global.md
@@ -1,0 +1,11 @@
+---
+title: "Cross-Team Baton Protocol"
+type: wisdom-global
+content_trust_score: 0.75
+created: "2026-03-01"
+updated: "2026-05-10"
+---
+
+# Cross-Team Baton Protocol
+
+Global wisdom on baton handoff ordering.

--- a/tests/fixtures/wiki-frontmatter/valid-work-log.md
+++ b/tests/fixtures/wiki-frontmatter/valid-work-log.md
@@ -1,0 +1,12 @@
+---
+title: "Sprint 12 Work Log"
+type: work-log
+content_trust_score: 0
+created: "2026-04-01"
+updated: "2026-04-30"
+status: draft
+---
+
+# Sprint 12 Work Log
+
+Ticket and PR log for sprint 12.

--- a/tests/wiki-frontmatter.spec.js
+++ b/tests/wiki-frontmatter.spec.js
@@ -1,0 +1,121 @@
+// tests/wiki-frontmatter.spec.js — Frontmatter schema + Ed25519 attestation tests
+// test_strategy: tdd-pyramid  Refs #2052
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const crypto = require('crypto');
+const { validateContent, verifyAttestation } = require('../scripts/wiki/validate-frontmatter');
+const { buildAttestation, sha256Hex } = require('../scripts/wiki/sign-frontmatter');
+
+const FIXTURES = path.join(__dirname, 'fixtures/wiki-frontmatter');
+const fs = require('fs');
+
+function fixture(name) { return fs.readFileSync(path.join(FIXTURES, name), 'utf-8'); }
+
+// --- Schema parseable ---
+test('schema loads via require()', () => {
+  const schema = require('../config/wiki-frontmatter.schema.json');
+  expect(schema.$schema).toContain('json-schema.org');
+  expect(schema.required).toContain('content_trust_score');
+  expect(schema.required).not.toContain('trust_attestation'); // optional field
+});
+
+// --- Valid fixtures ---
+test('valid-code.md passes schema', () => {
+  const r = validateContent(fixture('valid-code.md'));
+  expect(r.valid).toBe(true);
+  expect(r.errors).toHaveLength(0);
+});
+
+test('valid-wisdom-global.md passes schema', () => {
+  const r = validateContent(fixture('valid-wisdom-global.md'));
+  expect(r.valid).toBe(true);
+});
+
+test('valid-work-log.md with score=0 boundary passes schema', () => {
+  const r = validateContent(fixture('valid-work-log.md'));
+  expect(r.valid).toBe(true);
+});
+
+// --- content_trust_score bounds (≥5 cases) ---
+test('score negative fails validation', () => {
+  const r = validateContent(fixture('invalid-score-negative.md'));
+  expect(r.valid).toBe(false);
+  expect(r.errors.some((e) => e.includes('minimum') || e.includes('<= 1') || e.includes('>= 0'))).toBe(true);
+});
+
+test('score above 1 fails validation', () => {
+  const r = validateContent(fixture('invalid-score-above-one.md'));
+  expect(r.valid).toBe(false);
+  expect(r.errors.some((e) => e.includes('maximum') || e.includes('<= 1'))).toBe(true);
+});
+
+test('score as string fails validation', () => {
+  const r = validateContent(fixture('invalid-score-string.md'));
+  expect(r.valid).toBe(false);
+  expect(r.errors.some((e) => e.includes('type') || e.includes('number'))).toBe(true);
+});
+
+test('score NaN (missing field) fails — missing required field', () => {
+  const raw = '---\ntitle: T\ntype: code\ncreated: "2026-01-01"\nupdated: "2026-01-01"\n---\nBody';
+  const r = validateContent(raw);
+  expect(r.valid).toBe(false);
+  expect(r.errors.some((e) => e.includes('content_trust_score') || e.includes('required'))).toBe(true);
+});
+
+test('score > 1 inline raw fails validation', () => {
+  const raw = '---\ntitle: T\ntype: code\ncontent_trust_score: 99\ncreated: "2026-01-01"\nupdated: "2026-01-01"\n---\nBody';
+  const r = validateContent(raw);
+  expect(r.valid).toBe(false);
+});
+
+// --- trust_attestation optional ---
+test('missing trust_attestation is accepted (optional)', () => {
+  const raw = fixture('valid-wisdom-global.md');
+  const r = validateContent(raw, { verifySignature: true });
+  expect(r.valid).toBe(true);
+});
+
+// --- Ed25519 signature verification ---
+test('valid Ed25519 signature verifies correctly', () => {
+  const body = '\nSome wiki body content.\n';
+  const kp = crypto.generateKeyPairSync('ed25519');
+  const rawPub = kp.publicKey.export({ format: 'der', type: 'spki' }).slice(12).toString('hex');
+  const att = buildAttestation(body, kp.privateKey, rawPub);
+  expect(att.algorithm).toBe('ed25519');
+  const result = verifyAttestation(att, body);
+  expect(result.ok).toBe(true);
+});
+
+test('tampered body causes signature verification failure', () => {
+  const body = '\nOriginal content.\n';
+  const kp = crypto.generateKeyPairSync('ed25519');
+  const rawPub = kp.publicKey.export({ format: 'der', type: 'spki' }).slice(12).toString('hex');
+  const att = buildAttestation(body, kp.privateKey, rawPub);
+  const result = verifyAttestation(att, '\nTampered content.\n');
+  expect(result.ok).toBe(false);
+  expect(result.error).toContain('hash mismatch');
+});
+
+test('tampered signature_b64 fails verification', () => {
+  const body = '\nWiki body.\n';
+  const kp = crypto.generateKeyPairSync('ed25519');
+  const rawPub = kp.publicKey.export({ format: 'der', type: 'spki' }).slice(12).toString('hex');
+  const att = buildAttestation(body, kp.privateKey, rawPub);
+  const tampered = { ...att, signature_b64: Buffer.alloc(64).toString('base64') };
+  const result = verifyAttestation(tampered, body);
+  expect(result.ok).toBe(false);
+});
+
+// --- Other schema errors ---
+test('missing title fails schema', () => {
+  const r = validateContent(fixture('invalid-missing-title.md'));
+  expect(r.valid).toBe(false);
+});
+
+test('invalid type enum fails schema', () => {
+  const r = validateContent(fixture('invalid-type-enum.md'));
+  expect(r.valid).toBe(false);
+  expect(r.errors.some((e) => e.includes('allowed values') || e.includes('enum'))).toBe(true);
+});


### PR DESCRIPTION
Refs #2052
Refs Epic #1942
merge-evidence-deferred-final: #2052

## Summary

- `config/wiki-frontmatter.schema.json`: JSON Schema v7 defining wiki page frontmatter contract. Required: `title`, `type` (code|work-log|wisdom-global|wisdom-project), `content_trust_score` [0,1], `created`, `updated`. Optional: `trust_attestation` (Ed25519 algorithm/signer/signature_b64/signed_payload_hash).
- `scripts/wiki/validate-frontmatter.js`: CommonJS validator using gray-matter + Ajv v6. Verifies schema, enforces bounds, optionally verifies Ed25519 signature.
- `scripts/wiki/sign-frontmatter.js`: Companion CLI to generate and attach Ed25519 `trust_attestation` block to any wiki page (ephemeral or persistent key).
- `tests/wiki-frontmatter.spec.js`: 15 Playwright tests — 15/15 pass.
- `tests/fixtures/wiki-frontmatter/`: 3 valid + 5 invalid fixture pages.

## Baton artifacts on #2052

COLLABORATOR_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2052#issuecomment-4560397079
ADMIN_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2052#issuecomment-4560398225
CONSULTANT_CLOSEOUT: https://github.com/chf3198/megingjord-harness/issues/2052#issuecomment-4560399616

## Test evidence

`npx playwright test tests/wiki-frontmatter.spec.js` — 15 passed (2.2s)

## Lint

`node scripts/lint.js` — Scanned 387 files. All within 100-line limit.

## Checklist

- [x] All ACs verified PASS in the-collaborator-handoff-artifact
- [x] 15/15 tests green
- [x] lint clean
- [x] All 4 baton artifacts posted on #2052 before PR creation
- [x] No deployed runtime artifacts touched — sync-verification N/A
- [x] CommonJS portable — loadable by Claude Code, Codex, Copilot, Antigravity