### PR TITLE
fix(governance): upgrade doc-coverage to blocking validator

### DIFF
--- a/.changes/unreleased/2424.md
+++ b/.changes/unreleased/2424.md
@@ -1,0 +1,17 @@
+## [#2424] Promote doc-coverage block from advisory to blocking gate
+
+### Changed
+- `scripts/global/megalint/doc-coverage.js`: Upgraded `validate()` to parse and
+  verify the `doc-coverage:` block in `COLLABORATOR_HANDOFF` comments, returning
+  blocking violations for missing required surfaces (previously a no-op).
+  New exports: `parseDocBlock`, `checkBlock`. Refs #2426.
+- `scripts/global/megalint/collaborator-handoff.js`: Removed advisory
+  `checkDocCoverageAdvisory`; replaced with blocking call to `doc-coverage.js`
+  `checkBlock()` for `lane:code-change`. Refs #2424.
+- `docs/howto/baton-workflow.md`: Added `doc-coverage:` block schema to
+  COLLABORATOR_HANDOFF template. Refs #2425.
+- `tests/collaborator-handoff-doc-coverage.spec.js`: Updated to test new
+  blocking behavior.
+
+### Escape hatch
+Set `DOC_COVERAGE_GATE_ADVISORY=1` to revert to advisory-only (G5 portability).

--- a/docs/howto/baton-workflow.md
+++ b/docs/howto/baton-workflow.md
@@ -72,7 +72,16 @@ Role: collaborator
 AC evidence:
 - AC1: <test output or command result>
 - AC2: <file path or CI link>
