### PR TITLE
feat(wiki): MCP /project-state handler #2056

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ npm run deploy:both:apply
 | `mailbox:flush` | `node scripts/global/mailbox-outbox.js flush` |
 | `mailbox:poll` | `node scripts/global/mailbox-client.js poll` |
 | `mailbox:send` | `node scripts/global/mailbox-client.js send` |
+| `mcp:project-state` | `node scripts/global/mcp-project-state.js` |
 | `merge-evidence:snapshot` | `node scripts/global/merge-evidence-snapshot.js` |
 | `prepare` | `bash scripts/install-git-hooks.sh` |
 | `quality:parity` | `node scripts/global/quality-parity-report.js --json` |

--- a/package.json
+++ b/package.json
@@ -246,6 +246,7 @@
     "wiki:lint": "node scripts/wiki/lint.js",
     "wiki:reindex": "node scripts/wiki/reindex.js",
     "wiki:search": "node scripts/wiki/search.js",
+    "mcp:project-state": "node scripts/global/mcp-project-state.js",
     "worktree:bootstrap": "bash scripts/worktree-bootstrap-node-modules.sh",
     "worktree:start": "bash scripts/worktree-session-start.sh",
     "governance:rule-parity": "node scripts/global/governance-rule-parity.js",

--- a/scripts/global/mcp-project-state.js
+++ b/scripts/global/mcp-project-state.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+'use strict';
+// mcp-project-state.js — MCP /project-state handler (#2056)
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { sign } = require('./baton-signing.js');
+const AUDIT = path.join(os.homedir(), '.megingjord', 'mcp-project-state-audit.jsonl');
+const SUBTREES = {
+  code: ['code'], 'work-log': ['work-log'],
+  wisdom: [path.join('wisdom', 'global'), path.join('wisdom', 'project')],
+  all: ['code', 'work-log', path.join('wisdom', 'global'), path.join('wisdom', 'project')],
+};
+function resolveWikiRoot() {
+  return [process.env.WIKI_DIR, path.join(os.homedir(), '.copilot', 'wiki'),
+    path.join(__dirname, '..', '..', 'wiki')].find((d) => d && fs.existsSync(d)) || null;
+}
+function collectMd(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const full = path.join(dir, e.name);
+    return e.isDirectory() ? collectMd(full) : (e.name.endsWith('.md') ? [full] : []);
+  });
+}
+function scoreFile(fp, filter) {
+  if (!filter) return 1;
+  try {
+    const text = fs.readFileSync(fp, 'utf8').toLowerCase();
+    return filter.toLowerCase().split(/\s+/).filter((w) => w && text.includes(w)).length;
+  } catch { return 0; }
+}
+function decodeToken(tok) {
+  if (!tok) return 0;
+  try { return parseInt(Buffer.from(tok, 'base64').toString(), 10) || 0; } catch { return 0; }
+}
+function encodeToken(n) { return Buffer.from(String(n)).toString('base64'); }
+function appendAudit(entry) {
+  try {
+    const dir = path.dirname(AUDIT);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.appendFileSync(AUDIT, JSON.stringify(entry) + '\n', 'utf8');
+  } catch { /* best-effort */ }
+}
+function parseParams(params) {
+  const par = params || {};
+  return {
+    query_type: par.query_type || 'all',
+    filter: par.filter || '',
+    page_token: par.page_token || null,
+    safeSize: Math.min(Math.max(1, Number(par.page_size) || 10), 50),
+    signer: par.signer || 'Clio Harper',
+    mutation: par.mutation || null,
+  };
+}
+
+function paginate(allFiles, page_token, safeSize, wikiRoot) {
+  const offset = decodeToken(page_token);
+  const slice = allFiles.slice(offset, offset + safeSize);
+  const next = offset + safeSize;
+  const next_page_token = next < allFiles.length ? encodeToken(next) : null;
+  const items = slice.map((e) => ({
+    path: e.path.replace(wikiRoot + path.sep, ''), score: e.score,
+  }));
+  return { items, next_page_token };
+}
+
+async function handle(params, options) {
+  const cfg = parseParams(params);
+  const wikiRoot = (options || {}).wikiRoot || resolveWikiRoot();
+  const ts = new Date().toISOString();
+  const audit_id = `pstate-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  if (!wikiRoot || !require('node:fs').existsSync(wikiRoot)) {
+    appendAudit({ ts, audit_id, query_type: cfg.query_type, filter: cfg.filter,
+      error: 'wiki_root_not_found', signer: cfg.signer });
+    return { ok: false, error: 'wiki_root_not_found', audit_id };
+  }
+  const allFiles = (SUBTREES[cfg.query_type] || SUBTREES.all)
+    .flatMap((s) => collectMd(path.join(wikiRoot, s))
+      .map((fp) => ({ path: fp, score: scoreFile(fp, cfg.filter) })))
+    .filter((f) => !cfg.filter || f.score > 0)
+    .sort((a, b) => b.score - a.score);
+  const { items, next_page_token } = paginate(allFiles, cfg.page_token, cfg.safeSize, wikiRoot);
+  let sig_block = null;
+  if (cfg.mutation) {
+    const raw = await sign(JSON.stringify({ mutation: cfg.mutation, ts, signer: cfg.signer }));
+    sig_block = { signature: raw.signature, key_id: raw.key_id,
+      timestamp: raw.timestamp, tier: raw.tier, public_key: raw.publicKey };
+  }
+  appendAudit({ ts, audit_id, query_type: cfg.query_type, filter: cfg.filter || null,
+    page_token: cfg.page_token, page_size: cfg.safeSize, total_candidates: allFiles.length,
+    returned: items.length, signer: cfg.signer, mutation: cfg.mutation || null,
+    signed: !!sig_block });
+  return { ok: true, items, total_candidates: allFiles.length,
+    page_size: cfg.safeSize, next_page_token, audit_id, sig_block };
+}
+module.exports = { handle, resolveWikiRoot, decodeToken, encodeToken, SUBTREES };
+if (require.main === module) {
+  const cliArgs = process.argv[2] ? JSON.parse(process.argv[2]) : {};
+  handle(cliArgs).then((r) => process.stdout.write(JSON.stringify(r, null, 2) + '\n'));
+}

--- a/tests/mcp-project-state.spec.js
+++ b/tests/mcp-project-state.spec.js
@@ -1,0 +1,96 @@
+'use strict';
+// mcp-project-state.spec.js — tdd-pyramid+contract-test (#2056)
+const { test, expect } = require('@playwright/test');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+const mod = require('../scripts/global/mcp-project-state.js');
+
+function buildWiki(base) {
+  [path.join(base,'code','symbols'), path.join(base,'work-log','tickets'),
+   path.join(base,'wisdom','global','concepts'), path.join(base,'wisdom','project','research')]
+    .forEach((d) => fs.mkdirSync(d, { recursive: true }));
+  fs.writeFileSync(path.join(base,'code','symbols','handler.md'), '# handler\nMCP code');
+  fs.writeFileSync(path.join(base,'work-log','tickets','t1.md'), '# ticket\nbaton workflow');
+  fs.writeFileSync(path.join(base,'wisdom','global','concepts','signing.md'), '# signing\ned25519');
+  fs.writeFileSync(path.join(base,'wisdom','project','research','r1.md'), '# research\npagination');
+  return base;
+}
+
+let tmpWiki;
+test.beforeAll(() => { tmpWiki = buildWiki(fs.mkdtempSync(path.join(os.tmpdir(), 'wiki2056-'))); });
+test.afterAll(() => { fs.rmSync(tmpWiki, { recursive: true, force: true }); });
+
+const W = () => ({ wikiRoot: tmpWiki });
+
+test('1: ok:true with items for all query_type', async () => {
+  const r = await mod.handle({ query_type: 'all' }, W());
+  expect(r.ok).toBe(true);
+  expect(Array.isArray(r.items)).toBe(true);
+  expect(r.audit_id).toMatch(/^pstate-/);
+});
+
+test('2: ok:false when wiki root not found', async () => {
+  const r = await mod.handle({}, { wikiRoot: '/no/such/wiki' });
+  expect(r.ok).toBe(false);
+  expect(r.error).toBe('wiki_root_not_found');
+});
+
+test('3: query_type=code returns only code-subtree items', async () => {
+  const r = await mod.handle({ query_type: 'code' }, W());
+  expect(r.ok).toBe(true);
+  expect(r.items.every((i) => i.path.startsWith('code'))).toBe(true);
+});
+
+test('4: filter returns scored items matching keyword', async () => {
+  const r = await mod.handle({ filter: 'signing' }, W());
+  expect(r.ok).toBe(true);
+  expect(r.items.length).toBeGreaterThanOrEqual(1);
+  expect(r.items[0].score).toBeGreaterThan(0);
+});
+
+test('5: page_size=1 yields one item and a next_page_token', async () => {
+  const r = await mod.handle({ page_size: 1 }, W());
+  expect(r.items.length).toBe(1);
+  expect(r.next_page_token).not.toBeNull();
+});
+
+test('6: second page via next_page_token returns different item', async () => {
+  const first = await mod.handle({ page_size: 1 }, W());
+  const second = await mod.handle({ page_size: 1, page_token: first.next_page_token }, W());
+  expect(second.items[0].path).not.toBe(first.items[0].path);
+});
+
+test('7: requesting all items yields null next_page_token', async () => {
+  const r = await mod.handle({ page_size: 50 }, W());
+  expect(r.next_page_token).toBeNull();
+});
+
+test('8: audit_id is unique across concurrent calls', async () => {
+  const [a, b] = await Promise.all([mod.handle({}, W()), mod.handle({}, W())]);
+  expect(a.audit_id).not.toBe(b.audit_id);
+});
+
+test('9: sig_block is null when no mutation provided', async () => {
+  const r = await mod.handle({}, W());
+  expect(r.sig_block).toBeNull();
+});
+
+test('10: sig_block has all Ed25519 fields when mutation provided', async () => {
+  const r = await mod.handle({ mutation: { action: 'update', target: 'code/x.md' } }, W());
+  expect(r.ok).toBe(true);
+  expect(r.sig_block).not.toBeNull();
+  expect(typeof r.sig_block.signature).toBe('string');
+  expect(r.sig_block.signature.length).toBeGreaterThan(80);
+  expect(['T3-env', 'T4']).toContain(r.sig_block.tier);
+});
+
+test('11: decodeToken/encodeToken roundtrip', () => {
+  expect(mod.decodeToken(mod.encodeToken(42))).toBe(42);
+  expect(mod.decodeToken(null)).toBe(0);
+});
+
+test('12: SUBTREES export contains required keys', () => {
+  expect(Object.keys(mod.SUBTREES)).toEqual(
+    expect.arrayContaining(['code', 'work-log', 'wisdom', 'all']));
+});


### PR DESCRIPTION
## Summary
- MCP capability handler for /project-state queries
- Pagination, audit_trail emission, Ed25519 mutations per #2052

Refs #2056
merge-evidence-deferred-final: #2056

Refs Epic #1942

## Test strategy
- Strategy: tdd-pyramid
- Evidence: tests/mcp-project-state.spec.js (12/12 pass)