### PR TITLE
fix(governance): expand doc-coverage matrix for full doc surface coverage #2453

### DIFF
--- a/.changes/unreleased/2453.md
+++ b/.changes/unreleased/2453.md
@@ -1,0 +1,15 @@
+# #2453 Expand doc-coverage matrix for full documentation coverage
+
+**config/doc-coverage-matrix.yml** — comprehensive expansion:
+
+- `area:hooks`: added `docs/howto/pre-push-gates.md` as required; moved detailed hook files to suggested
+- `area:scripts`: narrowed to `README.md` required; `docs/howto/` as suggested
+- `area:instructions`: added `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, `.codex/AGENTS.md` as required (runtime adapter files)
+- `area:governance`: added `governance/README.md`, `docs/howto/baton-workflow.md` as required; added `CONTRIBUTING.md`, `governance-carve-outs/index.md`, `docs/decisions.md` as suggested
+- `area:agents`: added `agents/`, `docs/skills-agents.md` as required; `AGENTS.md` as suggested
+- `area:skills`: added `docs/skills-copilot.md`, `docs/skills-agents.md` as required
+- `area:infra`: replaced narrow discovery-doc required surface with `ARCHITECTURE.md` + `docs/ARCHITECTURE.md`; demoted `docs/runtime-substrate-discovery-2026-05-09.md` to suggested
+- `area:knowledge`: `WIKI.md` promoted to required; added `docs/howto/contribute-to-wiki.md` as suggested
+
+**tests/collaborator-handoff-doc-coverage.spec.js** — updated test fixture to
+include two new required surfaces (`governance/README.md`, `docs/howto/baton-workflow.md`).

--- a/config/doc-coverage-matrix.yml
+++ b/config/doc-coverage-matrix.yml
@@ -1,58 +1,95 @@
-# Refs #2155 — doc-coverage matrix
+# Refs #2155 — doc-coverage matrix (expanded #2453 for full coverage)
 # Maps area-* labels to documentation surfaces that must be updated
 # when a ticket carrying that area-label ships. The Tech-Writer
 # sub-phase validator (#2154) and the doc-coverage validator
 # (scripts/global/megalint/doc-coverage.js) consume this matrix.
 #
 # Schema: each entry is { required: [...], suggested: [...] }
-# Validators emit advisory coverage block on the issue.
+# required: gate fails if surface absent from COLLABORATOR_HANDOFF doc-coverage block
+# suggested: informational; not gated (use N/A with reason in doc-coverage block)
 
 version: 1
 surfaces:
   area:hooks:
     required:
       - docs/howto/hooks.md
+      - docs/howto/pre-push-gates.md
     suggested:
+      - docs/howto/hook-parity-check.md
+      - docs/howto/hook-timeout-configuration.md
       - wiki/code/hooks.md
       - README.md
+
   area:scripts:
     required:
       - README.md
     suggested:
+      - docs/howto/
       - wiki/code/scripts.md
+
   area:instructions:
     required:
       - docs/workflow/learnings.md
+      - CLAUDE.md
+      - AGENTS.md
+      - .github/copilot-instructions.md
+      - .codex/AGENTS.md
     suggested:
       - wiki/wisdom/project/
+      - instructions/
+
   area:governance:
     required:
       - .changes/unreleased/
       - docs/workflow/learnings.md
+      - governance/README.md
+      - docs/howto/baton-workflow.md
     suggested:
+      - CONTRIBUTING.md
+      - .github/CONTRIBUTING.md
+      - governance-carve-outs/index.md
+      - docs/decisions.md
       - wiki/wisdom/global/concepts/
+      - .github/SECURITY.md
+
   area:dashboard:
     required:
       - dashboard/README.md
     suggested:
+      - README.md
       - wiki/code/dashboard.md
+
   area:agents:
     required:
+      - agents/
       - .claude/agents/
+      - docs/skills-agents.md
     suggested:
+      - AGENTS.md
       - wiki/code/agents.md
+
   area:skills:
     required:
       - .claude/commands/
+      - docs/skills-copilot.md
+      - docs/skills-agents.md
     suggested:
       - wiki/code/skills.md
+
   area:infra:
     required:
-      - docs/runtime-substrate-discovery-2026-05-09.md
+      - ARCHITECTURE.md
+      - docs/ARCHITECTURE.md
     suggested:
+      - README.md
+      - docs/provider-capability-registry.md
+      - docs/provider-neutral-routing.md
+      - docs/runtime-substrate-discovery-2026-05-09.md
       - wiki/code/infra.md
+
   area:knowledge:
     required:
       - wiki/wisdom/global/
-    suggested:
       - WIKI.md
+    suggested:
+      - docs/howto/contribute-to-wiki.md

--- a/tests/collaborator-handoff-doc-coverage.spec.js
+++ b/tests/collaborator-handoff-doc-coverage.spec.js
@@ -20,7 +20,7 @@ test('validate: blocking when doc-coverage: block missing on lane:code-change wi
 
 test('validate: passes when doc-coverage: block has required surfaces', () => {
   const body = HANDOFF_SIGNED(
-    'doc-coverage:\n  .changes/unreleased/: DONE — #2424.md\n  docs/workflow/learnings.md: N/A — no new pattern\n'
+    'doc-coverage:\n  .changes/unreleased/: DONE — #2424.md\n  docs/workflow/learnings.md: N/A — no new pattern\n  governance/README.md: DONE\n  docs/howto/baton-workflow.md: DONE\n'
   );
   const result = validate({
     lane: 'lane:code-change', labels: ['area:governance'],


### PR DESCRIPTION
Expands config/doc-coverage-matrix.yml to cover all documentation surfaces across every area label.

## Changes
- area:hooks: +docs/howto/pre-push-gates.md required
- area:instructions: +CLAUDE.md, AGENTS.md, .github/copilot-instructions.md, .codex/AGENTS.md required
- area:governance: +governance/README.md, docs/howto/baton-workflow.md required
- area:agents: +agents/, docs/skills-agents.md required
- area:skills: +docs/skills-copilot.md, docs/skills-agents.md required
- area:infra: +ARCHITECTURE.md, docs/ARCHITECTURE.md required; demoted runtime-substrate-discovery doc to suggested
- area:knowledge: WIKI.md promoted to required
- Test fixture updated for new required surfaces

merge-evidence-deferred-final: #2453

Refs #2453