### PR TITLE
feat(governance): codify tier-graceful degradation pattern #2400

### DIFF
--- a/.changes/unreleased/2400.md
+++ b/.changes/unreleased/2400.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `instructions/harness-goals.instructions.md` gains a "Tier-graceful degradation" cross-cutting pattern paragraph between G5 and G6, codifying the optimal-with-fallback rule explicitly. G5 + G6 paragraphs cross-reference the new pattern. Engineering-practice rule: PRs that depend on tier-2-or-higher resources must ship a tier-1 fallback in the same PR. (#2400, surfaced via #1112 / #2397; references #2398 MINIMUM_TIER)

--- a/instructions/harness-goals.instructions.md
+++ b/instructions/harness-goals.instructions.md
@@ -48,13 +48,23 @@ resource when available AND MUST degrade gracefully to the lowest available
 tier when the higher resource is absent or unreachable.
 
 - "Available" is determined by environment (G5): the operator's asserted
-  MEGINGJORD_MINIMUM_TIER (Epic #2398) defines the highest tier the
-  implementation may assume.
+  minimum tier (env var MEGINGJORD_MINIMUM_TIER specified in the future
+  Epic-tracked tier-portability work, currently Epic #2398) defines the
+  highest tier the implementation may assume. Until that env var ships,
+  the rule is interpreted from the operator's documented baseline.
 - "Unreachable" is determined by runtime (G6): network outage, rate-limit,
   authentication failure, or any other transient condition.
 - The two are distinct: G5 absent means "this operator never has the resource";
   G6 unreachable means "the resource is normally present but currently down."
   Both lead to the same fallback path.
+
+Cross-runtime applicability: the pattern is runtime-agnostic. It applies
+uniformly to Claude Code, Codex, Copilot, and Antigravity runtimes (and any
+future entrants verified via the cross-orchestrator compatibility suite
+tests/orchestrator-compatibility.spec.js shipped in #2388). Runtime-specific
+tier assertions (e.g., a fleet-only feature for OpenClaw) carry their own
+MINIMUM_TIER and per-runtime fallback design but the optimal-with-fallback
+discipline holds identically.
 
 Reference implementation: scripts/global/mailbox-client.js MAY post to HAMR R2
 when MEGINGJORD_HAMR_DISABLED is unset and the worker is reachable, falling
@@ -65,7 +75,10 @@ IS the upgrade.
 Engineering practice: when introducing a feature that uses a tier-2-or-higher
 resource, the same PR must ship the tier-1 fallback. Single-tier dependencies
 on resources above the operator's asserted minimum are rejected at code review
-as G5 violations.
+as G5 violations. CI enforcement (a megalint validator that scans PR diffs for
+tier-2-or-higher dependencies without tier-1 fallback) is tracked as a follow-on
+under Epic #2398 AC3 (per-script tier audit + frontmatter tags); until that
+validator ships, the rule is reviewer-enforced.
 
 ## Decision Lens (lightweight, required)
 

--- a/instructions/harness-goals.instructions.md
+++ b/instructions/harness-goals.instructions.md
@@ -40,7 +40,6 @@ G10 Maintainability.
 - G10 Maintainability: files <=100 lines; cyclomatic complexity <=10 per function;
   no dead code at merge; changes documented via GOV-009 EDD before implementation.
 
-
 ## Tier-graceful degradation (cross-cutting pattern between G5 and G6)
 
 Every feature that can benefit from a higher-tier resource SHOULD use that

--- a/instructions/harness-goals.instructions.md
+++ b/instructions/harness-goals.instructions.md
@@ -28,12 +28,44 @@ G10 Maintainability.
   minimal-resource fallback. Operator-environment variance is a first-class
   portability dimension distinct from G6: G6 covers temporary outages of normally-
   available resources, G5 covers baseline-absent resources for a given operator.
+  See "Tier-graceful degradation" below for the optimal-with-fallback
+  pattern that bridges G5 and G6.
 - G6 Resilience: graceful degradation and fallback paths for partial outages.
+  See "Tier-graceful degradation" below for the cross-cutting pattern that
+  ties G5 baseline-absent and G6 transiently-unreachable into a single
+  fallback path.
 - G7 Throughput: acceptable speed after higher-priority goals are satisfied.
 - G8 Observability: decisions and outcomes are visible, auditable, and attributable.
 - G9 Interoperability: preserve compatibility across agent surfaces and runtimes.
 - G10 Maintainability: files <=100 lines; cyclomatic complexity <=10 per function;
   no dead code at merge; changes documented via GOV-009 EDD before implementation.
+
+
+## Tier-graceful degradation (cross-cutting pattern between G5 and G6)
+
+Every feature that can benefit from a higher-tier resource SHOULD use that
+resource when available AND MUST degrade gracefully to the lowest available
+tier when the higher resource is absent or unreachable.
+
+- "Available" is determined by environment (G5): the operator's asserted
+  MEGINGJORD_MINIMUM_TIER (Epic #2398) defines the highest tier the
+  implementation may assume.
+- "Unreachable" is determined by runtime (G6): network outage, rate-limit,
+  authentication failure, or any other transient condition.
+- The two are distinct: G5 absent means "this operator never has the resource";
+  G6 unreachable means "the resource is normally present but currently down."
+  Both lead to the same fallback path.
+
+Reference implementation: scripts/global/mailbox-client.js MAY post to HAMR R2
+when MEGINGJORD_HAMR_DISABLED is unset and the worker is reachable, falling
+back to .gnap/messages/<team>/<timestamp>.json committed to the issue branch
+when either condition fails. The fallback IS the default; the optimization
+IS the upgrade.
+
+Engineering practice: when introducing a feature that uses a tier-2-or-higher
+resource, the same PR must ship the tier-1 fallback. Single-tier dependencies
+on resources above the operator's asserted minimum are rejected at code review
+as G5 violations.
 
 ## Decision Lens (lightweight, required)
 

--- a/tests/harness-goals-tier-graceful.spec.js
+++ b/tests/harness-goals-tier-graceful.spec.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'instructions', 'harness-goals.instructions.md'),
+  'utf8');
+
+test('Tier-graceful degradation pattern paragraph is present', () => {
+  assert.match(SRC, /## Tier-graceful degradation \(cross-cutting pattern between G5 and G6\)/);
+});
+
+test('Pattern includes optimal-with-fallback statement', () => {
+  assert.match(SRC, /SHOULD use that[\s\S]+resource when available AND MUST degrade gracefully/);
+});
+
+test('Pattern references MEGINGJORD_MINIMUM_TIER (Epic #2398)', () => {
+  assert.match(SRC, /MEGINGJORD_MINIMUM_TIER/);
+  assert.match(SRC, /Epic #2398/);
+});
+
+test('G5 paragraph cross-references the new pattern', () => {
+  assert.match(SRC, /G5 covers baseline-absent resources for a given operator\.[\s\n]+See "Tier-graceful degradation"/);
+});
+
+test('G6 paragraph cross-references the new pattern', () => {
+  assert.match(SRC, /G6 Resilience: graceful degradation and fallback paths for partial outages\.[\s\n]+See "Tier-graceful degradation"/);
+});
+
+test('Engineering-practice rule for tier-2-or-higher PRs is present', () => {
+  assert.match(SRC, /tier-1 fallback[\s\S]+rejected at code review/);
+});


### PR DESCRIPTION
Refs #2400

## Summary

Codifies the **tier-graceful degradation pattern** in `instructions/harness-goals.instructions.md` as a cross-cutting section between G5 and G6. The rule of thumb "use optimal resource when available, fall back to baseline when not" was implicit in operator practice but NOT documented; surfaced today during #1112 Phase-0 R&D synthesis when the client identified the G5 violation in the original plan.

Per the new pattern:
- "Available" is G5 (asserted MINIMUM_TIER per future #2398 Epic; until that ships, interpreted from operator's documented baseline)
- "Unreachable" is G6 (transient outage)
- Both lead to the same fallback path
- Pattern is runtime-agnostic; applies uniformly to Claude Code / Codex / Copilot / Antigravity verified via #2388 cross-orchestrator compat suite
- PRs introducing tier-2-or-higher dependencies MUST ship the tier-1 fallback in the same PR

merge-evidence-deferred-final: #2400

## Test plan
- [x] 6/6 tests in tests/harness-goals-tier-graceful.spec.js pass
- [x] All lefthook pre-push stages green (lint-md, lint-js, megalint, closeout-preflight, etc.)
- [x] Cross-family fleet adversarial review iter-2 converged (qwen2.5-coder:7b; Q-A/B/C/D YES + Q-E NO new issues)

## Baton artifacts (posted on #2400)

MANAGER_HANDOFF: posted on issue
COLLABORATOR_HANDOFF: posted on issue
ADMIN_HANDOFF: posted on issue
CONSULTANT_CLOSEOUT: posted on issue
