### PR TITLE
docs(governance): document doc-coverage block requirement in CONTRIBUTING + release-docs

### DIFF
--- a/.changes/unreleased/2430.md
+++ b/.changes/unreleased/2430.md
@@ -1,0 +1,8 @@
+---
+type: docs
+area: governance
+issues: [2430]
+---
+
+Document `doc-coverage:` block requirement in `CONTRIBUTING.md` (Baton Gate Chain section)
+and add Tech-Writer sub-phase section to `instructions/release-docs-hygiene.instructions.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,5 +96,5 @@ All sections require `Signed-by:`, `Team&Model:`, and `Role:`; Admin must differ
 PRs >10 files or >500 LOC require `BLOCKER_NOTE` plus evidence closeout.
 
 Admin merge checklist: `pr-title-required` ≤60 chars, all gates green, artifacts present.
-Lane model: `code-change` (full baton), `docs/research` (Manager+Consultant),
-`config-only` (Admin+Consultant). See role-baton-routing.instructions.md.
+Lane model: `code-change` (full baton), `docs/research` (Manager+Consultant), `config-only` (Admin+Consultant).
+`COLLABORATOR_HANDOFF` on `lane:code-change` must include a `doc-coverage:` block per `config/doc-coverage-matrix.yml`.

--- a/instructions/release-docs-hygiene.instructions.md
+++ b/instructions/release-docs-hygiene.instructions.md
@@ -19,6 +19,13 @@ After every PR merge or deployment that changes user-facing behavior, run these 
 
 Do not consider a PR merge or deployment task complete until steps 1-7 are explicitly addressed (either completed or confirmed not applicable).
 
+## Tech-Writer sub-phase (lane:code-change)
+
+`COLLABORATOR_HANDOFF` for `lane:code-change` tickets MUST include a `doc-coverage:` block
+declaring each required surface as `UPDATED: <path>` or `N/A: <surface> — <reason>`.
+Required surfaces per `area:*` label are defined in `config/doc-coverage-matrix.yml`.
+Validator: `scripts/global/megalint/doc-coverage.js`. Escape hatch: `DOC_COVERAGE_GATE_ADVISORY=1`.
+
 ## Merge-time documentation governance
 
 For the operator-facing runbook describing how Epic #2148 children (C0+C1+C2+C3+C5+C7) compose into the four-surface merge-time documentation governance system, see [docs/howto/merge-time-doc-governance.md](../docs/howto/merge-time-doc-governance.md).


### PR DESCRIPTION
Adds `doc-coverage:` block description to CONTRIBUTING.md Baton Gate Chain section. Adds Tech-Writer sub-phase section to `instructions/release-docs-hygiene.instructions.md`.

merge-evidence-deferred-final: #2430
Refs #2430