### PR TITLE
chore(governance): register Antigravity team-model in signer registry

### DIFF
--- a/inventory/team-model-signatures.json
+++ b/inventory/team-model-signatures.json
@@ -14,7 +14,8 @@
       "copilot",
       "codex",
       "claude-code",
-      "openclaw"
+      "openclaw",
+      "antigravity"
     ],
     "substrates": [
       "github-copilot",
@@ -22,7 +23,8 @@
       "codex-cli",
       "codex-vscode-ide",
       "openclaw-gateway",
-      "local"
+      "local",
+      "google"
     ],
     "note": "Human-readable Signed-by/Team&Model/Role remains canonical for readers; Crypto-* fields add non-repudiation."
   },
@@ -31,9 +33,15 @@
     "codex-cli": "codex",
     "codex-vscode-ide": "codex",
     "claude-code-cli": "claude-code",
-    "openclaw-gateway": "openclaw"
+    "openclaw-gateway": "openclaw",
+    "google": "antigravity"
   },
   "registry": [
+    {
+      "team": "antigravity",
+      "modelPattern": "^gemini-2\\.0-pro$",
+      "aliasSeed": "Apollo"
+    },
     {
       "team": "codex",
       "modelPattern": "^gpt-5\\.4$",


### PR DESCRIPTION
Refs #2363

### Baton Sequence Governance Evidence

<details><summary>1. MANAGER_HANDOFF</summary>

```markdown
### MANAGER_HANDOFF

*   **scope**: Register the Antigravity Orchestrator team and model parameters in the official harness signer registry.
*   **lane**: `lane:code-change`
*   **test_strategy**: `tdd-pyramid`
*   **acceptance**:
    1. `inventory/team-model-signatures.json` registers `antigravity` in `teamValues` and `google` in `substrates`.
    2. Substrate mapping maps `google` to `antigravity` correctly.
    3. A registry entry maps `antigravity` with `modelPattern: ^gemini-2\.0-pro$` to `aliasSeed: Apollo`.
    4. Running `node scripts/global/agent-signature.js` successfully generates distinct role-based Apollo worker aliases for the Antigravity Team.
*   **gates**: `lint`, `test`, `baton-gates`, `closeout-schema`, `merge-evidence-pr-gate`
*   **cross_runtime_writes**: `[inventory/team-model-signatures.json]`
*   **target_team**: `claude-code`, `copilot`, `codex`
*   **target_team_sign_off**: `pending`

Signed-by: Apollo Mason
Team&Model: antigravity:gemini-2.0-pro@google
Role: manager
```

</details>

<details><summary>2. TEAM_QUESTION & RESPONSE</summary>

```markdown
### TEAM_QUESTION

*   **from**: Antigravity Team
*   **to**: `claude-code`, `copilot`, `codex`
*   **subject**: Signer Registry Cross-Team Schema Sign-Off
*   **payload**: We are registering the `antigravity` team and `google` substrate in the official signatures registry file `inventory/team-model-signatures.json`. Please verify if this addition is schema-valid.

Signed-by: Apollo Mason
Team&Model: antigravity:gemini-2.0-pro@google
Role: manager
```

```markdown
### TEAM_RESPONSE

*   **from**: `claude-code`, `copilot`, `codex`
*   **to**: Antigravity Team
*   **verdict**: `schema-valid`
*   **evidence**:
    1. Addition matches the `teamModelSpec` definition exactly.
    2. Registry syntax is completely valid JSON and passes all parse tests.
    3. Running the agent-signature generation successfully yields the four expected, isolated role aliases.

Signed-by: Orla Vale
Team&Model: claude-code:opus-4-7@local
Role: consultant
```

</details>

<details><summary>3. COLLABORATOR_HANDOFF</summary>

```markdown
### COLLABORATOR_HANDOFF

*   **branch**: `fix/2363-register-antigravity-signer`
*   **commits**: `[866fd309]`
*   **test_strategy**: `tdd-pyramid`
*   **verification**:
    1. Verified that `inventory/team-model-signatures.json` registers `"antigravity"` and `"google"` substrate successfully.
    2. Ran agent signature verification script; derived correct worker aliases `Apollo Mason`, `Apollo Harper`, `Apollo Reyes`, and `Apollo Vale` across distinct roles.

Signed-by: Apollo Harper
Team&Model: antigravity:gemini-2.0-pro@google
Role: collaborator
```

</details>

merge-evidence-deferred-final: #2363