### PR TITLE
feat(governance): broker-synthesis-status read-only wrapper #2406

### DIFF
--- a/.changes/unreleased/2406.md
+++ b/.changes/unreleased/2406.md
@@ -1,0 +1,3 @@
+### Added
+
+- `npm run synthesis:status -- --epic <N>` emits live-state JSON for an active synthesis run (admin team, kickoff, phase, wave, elapsed/remaining hours vs the 24h cap from #2396, latest K-S p-value vs the threshold from v3 §5). Phase-1 AC7 of Epic #1112. (#2406)

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ npm run deploy:both:apply
 | `sync:codex:dry` | `bash scripts/sync.sh --dry-run --target codex` |
 | `sync:dry` | `bash scripts/sync.sh --dry-run` |
 | `synthesis:init` | `node scripts/global/synthesis-init.js` |
+| `synthesis:status` | `node scripts/global/broker-synthesis-status.js` |
 | `test` | `npx playwright test` |
 | `test:compatibility` | `node --test tests/orchestrator-compatibility.spec.js` |
 | `test:headed` | `npx playwright test --headed` |

--- a/package.json
+++ b/package.json
@@ -260,7 +260,8 @@
     "routing:fallback-report": "node scripts/global/routing-fallback-report.js",
     "it-ops:usage-report": "node scripts/global/it-bypass-usage-report.js",
     "test:compatibility": "node --test tests/orchestrator-compatibility.spec.js",
-    "synthesis:init": "node scripts/global/synthesis-init.js"
+    "synthesis:init": "node scripts/global/synthesis-init.js",
+    "synthesis:status": "node scripts/global/broker-synthesis-status.js"
   },
   "keywords": [
     "devops",

--- a/scripts/global/broker-synthesis-status.js
+++ b/scripts/global/broker-synthesis-status.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// broker-synthesis-status — thin read-only wrapper exposing
+// `synthesis status --epic <N>` for live synthesis state.
+// Refs Epic #1112 AC7 (#2406). Companion to broker.js (#1088).
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+
+const MS_PER_HOUR = 3600 * 1000;
+const TERMINAL_CAP_HOURS = 24;
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 2) {
+    if (argv[i]?.startsWith('--')) args[argv[i].slice(2)] = argv[i + 1];
+  }
+  return args;
+}
+
+function readJsonIfExists(p) {
+  if (!fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function readTextIfExists(p) {
+  if (!fs.existsSync(p)) return null;
+  return fs.readFileSync(p, 'utf8');
+}
+
+function status(rdN, opts = {}) {
+  if (!rdN || !Number.isInteger(rdN)) {
+    throw new Error('--epic <N> is required and must be an integer');
+  }
+  const root = opts.root || process.cwd();
+  const synthDir = path.join(root, 'planning', `synthesis-${rdN}`);
+  if (!fs.existsSync(synthDir)) {
+    throw new Error(`synthesis-${rdN} does not exist at ${synthDir}`);
+  }
+  const pulse = readJsonIfExists(path.join(synthDir, 'pulse.json'));
+  const stability = readJsonIfExists(path.join(synthDir, 'stability.json'));
+  const statusText = readTextIfExists(path.join(synthDir, 'status.md')) || '';
+  const phaseMatch = statusText.match(/Phase:\s*([^\n]+)/);
+  const waveMatch = statusText.match(/Wave:\s*(\d+)/);
+  const now = opts.now ? new Date(opts.now) : new Date();
+  const kickoff = pulse?.kickoff ? new Date(pulse.kickoff) : null;
+  const elapsedHours = kickoff ? (now - kickoff) / MS_PER_HOUR : null;
+  const capHours = opts.capHours || TERMINAL_CAP_HOURS;
+  const remainingHours = elapsedHours !== null ? Math.max(0, capHours - elapsedHours) : null;
+  const wavePValues = stability?.wave_p_values || [];
+  const latestPValue = wavePValues.length > 0 ? wavePValues[wavePValues.length - 1] : null;
+  return {
+    rdN, admin: pulse?.admin || null, kickoff: pulse?.kickoff || null,
+    phase: phaseMatch?.[1].trim() || null, wave: waveMatch ? Number(waveMatch[1]) : null,
+    elapsedHours: elapsedHours !== null ? Math.round(elapsedHours * 100) / 100 : null,
+    remainingHours: remainingHours !== null ? Math.round(remainingHours * 100) / 100 : null,
+    capHours, latestKsPvalue: latestPValue, totalWavesObserved: wavePValues.length,
+    ksThreshold: stability?.threshold || null, consecutiveRequired: stability?.consecutive_required || null,
+  };
+}
+
+if (require.main === module) {
+  const args = parseArgs(process.argv);
+  try {
+    const result = status(Number(args.epic), { capHours: args['cap-hours'] ? Number(args['cap-hours']) : undefined });
+    console.log(JSON.stringify(result, null, 2));
+  } catch (e) {
+    console.error(e.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { status };

--- a/tests/broker-synthesis-status.spec.js
+++ b/tests/broker-synthesis-status.spec.js
@@ -1,0 +1,72 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { status } = require('../scripts/global/broker-synthesis-status.js');
+
+function mkSynthDir(rdN, opts = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'broker-status-'));
+  const synth = path.join(root, 'planning', `synthesis-${rdN}`);
+  fs.mkdirSync(synth, { recursive: true });
+  fs.writeFileSync(path.join(synth, 'pulse.json'), JSON.stringify({
+    rdN, admin: opts.admin || 'cc', kickoff: opts.kickoff || '2026-05-29T20:00:00Z',
+    version: 'protocol-v3', teams: ['cc', 'cp', 'cx', 'ag'],
+  }));
+  fs.writeFileSync(path.join(synth, 'status.md'),
+    `# Status — synthesis-${rdN}\n\nPhase: ${opts.phase || 'Phase-D'}\nWave: ${opts.wave || 2}\n`);
+  fs.writeFileSync(path.join(synth, 'stability.json'), JSON.stringify({
+    wave_p_values: opts.pValues || [0.12, 0.08, 0.04],
+    threshold: 0.05, consecutive_required: 3,
+  }));
+  return root;
+}
+
+test('status returns structured JSON summary for existing synthesis', () => {
+  const root = mkSynthDir(1234);
+  const r = status(1234, { root, now: '2026-05-29T22:00:00Z' });
+  assert.strictEqual(r.rdN, 1234);
+  assert.strictEqual(r.admin, 'cc');
+  assert.strictEqual(r.phase, 'Phase-D');
+  assert.strictEqual(r.wave, 2);
+});
+
+test('elapsed and remaining hours computed correctly', () => {
+  const root = mkSynthDir(1234, { kickoff: '2026-05-29T20:00:00Z' });
+  const r = status(1234, { root, now: '2026-05-29T22:00:00Z' });
+  assert.strictEqual(r.elapsedHours, 2);
+  assert.strictEqual(r.remainingHours, 22);
+  assert.strictEqual(r.capHours, 24);
+});
+
+test('latest K-S p-value reported from stability.json', () => {
+  const root = mkSynthDir(1234, { pValues: [0.15, 0.09, 0.03] });
+  const r = status(1234, { root });
+  assert.strictEqual(r.latestKsPvalue, 0.03);
+  assert.strictEqual(r.totalWavesObserved, 3);
+  assert.strictEqual(r.ksThreshold, 0.05);
+  assert.strictEqual(r.consecutiveRequired, 3);
+});
+
+test('error on missing --epic', () => {
+  assert.throws(() => status(null, { root: '/tmp' }), /epic.*required.*integer/);
+});
+
+test('error on non-existent synthesis dir', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'broker-empty-'));
+  assert.throws(() => status(1234, { root }), /does not exist/);
+});
+
+test('custom capHours respected', () => {
+  const root = mkSynthDir(1234, { kickoff: '2026-05-29T18:00:00Z' });
+  const r = status(1234, { root, now: '2026-05-29T22:00:00Z', capHours: 12 });
+  assert.strictEqual(r.elapsedHours, 4);
+  assert.strictEqual(r.remainingHours, 8);
+  assert.strictEqual(r.capHours, 12);
+});
+
+test('remainingHours clamps to 0 when over-cap', () => {
+  const root = mkSynthDir(1234, { kickoff: '2026-05-29T00:00:00Z' });
+  const r = status(1234, { root, now: '2026-05-30T08:00:00Z' });
+  assert.strictEqual(r.remainingHours, 0);
+});


### PR DESCRIPTION
Refs #2406

## Summary

Phase-1 AC7 of Epic #1112 — `scripts/global/broker-synthesis-status.js` (72 lines) is a read-only wrapper exposing `npm run synthesis:status -- --epic <N>`. Reads pulse.json + status.md + stability.json from `planning/synthesis-<rdN>/` and emits unified JSON summary including admin team, kickoff, phase, wave, elapsed/remaining hours vs the 24h cap from #2396, latest K-S p-value, and stability config.

Tier-1 by design (pure Node + filesystem; no broker mutation; no network I/O). Pre-applied prettier on package.json + README regen to avoid the #2403 CI failure pattern.

merge-evidence-deferred-final: #2406

## Test plan
- [x] 7/7 tests pass (existing-synthesis-returns-summary, elapsed/remaining-hours, latest-p-value, error-on-missing-epic, error-on-non-existent-synthesis, custom-capHours, remainingHours-clamps-to-0)
- [x] Tier-1 by design
