### PR TITLE
feat(routing): add antigravity to runtimeKinds adapter policy #2368

### DIFF
--- a/.changes/unreleased/2368.md
+++ b/.changes/unreleased/2368.md
@@ -1,0 +1,3 @@
+### Added
+
+- `antigravity` added to `runtimeKinds` array in `scripts/global/routing-provider-adapters.json` (alongside `codex`, `copilot`, `claude-code`), enabling provider-routing decisions to classify Antigravity sessions by runtime kind. Additive-only; no impact on existing runtime configurations. Part of the Antigravity 100%-parity sequence on Epic #2362. (#2368)

--- a/scripts/global/routing-provider-adapters.json
+++ b/scripts/global/routing-provider-adapters.json
@@ -1,35 +1,58 @@
 {
   "version": "1.0.0",
   "description": "Provider adapters for provider-neutral lane capability tiers.",
-  "runtimeKinds": ["codex", "copilot", "claude-code"],
+  "runtimeKinds": [
+    "antigravity",
+    "claude-code",
+    "codex",
+    "copilot"
+  ],
   "lanes": {
     "free": {
       "capabilityTier": "free-auto",
       "defaultAdapter": "openai-compatible:mini",
       "defaultProvider": "openai-compatible",
       "defaultModelId": "gpt-5-mini",
-      "adapters": ["openai-compatible:mini", "openrouter:free", "litellm:free"]
+      "adapters": [
+        "openai-compatible:mini",
+        "openrouter:free",
+        "litellm:free"
+      ]
     },
     "fleet": {
       "capabilityTier": "fleet-coding-local",
       "defaultAdapter": "ollama:qwen-coder",
       "defaultProvider": "ollama",
       "defaultModelId": "qwen2.5:7b-instruct",
-      "adapters": ["ollama:qwen-coder", "fleet:heavy-coding", "fleet:coding"]
+      "adapters": [
+        "ollama:qwen-coder",
+        "fleet:heavy-coding",
+        "fleet:coding"
+      ]
     },
     "haiku": {
       "capabilityTier": "balanced-cloud",
       "defaultAdapter": "anthropic:haiku",
       "defaultProvider": "anthropic",
       "defaultModelId": "claude-haiku-4-5-20251001",
-      "adapters": ["anthropic:haiku", "openai-compatible:small", "openrouter:small", "litellm:small"]
+      "adapters": [
+        "anthropic:haiku",
+        "openai-compatible:small",
+        "openrouter:small",
+        "litellm:small"
+      ]
     },
     "premium": {
       "capabilityTier": "frontier-reasoning",
       "defaultAdapter": "anthropic:sonnet",
       "defaultProvider": "anthropic",
       "defaultModelId": "claude-sonnet-4-6",
-      "adapters": ["anthropic:sonnet", "openai-compatible:frontier", "openrouter:frontier", "litellm:frontier"]
+      "adapters": [
+        "anthropic:sonnet",
+        "openai-compatible:frontier",
+        "openrouter:frontier",
+        "litellm:frontier"
+      ]
     }
   }
 }

--- a/tests/routing-provider-adapters-runtime-kinds.spec.js
+++ b/tests/routing-provider-adapters-runtime-kinds.spec.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ADAPTERS = JSON.parse(fs.readFileSync(
+  path.join(__dirname, '..', 'scripts', 'global', 'routing-provider-adapters.json'),
+  'utf8'));
+
+test('runtimeKinds contains all four supported runtimes (claude-code, codex, copilot, antigravity)', () => {
+  const expected = ['antigravity', 'claude-code', 'codex', 'copilot'];
+  for (const kind of expected) {
+    assert.ok(ADAPTERS.runtimeKinds.includes(kind),
+      `runtimeKinds must include "${kind}" — found: ${JSON.stringify(ADAPTERS.runtimeKinds)}`);
+  }
+});
+
+test('runtimeKinds is sorted alphabetically (canonical form)', () => {
+  const sorted = [...ADAPTERS.runtimeKinds].sort();
+  assert.deepStrictEqual(ADAPTERS.runtimeKinds, sorted,
+    'runtimeKinds should be sorted alphabetically for deterministic diffs');
+});
+
+test('Antigravity runtime kind is canonical lowercase string (matches signer registry)', () => {
+  assert.ok(ADAPTERS.runtimeKinds.includes('antigravity'),
+    'antigravity must be lowercase to match inventory/team-model-signatures.json team-string');
+});


### PR DESCRIPTION
Refs #2368

## Summary

Adds `antigravity` to the `runtimeKinds` array in `scripts/global/routing-provider-adapters.json`, alphabetically sorted alongside the existing `[codex, copilot, claude-code]`. Provider-routing decisions can now classify Antigravity sessions by runtime kind at the adapter-policy layer.

Part of the Antigravity 100%-parity sequence under Epic #2362 (Manager-pickup-commitment posted on Epic #2362 today). Closes the round-4 §3 routing-policy gap noted on #2360 comment 4571630656.

merge-evidence-deferred-final: #2368

## Test plan
- [x] node --test tests/routing-provider-adapters-runtime-kinds.spec.js (3 of 3 pass — presence, sort, lowercase)
- [x] All lefthook pre-push stages green (lint-js, lint-md, lint-line-cap, lint-readability, lint-sh, lint-py, megalint, closeout-preflight, branch-name-regex, git-freshness)
- [x] Cross-family fleet adversarial review (qwen2.5-coder:7b on 36gbwinresource) verdict approve_for_merge with mean 86.1; all 7 adversarial questions resolved cleanly

## Baton artifacts (posted on #2368)

MANAGER_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2368#issuecomment-4577016222
COLLABORATOR_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2368#issuecomment-4577039845
ADMIN_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2368#issuecomment-4577040120
CONSULTANT_CLOSEOUT: https://github.com/chf3198/megingjord-harness/issues/2368#issuecomment-4577040388

Cross-team conflict scan:
- git worktree list shows only the #2368 worktree under this operator
- gh pr list --search "2368" returns no other open PRs touching this surface
- routing-provider-adapters.json is single-source-of-truth for adapter policy; no other team has it open
