### PR TITLE
feat(dashboard): add antigravity vendor classification #2367

### DIFF
--- a/.changes/unreleased/2367.md
+++ b/.changes/unreleased/2367.md
@@ -1,0 +1,3 @@
+### Added
+
+- Dashboard now classifies Antigravity-runtime sessions with a distinct icon (🌌) and CSS class (`.agent-antigravity` with Google green border #34a853) in the multi-agent sessions panel. Previously Antigravity sessions fell through to the 'unknown' default. (#2367)

--- a/dashboard/css/multi-agent.css
+++ b/dashboard/css/multi-agent.css
@@ -41,6 +41,7 @@
 .agent-copilot { border-color: #58a6ff; }
 .agent-claude  { border-color: #f97316; }
 .agent-codex   { border-color: #8b5cf6; }
+.agent-antigravity { border-color: #34a853; }
 .agent-cursor  { border-color: #10b981; }
 .agent-cline   { border-color: #d29922; }
 .agent-unknown { border-color: var(--border); }

--- a/dashboard/js/multi-agent-sessions.js
+++ b/dashboard/js/multi-agent-sessions.js
@@ -2,11 +2,11 @@
 // Epic #742 | ≤100 lines
 
 const VENDOR_ICONS = {
-  copilot: '🤖', claude: '🟠', codex: '🟦', cursor: '🎯', cline: '🔧', unknown: '❓'
+  copilot: '🤖', claude: '🟠', codex: '🟦', antigravity: '🌌', cursor: '🎯', cline: '🔧', unknown: '❓'
 };
 const VENDOR_COLORS = {
   copilot: 'agent-copilot', claude: 'agent-claude', codex: 'agent-codex',
-  cursor: 'agent-cursor', cline: 'agent-cline', unknown: 'agent-unknown'
+  antigravity: 'agent-antigravity', cursor: 'agent-cursor', cline: 'agent-cline', unknown: 'agent-unknown'
 };
 const AGENT_HEARTBEAT_KEY = 'agent_heartbeats';
 const MAX_VISIBLE = 3;

--- a/tests/dashboard-multi-agent-antigravity.spec.js
+++ b/tests/dashboard-multi-agent-antigravity.spec.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const JS_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'dashboard', 'js', 'multi-agent-sessions.js'),
+  'utf8');
+const CSS_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'dashboard', 'css', 'multi-agent.css'),
+  'utf8');
+
+test('VENDOR_ICONS includes antigravity', () => {
+  assert.match(JS_SRC, /antigravity:\s*'🌌'/);
+});
+
+test('VENDOR_COLORS maps antigravity to agent-antigravity class', () => {
+  assert.match(JS_SRC, /antigravity:\s*'agent-antigravity'/);
+});
+
+test('multi-agent.css defines .agent-antigravity border-color rule', () => {
+  assert.match(CSS_SRC, /\.agent-antigravity\s*\{\s*border-color:\s*#34a853\s*;\s*\}/);
+});
+
+test('existing vendor entries retained (parity check)', () => {
+  for (const vendor of ['copilot', 'claude', 'codex', 'cursor', 'cline', 'unknown']) {
+    assert.match(JS_SRC, new RegExp(`${vendor}:\\s*['"]`));
+  }
+});


### PR DESCRIPTION
Refs #2367

## Summary

`dashboard/js/multi-agent-sessions.js` and `dashboard/css/multi-agent.css` now classify Antigravity-runtime sessions with a distinct icon (🌌) and CSS class (`.agent-antigravity` with Google green #34a853). Previously Antigravity sessions fell through to the 'unknown' default.

Part of the Antigravity 100%-parity sequence under Epic #2362; closes round-4 §3 dashboard-observability gap. JS at 98 lines, CSS at 88 lines (both below 100 cap).

merge-evidence-deferred-final: #2367

## Test plan
- [x] 4/4 tests in tests/dashboard-multi-agent-antigravity.spec.js pass
- [x] All lefthook pre-push stages green
- [x] Cross-family fleet adversarial review (qwen2.5-coder:7b) verdict approve_for_merge with mean 90.4

## Baton artifacts (posted on #2367)

MANAGER_HANDOFF: https://github.com/chf3198/megingjord-harness/issues/2367#issuecomment-4577378854
COLLABORATOR_HANDOFF: posted on issue (≥80s aged before this PR)
ADMIN_HANDOFF: posted on issue
CONSULTANT_CLOSEOUT: https://github.com/chf3198/megingjord-harness/issues/2367#issuecomment-4577410611
