### PR TITLE
feat(wiki): auto-update 11-stage pipeline #2055

### DIFF
--- a/.github/workflows/wiki-auto-update.yml
+++ b/.github/workflows/wiki-auto-update.yml
@@ -1,0 +1,112 @@
+# wiki-auto-update.yml — Auto-update wiki on PR merge (11-stage pipeline)
+# Triggers on pull_request closed + merged. Refs #2055 Epic #1942 Phase-1 C5.
+# Stage 2 rejects HIGH-severity invisible characters and aborts the run.
+name: wiki-auto-update
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: wiki-auto-update-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  pipeline:
+    name: wiki-auto-update-pipeline
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # -----------------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # -----------------------------------------------------------------------
+      # Stage 1 — Classify diff
+      # -----------------------------------------------------------------------
+      - name: Stage 1 - Classify diff
+        id: classify
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          FILES=$(gh pr view "$PR_NUMBER" --json files \
+            --jq '.files[].path' | tr '\n' ',')
+          echo "changed_files=$FILES" >> "$GITHUB_OUTPUT"
+          echo "Classified files: $FILES"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      # -----------------------------------------------------------------------
+      # Stage 2 — Invisible-char scan (HIGH-severity aborts)
+      # -----------------------------------------------------------------------
+      - name: Stage 2 - Invisible-char scan
+        id: invis_scan
+        env:
+          CHANGED_FILES: ${{ steps.classify.outputs.changed_files }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          node -e "
+          const { scanInvisibleChars } = require('./scripts/wiki/auto-update-pipeline');
+          const fs = require('fs');
+          const files = (process.env.CHANGED_FILES || '').split(',').filter(Boolean);
+          let allText = '';
+          for (const f of files) {
+            try { allText += fs.readFileSync(f, 'utf-8') + '\n'; } catch (_) {}
+          }
+          const result = scanInvisibleChars(allText);
+          console.log(JSON.stringify(result));
+          if (result.maxSeverity === 'HIGH') {
+            const names = result.findings.filter(f => f.severity === 'HIGH').map(f => f.name);
+            process.stderr.write('Stage 2 abort: HIGH invisible chars: ' + names.join(', ') + '\n');
+            process.exit(1);
+          }
+          console.log('Stage 2 pass: no HIGH-severity invisible chars');
+          "
+
+      # -----------------------------------------------------------------------
+      # Stages 3-11 — orchestrator script
+      # -----------------------------------------------------------------------
+      - name: Stages 3-11 - Run pipeline orchestrator
+        id: pipeline
+        env:
+          CHANGED_FILES: ${{ steps.classify.outputs.changed_files }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          OUTPUT=$(node scripts/wiki/auto-update-pipeline.js)
+          echo "$OUTPUT"
+          {
+            echo 'summary<<PIPELINE_SUMMARY_EOF'
+            echo "$OUTPUT"
+            echo 'PIPELINE_SUMMARY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      # -----------------------------------------------------------------------
+      # Stage 11 — Post summary comment on originating PR
+      # -----------------------------------------------------------------------
+      - name: Stage 11 - Post summary comment
+        if: always() && steps.pipeline.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SUMMARY: ${{ steps.pipeline.outputs.summary }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "$SUMMARY"

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ npm run deploy:both:apply
 | `validate:compat` | `node scripts/validate-plugin-compat.js` |
 | `validate:triage` | `node scripts/validate-plugin-triage.js` |
 | `wiki:anneal` | `node scripts/wiki/anneal.js` |
+| `wiki:auto-update` | `node scripts/wiki/auto-update-pipeline.js` |
 | `wiki:drift` | `node scripts/wiki/drift-detector.js` |
 | `wiki:ingest` | `node scripts/wiki/ingest.js` |
 | `wiki:ingest:code` | `node scripts/wiki/ingest-code.js` |

--- a/package.json
+++ b/package.json
@@ -240,6 +240,7 @@
     "validate:compat": "node scripts/validate-plugin-compat.js",
     "validate:triage": "node scripts/validate-plugin-triage.js",
     "wiki:anneal": "node scripts/wiki/anneal.js",
+    "wiki:auto-update": "node scripts/wiki/auto-update-pipeline.js",
     "wiki:drift": "node scripts/wiki/drift-detector.js",
     "wiki:ingest": "node scripts/wiki/ingest.js",
     "wiki:ingest:code": "node scripts/wiki/ingest-code.js",

--- a/scripts/wiki/auto-update-pipeline.js
+++ b/scripts/wiki/auto-update-pipeline.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// scripts/wiki/auto-update-pipeline.js — Thin orchestrator for 11-stage pipeline.
+// Triggered by wiki-auto-update.yml on pull_request closed+merged.
+// Also available on-demand: npm run wiki:auto-update
+// CommonJS. Refs #2055
+'use strict';
+
+const {
+  classifyDiff, scanInvisibleChars, generateFrontmatter, INVISIBLE_CHAR_PATTERNS,
+} = require('./pipeline-classify');
+const {
+  stage1Classify, stage2InvisibleCharScan, stage3ExtractCode,
+  stage4ExtractWorkLog, stage5ExtractWisdom, stage6GenerateFrontmatter,
+} = require('./pipeline-stages-a');
+const {
+  stage7Sign, stage8Validate, stage9Write, stage10Commit, stage11Summary,
+} = require('./pipeline-stages-b');
+
+const STAGE_FNS = [
+  stage1Classify, stage2InvisibleCharScan, stage3ExtractCode,
+  stage4ExtractWorkLog, stage5ExtractWisdom, stage6GenerateFrontmatter,
+  stage7Sign, stage8Validate, stage9Write, stage10Commit, stage11Summary,
+];
+
+/**
+ * Run the full 11-stage wiki auto-update pipeline.
+ * @param {object} opts
+ * @param {string[]} opts.changedFiles   - file paths changed in the PR
+ * @param {string[]} [opts.fileContents] - raw content strings for invisible-char scan
+ * @param {number|string} opts.prNumber  - originating PR number
+ * @param {string} [opts.date]           - ISO date override (defaults to today)
+ * @param {boolean} [opts.sign]          - Ed25519-sign pages
+ * @param {boolean} [opts.writeEnabled]  - write files to disk
+ * @param {string} [opts.repoRoot]       - repo root for file writes
+ * @param {object} [opts.fs]             - fs module override for testing
+ * @returns {object} pipeline context
+ */
+function runPipeline(opts = {}) {
+  const ctx = {
+    changedFiles: opts.changedFiles || [],
+    fileContents: opts.fileContents || [],
+    prNumber: opts.prNumber || 0,
+    date: opts.date || new Date().toISOString().split('T')[0],
+    sign: opts.sign || false,
+    writeEnabled: opts.writeEnabled || false,
+    repoRoot: opts.repoRoot || process.cwd(),
+    fs: opts.fs || require('fs'),
+    log: [],
+    classified: null,
+    invisibleScan: null,
+    codeDeltas: [],
+    workLogEntries: [],
+    wisdomEntries: [],
+    generatedPages: [],
+    validationErrors: [],
+    writtenPaths: [],
+    commitPlan: null,
+    summary: '',
+  };
+  for (const stageFn of STAGE_FNS) stageFn(ctx);
+  return ctx;
+}
+
+module.exports = {
+  runPipeline, classifyDiff, scanInvisibleChars, generateFrontmatter, INVISIBLE_CHAR_PATTERNS,
+};
+
+if (require.main === module) {
+  const changedFiles = (process.env.CHANGED_FILES || '').split(',').filter(Boolean);
+  const prNumber = process.env.PR_NUMBER || '0';
+  try {
+    const ctx = runPipeline({ changedFiles, prNumber });
+    console.log(ctx.summary);
+    process.exit(0);
+  } catch (err) {
+    console.error(`Pipeline error: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/wiki/pipeline-classify.js
+++ b/scripts/wiki/pipeline-classify.js
@@ -1,0 +1,67 @@
+// scripts/wiki/pipeline-classify.js — Diff classification + invisible-char scan.
+// Consumed by auto-update-pipeline.js. CommonJS. Refs #2055
+'use strict';
+
+// HIGH: characters that can alter parsing or hide injected content.
+const INVISIBLE_CHAR_PATTERNS = [
+  { regex: /[‪-‮⁦-⁩]/g, severity: 'HIGH', name: 'bidi-override' },
+  { regex: /​/g, severity: 'HIGH', name: 'zero-width-space' },
+  { regex: /﻿/g, severity: 'HIGH', name: 'bom-mid-file' },
+  { regex: /[‌‍­]/g, severity: 'LOW', name: 'zero-width-misc' },
+];
+
+/**
+ * Scan text for invisible characters.
+ * @param {string} text
+ * @returns {{ findings: Array<{name, severity, count}>, maxSeverity: 'HIGH'|'LOW'|'NONE' }}
+ */
+function scanInvisibleChars(text) {
+  const findings = [];
+  for (const { regex, severity, name } of INVISIBLE_CHAR_PATTERNS) {
+    const matches = text.match(regex);
+    if (matches && matches.length > 0) findings.push({ name, severity, count: matches.length });
+  }
+  const maxSeverity = findings.some((f) => f.severity === 'HIGH')
+    ? 'HIGH' : findings.length > 0 ? 'LOW' : 'NONE';
+  return { findings, maxSeverity };
+}
+
+/**
+ * Classify changed file paths into wiki update target categories.
+ * @param {string[]} changedFiles
+ * @returns {{ code: string[], workLog: string[], wisdom: string[] }}
+ */
+function classifyDiff(changedFiles) {
+  const code = [];
+  const workLog = [];
+  const wisdom = [];
+  for (const f of changedFiles) {
+    if (/^(scripts|cloudflare|dashboard)\//.test(f) || /\.(ts|js)$/.test(f)) {
+      code.push(f);
+    } else if (/^\.github\/workflows\//.test(f) || /\.(yml|yaml)$/.test(f)) {
+      workLog.push(f);
+    } else if (/\.(md|txt)$/.test(f)) {
+      wisdom.push(f);
+    }
+  }
+  return { code, workLog, wisdom };
+}
+
+/**
+ * Generate wiki frontmatter per #2052 schema (with content_trust_score).
+ * @param {{ title: string, type: string, prNumber: number|string, date: string }} opts
+ * @returns {object} frontmatter data
+ */
+function generateFrontmatter({ title, type, prNumber, date }) {
+  return {
+    title,
+    type,
+    content_trust_score: 0.7,
+    created: date,
+    updated: date,
+    tags: [`pr-${prNumber}`, 'auto-update'],
+    status: 'auto-generated',
+  };
+}
+
+module.exports = { scanInvisibleChars, classifyDiff, generateFrontmatter, INVISIBLE_CHAR_PATTERNS };

--- a/scripts/wiki/pipeline-classify.js
+++ b/scripts/wiki/pipeline-classify.js
@@ -35,13 +35,13 @@ function classifyDiff(changedFiles) {
   const code = [];
   const workLog = [];
   const wisdom = [];
-  for (const f of changedFiles) {
-    if (/^(scripts|cloudflare|dashboard)\//.test(f) || /\.(ts|js)$/.test(f)) {
-      code.push(f);
-    } else if (/^\.github\/workflows\//.test(f) || /\.(yml|yaml)$/.test(f)) {
-      workLog.push(f);
-    } else if (/\.(md|txt)$/.test(f)) {
-      wisdom.push(f);
+  for (const filePath of changedFiles) {
+    if (/^(scripts|cloudflare|dashboard)\//.test(filePath) || /\.(ts|js)$/.test(filePath)) {
+      code.push(filePath);
+    } else if (/^\.github\/workflows\//.test(filePath) || /\.(yml|yaml)$/.test(filePath)) {
+      workLog.push(filePath);
+    } else if (/\.(md|txt)$/.test(filePath)) {
+      wisdom.push(filePath);
     }
   }
   return { code, workLog, wisdom };

--- a/scripts/wiki/pipeline-stages-a.js
+++ b/scripts/wiki/pipeline-stages-a.js
@@ -76,7 +76,7 @@ function stage6GenerateFrontmatter(ctx) {
     const body = `# ${fm.title}\n\nAuto-generated from PR #${prN}.\n`;
     ctx.generatedPages.push({ slug, wikiType, fm, body });
   };
-  for (const d of ctx.codeDeltas) push(d.slug, 'code', ctx.prNumber);
+  for (const delta of ctx.codeDeltas) push(delta.slug, 'code', ctx.prNumber);
   for (const e of ctx.workLogEntries) push(e.slug, 'work-log', ctx.prNumber);
   for (const e of ctx.wisdomEntries) push(e.slug, 'wisdom-project', ctx.prNumber);
   ctx.log.push({ stage: 6, name: 'generate-frontmatter', pages: ctx.generatedPages.length });

--- a/scripts/wiki/pipeline-stages-a.js
+++ b/scripts/wiki/pipeline-stages-a.js
@@ -1,0 +1,88 @@
+// scripts/wiki/pipeline-stages-a.js — Stages 1-6 of wiki auto-update pipeline.
+// CommonJS. Refs #2055
+'use strict';
+
+const path = require('path');
+const { classifyDiff, scanInvisibleChars, generateFrontmatter } = require('./pipeline-classify');
+
+/**
+ * Stage 1: Classify changed files into wiki target categories.
+ * @param {object} ctx pipeline context
+ */
+function stage1Classify(ctx) {
+  ctx.classified = classifyDiff(ctx.changedFiles || []);
+  ctx.log.push({ stage: 1, name: 'classify-diff', result: ctx.classified });
+}
+
+/**
+ * Stage 2: Scan file contents for invisible chars. Aborts on HIGH severity.
+ * @param {object} ctx pipeline context
+ */
+function stage2InvisibleCharScan(ctx) {
+  const scan = scanInvisibleChars((ctx.fileContents || []).join('\n'));
+  ctx.invisibleScan = scan;
+  ctx.log.push({ stage: 2, name: 'invisible-char-scan', scan });
+  if (scan.maxSeverity === 'HIGH') {
+    const names = scan.findings.filter((f) => f.severity === 'HIGH').map((f) => f.name);
+    throw new Error(`Stage 2 abort: HIGH-severity invisible chars detected: ${names.join(', ')}`);
+  }
+}
+
+/**
+ * Stage 3: Extract code-ingest deltas (Wiki A).
+ * @param {object} ctx pipeline context
+ */
+function stage3ExtractCode(ctx) {
+  ctx.codeDeltas = ctx.classified.code.map((f) => ({
+    file: f,
+    slug: path.basename(f, path.extname(f)).replace(/[^a-z0-9-]/gi, '-').toLowerCase(),
+  }));
+  ctx.log.push({ stage: 3, name: 'extract-code-deltas', count: ctx.codeDeltas.length });
+}
+
+/**
+ * Stage 4: Extract work-log entries (Wiki B).
+ * @param {object} ctx pipeline context
+ */
+function stage4ExtractWorkLog(ctx) {
+  ctx.workLogEntries = ctx.classified.workLog.map((f) => ({
+    file: f,
+    slug: `pr-${ctx.prNumber}-${path.basename(f, path.extname(f))}`.toLowerCase(),
+  }));
+  ctx.log.push({ stage: 4, name: 'extract-work-log', count: ctx.workLogEntries.length });
+}
+
+/**
+ * Stage 5: Extract wisdom entries (Wiki C scope=project).
+ * @param {object} ctx pipeline context
+ */
+function stage5ExtractWisdom(ctx) {
+  ctx.wisdomEntries = ctx.classified.wisdom.map((f) => ({
+    file: f,
+    slug: path.basename(f, path.extname(f)).replace(/[^a-z0-9-]/gi, '-').toLowerCase(),
+  }));
+  ctx.log.push({ stage: 5, name: 'extract-wisdom', count: ctx.wisdomEntries.length });
+}
+
+/**
+ * Stage 6: Generate frontmatter per #2052 schema (with content_trust_score).
+ * @param {object} ctx pipeline context
+ */
+function stage6GenerateFrontmatter(ctx) {
+  const today = ctx.date || new Date().toISOString().split('T')[0];
+  ctx.generatedPages = [];
+  const push = (slug, wikiType, prN) => {
+    const fm = generateFrontmatter({ title: slug, type: wikiType, prNumber: prN, date: today });
+    const body = `# ${fm.title}\n\nAuto-generated from PR #${prN}.\n`;
+    ctx.generatedPages.push({ slug, wikiType, fm, body });
+  };
+  for (const d of ctx.codeDeltas) push(d.slug, 'code', ctx.prNumber);
+  for (const e of ctx.workLogEntries) push(e.slug, 'work-log', ctx.prNumber);
+  for (const e of ctx.wisdomEntries) push(e.slug, 'wisdom-project', ctx.prNumber);
+  ctx.log.push({ stage: 6, name: 'generate-frontmatter', pages: ctx.generatedPages.length });
+}
+
+module.exports = {
+  stage1Classify, stage2InvisibleCharScan, stage3ExtractCode,
+  stage4ExtractWorkLog, stage5ExtractWisdom, stage6GenerateFrontmatter,
+};

--- a/scripts/wiki/pipeline-stages-b.js
+++ b/scripts/wiki/pipeline-stages-b.js
@@ -1,0 +1,98 @@
+// scripts/wiki/pipeline-stages-b.js — Stages 7-11 of wiki auto-update pipeline.
+// CommonJS. Refs #2055
+'use strict';
+
+const path = require('path');
+const crypto = require('crypto');
+const matter = require('gray-matter');
+const { validateContent } = require('./validate-frontmatter');
+const { buildAttestation } = require('./sign-frontmatter');
+
+const WIKI_TYPE_DIR = {
+  code: 'wiki/code', 'work-log': 'wiki/work-log', 'wisdom-project': 'wiki/wisdom/project',
+};
+
+/**
+ * Stage 7: Optionally Ed25519-sign trust_attestation (#2052).
+ * @param {object} ctx pipeline context
+ */
+function stage7Sign(ctx) {
+  if (!ctx.sign) { ctx.log.push({ stage: 7, name: 'sign', skipped: true }); return; }
+  const kp = crypto.generateKeyPairSync('ed25519');
+  const rawPub = kp.publicKey.export({ format: 'der', type: 'spki' }).slice(12).toString('hex');
+  for (const page of ctx.generatedPages) {
+    page.fm.trust_attestation = buildAttestation(page.body, kp.privateKey, rawPub);
+  }
+  ctx.log.push({ stage: 7, name: 'sign', pages: ctx.generatedPages.length });
+}
+
+/**
+ * Stage 8: Validate generated entries against frontmatter schema (#2052).
+ * @param {object} ctx pipeline context
+ */
+function stage8Validate(ctx) {
+  const errors = [];
+  for (const page of ctx.generatedPages) {
+    const result = validateContent(matter.stringify(page.body, page.fm), { verifySignature: false });
+    if (!result.valid) errors.push({ slug: page.slug, errors: result.errors });
+  }
+  ctx.validationErrors = errors;
+  ctx.log.push({ stage: 8, name: 'validate-frontmatter', errors: errors.length });
+  if (errors.length > 0) {
+    throw new Error(
+      `Stage 8: frontmatter validation failed for: ${errors.map((e) => e.slug).join(', ')}`
+    );
+  }
+}
+
+/**
+ * Stage 9: Write pages to wiki paths (dry-run unless writeEnabled).
+ * @param {object} ctx pipeline context
+ */
+function stage9Write(ctx) {
+  ctx.writtenPaths = [];
+  for (const page of ctx.generatedPages) {
+    const dir = WIKI_TYPE_DIR[page.wikiType] || 'wiki/wisdom/project';
+    const filePath = `${dir}/${page.slug}.md`;
+    const content = matter.stringify(page.body, page.fm);
+    if (ctx.writeEnabled && ctx.fs) {
+      ctx.fs.mkdirSync(path.join(ctx.repoRoot || '.', dir), { recursive: true });
+      ctx.fs.writeFileSync(path.join(ctx.repoRoot || '.', filePath), content);
+    }
+    ctx.writtenPaths.push({ filePath, content });
+  }
+  ctx.log.push({ stage: 9, name: 'write-pages', paths: ctx.writtenPaths.map((p) => p.filePath) });
+}
+
+/**
+ * Stage 10: Record commit plan (dry-run; no git commands executed).
+ * @param {object} ctx pipeline context
+ */
+function stage10Commit(ctx) {
+  const branch = `wiki-auto-update/pr-${ctx.prNumber}`;
+  ctx.commitPlan = {
+    branch,
+    message: `chore(wiki): auto-update from PR #${ctx.prNumber} #2055`,
+    files: ctx.writtenPaths.map((p) => p.filePath),
+    prTitle: `chore(wiki): auto-update from PR #${ctx.prNumber}`,
+    executed: false,
+  };
+  ctx.log.push({ stage: 10, name: 'commit-plan', branch, files: ctx.commitPlan.files.length });
+}
+
+/**
+ * Stage 11: Build auto-update summary string for PR comment.
+ * @param {object} ctx pipeline context
+ */
+function stage11Summary(ctx) {
+  const wb = ctx.writtenPaths.length > 0
+    ? `**Written paths:**\n${ctx.writtenPaths.map((p) => `- \`${p.filePath}\``).join('\n')}`
+    : '_No pages written (dry-run or no changes classified)._';
+  const counts = `- Code deltas: ${ctx.codeDeltas.length}\n- Work-log entries: ${ctx.workLogEntries.length}\n`
+    + `- Wisdom entries: ${ctx.wisdomEntries.length}\n- Pages generated: ${ctx.generatedPages.length}\n`
+    + `- Validation errors: ${ctx.validationErrors.length}`;
+  ctx.summary = `## Wiki Auto-Update Summary\n\nPR #${ctx.prNumber} triggered wiki auto-update pipeline (Refs #2055).\n\n${counts}\n\n${wb}`;
+  ctx.log.push({ stage: 11, name: 'summary', length: ctx.summary.length });
+}
+
+module.exports = { stage7Sign, stage8Validate, stage9Write, stage10Commit, stage11Summary };

--- a/tests/fixtures/auto-update/diff-code-change.txt
+++ b/tests/fixtures/auto-update/diff-code-change.txt
@@ -1,0 +1,3 @@
+scripts/wiki/auto-update-pipeline.js
+scripts/global/agent-signature.js
+dashboard/js/panel-anim.js

--- a/tests/fixtures/auto-update/diff-wisdom-project.txt
+++ b/tests/fixtures/auto-update/diff-wisdom-project.txt
@@ -1,0 +1,2 @@
+instructions/wiki-knowledge.instructions.md
+docs/howto/contribute-to-wiki.md

--- a/tests/fixtures/auto-update/diff-work-log.txt
+++ b/tests/fixtures/auto-update/diff-work-log.txt
@@ -1,0 +1,2 @@
+.github/workflows/wiki-auto-update.yml
+.github/workflows/baton-gates.yml

--- a/tests/wiki-auto-update-pipeline.spec.js
+++ b/tests/wiki-auto-update-pipeline.spec.js
@@ -1,0 +1,281 @@
+// tests/wiki-auto-update-pipeline.spec.js — 11-stage pipeline + invisible-char tests
+// test_strategy: tdd-pyramid  Refs #2055
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const {
+  runPipeline,
+  classifyDiff,
+  scanInvisibleChars,
+  generateFrontmatter,
+} = require('../scripts/wiki/auto-update-pipeline');
+
+const FIXTURES = path.join(__dirname, 'fixtures/auto-update');
+
+// ---------------------------------------------------------------------------
+// classifyDiff routing
+// ---------------------------------------------------------------------------
+
+test('classifyDiff routes .js files to code', () => {
+  const r = classifyDiff(['scripts/wiki/foo.js', 'dashboard/js/bar.js']);
+  expect(r.code).toContain('scripts/wiki/foo.js');
+  expect(r.code).toContain('dashboard/js/bar.js');
+  expect(r.workLog).toHaveLength(0);
+  expect(r.wisdom).toHaveLength(0);
+});
+
+test('classifyDiff routes .yml workflow files to workLog', () => {
+  const r = classifyDiff(['.github/workflows/baton-gates.yml']);
+  expect(r.workLog).toContain('.github/workflows/baton-gates.yml');
+  expect(r.code).toHaveLength(0);
+});
+
+test('classifyDiff routes .md files to wisdom', () => {
+  const r = classifyDiff(['docs/howto/some-guide.md', 'wiki/concepts/foo.md']);
+  expect(r.wisdom).toContain('docs/howto/some-guide.md');
+  expect(r.wisdom).toContain('wiki/concepts/foo.md');
+  expect(r.code).toHaveLength(0);
+});
+
+test('classifyDiff handles mixed change list', () => {
+  const r = classifyDiff([
+    'scripts/global/foo.js',
+    '.github/workflows/ci.yml',
+    'instructions/bar.md',
+  ]);
+  expect(r.code).toContain('scripts/global/foo.js');
+  expect(r.workLog).toContain('.github/workflows/ci.yml');
+  expect(r.wisdom).toContain('instructions/bar.md');
+});
+
+test('classifyDiff ignores unknown extensions', () => {
+  const r = classifyDiff(['some/binary.bin', 'image.png']);
+  expect(r.code).toHaveLength(0);
+  expect(r.workLog).toHaveLength(0);
+  expect(r.wisdom).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// scanInvisibleChars
+// ---------------------------------------------------------------------------
+
+test('scanInvisibleChars returns NONE for clean text', () => {
+  const r = scanInvisibleChars('Hello, world! Normal text.');
+  expect(r.maxSeverity).toBe('NONE');
+  expect(r.findings).toHaveLength(0);
+});
+
+test('scanInvisibleChars detects zero-width space as HIGH', () => {
+  const r = scanInvisibleChars('Hello​world');
+  expect(r.maxSeverity).toBe('HIGH');
+  expect(r.findings.some((f) => f.severity === 'HIGH')).toBe(true);
+});
+
+test('scanInvisibleChars detects BOM mid-file as HIGH', () => {
+  const r = scanInvisibleChars('text﻿more');
+  expect(r.maxSeverity).toBe('HIGH');
+});
+
+test('scanInvisibleChars detects LOW-severity zero-width-misc', () => {
+  const r = scanInvisibleChars('foo‌bar');
+  expect(r.maxSeverity).toBe('LOW');
+  expect(r.findings.some((f) => f.severity === 'LOW')).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// generateFrontmatter
+// ---------------------------------------------------------------------------
+
+test('generateFrontmatter produces schema-required fields', () => {
+  const fm = generateFrontmatter({ title: 'test-page', type: 'code', prNumber: 99, date: '2026-05-27' });
+  expect(fm.title).toBe('test-page');
+  expect(fm.type).toBe('code');
+  expect(fm.content_trust_score).toBeGreaterThanOrEqual(0);
+  expect(fm.content_trust_score).toBeLessThanOrEqual(1);
+  expect(fm.created).toBe('2026-05-27');
+  expect(fm.updated).toBe('2026-05-27');
+  expect(fm.tags).toContain('pr-99');
+});
+
+// ---------------------------------------------------------------------------
+// Full 11-stage pipeline — happy path
+// ---------------------------------------------------------------------------
+
+test('pipeline executes all 11 stages in order', () => {
+  const ctx = runPipeline({
+    changedFiles: ['scripts/wiki/foo.js', '.github/workflows/ci.yml', 'docs/guide.md'],
+    prNumber: 123,
+    date: '2026-05-27',
+  });
+  const stageNums = ctx.log.map((e) => e.stage);
+  expect(stageNums).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+});
+
+test('pipeline returns correct page counts per wiki type', () => {
+  const ctx = runPipeline({
+    changedFiles: ['scripts/wiki/foo.js', '.github/workflows/ci.yml', 'docs/guide.md'],
+    prNumber: 10,
+    date: '2026-05-27',
+  });
+  expect(ctx.codeDeltas.length).toBe(1);
+  expect(ctx.workLogEntries.length).toBe(1);
+  expect(ctx.wisdomEntries.length).toBe(1);
+  expect(ctx.generatedPages.length).toBe(3);
+});
+
+test('pipeline produces valid summary string', () => {
+  const ctx = runPipeline({
+    changedFiles: ['scripts/foo.js'],
+    prNumber: 42,
+    date: '2026-05-27',
+  });
+  expect(ctx.summary).toContain('Wiki Auto-Update Summary');
+  expect(ctx.summary).toContain('PR #42');
+  expect(ctx.summary).toContain('Code deltas: 1');
+});
+
+test('pipeline produces commit plan in stage 10', () => {
+  const ctx = runPipeline({
+    changedFiles: ['scripts/foo.js'],
+    prNumber: 42,
+    date: '2026-05-27',
+  });
+  expect(ctx.commitPlan).not.toBeNull();
+  expect(ctx.commitPlan.branch).toBe('wiki-auto-update/pr-42');
+  expect(ctx.commitPlan.message).toContain('#2055');
+});
+
+// ---------------------------------------------------------------------------
+// Stage 2 — invisible-char rejection aborts pipeline
+// ---------------------------------------------------------------------------
+
+test('pipeline aborts at stage 2 on HIGH-severity invisible char', () => {
+  expect(() =>
+    runPipeline({
+      changedFiles: ['scripts/foo.js'],
+      fileContents: ['normal text', 'bad​invisible'],
+      prNumber: 1,
+    })
+  ).toThrow(/Stage 2 abort/);
+});
+
+test('pipeline stage 2 abort logs up to stage 2 only', () => {
+  let ctx;
+  try {
+    runPipeline({
+      changedFiles: ['scripts/foo.js'],
+      fileContents: ['has​zwsp'],
+      prNumber: 1,
+    });
+  } catch (_) {
+    ctx = null;
+  }
+  // When it throws we cannot inspect ctx, but verify the throw message
+  expect(() =>
+    runPipeline({ changedFiles: [], fileContents: ['x​y'], prNumber: 1 })
+  ).toThrow('Stage 2 abort');
+});
+
+test('pipeline LOW-severity invisible chars do NOT abort', () => {
+  const ctx = runPipeline({
+    changedFiles: ['scripts/foo.js'],
+    fileContents: ['foo‌bar'],  // zero-width non-joiner = LOW
+    prNumber: 2,
+    date: '2026-05-27',
+  });
+  expect(ctx.invisibleScan.maxSeverity).toBe('LOW');
+  expect(ctx.log[ctx.log.length - 1].stage).toBe(11);
+});
+
+// ---------------------------------------------------------------------------
+// Stage 8 — frontmatter schema validation
+// ---------------------------------------------------------------------------
+
+test('generated frontmatter passes #2052 schema validation', () => {
+  const ctx = runPipeline({
+    changedFiles: ['scripts/wiki/foo.js', 'docs/guide.md', '.github/workflows/ci.yml'],
+    prNumber: 99,
+    date: '2026-05-27',
+  });
+  expect(ctx.validationErrors).toHaveLength(0);
+  expect(ctx.log.find((e) => e.stage === 8).errors).toBe(0);
+});
+
+// ---------------------------------------------------------------------------
+// Stage 9 — write paths in dry-run (no disk writes)
+// ---------------------------------------------------------------------------
+
+test('dry-run pipeline records writtenPaths without disk writes', () => {
+  const ctx = runPipeline({
+    changedFiles: ['scripts/bar.js'],
+    prNumber: 7,
+    date: '2026-05-27',
+    writeEnabled: false,
+  });
+  expect(ctx.writtenPaths.length).toBe(1);
+  expect(ctx.writtenPaths[0].filePath).toMatch(/^wiki\/code\//);
+});
+
+test('writeEnabled pipeline writes to disk via fs override', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wiki-pipeline-'));
+  const mockFs = {
+    mkdirSync: (p, opts) => fs.mkdirSync(p, opts),
+    writeFileSync: (p, c) => fs.writeFileSync(p, c),
+  };
+  const ctx = runPipeline({
+    changedFiles: ['scripts/bar.js'],
+    prNumber: 8,
+    date: '2026-05-27',
+    writeEnabled: true,
+    repoRoot: tmpDir,
+    fs: mockFs,
+  });
+  expect(ctx.writtenPaths.length).toBe(1);
+  const written = path.join(tmpDir, ctx.writtenPaths[0].filePath);
+  expect(fs.existsSync(written)).toBe(true);
+  const content = fs.readFileSync(written, 'utf-8');
+  expect(content).toContain('content_trust_score');
+});
+
+// ---------------------------------------------------------------------------
+// Fixture-based diff routing tests
+// ---------------------------------------------------------------------------
+
+test('fixture: code-change diff classifies to code only', () => {
+  const raw = fs.readFileSync(path.join(FIXTURES, 'diff-code-change.txt'), 'utf-8');
+  const files = raw.split('\n').filter(Boolean);
+  const r = classifyDiff(files);
+  expect(r.code.length).toBeGreaterThan(0);
+  expect(r.workLog).toHaveLength(0);
+  expect(r.wisdom).toHaveLength(0);
+});
+
+test('fixture: work-log diff classifies to workLog only', () => {
+  const raw = fs.readFileSync(path.join(FIXTURES, 'diff-work-log.txt'), 'utf-8');
+  const files = raw.split('\n').filter(Boolean);
+  const r = classifyDiff(files);
+  expect(r.workLog.length).toBeGreaterThan(0);
+  expect(r.code).toHaveLength(0);
+  expect(r.wisdom).toHaveLength(0);
+});
+
+test('fixture: wisdom diff classifies to wisdom only', () => {
+  const raw = fs.readFileSync(path.join(FIXTURES, 'diff-wisdom-project.txt'), 'utf-8');
+  const files = raw.split('\n').filter(Boolean);
+  const r = classifyDiff(files);
+  expect(r.wisdom.length).toBeGreaterThan(0);
+  expect(r.code).toHaveLength(0);
+  expect(r.workLog).toHaveLength(0);
+});
+
+test('pipeline runs clean with code-change fixture', () => {
+  const raw = fs.readFileSync(path.join(FIXTURES, 'diff-code-change.txt'), 'utf-8');
+  const files = raw.split('\n').filter(Boolean);
+  const ctx = runPipeline({ changedFiles: files, prNumber: 200, date: '2026-05-27' });
+  const stageNums = ctx.log.map((e) => e.stage);
+  expect(stageNums).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+  expect(ctx.validationErrors).toHaveLength(0);
+});


### PR DESCRIPTION
Refs #2055

## Summary

- Split monolithic auto-update-pipeline.js (289 lines) into four ≤100-line modules: pipeline-classify.js (67), pipeline-stages-a.js (88), pipeline-stages-b.js (98), auto-update-pipeline.js thin orchestrator (79)
- Deleted superseded pipeline-stages.js (139 lines; was duplicate of the a+b split)
- Added wiki-auto-update.yml CI workflow, 24 tdd-pyramid tests, and three diff-routing fixtures

## Baton artifacts

COLLABORATOR_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2055#issuecomment-4560531960
ADMIN_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2055#issuecomment-4560541272
CONSULTANT_CLOSEOUT: https://github.com/chf3198/megingjord-harness/issues/2055#issuecomment-4560542606

## Test plan

- [x] `npx playwright test tests/wiki-auto-update-pipeline.spec.js` — 24/24 pass
- [x] `npm run lint` — 391 files, all ≤100 lines
- [x] `npm run lint:readability:ci` — 475/475 warnings (at budget)
- [x] `npm run docs:compile` — README updated

merge-evidence-deferred-final: #2055