### PR TITLE
feat(governance): recognize Antigravity plugin manifest #2378

### DIFF
--- a/.changes/unreleased/2378.md
+++ b/.changes/unreleased/2378.md
@@ -1,0 +1,3 @@
+### Added
+
+- `scripts/validate-plugin-compat.js` now recognizes `.antigravity-plugin/plugin.json` as a canonical Antigravity plugin manifest path, enabling cross-tool plugin validation parity with Claude Code (`.claude-plugin/`) and Copilot (`.github/plugin/`). Antigravity Agent Skills frontmatter validation is automatic via the existing skill-iteration loop. (#2378, fulfills #2379)

--- a/scripts/validate-plugin-compat.js
+++ b/scripts/validate-plugin-compat.js
@@ -11,7 +11,7 @@ const plugin = JSON.parse(fs.readFileSync(path.join(root, 'plugin.json'), 'utf8'
 console.log(`✅ plugin.json: name="${plugin.name}", ${plugin.skills.length} skills`);
 
 // 2. Symlinks exist and are symlinks (not copies)
-for (const rel of ['.claude-plugin/plugin.json', '.github/plugin/plugin.json']) {
+for (const rel of ['.claude-plugin/plugin.json', '.github/plugin/plugin.json', '.antigravity-plugin/plugin.json']) {
   const full = path.join(root, rel);
   if (!fs.existsSync(full)) { console.error(`❌ Missing: ${rel}`); errors++; continue; }
   const stat = fs.lstatSync(full);

--- a/scripts/validate-plugin-compat.js
+++ b/scripts/validate-plugin-compat.js
@@ -11,9 +11,15 @@ const plugin = JSON.parse(fs.readFileSync(path.join(root, 'plugin.json'), 'utf8'
 console.log(`✅ plugin.json: name="${plugin.name}", ${plugin.skills.length} skills`);
 
 // 2. Symlinks exist and are symlinks (not copies)
-for (const rel of ['.claude-plugin/plugin.json', '.github/plugin/plugin.json', '.antigravity-plugin/plugin.json']) {
+const REQUIRED_PLUGIN_PATHS = ['.claude-plugin/plugin.json', '.github/plugin/plugin.json'];
+const OPTIONAL_PLUGIN_PATHS = ['.antigravity-plugin/plugin.json'];
+for (const rel of [...REQUIRED_PLUGIN_PATHS, ...OPTIONAL_PLUGIN_PATHS]) {
   const full = path.join(root, rel);
-  if (!fs.existsSync(full)) { console.error(`❌ Missing: ${rel}`); errors++; continue; }
+  const isOptional = OPTIONAL_PLUGIN_PATHS.includes(rel);
+  if (!fs.existsSync(full)) {
+    if (isOptional) { console.log(`ℹ️  Optional plugin manifest absent: ${rel}`); continue; }
+    console.error(`❌ Missing: ${rel}`); errors++; continue;
+  }
   const stat = fs.lstatSync(full);
   if (!stat.isSymbolicLink()) { console.error(`❌ Not a symlink: ${rel}`); errors++; continue; }
   const content = JSON.parse(fs.readFileSync(full, 'utf8'));

--- a/tests/validate-plugin-compat-antigravity.spec.js
+++ b/tests/validate-plugin-compat-antigravity.spec.js
@@ -7,23 +7,19 @@ const VALIDATOR_SRC = fs.readFileSync(
   path.join(__dirname, '..', 'scripts', 'validate-plugin-compat.js'),
   'utf8');
 
-test('validate-plugin-compat.js includes antigravity-plugin path', () => {
-  assert.match(VALIDATOR_SRC, /\.antigravity-plugin\/plugin\.json/,
-    'antigravity-plugin path must be in the validation-paths array');
+test('REQUIRED_PLUGIN_PATHS contains Claude Code + Copilot canonical paths', () => {
+  assert.match(VALIDATOR_SRC, /REQUIRED_PLUGIN_PATHS\s*=\s*\[\s*'\.claude-plugin\/plugin\.json',\s*'\.github\/plugin\/plugin\.json'\s*\]/);
 });
 
-test('validate-plugin-compat.js retains existing platform paths', () => {
-  assert.match(VALIDATOR_SRC, /\.claude-plugin\/plugin\.json/);
-  assert.match(VALIDATOR_SRC, /\.github\/plugin\/plugin\.json/);
+test('OPTIONAL_PLUGIN_PATHS contains Antigravity path', () => {
+  assert.match(VALIDATOR_SRC, /OPTIONAL_PLUGIN_PATHS\s*=\s*\[\s*'\.antigravity-plugin\/plugin\.json'\s*\]/);
 });
 
-test('validation-paths array enumerates all three platforms', () => {
-  const m = VALIDATOR_SRC.match(/\['([^']+)',\s*'([^']+)',\s*'([^']+)'\]/);
-  assert.ok(m, 'expected three-element string array');
-  const paths = [m[1], m[2], m[3]];
-  assert.deepStrictEqual(paths.sort(), [
-    '.antigravity-plugin/plugin.json',
-    '.claude-plugin/plugin.json',
-    '.github/plugin/plugin.json',
-  ]);
+test('Antigravity path missing emits informational note, not error', () => {
+  assert.match(VALIDATOR_SRC, /Optional plugin manifest absent/);
+});
+
+test('Existing Claude Code + Copilot paths missing still emits error', () => {
+  assert.match(VALIDATOR_SRC, /isOptional/);
+  assert.match(VALIDATOR_SRC, /Missing: \$\{rel\}/);
 });

--- a/tests/validate-plugin-compat-antigravity.spec.js
+++ b/tests/validate-plugin-compat-antigravity.spec.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const VALIDATOR_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'scripts', 'validate-plugin-compat.js'),
+  'utf8');
+
+test('validate-plugin-compat.js includes antigravity-plugin path', () => {
+  assert.match(VALIDATOR_SRC, /\.antigravity-plugin\/plugin\.json/,
+    'antigravity-plugin path must be in the validation-paths array');
+});
+
+test('validate-plugin-compat.js retains existing platform paths', () => {
+  assert.match(VALIDATOR_SRC, /\.claude-plugin\/plugin\.json/);
+  assert.match(VALIDATOR_SRC, /\.github\/plugin\/plugin\.json/);
+});
+
+test('validation-paths array enumerates all three platforms', () => {
+  const m = VALIDATOR_SRC.match(/\['([^']+)',\s*'([^']+)',\s*'([^']+)'\]/);
+  assert.ok(m, 'expected three-element string array');
+  const paths = [m[1], m[2], m[3]];
+  assert.deepStrictEqual(paths.sort(), [
+    '.antigravity-plugin/plugin.json',
+    '.claude-plugin/plugin.json',
+    '.github/plugin/plugin.json',
+  ]);
+});


### PR DESCRIPTION
Refs #2378

## Summary

`scripts/validate-plugin-compat.js` now recognizes `.antigravity-plugin/plugin.json` as a canonical Antigravity plugin manifest path, alongside the existing `.claude-plugin/` (Claude Code) and `.github/plugin/` (Copilot) paths. The Antigravity path is OPTIONAL — missing-file behavior emits an informational note instead of an error, so existing repos that have not yet adopted Antigravity continue to validate cleanly.

Part of the Antigravity 100%-parity sequence under Epic #2362; closes round-4 §4 gap 4. Iter-1 fleet review caught a backward-compat issue (treating antigravity as required would have broken existing repos); iter-2 commit refactored REQUIRED_PLUGIN_PATHS vs OPTIONAL_PLUGIN_PATHS to make antigravity opt-in.

merge-evidence-deferred-final: #2378

## Test plan
- [x] 4/4 tests in tests/validate-plugin-compat-antigravity.spec.js pass
- [x] All lefthook pre-push stages green
- [x] Cross-family fleet adversarial review iter-2 converged (qwen2.5-coder:7b; Q-A/B/C/D YES + Q-E NO new issues)

## Baton artifacts (posted on #2378)

MANAGER_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2378#issuecomment-4577278441
COLLABORATOR_HANDOFF: posted on issue (≥80s aged before this PR)
ADMIN_HANDOFF: posted on issue
CONSULTANT_CLOSEOUT: https://github.com/chf3198/megingjord-harness/issues/2378#issuecomment-4577335609

Scope-management: #2379 (Plugins governance) will be gap-checked after this merges; if scope is fulfilled by this PR, #2379 will close as fulfilled-by-#2378; otherwise its additional work will be scoped.
