### PR TITLE
docs: add control-plane positioning sentence to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Quality Gates](https://github.com/chf3198/megingjord-harness/actions/workflows/quality-gates.yml/badge.svg)](https://github.com/chf3198/megingjord-harness/actions/workflows/quality-gates.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/chf3198/megingjord-harness/badge)](https://scorecard.dev/viewer/?uri=github.com/chf3198/megingjord-harness)
 
-**Megingjord** is a governance-first AI agent harness with skills, hooks, agents, runtime scripts, and a Karpathy-style LLM wiki.
+**Megingjord** is a governance-first AI agent harness with skills, hooks, agents, runtime scripts, and a Karpathy-style LLM wiki. It operates as a control plane for AI coding agent runtimes — governing Copilot, Claude Code, and Codex the way Kubernetes governs containers: deploying configuration, enforcing policy, and maintaining desired workflow state across all three simultaneously.
 
 ## Architecture at a glance
 


### PR DESCRIPTION
Refs #2391

## Summary

Adds a single positioning sentence to README.md after the existing one-liner. No other files changed.

**Before:**
> Megingjord is a governance-first AI agent harness with skills, hooks, agents, runtime scripts, and a Karpathy-style LLM wiki.

**After:**
> Megingjord is a governance-first AI agent harness with skills, hooks, agents, runtime scripts, and a Karpathy-style LLM wiki. It operates as a control plane for AI coding agent runtimes — governing Copilot, Claude Code, and Codex the way Kubernetes governs containers: deploying configuration, enforcing policy, and maintaining desired workflow state across all three simultaneously.

## Evidence

- AC1: PASS — sentence present, describes multi-runtime control-plane role
- AC2: PASS — does not duplicate ARCHITECTURE.md (that doc covers internal layers, this covers external positioning)
- AC3: PASS — `npm run lint` exit 0, 287 files scanned, all within 100-line limit

Research basis: #2357 (categorization + competitive landscape analysis, 2026-05-29)