### PR TITLE
feat(governance): synthesis-init scaffolding script #2403

### DIFF
--- a/.changes/unreleased/2403.md
+++ b/.changes/unreleased/2403.md
@@ -1,0 +1,3 @@
+### Added
+
+- `npm run synthesis:init -- --epic <N>` scaffolds `planning/synthesis-<rdN>/` per protocol-v3 §6 (artifacts/, positions/, decisions.md, pulse.json, status.md, stability.json). Admin team computed via round-robin per v3 §1; `--admin-team <code>` overrides. Phase-1 AC2 of Epic #1112. (#2403)

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ npm run deploy:both:apply
 | `sync:codex` | `bash scripts/sync.sh --target codex` |
 | `sync:codex:dry` | `bash scripts/sync.sh --dry-run --target codex` |
 | `sync:dry` | `bash scripts/sync.sh --dry-run` |
+| `synthesis:init` | `node scripts/global/synthesis-init.js` |
 | `test` | `npx playwright test` |
 | `test:compatibility` | `node --test tests/orchestrator-compatibility.spec.js` |
 | `test:headed` | `npx playwright test --headed` |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "megingjord-harness",
   "version": "3.3.8",
-  "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex \u2014 multi-runtime skills, hooks, agents, wiki, and install tooling",
+  "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex — multi-runtime skills, hooks, agents, wiki, and install tooling",
   "private": true,
   "scripts": {
     "adr:build": "log4brains build",
@@ -205,7 +205,7 @@
     "routing:refresh": "node scripts/global/routing-refresh.js --update-matrix",
     "routing:report": "node scripts/global/routing-baseline-report.js --days 7",
     "routing:telemetry": "node scripts/global/token-telemetry-report.js --json",
-    "setup": "npm install && echo '\u2705 megingjord ready \u2014 run: npm start'",
+    "setup": "npm install && echo '✅ megingjord ready — run: npm start'",
     "signing:bootstrap": "node scripts/global/crypto-signing-bootstrap.js",
     "start": "node scripts/dashboard-server.js",
     "state:offload": "node scripts/global/state-offload-client.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "megingjord-harness",
   "version": "3.3.8",
-  "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex — multi-runtime skills, hooks, agents, wiki, and install tooling",
+  "description": "Megingjord: Governance-first AI agent harness for Copilot, Claude Code, and Codex \u2014 multi-runtime skills, hooks, agents, wiki, and install tooling",
   "private": true,
   "scripts": {
     "adr:build": "log4brains build",
@@ -205,7 +205,7 @@
     "routing:refresh": "node scripts/global/routing-refresh.js --update-matrix",
     "routing:report": "node scripts/global/routing-baseline-report.js --days 7",
     "routing:telemetry": "node scripts/global/token-telemetry-report.js --json",
-    "setup": "npm install && echo '✅ megingjord ready — run: npm start'",
+    "setup": "npm install && echo '\u2705 megingjord ready \u2014 run: npm start'",
     "signing:bootstrap": "node scripts/global/crypto-signing-bootstrap.js",
     "start": "node scripts/dashboard-server.js",
     "state:offload": "node scripts/global/state-offload-client.js",
@@ -259,7 +259,8 @@
     "gov:parity": "node scripts/global/megalint/parity-validator.js",
     "routing:fallback-report": "node scripts/global/routing-fallback-report.js",
     "it-ops:usage-report": "node scripts/global/it-bypass-usage-report.js",
-    "test:compatibility": "node --test tests/orchestrator-compatibility.spec.js"
+    "test:compatibility": "node --test tests/orchestrator-compatibility.spec.js",
+    "synthesis:init": "node scripts/global/synthesis-init.js"
   },
   "keywords": [
     "devops",

--- a/scripts/global/synthesis-init.js
+++ b/scripts/global/synthesis-init.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// synthesis-init — scaffolds planning/synthesis-<rdN>/ tree per protocol v3 §6.
+// Refs Epic #1112 AC2 (#2403).
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+
+const TEAMS = ['cc', 'cp', 'cx', 'ag'];
+const ROLE_SURNAMES = { manager: 'Mason', collaborator: 'Harper', admin: 'Reyes', consultant: 'Vale' };
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 2) {
+    if (argv[i]?.startsWith('--')) args[argv[i].slice(2)] = argv[i + 1];
+  }
+  return args;
+}
+
+function adminTeam(rdN, adminOverride) {
+  if (adminOverride) return adminOverride;
+  return TEAMS[rdN % TEAMS.length];
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function writeJson(p, data) {
+  fs.writeFileSync(p, JSON.stringify(data, null, 2) + '\n');
+}
+
+function writeText(p, content) {
+  fs.writeFileSync(p, content);
+}
+
+function init(rdN, adminOverride, opts = {}) {
+  if (!rdN || !Number.isInteger(rdN)) {
+    throw new Error('--epic <N> is required and must be an integer');
+  }
+  const root = opts.root || process.cwd();
+  const synthDir = path.join(root, 'planning', `synthesis-${rdN}`);
+  if (fs.existsSync(synthDir) && !opts.force) {
+    return { synthDir, created: false, message: 'already exists; pass --force to overwrite' };
+  }
+  ensureDir(path.join(synthDir, 'artifacts'));
+  ensureDir(path.join(synthDir, 'positions'));
+  const admin = adminTeam(rdN, adminOverride);
+  const kickoff = opts.now || new Date().toISOString();
+  writeJson(path.join(synthDir, 'pulse.json'), {
+    rdN, admin, kickoff, version: 'protocol-v3',
+    teams: TEAMS, expected_artifacts: TEAMS.map(t => `${t}-rd.md`),
+  });
+  writeText(path.join(synthDir, 'decisions.md'), `# Decisions for synthesis-${rdN}\n\nAdmin: ${admin}\n\n<!-- D-IDs allocated by admin in submission order -->\n`);
+  writeText(path.join(synthDir, 'status.md'), `# Status — synthesis-${rdN}\n\nPhase: Pre-flight\nWave: 0\nKickoff: ${kickoff}\n`);
+  writeJson(path.join(synthDir, 'stability.json'), { wave_p_values: [], threshold: 0.05, consecutive_required: 3 });
+  for (const team of TEAMS) {
+    writeText(path.join(synthDir, 'positions', `${team}.md`), `# ${team.toUpperCase()} positions for synthesis-${rdN}\n\n<!-- append-only position log per v3 §6 -->\n`);
+  }
+  return { synthDir, created: true, admin };
+}
+
+if (require.main === module) {
+  const args = parseArgs(process.argv);
+  try {
+    const result = init(Number(args.epic), args['admin-team'], { force: args.force === 'true' });
+    console.log(JSON.stringify(result, null, 2));
+  } catch (e) {
+    console.error(e.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { init, adminTeam, TEAMS, ROLE_SURNAMES };

--- a/tests/synthesis-init.spec.js
+++ b/tests/synthesis-init.spec.js
@@ -1,0 +1,83 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { init, adminTeam, TEAMS } = require('../scripts/global/synthesis-init.js');
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'synthesis-init-'));
+}
+
+test('init creates planning/synthesis-<N>/ tree with all 6 v3 §6 paths', () => {
+  const root = mkTmp();
+  init(1234, null, { root, now: '2026-05-29T23:55:00Z' });
+  const synth = path.join(root, 'planning', 'synthesis-1234');
+  assert.ok(fs.statSync(path.join(synth, 'artifacts')).isDirectory());
+  assert.ok(fs.statSync(path.join(synth, 'positions')).isDirectory());
+  assert.ok(fs.existsSync(path.join(synth, 'pulse.json')));
+  assert.ok(fs.existsSync(path.join(synth, 'decisions.md')));
+  assert.ok(fs.existsSync(path.join(synth, 'status.md')));
+  assert.ok(fs.existsSync(path.join(synth, 'stability.json')));
+});
+
+test('init populates pulse.json with kickoff + admin + ticket + version', () => {
+  const root = mkTmp();
+  init(1234, null, { root, now: '2026-05-29T23:55:00Z' });
+  const pulse = JSON.parse(fs.readFileSync(path.join(root, 'planning', 'synthesis-1234', 'pulse.json'), 'utf8'));
+  assert.strictEqual(pulse.rdN, 1234);
+  assert.strictEqual(pulse.kickoff, '2026-05-29T23:55:00Z');
+  assert.strictEqual(pulse.version, 'protocol-v3');
+  assert.ok(TEAMS.includes(pulse.admin));
+  assert.deepStrictEqual(pulse.teams, ['cc', 'cp', 'cx', 'ag']);
+});
+
+test('admin rotation is deterministic per ticket-N mod team-count', () => {
+  assert.strictEqual(adminTeam(0), 'cc');
+  assert.strictEqual(adminTeam(1), 'cp');
+  assert.strictEqual(adminTeam(2), 'cx');
+  assert.strictEqual(adminTeam(3), 'ag');
+  assert.strictEqual(adminTeam(4), 'cc');
+  assert.strictEqual(adminTeam(1112), 'cc');
+  assert.strictEqual(adminTeam(2403), 'ag');
+});
+
+test('--admin-team override wins over rotation', () => {
+  assert.strictEqual(adminTeam(0, 'cx'), 'cx');
+  assert.strictEqual(adminTeam(1112, 'ag'), 'ag');
+});
+
+test('init is idempotent: re-init on existing dir does not overwrite without --force', () => {
+  const root = mkTmp();
+  init(99, null, { root });
+  // Mark a file so we can detect overwrite
+  const stamp = path.join(root, 'planning', 'synthesis-99', 'pulse.json');
+  fs.writeFileSync(stamp + '.marker', 'preserved');
+  const r2 = init(99, null, { root });
+  assert.strictEqual(r2.created, false);
+  assert.ok(fs.existsSync(stamp + '.marker'));
+});
+
+test('init throws on missing or non-integer --epic', () => {
+  const root = mkTmp();
+  assert.throws(() => init(null, null, { root }), /epic.*required.*integer/);
+  assert.throws(() => init('abc', null, { root }), /epic.*required.*integer/);
+});
+
+test('per-team position log files seeded for all 4 teams', () => {
+  const root = mkTmp();
+  init(1234, null, { root });
+  const posDir = path.join(root, 'planning', 'synthesis-1234', 'positions');
+  for (const t of TEAMS) {
+    assert.ok(fs.existsSync(path.join(posDir, `${t}.md`)));
+  }
+});
+
+test('stability.json has K-S threshold + consecutive_required per v3 §5', () => {
+  const root = mkTmp();
+  init(1234, null, { root });
+  const stab = JSON.parse(fs.readFileSync(path.join(root, 'planning', 'synthesis-1234', 'stability.json'), 'utf8'));
+  assert.strictEqual(stab.threshold, 0.05);
+  assert.strictEqual(stab.consecutive_required, 3);
+  assert.deepStrictEqual(stab.wave_p_values, []);
+});


### PR DESCRIPTION
Refs #2403

## Summary

Phase-1 AC2 of Epic #1112 — `scripts/global/synthesis-init.js` (73 lines) scaffolds the per-Epic synthesis tree per protocol v3 §6 (shipped #2402). `npm run synthesis:init -- --epic <N>` creates `planning/synthesis-<rdN>/` with artifacts/, positions/, decisions.md, pulse.json, status.md, stability.json. Admin team computed via round-robin per v3 §1 (#2394 conclusion); `--admin-team` overrides.

merge-evidence-deferred-final: #2403

## Test plan
- [x] 8/8 tests in tests/synthesis-init.spec.js pass (tree creation, pulse content, admin rotation determinism, --admin-team override, idempotency, error on missing --epic, per-team position log seeding, stability K-S config)
- [x] Tier-1 by design (pure Node + filesystem; no network I/O)
- [x] Lint readability + line-cap respected (73 lines)