+
+doc-coverage:
+  <surface-1>: DONE — <evidence or path>
+  <surface-2>: N/A — <reason why not applicable>
 ```
+
+The `doc-coverage:` block is **required** for `lane:code-change` tickets when
+area labels mandate surfaces (see `config/doc-coverage-matrix.yml`). Each line
+lists a required surface path-prefix and its status (`DONE` or `N/A — reason`).
+Set `DOC_COVERAGE_GATE_ADVISORY=1` to revert to advisory mode. Refs #2424.
 
 Wait at least 60 seconds, then create the PR:
 

--- a/scripts/global/megalint/collaborator-handoff.js
+++ b/scripts/global/megalint/collaborator-handoff.js
@@ -1,25 +1,16 @@
 'use strict';
 // collaborator-handoff — validates COLLABORATOR_HANDOFF signer + content.
 // Refs #2302: LIGHTWEIGHT imported from lane-enum.js (single source of truth).
-// Updated to include lane:research (was missing vs canonical set).
+// #2424: doc-coverage block now blocking (not advisory).
 
 const path = require('path');
 const { roleIdentity } = require(path.join(__dirname, '..', 'baton-independence.js'));
 const { LIGHTWEIGHT, laneSeverity } = require(path.join(__dirname, '..', 'lane-enum.js'));
+const docCoverage = require('./doc-coverage.js');
 
 function findCollaboratorHandoff(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?COLLABORATOR_HANDOFF\b/;
   return [...(comments || [])].reverse().find(c => headerRe.test(c.body || ''));
-}
-
-const DOC_COVERAGE_RE = /(^|\n)\s*doc-coverage\s*:/i;
-
-function checkDocCoverageAdvisory(body, lane) {
-  // Refs Epic #2148 / #2154 - Tech-Writer sub-phase advisory
-  if (lane !== 'lane:code-change') return [];
-  if (DOC_COVERAGE_RE.test(body)) return [];
-  return [{ rule: 'doc-coverage-advisory', severity: 'advisory',
-    detail: 'COLLABORATOR_HANDOFF lacks doc-coverage block (Tech-Writer sub-phase advisory per Epic #2148).' }];
 }
 
 function checkSignerFields(body) {
@@ -48,10 +39,15 @@ function validate(input) {
     return { ok: false, violations: [{ rule: 'missing-collaborator-handoff',
       detail: 'COLLABORATOR_HANDOFF comment not found on issue' }], found: false };
   }
-  const violations = checkSignerFields(handoff.body || '');
-  const advisory = checkDocCoverageAdvisory(handoff.body || '', input.lane);
-  const signer = roleIdentity({ body: handoff.body, author: handoff.user && handoff.user.login });
-  return { ok: violations.length === 0, violations, advisory, found: true, signer };
+  const body = handoff.body || '';
+  const violations = checkSignerFields(body);
+  if (input.lane === 'lane:code-change' && process.env.DOC_COVERAGE_GATE_ADVISORY !== '1') {
+    let matrix;
+    try { matrix = docCoverage.loadMatrix(); } catch (_) { matrix = null; }
+    if (matrix) violations.push(...docCoverage.checkBlock(body, input.labels || [], matrix));
+  }
+  const signer = roleIdentity({ body, author: handoff.user && handoff.user.login });
+  return { ok: violations.length === 0, violations, found: true, signer };
 }
 
-module.exports = { validate, findCollaboratorHandoff, checkDocCoverageAdvisory, LIGHTWEIGHT };
+module.exports = { validate, findCollaboratorHandoff, LIGHTWEIGHT };

--- a/scripts/global/megalint/doc-coverage.js
+++ b/scripts/global/megalint/doc-coverage.js
@@ -1,6 +1,7 @@
 'use strict';
-// doc-coverage — advisory validator that reads config/doc-coverage-matrix.yml
-// and emits a coverage block. Refs #2155.
+// doc-coverage — validates doc-coverage: block in COLLABORATOR_HANDOFF.
+// Upgraded from advisory to blocking. Refs #2426.
+// Set DOC_COVERAGE_GATE_ADVISORY=1 for advisory-only mode (G5 escape hatch).
 
 const fs = require('fs');
 const path = require('path');
@@ -10,8 +11,7 @@ const MATRIX_PATH = path.join(__dirname, '..', '..', '..', 'config', 'doc-covera
 function parseYamlSurfaces(text) {
   const lines = text.split('\n');
   const out = {};
-  let area = null;
-  let bucket = null;
+  let area = null; let bucket = null;
   for (const raw of lines) {
     const line = raw.replace(/\s+$/, '');
     if (!line || line.startsWith('#') || line === 'surfaces:') continue;
@@ -26,13 +26,11 @@ function parseYamlSurfaces(text) {
 }
 
 function loadMatrix(matrixPath = MATRIX_PATH) {
-  const text = fs.readFileSync(matrixPath, 'utf8');
-  return parseYamlSurfaces(text);
+  return parseYamlSurfaces(fs.readFileSync(matrixPath, 'utf8'));
 }
 
 function surfacesForLabels(labels, matrix) {
-  const required = new Set();
-  const suggested = new Set();
+  const required = new Set(); const suggested = new Set();
   for (const label of labels || []) {
     const entry = matrix[label];
     if (!entry) continue;
@@ -42,22 +40,45 @@ function surfacesForLabels(labels, matrix) {
   return { required: [...required].sort(), suggested: [...suggested].sort() };
 }
 
-function validate(input) {
-  let matrix;
-  try { matrix = loadMatrix(); }
-  catch (error) {
-    return { ok: true, violations: [], found: false, advisory: `doc-coverage matrix not loadable: ${error.message}` };
+function parseDocBlock(body) {
+  const lines = (body || '').split('\n');
+  let inBlock = false; const entries = {};
+  for (const line of lines) {
+    if (!inBlock) {
+      if (/^\s*doc-coverage\s*:/i.test(line)) { inBlock = true; continue; }
+    } else {
+      if (/^\S/.test(line)) break;
+      const m = line.match(/^\s+([^:]+):\s*(.+)/);
+      if (m) entries[m[1].trim()] = m[2].trim();
+    }
   }
-  const expected = surfacesForLabels(input.labels, matrix);
-  if (!expected.required.length && !expected.suggested.length) {
-    return { ok: true, violations: [], advisory: null };
-  }
-  const advisory = [
-    'Doc-coverage advisory:',
-    `  required surfaces: ${expected.required.join(', ') || '(none)'}`,
-    `  suggested surfaces: ${expected.suggested.join(', ') || '(none)'}`,
-  ].join('\n');
-  return { ok: true, violations: [], advisory };
+  return inBlock ? entries : null;
 }
 
-module.exports = { validate, loadMatrix, parseYamlSurfaces, surfacesForLabels };
+function checkBlock(body, labels, matrix) {
+  const expected = surfacesForLabels(labels, matrix);
+  if (!expected.required.length) return [];
+  const block = parseDocBlock(body);
+  if (!block) return [{ rule: 'doc-coverage-missing-block',
+    detail: `COLLABORATOR_HANDOFF missing doc-coverage: block. Required: ${expected.required.join(', ')}` }];
+  return expected.required
+    .filter(s => !Object.keys(block).some(k => k.startsWith(s) || s.startsWith(k)))
+    .map(s => ({ rule: 'doc-coverage-surface-missing',
+      detail: `doc-coverage: required surface "${s}" not found in block` }));
+}
+
+function validate(input) {
+  if (process.env.DOC_COVERAGE_GATE_ADVISORY === '1') {
+    return { ok: true, violations: [], advisory: 'doc-coverage: advisory mode (DOC_COVERAGE_GATE_ADVISORY=1)' };
+  }
+  let matrix;
+  try { matrix = loadMatrix(); }
+  catch (e) { return { ok: true, violations: [], advisory: `doc-coverage: matrix not loadable: ${e.message}` }; }
+  const handoff = (input.comments || []).slice().reverse()
+    .find(c => /(^|\n)\s*(?:##\s*)?COLLABORATOR_HANDOFF\b/i.test(c.body || ''));
+  const body = handoff ? handoff.body : (input.body || '');
+  const violations = checkBlock(body, input.labels, matrix);
+  return { ok: violations.length === 0, violations };
+}
+
+module.exports = { validate, loadMatrix, parseYamlSurfaces, surfacesForLabels, parseDocBlock, checkBlock };

--- a/tests/collaborator-handoff-doc-coverage.spec.js
+++ b/tests/collaborator-handoff-doc-coverage.spec.js
@@ -1,28 +1,72 @@
-// Refs #2154 - tests for Tech-Writer sub-phase doc-coverage advisory
+// Refs #2424 - tests for doc-coverage block blocking gate (upgraded from advisory)
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { checkDocCoverageAdvisory } = require('../scripts/global/megalint/collaborator-handoff.js');
+const { validate } = require('../scripts/global/megalint/collaborator-handoff.js');
+const { checkBlock, parseDocBlock, loadMatrix } = require('../scripts/global/megalint/doc-coverage.js');
 
-test('checkDocCoverageAdvisory: emits advisory when doc-coverage missing on lane:code-change', () => {
-  const result = checkDocCoverageAdvisory('## COLLABORATOR_HANDOFF\nbody no doc-coverage here', 'lane:code-change');
-  assert.equal(result.length, 1);
-  assert.equal(result[0].rule, 'doc-coverage-advisory');
-  assert.equal(result[0].severity, 'advisory');
+const HANDOFF_SIGNED = (extra) =>
+  `## COLLABORATOR_HANDOFF\n${extra}\nSigned-by: Alex Harper\nTeam&Model: copilot:sonnet@anthropic\nRole: collaborator\n`;
+
+test('validate: blocking when doc-coverage: block missing on lane:code-change with governance label', () => {
+  const matrix = loadMatrix();
+  const body = HANDOFF_SIGNED('no doc block here');
+  const result = validate({
+    lane: 'lane:code-change', labels: ['area:governance'],
+    comments: [{ body, user: { login: 'alex' } }],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.violations.some(v => v.rule === 'doc-coverage-missing-block'), JSON.stringify(result.violations));
 });
 
-test('checkDocCoverageAdvisory: silent when doc-coverage block present', () => {
-  const body = '## COLLABORATOR_HANDOFF\n\ndoc-coverage:\n  UPDATED: README.md\n';
-  assert.deepEqual(checkDocCoverageAdvisory(body, 'lane:code-change'), []);
+test('validate: passes when doc-coverage: block has required surfaces', () => {
+  const body = HANDOFF_SIGNED(
+    'doc-coverage:\n  .changes/unreleased/: DONE — #2424.md\n  docs/workflow/learnings.md: N/A — no new pattern\n'
+  );
+  const result = validate({
+    lane: 'lane:code-change', labels: ['area:governance'],
+    comments: [{ body, user: { login: 'alex' } }],
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.violations));
 });
 
-test('checkDocCoverageAdvisory: silent on lightweight lanes', () => {
-  assert.deepEqual(checkDocCoverageAdvisory('no coverage', 'lane:docs-research'), []);
-  assert.deepEqual(checkDocCoverageAdvisory('no coverage', 'lane:docs-only'), []);
-  assert.deepEqual(checkDocCoverageAdvisory('no coverage', 'lane:trivial'), []);
-  assert.deepEqual(checkDocCoverageAdvisory('no coverage', 'lane:config-only'), []);
+test('validate: skips doc-coverage check on lightweight lanes', () => {
+  const result = validate({
+    lane: 'lane:docs-research', labels: ['area:governance'],
+    comments: [{ body: HANDOFF_SIGNED(''), user: { login: 'alex' } }],
+  });
+  assert.equal(result.ok, true);
 });
 
-test('checkDocCoverageAdvisory: regex case-insensitive', () => {
-  const body = '## COLLABORATOR_HANDOFF\nDOC-COVERAGE: present';
-  assert.deepEqual(checkDocCoverageAdvisory(body, 'lane:code-change'), []);
+test('validate: advisory mode env var bypasses blocking', () => {
+  process.env.DOC_COVERAGE_GATE_ADVISORY = '1';
+  const result = validate({
+    lane: 'lane:code-change', labels: ['area:governance'],
+    comments: [{ body: HANDOFF_SIGNED('no block'), user: { login: 'alex' } }],
+  });
+  delete process.env.DOC_COVERAGE_GATE_ADVISORY;
+  assert.equal(result.ok, true);
+});
+
+test('parseDocBlock: returns null when no doc-coverage: header', () => {
+  assert.equal(parseDocBlock('no block here'), null);
+});
+
+test('parseDocBlock: parses entries from indented block', () => {
+  const body = 'doc-coverage:\n  .changes/unreleased/: DONE\n  README.md: N/A\n';
+  const block = parseDocBlock(body);
+  assert.ok(block);
+  assert.equal(block['.changes/unreleased/'], 'DONE');
+  assert.equal(block['README.md'], 'N/A');
+});
+
+test('checkBlock: returns violation for missing required surface', () => {
+  const matrix = loadMatrix();
+  const violations = checkBlock('doc-coverage:\n  README.md: DONE\n', ['area:governance'], matrix);
+  assert.ok(violations.some(v => v.rule === 'doc-coverage-surface-missing'));
+});
+
+test('checkBlock: passes when no required surfaces for given labels', () => {
+  const matrix = loadMatrix();
+  const violations = checkBlock('', [], matrix);
+  assert.equal(violations.length, 0);
 });


### PR DESCRIPTION
Promotes doc-coverage block validation from advisory no-op to hard-blocking gate in megalint.

## Changes
- `doc-coverage.js`: New `parseDocBlock()`, `checkBlock()`; `validate()` now returns real violations. Env var `DOC_COVERAGE_GATE_ADVISORY=1` for G5 escape hatch.
- `collaborator-handoff.js`: Advisory replaced with blocking `checkBlock()` call for `lane:code-change`.
- `docs/howto/baton-workflow.md`: Added `doc-coverage:` block schema to COLLABORATOR_HANDOFF template.
- `tests/collaborator-handoff-doc-coverage.spec.js`: Updated for blocking behavior (8/8 pass).
- `.changes/unreleased/2424.md`: Changelog fragment.

merge-evidence-deferred-final: #2424
Closes #2425
Closes #2426
Refs #2424