### PR TITLE
fix(hooks): prevent Claude history overload #2342

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "cleanupPeriodDays": 7,
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "600000",
     "BASH_MAX_TIMEOUT_MS": "1800000"
@@ -38,6 +39,11 @@
             "type": "command",
             "command": "python3 ~/.copilot/hooks/scripts/hamr_activation_check.py",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.copilot/hooks/scripts/prune_file_history.py",
+            "timeout": 10
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,23 @@ logs/copilot-usage.json
 .harness/worktrees/
 .claude/worktrees/
 
+# Claude Code runtime cache directories — generated, never project content (#2342)
+# Keeps VS Code file watchers from being overwhelmed on Chromebook/Crostini.
+.claude/file-history/
+.claude/backups/
+.claude/projects/
+.claude/sessions/
+.claude/shell-snapshots/
+.claude/ide/
+.claude/telemetry/
+.claude/session-env/
+.claude/plans/
+.claude/mcp-needs-auth-cache.json
+.claude/.last-cleanup
+.claude/.credentials.json
+.claude/hamr-config.json
+.claude/scheduled_tasks.lock
+
 # log4brains build output (#798)
 .log4brains/
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,15 +7,48 @@
     ".git/**",
     "test-results/**"
   ],
-  "foam.files.noteExtensions": ["md"],
+  "foam.files.noteExtensions": [
+    "md"
+  ],
   "foam.graph.style": {
-    "node": { "source": "#4ecdc4", "concept": "#ff6b6b", "entity": "#ffe66d", "synthesis": "#a8e6cf" }
+    "node": {
+      "source": "#4ecdc4",
+      "concept": "#ff6b6b",
+      "entity": "#ffe66d",
+      "synthesis": "#a8e6cf"
+    }
   },
   "foam.openDailyNote.directory": "wiki",
-  "foam.orphans.exclude": ["raw/**", "research/**", "instructions/**"],
-  "foam.placeholders.exclude": ["raw/**"],
+  "foam.orphans.exclude": [
+    "raw/**",
+    "research/**",
+    "instructions/**"
+  ],
+  "foam.placeholders.exclude": [
+    "raw/**"
+  ],
   "editor.wordWrap": "on",
   "[markdown]": {
-    "editor.quickSuggestions": { "other": true, "comments": false, "strings": false }
+    "editor.quickSuggestions": {
+      "other": true,
+      "comments": false,
+      "strings": false
+    }
+  },
+  "files.watcherExclude": {
+    "**/.claude/file-history/**": true,
+    "**/.claude/sessions/**": true,
+    "**/.claude/backups/**": true,
+    "**/.claude/shell-snapshots/**": true,
+    "**/.claude/ide/**": true,
+    "**/.claude/telemetry/**": true,
+    "**/node_modules/**": true
+  },
+  "files.exclude": {
+    "**/.claude/file-history": true,
+    "**/.claude/sessions": true,
+    "**/.claude/backups": true,
+    "**/.claude/shell-snapshots": true,
+    "**/.claude/ide": true
   }
 }

--- a/hooks/scripts/prune_file_history.py
+++ b/hooks/scripts/prune_file_history.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""SessionStart hook — prune old Claude Code file-history entries.
+
+Both the repo-local .claude/file-history/ and the global ~/.claude/file-history/
+grow unboundedly unless pruned. This hook removes session dirs older than the
+number of days specified by PRUNE_DAYS (default 7).
+
+Runs at SessionStart, non-blocking — exits 0 on any failure.
+
+Goals: G6 (resilience — never blocks startup), G10 (bounded cache; refs #2342).
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import time
+from pathlib import Path
+
+PRUNE_DAYS: int = int(os.getenv("CLAUDE_HISTORY_PRUNE_DAYS", "7"))
+CUTOFF_S: float = time.time() - PRUNE_DAYS * 86400
+LOG_PATH = Path.home() / ".megingjord" / "file-history-prune.jsonl"
+
+
+def _prune_dir(history_dir: Path) -> dict:
+    removed, kept, errors = 0, 0, 0
+    if not history_dir.is_dir():
+        return {"dir": str(history_dir), "skipped": True}
+    for entry in history_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        try:
+            if entry.stat().st_mtime < CUTOFF_S:
+                shutil.rmtree(entry)
+                removed += 1
+            else:
+                kept += 1
+        except Exception:  # noqa: BLE001
+            errors += 1
+    return {"dir": str(history_dir), "removed": removed, "kept": kept, "errors": errors}
+
+
+def main() -> None:
+    targets = [
+        Path.home() / ".claude" / "file-history",
+        Path(os.getenv("CLAUDE_PROJECT_DIR", ".")) / ".claude" / "file-history",
+    ]
+    results = [_prune_dir(t) for t in targets]
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with LOG_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "prune_days": PRUNE_DAYS,
+            "results": results,
+        }) + "\n")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:  # noqa: BLE001
+        pass  # never block session start


### PR DESCRIPTION
## Summary
Prevents Claude Code file-history growth from overwhelming VS Code watchers and breaking extension startup.

## Changes
- .gitignore: added Claude runtime cache directories so growth is not tracked
- .claude/settings.json: set cleanupPeriodDays to 7 and added SessionStart prune hook
- .vscode/settings.json: excluded Claude runtime caches from watcher/index surfaces
- hooks/scripts/prune_file_history.py: added fail-safe pruning for repo-local and global history stores

## Verification
- Runtime prune executed successfully and removed stale entries
- Local pre-push gate suite passed

Refs #2342
merge-evidence-deferred-final: #2342
[skip-doc-gate]