### PR TITLE
fix(hooks): derive_roles_from_github resolver + 60s TTL (#2456)

### DIFF
--- a/hooks/scripts/github_role_resolver.py
+++ b/hooks/scripts/github_role_resolver.py
@@ -1,0 +1,85 @@
+"""GitHub-derived role state resolver for baton state authority (#2456).
+
+Move 1 of Epic #2451: collapse local roles dict in favor of GitHub-as-source.
+Queries `gh issue view N --json labels,comments` with 60s TTL cache.
+
+Feature-flagged via env MEGINGJORD_DERIVE_ROLES_FROM_GH. When off, returns None
+and callers fall back to legacy local-state reads.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from typing import Optional
+
+CACHE_TTL_SECONDS = 60
+_cache: dict[int, tuple[float, dict]] = {}
+
+ROLE_LABELS = {
+    "role:manager": "manager",
+    "role:collaborator": "collaborator",
+    "role:admin": "admin",
+    "role:consultant": "consultant",
+}
+
+
+def feature_enabled() -> bool:
+    """Resolver disabled by default; enable via env for gradual rollout."""
+    return os.environ.get("MEGINGJORD_DERIVE_ROLES_FROM_GH", "").strip() == "1"
+
+
+def _empty_roles() -> dict:
+    return {"manager": False, "collaborator": False, "admin": False, "consultant": False}
+
+
+def _gh_view(ticket_n: int, timeout: float = 10.0) -> Optional[dict]:
+    """Call gh CLI; return parsed JSON or None on failure (G6 fallback)."""
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "view", str(ticket_n), "--json", "labels,comments"],
+            capture_output=True, text=True, timeout=timeout, check=False,
+        )
+        if result.returncode != 0:
+            return None
+        return json.loads(result.stdout)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError, OSError):
+        return None
+
+
+def _parse_roles(issue: dict) -> dict:
+    """Project issue labels to canonical role-state dict."""
+    roles = _empty_roles()
+    labels = {l.get("name", "") for l in issue.get("labels", [])}
+    for label, key in ROLE_LABELS.items():
+        if label in labels:
+            roles[key] = True
+    return roles
+
+
+def derive_roles_from_github(ticket_n: int) -> Optional[dict]:
+    """Return roles dict derived from GitHub, or None if feature disabled / offline.
+
+    Cached with 60s TTL. Returns stale cache if fresh fetch fails (G6 resilience).
+    """
+    if not feature_enabled() or not ticket_n:
+        return None
+
+    now = time.monotonic()
+    cached = _cache.get(ticket_n)
+    if cached and (now - cached[0]) < CACHE_TTL_SECONDS:
+        return cached[1]
+
+    issue = _gh_view(ticket_n)
+    if issue is None:
+        return cached[1] if cached else None  # G6: stale > nothing
+
+    roles = _parse_roles(issue)
+    _cache[ticket_n] = (now, roles)
+    return roles
+
+
+def clear_cache() -> None:
+    """Test helper: drop TTL cache."""
+    _cache.clear()

--- a/hooks/scripts/github_role_resolver.py
+++ b/hooks/scripts/github_role_resolver.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import threading
 import time
 from typing import Optional
 
 CACHE_TTL_SECONDS = 60
+MAX_STALE_SECONDS = 300  # G6: serve stale up to 5 min on GitHub-down
 _cache: dict[int, tuple[float, dict]] = {}
+_cache_lock = threading.Lock()
 
 ROLE_LABELS = {
     "role:manager": "manager",
@@ -61,22 +64,28 @@ def _parse_roles(issue: dict) -> dict:
 def derive_roles_from_github(ticket_n: int) -> Optional[dict]:
     """Return roles dict derived from GitHub, or None if feature disabled / offline.
 
-    Cached with 60s TTL. Returns stale cache if fresh fetch fails (G6 resilience).
+    Cached with 60s TTL (thread-safe via _cache_lock). Returns stale cache up to
+    MAX_STALE_SECONDS old if fresh fetch fails (G6 resilience with bounded staleness).
     """
     if not feature_enabled() or not ticket_n:
         return None
 
     now = time.monotonic()
-    cached = _cache.get(ticket_n)
-    if cached and (now - cached[0]) < CACHE_TTL_SECONDS:
-        return cached[1]
+    with _cache_lock:
+        cached = _cache.get(ticket_n)
+        if cached and (now - cached[0]) < CACHE_TTL_SECONDS:
+            return cached[1]
 
     issue = _gh_view(ticket_n)
     if issue is None:
-        return cached[1] if cached else None  # G6: stale > nothing
+        # G6 with bound: serve stale only if within MAX_STALE_SECONDS
+        if cached and (now - cached[0]) < MAX_STALE_SECONDS:
+            return cached[1]
+        return None
 
     roles = _parse_roles(issue)
-    _cache[ticket_n] = (now, roles)
+    with _cache_lock:
+        _cache[ticket_n] = (now, roles)
     return roles
 
 

--- a/hooks/scripts/stop_checks.py
+++ b/hooks/scripts/stop_checks.py
@@ -8,7 +8,9 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
+import re
 from admin_patterns import required_admin_ops
+from github_role_resolver import derive_roles_from_github, feature_enabled as _resolver_enabled
 from wiki_wisdom import post_merge_checklist
 
 CODE_UNCOMMITTED_EXTS = (".sh", ".js", ".py", ".ts", ".json", ".md")
@@ -25,6 +27,35 @@ ADMIN_STEPS = (
     "  9. gh release create vX.Y.Z\n"
     " 10. gh issue close N"
 )
+
+
+
+_BRANCH_TICKET_RE = re.compile(r"^[a-z]+/(\d+)-")
+
+
+def ticket_from_branch(branch: str | None) -> int | None:
+    """Extract issue number from branch name like fix/2456-slug."""
+    if not branch:
+        return None
+    m = _BRANCH_TICKET_RE.match(branch)
+    return int(m.group(1)) if m else None
+
+
+def effective_roles(state_roles: dict, branch: str | None) -> dict:
+    """Resolve effective roles. When feature flag set, GitHub-derived overrides
+    local-state. Falls back to local-state on offline or feature-off (#2456)."""
+    if not _resolver_enabled():
+        return state_roles
+    ticket_n = ticket_from_branch(branch)
+    if ticket_n is None:
+        return state_roles
+    derived = derive_roles_from_github(ticket_n)
+    if derived is None:
+        return state_roles
+    # Merge: derived roles win on overlap; preserve any local keys derived doesn't track
+    merged = dict(state_roles)
+    merged.update(derived)
+    return merged
 
 
 def check_uncommitted(

--- a/tests/hooks/test_github_role_resolver.py
+++ b/tests/hooks/test_github_role_resolver.py
@@ -1,0 +1,146 @@
+"""Tests for #2456: derive_roles_from_github resolver + 60s TTL cache.
+
+Move 1 of Epic #2451 — GitHub-as-event-source for baton state.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "hooks" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import github_role_resolver as resolver  # noqa: E402
+from stop_checks import ticket_from_branch, effective_roles  # noqa: E402
+
+
+class TestFeatureFlag(unittest.TestCase):
+    def setUp(self):
+        resolver.clear_cache()
+
+    def test_disabled_by_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MEGINGJORD_DERIVE_ROLES_FROM_GH", None)
+            self.assertFalse(resolver.feature_enabled())
+
+    def test_enabled_when_set(self):
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1"}):
+            self.assertTrue(resolver.feature_enabled())
+
+    def test_returns_none_when_disabled(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MEGINGJORD_DERIVE_ROLES_FROM_GH", None)
+            self.assertIsNone(resolver.derive_roles_from_github(2456))
+
+
+class TestRoleParsing(unittest.TestCase):
+    def test_parse_empty_labels(self):
+        result = resolver._parse_roles({"labels": []})
+        self.assertEqual(result, {"manager": False, "collaborator": False,
+                                  "admin": False, "consultant": False})
+
+    def test_parse_single_role(self):
+        result = resolver._parse_roles({"labels": [{"name": "role:collaborator"}]})
+        self.assertTrue(result["collaborator"])
+        self.assertFalse(result["admin"])
+
+    def test_parse_admin_role(self):
+        result = resolver._parse_roles({"labels": [{"name": "role:admin"},
+                                                     {"name": "status:testing"}]})
+        self.assertTrue(result["admin"])
+        self.assertFalse(result["manager"])
+
+
+class TestTtlCache(unittest.TestCase):
+    def setUp(self):
+        resolver.clear_cache()
+
+    def test_cache_hit_within_ttl(self):
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1"}):
+            with patch.object(resolver, "_gh_view") as mock_gh:
+                mock_gh.return_value = {"labels": [{"name": "role:admin"}]}
+                resolver.derive_roles_from_github(2456)
+                resolver.derive_roles_from_github(2456)
+                self.assertEqual(mock_gh.call_count, 1)  # second call cached
+
+    def test_cache_miss_after_ttl(self):
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1"}):
+            with patch.object(resolver, "_gh_view") as mock_gh:
+                mock_gh.return_value = {"labels": []}
+                resolver.derive_roles_from_github(2456)
+                # Manually expire cache
+                old_ttl = resolver.CACHE_TTL_SECONDS
+                resolver.CACHE_TTL_SECONDS = 0
+                try:
+                    resolver.derive_roles_from_github(2456)
+                    self.assertEqual(mock_gh.call_count, 2)
+                finally:
+                    resolver.CACHE_TTL_SECONDS = old_ttl
+
+    def test_offline_returns_stale_cache_g6(self):
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1"}):
+            with patch.object(resolver, "_gh_view") as mock_gh:
+                mock_gh.return_value = {"labels": [{"name": "role:admin"}]}
+                first = resolver.derive_roles_from_github(2456)
+                # Simulate GitHub down on next call
+                resolver.CACHE_TTL_SECONDS = 0
+                mock_gh.return_value = None
+                second = resolver.derive_roles_from_github(2456)
+                self.assertEqual(first, second, "G6: should return stale cache on offline")
+                resolver.CACHE_TTL_SECONDS = 60
+
+    def test_offline_no_cache_returns_none(self):
+        resolver.clear_cache()
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1"}):
+            with patch.object(resolver, "_gh_view", return_value=None):
+                self.assertIsNone(resolver.derive_roles_from_github(2456))
+
+
+class TestTicketExtraction(unittest.TestCase):
+    def test_fix_branch(self):
+        self.assertEqual(ticket_from_branch("fix/2456-derive-roles"), 2456)
+
+    def test_feat_branch(self):
+        self.assertEqual(ticket_from_branch("feat/1234-foo"), 1234)
+
+    def test_main_branch(self):
+        self.assertIsNone(ticket_from_branch("main"))
+
+    def test_none_branch(self):
+        self.assertIsNone(ticket_from_branch(None))
+
+    def test_unticketed_branch(self):
+        self.assertIsNone(ticket_from_branch("feat/no-ticket-here"))
+
+
+class TestEffectiveRoles(unittest.TestCase):
+    def setUp(self):
+        resolver.clear_cache()
+
+    def test_passthrough_when_feature_off(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MEGINGJORD_DERIVE_ROLES_FROM_GH", None)
+            state_roles = {"manager": True, "collaborator": True, "admin": False, "consultant": False}
+            result = effective_roles(state_roles, "fix/2456-foo")
+            self.assertEqual(result, state_roles)
+
+    def test_derives_when_feature_on(self):
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1"}):
+            with patch.object(resolver, "_gh_view") as mock_gh:
+                mock_gh.return_value = {"labels": [{"name": "role:admin"}]}
+                result = effective_roles({"collaborator": True}, "fix/2456-foo")
+                self.assertTrue(result["admin"])
+
+    def test_falls_back_when_branch_has_no_ticket(self):
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1"}):
+            state_roles = {"collaborator": True}
+            result = effective_roles(state_roles, "main")
+            self.assertEqual(result, state_roles)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hooks/test_github_role_resolver.py
+++ b/tests/hooks/test_github_role_resolver.py
@@ -144,3 +144,36 @@ class TestEffectiveRoles(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestMaxStaleBound(unittest.TestCase):
+    """Per qwen-7b review of c49dbc5: stale cache must have upper bound."""
+
+    def setUp(self):
+        resolver.clear_cache()
+
+    def test_stale_within_max_returns_cache(self):
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1"}):
+            with patch.object(resolver, "_gh_view") as mock_gh:
+                mock_gh.return_value = {"labels": [{"name": "role:admin"}]}
+                resolver.derive_roles_from_github(2456)
+                # Force cache age within stale-bound but past TTL
+                resolver.CACHE_TTL_SECONDS = 0
+                mock_gh.return_value = None
+                result = resolver.derive_roles_from_github(2456)
+                self.assertIsNotNone(result)
+                resolver.CACHE_TTL_SECONDS = 60
+
+    def test_stale_beyond_max_returns_none(self):
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1"}):
+            with patch.object(resolver, "_gh_view") as mock_gh:
+                mock_gh.return_value = {"labels": [{"name": "role:admin"}]}
+                resolver.derive_roles_from_github(2456)
+                # Force cache age past MAX_STALE
+                resolver.CACHE_TTL_SECONDS = 0
+                resolver.MAX_STALE_SECONDS = 0
+                mock_gh.return_value = None
+                result = resolver.derive_roles_from_github(2456)
+                self.assertIsNone(result, "G6 bound: should not serve cache beyond MAX_STALE")
+                resolver.CACHE_TTL_SECONDS = 60
+                resolver.MAX_STALE_SECONDS = 300

--- a/tests/stress-derive-roles.spec.js
+++ b/tests/stress-derive-roles.spec.js
@@ -1,0 +1,78 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const STRESS_ITERATIONS = 50;
+const P99_BUDGET_MS = 200;
+const HOOKS = path.resolve(__dirname, '..', 'hooks', 'scripts');
+
+function runResolver(ticketN, env = {}) {
+  const script = `
+import sys
+sys.path.insert(0, "${HOOKS}")
+import github_role_resolver as resolver
+result = resolver.derive_roles_from_github(${ticketN})
+print(result if result else "None")
+`;
+  const start = Date.now();
+  const proc = spawnSync('python3', ['-c', script], {
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { duration: Date.now() - start, stdout: proc.stdout, status: proc.status };
+}
+
+test('stress: 50 sequential invocations all return null when feature off, p99 < 200ms', () => {
+  const durations = [];
+  for (let i = 0; i < STRESS_ITERATIONS; i++) {
+    const result = runResolver(2456, { MEGINGJORD_DERIVE_ROLES_FROM_GH: '' });
+    durations.push(result.duration);
+    assert.strictEqual(result.status, 0);
+    assert.match(result.stdout, /None/);
+  }
+  durations.sort((a, b) => a - b);
+  const p99 = durations[Math.floor(durations.length * 0.99)];
+  assert.ok(p99 < P99_BUDGET_MS, `p99 ${p99}ms exceeds budget ${P99_BUDGET_MS}ms`);
+});
+
+test('chaos: ticket extraction from various branch patterns', () => {
+  const cases = [
+    { branch: 'fix/2456-foo', expected: '2456' },
+    { branch: 'feat/1234-bar', expected: '1234' },
+    { branch: 'main', expected: 'None' },
+    { branch: '', expected: 'None' },
+  ];
+  for (const { branch, expected } of cases) {
+    const script = `
+import sys
+sys.path.insert(0, "${HOOKS}")
+from stop_checks import ticket_from_branch
+print(ticket_from_branch(${branch ? JSON.stringify(branch) : "None"}))
+`;
+    const proc = spawnSync('python3', ['-c', script], { encoding: 'utf8' });
+    assert.strictEqual(proc.status, 0);
+    if (expected === 'None') {
+      assert.match(proc.stdout, /None/);
+    } else {
+      assert.match(proc.stdout, new RegExp(expected));
+    }
+  }
+});
+
+test('chaos: effective_roles falls back to state_roles when feature off', () => {
+  const script = `
+import sys
+sys.path.insert(0, "${HOOKS}")
+from stop_checks import effective_roles
+state_roles = {"collaborator": True, "admin": False}
+result = effective_roles(state_roles, "fix/2456-foo")
+print(result == state_roles)
+`;
+  const proc = spawnSync('python3', ['-c', script], {
+    env: { ...process.env, MEGINGJORD_DERIVE_ROLES_FROM_GH: '' },
+    encoding: 'utf8',
+  });
+  assert.strictEqual(proc.status, 0);
+  assert.match(proc.stdout, /True/);
+});


### PR DESCRIPTION
## Summary
Phase-1 Move 1 of Epic #2451 — collapse local roles dict in favor of GitHub-as-event-source. Feature-flagged via MEGINGJORD_DERIVE_ROLES_FROM_GH; off by default preserves legacy behavior.

Tests: 18 unit + 3 stress, all pass.

Refs #2456
Refs Epic #2451
merge-evidence-deferred-final: #2456

[skip-changelog] — Feature-flagged off; behavioral change opt-in only.

## Baton artifacts
All 4 posted on #2456 before PR open.