### PR TITLE
feat(governance): synthesis-prompts templated prompts #2404

### DIFF
--- a/.changes/unreleased/2404.md
+++ b/.changes/unreleased/2404.md
@@ -1,0 +1,3 @@
+### Added
+
+- `scripts/global/synthesis-prompts/` — three parametric templates (admin-init, team-prep, team-init) per protocol-v3 §3-§5. `scripts/global/synthesis-prompt-render.js` exports `renderPrompt(name, vars)`. Phase-1 AC3 of Epic #1112. (#2404)

--- a/scripts/global/synthesis-prompt-render.js
+++ b/scripts/global/synthesis-prompt-render.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// synthesis-prompt-render — render a template from scripts/global/synthesis-prompts/
+// with {{placeholder}} substitution. Refs #1112 AC3 (#2404).
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+
+const TEMPLATE_DIR = path.join(__dirname, 'synthesis-prompts');
+const PLACEHOLDER_RE = /\{\{(\w+)\}\}/g;
+
+function renderPrompt(name, vars) {
+  if (!name || typeof name !== 'string') {
+    throw new Error('renderPrompt: name required');
+  }
+  if (!vars || typeof vars !== 'object') {
+    throw new Error('renderPrompt: vars object required');
+  }
+  const templatePath = path.join(TEMPLATE_DIR, `${name}.md`);
+  if (!fs.existsSync(templatePath)) {
+    throw new Error(`renderPrompt: template not found: ${name}.md`);
+  }
+  const src = fs.readFileSync(templatePath, 'utf8');
+  const missing = [];
+  const rendered = src.replace(PLACEHOLDER_RE, (_, key) => {
+    if (!(key in vars)) { missing.push(key); return `{{${key}}}`; }
+    return String(vars[key]);
+  });
+  if (missing.length > 0) {
+    throw new Error(`renderPrompt: missing required vars: ${[...new Set(missing)].join(', ')}`);
+  }
+  return rendered;
+}
+
+if (require.main === module) {
+  const [, , name, ...rest] = process.argv;
+  const vars = {};
+  for (let i = 0; i < rest.length; i += 2) {
+    if (rest[i]?.startsWith('--')) vars[rest[i].slice(2)] = rest[i + 1];
+  }
+  try { process.stdout.write(renderPrompt(name, vars)); }
+  catch (e) { console.error(e.message); process.exit(1); }
+}
+
+module.exports = { renderPrompt, TEMPLATE_DIR };

