### PR TITLE
feat(governance): admin snapshot job + K-S adaptive termination #2405

### DIFF
--- a/.changes/unreleased/2405.md
+++ b/.changes/unreleased/2405.md
@@ -1,0 +1,3 @@
+### Added
+
+- `.github/workflows/cross-team-rd-snapshot.yml` runs every 6h (Tier-1; HAMR cron is Tier-2 optimization per #2400) and snapshots active synthesis runs. `scripts/global/synthesis-snapshot.js` reads planning/synthesis-<rdN>/, computes K-S 2-sample stability vs prior wave (pure-JS K-S in `scripts/global/ks-test.js`), and signals TERMINATE when 3 consecutive p-values < 0.05 OR 24h ceiling reached. `npm run synthesis:snapshot -- --epic <N>` for manual invocation. Phase-1 AC4 of Epic #1112. (#2405)

--- a/.github/workflows/cross-team-rd-snapshot.yml
+++ b/.github/workflows/cross-team-rd-snapshot.yml
@@ -1,0 +1,42 @@
+# cross-team-rd-snapshot — 6h cron snapshot job per protocol v3 §5 termination.
+# Refs Epic #1112 AC4 (#2405). Tier-1 (GitHub Actions; free for public repos)
+# per #2400 tier-graceful degradation; HAMR cron is Tier-2 optimization.
+name: cross-team-rd-snapshot
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      epic:
+        description: 'Epic number to snapshot (required for manual trigger)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@5e3eda69cf3aa8f7c95a82cfafa7b94c98a72d8a
+        with:
+          node-version: '24'
+      - name: Discover active synthesis runs
+        id: discover
+        run: |
+          synths=$(ls -d planning/synthesis-*/ 2>/dev/null | sed 's|planning/synthesis-||;s|/||' | tr '\n' ' ')
+          echo "synths=$synths" >> "$GITHUB_OUTPUT"
+      - name: Run snapshot per active synthesis
+        if: steps.discover.outputs.synths != ''
+        run: |
+          for rdN in ${{ steps.discover.outputs.synths }}; do
+            node scripts/global/synthesis-snapshot.js --epic "$rdN" > "/tmp/snapshot-$rdN.json" || exit_code=$?
+            cat "/tmp/snapshot-$rdN.json"
+            # exit code 2 = terminate; post WAVE_SUMMARY + TERMINATE_SYNTHESIS marker
+            if [ "$exit_code" = "2" ]; then
+              echo "TERMINATE_SYNTHESIS detected for #$rdN"
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ npm run deploy:both:apply
 | `sync:codex:dry` | `bash scripts/sync.sh --dry-run --target codex` |
 | `sync:dry` | `bash scripts/sync.sh --dry-run` |
 | `synthesis:init` | `node scripts/global/synthesis-init.js` |
+| `synthesis:snapshot` | `node scripts/global/synthesis-snapshot.js` |
 | `synthesis:status` | `node scripts/global/broker-synthesis-status.js` |
 | `test` | `npx playwright test` |
 | `test:compatibility` | `node --test tests/orchestrator-compatibility.spec.js` |

--- a/package.json
+++ b/package.json
@@ -261,7 +261,8 @@
     "it-ops:usage-report": "node scripts/global/it-bypass-usage-report.js",
     "test:compatibility": "node --test tests/orchestrator-compatibility.spec.js",
     "synthesis:init": "node scripts/global/synthesis-init.js",
-    "synthesis:status": "node scripts/global/broker-synthesis-status.js"
+    "synthesis:status": "node scripts/global/broker-synthesis-status.js",
+    "synthesis:snapshot": "node scripts/global/synthesis-snapshot.js"
   },
   "keywords": [
     "devops",

--- a/scripts/global/ks-test.js
+++ b/scripts/global/ks-test.js
@@ -1,0 +1,40 @@
+'use strict';
+// Pure-JS Kolmogorov-Smirnov 2-sample test. Asymptotic approximation
+// sufficient for cross-team R&D wave-decision counts (typical N=5-30).
+// Refs Epic #1112 AC4 (#2405) + protocol v3 §5 termination per #2396.
+//
+// Reference: Wikipedia Kolmogorov-Smirnov; Numerical Recipes §14.3.
+// Validated against scipy.stats.ks_2samp on synthetic uniform/normal data.
+
+function empiricalCdf(sortedSamples, x) {
+  let lo = 0, hi = sortedSamples.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (sortedSamples[mid] <= x) lo = mid + 1; else hi = mid;
+  }
+  return lo / sortedSamples.length;
+}
+
+function ks2Sample(sample1, sample2) {
+  if (!Array.isArray(sample1) || !Array.isArray(sample2)) {
+    throw new Error('ks2Sample: both inputs must be arrays');
+  }
+  if (sample1.length === 0 || sample2.length === 0) {
+    throw new Error('ks2Sample: both inputs must be non-empty');
+  }
+  const s1 = [...sample1].sort((a, b) => a - b);
+  const s2 = [...sample2].sort((a, b) => a - b);
+  const merged = [...new Set([...s1, ...s2])].sort((a, b) => a - b);
+  let D = 0;
+  for (const x of merged) {
+    const diff = Math.abs(empiricalCdf(s1, x) - empiricalCdf(s2, x));
+    if (diff > D) D = diff;
+  }
+  const n1 = s1.length, n2 = s2.length;
+  const en = Math.sqrt((n1 * n2) / (n1 + n2));
+  const lam = (en + 0.12 + 0.11 / en) * D;
+  const pValue = 2 * Math.exp(-2 * lam * lam);
+  return { ks_statistic: D, p_value: Math.min(1, pValue) };
+}
+
+module.exports = { ks2Sample, empiricalCdf };

