### PR TITLE
docs(governance): rollout ownership semantics #2350

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ citizens.
 See [`docs/howto/installation.md`](docs/howto/installation.md) for the full
 install walkthrough, including adding a second project.
 
+## Ownership Semantics Rollout
+
+Execution role labels represent the active baton holder only.
+Waiting and terminal states must not carry execution role labels.
+
+See [docs/howto/baton-workflow.md](docs/howto/baton-workflow.md) for board filters,
+no-code remediation lane constraints, and the operator rollout checklist.
+
 ## Quick start
 
 ```bash

--- a/docs/howto/baton-workflow.md
+++ b/docs/howto/baton-workflow.md
@@ -6,8 +6,10 @@ Refs #639 #335
 ## Overview
 
 Every change in Megingjord goes through a single-threaded baton sequence. One role is
-active at a time per ticket. The GitHub issue IS the baton — whoever holds the active
-`role:*` label owns the current step.
+active at a time per ticket. The GitHub issue IS the baton.
+
+Execution `role:*` labels indicate the active baton holder on active states only.
+Terminal and waiting states carry no execution role label.
 
 ```
 Manager → Collaborator → Admin → Consultant → done + closed
@@ -166,21 +168,23 @@ gh issue close N
 
 ## Reduced Lanes
 
-### docs/research lane (Manager → Consultant only)
+### docs/research lane (Manager → Collaborator → Admin → Consultant)
 
-For PRs that only change `.md` files, instructions, or research docs:
+Docs/research changes still follow the four-role baton unless the ticket is explicitly
+classified as no-code remediation.
 
-Post these N/A markers on the issue before creating the PR:
+### no-code remediation lane (Manager → Consultant)
+
+Use this only for issue/thread metadata repair with zero repository file changes.
+
+Required issue markers:
 
 ```
-COLLABORATOR_HANDOFF: N/A — docs/research lane
-ADMIN_HANDOFF: N/A — docs/research lane
+COLLABORATOR_HANDOFF: N/A — no-code remediation lane
+ADMIN_HANDOFF: N/A — no-code remediation lane
 ```
 
-The CI `baton-gates.yml` reads the issue comments for these strings. N/A markers satisfy
-the gate while still enforcing the ≥60 s timing check against their timestamps.
-
-### config-only lane (Admin → Consultant only)
+### config-only lane (Manager → Admin → Consultant)
 
 For trivial single-value config changes with no design decision:
 
@@ -206,6 +210,36 @@ COLLABORATOR_HANDOFF: N/A — config-only lane
 - `status:backlog` or `status:done` with any `role:*` label — **except Epics**, which carry `role:manager` throughout their lifecycle (label-lint Rule E2; per Epic #1074)
 - `status:dormant` or `status:deferred` on non-Epic tickets (Rule E5)
 - Skipping a role without posting an explicit N/A marker
+
+## Board Filter Guidance
+
+Use this board filter for active baton work:
+
+```
+status:triage,status:ready,status:in-progress,status:testing,status:review
+```
+
+Use this filter for queue/terminal ownership hygiene:
+
+```
+status:queued,status:backlog,status:done,status:cancelled
+```
+
+## Rollout Announcement + Operator Checklist
+
+Announcement text:
+
+```
+Ownership semantics rollout: execution role labels now represent only active baton
+holders. Waiting and terminal states do not carry execution role labels. Historical
+ownership is reporting metadata, not a ticket role label.
+```
+
+Operator checklist:
+- Verify no closed ticket carries any execution `role:*` label
+- Verify waiting states (`backlog`, `queued`, `ready`) carry no execution role labels
+- Verify active states carry the matching execution role label
+- Verify board filters separate active baton work from queue/terminal hygiene
 
 ## Quick Reference
 

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -6,8 +6,9 @@ applyTo: "**"
 
 # Role Baton Routing (v2.0)
 
-The GitHub issue **is** the baton. One active role at a time. Every state carries exactly one
-`role:*` label — no exceptions, including closed tickets.
+The GitHub issue **is** the baton. One active role at a time.
+Execution `role:*` labels are present only on active, role-owned states.
+Terminal states do not carry execution roles.
 
 Authoritative board: **Megingjord Harness Board** (GitHub Projects).
 Baton view filter: `status:triage,ready,in-progress,testing,review` (backlog/done/cancelled/dormant/deferred hidden from active baton view).
@@ -159,14 +160,17 @@ Examples:
 
 Operator runbook: `docs/howto/no-code-remediation-workflow.md`.
 
-## Archival
+## Closed-ticket ownership model
 
-Closed tickets retain `role:manager`. A nightly Action swaps `role:manager` → `role:archived`
-on issues closed >30 days. Archived tickets are excluded from all dashboard and baton queries.
+Closed tickets do not carry execution `role:*` labels.
+Accountability ownership is historical metadata, not an execution-role label.
+Dashboard/audit views may resolve historical ownership to manager for reporting,
+but this must not re-add a `role:*` label to terminal issues.
 
 ## Hard Rules
 
-- `role:*` is never null — exactly one present at all times.
+- Execution `role:*` labels are required for active role-owned states only (`triage`, `in-progress`, `testing`, `review`, and Epic-only `dormant`/`deferred`).
+- Terminal and waiting states (`backlog`, `queued`, `ready`, `done`, `cancelled`) carry no execution `role:*` label, except Epic role exceptions documented in this file.
 - No concurrent role execution on a single ticket.
 - Emit the named handoff artifact before transitioning to the next role.
 - `ADMIN_HANDOFF` signer identity must differ from `COLLABORATOR_HANDOFF`.


### PR DESCRIPTION
## Summary
Aligns ownership-semantics documentation so execution role labels only apply to active baton states.

## What Changed
- instructions/role-baton-routing.instructions.md
  - Removed closed-ticket role-label contradiction
  - Clarified active-state-only execution role rules
- docs/howto/baton-workflow.md
  - Corrected reduced-lane guidance
  - Added board filter guidance
  - Added rollout announcement + operator checklist
- README.md
  - Added ownership rollout overview and link to runbook

## Verification
- npm run -s lint
- npm run -s docs:lint
- node scripts/global/closeout-preflight.js
- cross-team conflict gate warning-only result (no blocking overlaps)

Refs #2350
merge-evidence-deferred-final: #2350