--- a/scripts/global/synthesis-prompts/admin-init.md
+++ b/scripts/global/synthesis-prompts/admin-init.md
@@ -1,0 +1,17 @@
+# Synthesis kickoff — admin role
+
+You are the rotated admin for cross-team R&D synthesis on Epic #{{epic_n}}.
+Admin-team: {{admin_team}}
+Participating teams: {{team_list}}
+Wall-clock cap: {{wall_clock_cap}}h (per protocol v3 §5 K-S adaptive + 24h ceiling)
+
+Your duties per `instructions/cross-team-rd-synthesis.instructions.md` §8:
+
+1. Read all team Phase-R artifacts before posting WAVE_SUMMARY each wave
+2. Challenge weak evidence (blog-only citations on technical claims, missing 2025+ sources)
+3. Surface missed websearches (technical topic not covered by any team's citations)
+4. Run K-S stability test on decision distribution; report p-value in WAVE_SUMMARY
+5. Decide next wave focus based on outstanding rejects + weak evidence
+6. DO NOT vote on decisions (admin is facilitator); admin-team's vote comes through positions/{{admin_team}}.md
+
+First action: post the Phase-R kickoff prompt to each team's mailbox (per v3 §5 dispatcher).

--- a/scripts/global/synthesis-prompts/team-init.md
+++ b/scripts/global/synthesis-prompts/team-init.md
@@ -1,0 +1,22 @@
+# Synthesis Phase-R generation — {{team_code}} team
+
+Epic: #{{epic_n}}
+Your team-code: {{team_code}}
+Your alias: {{team_alias}}
+Phase: Phase-R independent first-pass
+
+Generate your Phase-R artifact at `planning/synthesis-{{epic_n}}/artifacts/{{team_code}}-rd.md` per protocol v3 §4:
+
+- Length: 200-400 lines
+- Mandatory: contamination declaration as first paragraph
+- Mandatory: ≥5 `websearch: <URL> (accessed <ISO-8601-UTC>) — <one-line gist>` citations
+- Mandatory: ≥10 `repo: path/file.ext#L<start>-L<end>` anchors
+- Optional but encouraged: A2A envelope wrapping (per v3 §4) for any inter-team coordination message
+
+Signal completion:
+RD-COMPLETE: {{team_code}} as {{team_alias}}, {{team_code}}:<model>@<substrate>, <line-count> lines, N=<websearch-count> websearch citations, N=<repo-evidence-count> repo anchors.
+
+Sign your artifact with:
+Signed-by: {{team_alias}}
+Team&Model: {{team_code}}:<model>@<substrate>
+Role: collaborator

--- a/scripts/global/synthesis-prompts/team-prep.md
+++ b/scripts/global/synthesis-prompts/team-prep.md
@@ -1,0 +1,17 @@
+# Synthesis Phase-R preparation — {{team_code}} team
+
+Epic: #{{epic_n}}
+Your team-code: {{team_code}}
+Your alias: {{team_alias}}
+Phase: Pre-flight + Phase-R independent first-pass
+
+Before Phase-R generation, per protocol v3 §3 + §4:
+
+1. Verify your substrate-derived identity matches your team-code per inventory/team-model-signatures.json substrateTeamMap
+2. Confirm your alias = expectedAliasFor({team: {{team_code}}, model: <your model>, role: collaborator})
+3. Read ONLY the issue text and this team-prep prompt. NO peer reads.
+4. Plan your websearch sources (≥5 with ISO-8601 access timestamps)
+5. Plan your repo evidence (≥10 file:line anchors grounding claims)
+6. Declare your contamination set (what have you read related to this topic before now)
+
+Signal ready: post `RD-PREP-COMPLETE: {{team_code}} as {{team_alias}}` to planning/synthesis-{{epic_n}}/positions/{{team_code}}.md

--- a/tests/synthesis-prompts.spec.js
+++ b/tests/synthesis-prompts.spec.js
@@ -1,0 +1,61 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { renderPrompt, TEMPLATE_DIR } = require('../scripts/global/synthesis-prompt-render.js');
+
+test('three canonical templates exist with .md extension', () => {
+  for (const name of ['admin-init', 'team-prep', 'team-init']) {
+    assert.ok(fs.existsSync(path.join(TEMPLATE_DIR, `${name}.md`)),
+      `template ${name}.md must exist`);
+  }
+});
+
+test('renderPrompt substitutes all placeholders in admin-init', () => {
+  const out = renderPrompt('admin-init', {
+    epic_n: '1112', admin_team: 'cc', team_list: 'cc, cp, cx, ag', wall_clock_cap: '24',
+  });
+  assert.ok(!out.match(/\{\{\w+\}\}/), 'no unsubstituted placeholders');
+  assert.match(out, /Epic #1112/);
+  assert.match(out, /Admin-team: cc/);
+  assert.match(out, /24h/);
+});
+
+test('renderPrompt substitutes all placeholders in team-prep', () => {
+  const out = renderPrompt('team-prep', {
+    epic_n: '1112', team_code: 'ag', team_alias: 'Apollo Harper',
+  });
+  assert.ok(!out.match(/\{\{\w+\}\}/));
+  assert.match(out, /team-code: ag/);
+  assert.match(out, /Apollo Harper/);
+});
+
+test('renderPrompt substitutes all placeholders in team-init', () => {
+  const out = renderPrompt('team-init', {
+    epic_n: '1112', team_code: 'cc', team_alias: 'Orla Harper',
+  });
+  assert.ok(!out.match(/\{\{\w+\}\}/));
+  assert.match(out, /planning\/synthesis-1112\/artifacts\/cc-rd\.md/);
+});
+
+test('renderPrompt throws on missing vars', () => {
+  assert.throws(() => renderPrompt('admin-init', { epic_n: '1112' }),
+    /missing required vars/);
+});
+
+test('renderPrompt throws on unknown template', () => {
+  assert.throws(() => renderPrompt('does-not-exist', { epic_n: '1112' }),
+    /template not found/);
+});
+
+test('renderPrompt throws on invalid args', () => {
+  assert.throws(() => renderPrompt(null, {}), /name required/);
+  assert.throws(() => renderPrompt('admin-init', null), /vars object required/);
+});
+
+test('all templates are ≤100 lines per repo line-cap', () => {
+  for (const name of ['admin-init', 'team-prep', 'team-init']) {
+    const lines = fs.readFileSync(path.join(TEMPLATE_DIR, `${name}.md`), 'utf8').split('\n').length;
+    assert.ok(lines <= 100, `${name}.md has ${lines} lines (cap 100)`);
+  }
+});


### PR DESCRIPTION
Refs #2404

## Summary

Phase-1 AC3 of Epic #1112 — `scripts/global/synthesis-prompts/` ships 3 parametric templates (admin-init, team-prep, team-init) covering protocol-v3 §3-§5 prompt structure. `scripts/global/synthesis-prompt-render.js` (44 lines) provides `renderPrompt(name, vars)` helper + CLI mode.

Placeholders: `{{epic_n}}`, `{{admin_team}}`, `{{team_list}}`, `{{wall_clock_cap}}`, `{{team_code}}`, `{{team_alias}}`.

merge-evidence-deferred-final: #2404

## Test plan
- [x] 8/8 tests pass (template existence, per-template substitution, missing-vars throws, unknown-template throws, invalid-args throws, ≤100-lines)
- [x] Tier-1 by design