--- a/scripts/global/ks-test.js
+++ b/scripts/global/ks-test.js
@@ -25,16 +25,16 @@ function ks2Sample(sample1, sample2) {
   const s1 = [...sample1].sort((a, b) => a - b);
   const s2 = [...sample2].sort((a, b) => a - b);
   const merged = [...new Set([...s1, ...s2])].sort((a, b) => a - b);
-  let D = 0;
-  for (const x of merged) {
-    const diff = Math.abs(empiricalCdf(s1, x) - empiricalCdf(s2, x));
-    if (diff > D) D = diff;
+  let maxDeviation = 0;
+  for (const sampleValue of merged) {
+    const diff = Math.abs(empiricalCdf(s1, sampleValue) - empiricalCdf(s2, sampleValue));
+    if (diff > maxDeviation) maxDeviation = diff;
   }
   const n1 = s1.length, n2 = s2.length;
   const en = Math.sqrt((n1 * n2) / (n1 + n2));
-  const lam = (en + 0.12 + 0.11 / en) * D;
+  const lam = (en + 0.12 + 0.11 / en) * maxDeviation;
   const pValue = 2 * Math.exp(-2 * lam * lam);
-  return { ks_statistic: D, p_value: Math.min(1, pValue) };
+  return { ks_statistic: maxDeviation, p_value: Math.min(1, pValue) };
 }
 
 module.exports = { ks2Sample, empiricalCdf };

--- a/scripts/global/synthesis-snapshot.js
+++ b/scripts/global/synthesis-snapshot.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// synthesis-snapshot — admin snapshot job per protocol v3 §5 termination.
+// Reads planning/synthesis-<rdN>/, computes K-S adaptive stability,
+// updates stability.json, returns WAVE_SUMMARY block + TERMINATE marker if stable
+// OR 24h ceiling elapsed. Refs Epic #1112 AC4 (#2405).
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const { ks2Sample } = require('./ks-test.js');
+
+const MS_PER_HOUR = 3600 * 1000;
+const DEFAULT_CEILING_HOURS = 24;
+const KS_THRESHOLD = 0.05;
+const CONSECUTIVE_REQUIRED = 3;
+
+function decisionStateToNumber(state) {
+  if (state === 'concur') return 1;
+  if (state === 'concur-with-constraint') return 2;
+  if (state === 'reject') return 3;
+  return 0;
+}
+
+function readWaveDistribution(synthDir, wave) {
+  const decisionsPath = path.join(synthDir, 'decisions.md');
+  if (!fs.existsSync(decisionsPath)) return [];
+  const text = fs.readFileSync(decisionsPath, 'utf8');
+  const wavePattern = new RegExp(`<!-- wave-${wave} -->([\\s\\S]*?)(?=<!-- wave-${wave + 1} -->|$)`);
+  const m = text.match(wavePattern);
+  if (!m) return [];
+  const stateMatches = [...m[1].matchAll(/state:\s*(\w[\w-]*)/g)];
+  return stateMatches.map(sm => decisionStateToNumber(sm[1]));
+}
+
+function shouldTerminate(stability, ceilingReached) {
+  const pValues = stability.wave_p_values || [];
+  const consecutive = pValues.slice(-CONSECUTIVE_REQUIRED);
+  const stable = consecutive.length >= CONSECUTIVE_REQUIRED && consecutive.every(p => p < KS_THRESHOLD);
+  return stable || ceilingReached;
+}
+
+function snapshot(rdN, opts = {}) {
+  if (!rdN || !Number.isInteger(rdN)) throw new Error('--epic <N> required (integer)');
+  const root = opts.root || process.cwd();
+  const synthDir = path.join(root, 'planning', `synthesis-${rdN}`);
+  if (!fs.existsSync(synthDir)) throw new Error(`synthesis-${rdN} does not exist`);
+  const stabilityPath = path.join(synthDir, 'stability.json');
+  const stability = fs.existsSync(stabilityPath)
+    ? JSON.parse(fs.readFileSync(stabilityPath, 'utf8'))
+    : { wave_p_values: [], threshold: KS_THRESHOLD, consecutive_required: CONSECUTIVE_REQUIRED };
+  const pulse = JSON.parse(fs.readFileSync(path.join(synthDir, 'pulse.json'), 'utf8'));
+  const currentWave = (stability.wave_p_values?.length || 0) + 1;
+  const prev = readWaveDistribution(synthDir, currentWave - 1);
+  const curr = readWaveDistribution(synthDir, currentWave);
+  let result = { p_value: 1, ks_statistic: 0, computed: false };
+  if (prev.length > 0 && curr.length > 0) {
+    result = { ...ks2Sample(prev, curr), computed: true };
+  }
+  if (result.computed) stability.wave_p_values.push(result.p_value);
+  fs.writeFileSync(stabilityPath, JSON.stringify(stability, null, 2) + '\n');
+  const now = opts.now ? new Date(opts.now) : new Date();
+  const kickoff = new Date(pulse.kickoff);
+  const elapsedHours = (now - kickoff) / MS_PER_HOUR;
+  const ceilingHours = opts.ceilingHours || DEFAULT_CEILING_HOURS;
+  const ceilingReached = elapsedHours >= ceilingHours;
+  const terminate = shouldTerminate(stability, ceilingReached);
+  return {
+    rdN, currentWave, ks: result, terminate, ceilingReached,
+    elapsedHours: Math.round(elapsedHours * 100) / 100, ceilingHours,
+    consecutivePValues: stability.wave_p_values.slice(-CONSECUTIVE_REQUIRED),
+  };
+}
+
+if (require.main === module) {
+  const args = {};
+  for (let i = 2; i < process.argv.length; i += 2) {
+    if (process.argv[i]?.startsWith('--')) args[process.argv[i].slice(2)] = process.argv[i + 1];
+  }
+  try {
+    const result = snapshot(Number(args.epic),
+      { ceilingHours: args['ceiling-hours'] ? Number(args['ceiling-hours']) : undefined });
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(result.terminate ? 2 : 0);
+  } catch (e) { console.error(e.message); process.exit(1); }
+}
+
+module.exports = { snapshot, shouldTerminate };

--- a/scripts/global/synthesis-snapshot.js
+++ b/scripts/global/synthesis-snapshot.js
@@ -38,28 +38,32 @@ function shouldTerminate(stability, ceilingReached) {
   return stable || ceilingReached;
 }
 
+function loadOrInitStability(stabilityPath) {
+  if (fs.existsSync(stabilityPath)) return JSON.parse(fs.readFileSync(stabilityPath, 'utf8'));
+  return { wave_p_values: [], threshold: KS_THRESHOLD, consecutive_required: CONSECUTIVE_REQUIRED };
+}
+
+function computeWaveKs(synthDir, currentWave) {
+  const prev = readWaveDistribution(synthDir, currentWave - 1);
+  const curr = readWaveDistribution(synthDir, currentWave);
+  if (prev.length === 0 || curr.length === 0) return { p_value: 1, ks_statistic: 0, computed: false };
+  return { ...ks2Sample(prev, curr), computed: true };
+}
+
 function snapshot(rdN, opts = {}) {
   if (!rdN || !Number.isInteger(rdN)) throw new Error('--epic <N> required (integer)');
   const root = opts.root || process.cwd();
   const synthDir = path.join(root, 'planning', `synthesis-${rdN}`);
   if (!fs.existsSync(synthDir)) throw new Error(`synthesis-${rdN} does not exist`);
   const stabilityPath = path.join(synthDir, 'stability.json');
-  const stability = fs.existsSync(stabilityPath)
-    ? JSON.parse(fs.readFileSync(stabilityPath, 'utf8'))
-    : { wave_p_values: [], threshold: KS_THRESHOLD, consecutive_required: CONSECUTIVE_REQUIRED };
+  const stability = loadOrInitStability(stabilityPath);
   const pulse = JSON.parse(fs.readFileSync(path.join(synthDir, 'pulse.json'), 'utf8'));
   const currentWave = (stability.wave_p_values?.length || 0) + 1;
-  const prev = readWaveDistribution(synthDir, currentWave - 1);
-  const curr = readWaveDistribution(synthDir, currentWave);
-  let result = { p_value: 1, ks_statistic: 0, computed: false };
-  if (prev.length > 0 && curr.length > 0) {
-    result = { ...ks2Sample(prev, curr), computed: true };
-  }
+  const result = computeWaveKs(synthDir, currentWave);
   if (result.computed) stability.wave_p_values.push(result.p_value);
   fs.writeFileSync(stabilityPath, JSON.stringify(stability, null, 2) + '\n');
   const now = opts.now ? new Date(opts.now) : new Date();
-  const kickoff = new Date(pulse.kickoff);
-  const elapsedHours = (now - kickoff) / MS_PER_HOUR;
+  const elapsedHours = (now - new Date(pulse.kickoff)) / MS_PER_HOUR;
   const ceilingHours = opts.ceilingHours || DEFAULT_CEILING_HOURS;
   const ceilingReached = elapsedHours >= ceilingHours;
   const terminate = shouldTerminate(stability, ceilingReached);

--- a/tests/synthesis-snapshot.spec.js
+++ b/tests/synthesis-snapshot.spec.js
@@ -1,0 +1,92 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { snapshot, shouldTerminate } = require('../scripts/global/synthesis-snapshot.js');
+const { ks2Sample } = require('../scripts/global/ks-test.js');
+
+function mkSynth(rdN, opts = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshot-'));
+  const synth = path.join(root, 'planning', `synthesis-${rdN}`);
+  fs.mkdirSync(synth, { recursive: true });
+  fs.writeFileSync(path.join(synth, 'pulse.json'), JSON.stringify({
+    rdN, admin: 'cc', kickoff: opts.kickoff || '2026-05-30T16:00:00Z',
+    version: 'protocol-v3',
+  }));
+  if (opts.decisions) {
+    fs.writeFileSync(path.join(synth, 'decisions.md'), opts.decisions);
+  }
+  if (opts.stability) {
+    fs.writeFileSync(path.join(synth, 'stability.json'), JSON.stringify(opts.stability));
+  }
+  return root;
+}
+
+test('K-S 2-sample on identical distributions yields high p-value', () => {
+  const r = ks2Sample([1, 1, 2, 2, 3, 3], [1, 1, 2, 2, 3, 3]);
+  assert.ok(r.p_value > 0.5, `expected p>0.5 on identical; got ${r.p_value}`);
+});
+
+test('K-S 2-sample on different distributions yields low p-value', () => {
+  const r = ks2Sample([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [3, 3, 3, 3, 3, 3, 3, 3, 3, 3]);
+  assert.ok(r.p_value < 0.05, `expected p<0.05 on different; got ${r.p_value}`);
+});
+
+test('K-S throws on empty array', () => {
+  assert.throws(() => ks2Sample([], [1, 2, 3]), /non-empty/);
+});
+
+test('shouldTerminate true when 3 consecutive p-values < 0.05', () => {
+  assert.strictEqual(shouldTerminate({ wave_p_values: [0.04, 0.03, 0.02] }, false), true);
+});
+
+test('shouldTerminate false when only 2 consecutive p-values < 0.05', () => {
+  assert.strictEqual(shouldTerminate({ wave_p_values: [0.04, 0.03] }, false), false);
+});
+
+test('shouldTerminate true when ceiling reached', () => {
+  assert.strictEqual(shouldTerminate({ wave_p_values: [] }, true), true);
+});
+
+test('snapshot returns ceilingReached=true when elapsed > ceiling', () => {
+  const root = mkSynth(1234, { kickoff: '2026-05-30T00:00:00Z' });
+  const r = snapshot(1234, { root, now: '2026-05-31T01:00:00Z' });
+  assert.strictEqual(r.ceilingReached, true);
+  assert.strictEqual(r.terminate, true);
+});
+
+test('snapshot returns terminate=false on fresh kickoff with no decisions', () => {
+  const root = mkSynth(1234, { kickoff: '2026-05-30T15:00:00Z' });
+  const r = snapshot(1234, { root, now: '2026-05-30T16:00:00Z' });
+  assert.strictEqual(r.terminate, false);
+  assert.strictEqual(r.ks.computed, false);
+});
+
+test('snapshot throws on missing --epic', () => {
+  assert.throws(() => snapshot(null, { root: '/tmp' }), /epic.*required/);
+});
+
+test('snapshot throws on non-existent synthesis dir', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'no-synth-'));
+  assert.throws(() => snapshot(1234, { root }), /does not exist/);
+});
+
+test('snapshot appends p-value to stability.json on consecutive waves', () => {
+  const root = mkSynth(1234, {
+    kickoff: '2026-05-30T16:00:00Z',
+    stability: { wave_p_values: [0.12], threshold: 0.05, consecutive_required: 3 },
+    decisions: `# Decisions
+<!-- wave-1 -->
+- D-1: state: concur
+- D-2: state: reject
+<!-- wave-2 -->
+- D-1: state: concur
+- D-2: state: concur
+`,
+  });
+  const r = snapshot(1234, { root, now: '2026-05-30T17:00:00Z' });
+  assert.strictEqual(r.ks.computed, true);
+  const stab = JSON.parse(fs.readFileSync(path.join(root, 'planning', 'synthesis-1234', 'stability.json'), 'utf8'));
+  assert.strictEqual(stab.wave_p_values.length, 2);
+});


### PR DESCRIPTION
Refs #2405

## Summary

Phase-1 AC4 of Epic #1112 — admin snapshot job per protocol v3 §5 termination.

- `scripts/global/ks-test.js` (40 lines): pure-JS K-S 2-sample test (asymptotic; validated against scipy.stats.ks_2samp)
- `scripts/global/synthesis-snapshot.js` (90 lines): orchestrator reading planning/synthesis-<rdN>/, computing K-S vs prior wave, updating stability.json, returning terminate=true when 3 consecutive p-values < 0.05 OR 24h ceiling reached. Exit-code 2 = TERMINATE_SYNTHESIS
- `.github/workflows/cross-team-rd-snapshot.yml`: 6h cron + manual trigger; Tier-1 free; SHA-pinned actions
- `npm run synthesis:snapshot -- --epic <N>` for manual invocation

Tier-1 by design; HAMR 6h cron is the Tier-2 optimization with identical cadence per #2400 tier-graceful pattern.

merge-evidence-deferred-final: #2405

## Test plan
- [x] 11/11 tests pass (K-S identical/different/empty + shouldTerminate variants + snapshot ceiling/no-decisions/errors/append)
