### PR TITLE
feat(hooks): append-only baton-events.jsonl emitter (#2457)

### DIFF
--- a/hooks/scripts/baton_event_emitter.py
+++ b/hooks/scripts/baton_event_emitter.py
@@ -1,0 +1,96 @@
+"""Append-only baton-events.jsonl emitter (#2457).
+
+Move 2 of Epic #2451: event-source baton transitions for audit + replay.
+Schema v3 compliant per scripts/global/event-schema-v3.js. PII redaction at
+instrumentation site (G4 privacy).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Optional
+
+SCHEMA_VERSION = 3
+SERVICE = "baton"
+DEFAULT_ENV = "local"
+EVENT_LOG_PATH = Path.home() / ".megingjord" / "baton-events.jsonl"
+SUMMARY_MAX = 200
+
+# Redaction patterns — mirror subset of scripts/global/log-redaction.js for hook context
+_REDACTION_PATTERNS = [
+    (re.compile(r'sk-ant-[A-Za-z0-9_-]{20,}'), '[REDACTED:anthropic-key]'),
+    (re.compile(r'sk-[A-Za-z0-9]{20,}'), '[REDACTED:openai-key]'),
+    (re.compile(r'gh[ps]_[A-Za-z0-9]{20,}'), '[REDACTED:github-pat]'),
+    (re.compile(r'Bearer [A-Za-z0-9_.-]{20,}'), 'Bearer [REDACTED]'),
+    (re.compile(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'), '[REDACTED:email]'),
+]
+
+
+def feature_enabled() -> bool:
+    """Off by default; enable via env."""
+    return os.environ.get("MEGINGJORD_BATON_EVENT_LOG", "").strip() == "1"
+
+
+def redact(text: str) -> str:
+    if not isinstance(text, str):
+        return text
+    out = text
+    for pattern, replacement in _REDACTION_PATTERNS:
+        out = pattern.sub(replacement, out)
+    return out
+
+
+def _redact_event(event: dict) -> dict:
+    """Recursive redaction of free-text fields."""
+    return {k: redact(v) if isinstance(v, str) else v for k, v in event.items()}
+
+
+def emit_baton_event(
+    event: str, ticket: Optional[int] = None, *,
+    from_role: Optional[str] = None, to_role: Optional[str] = None,
+    signer: Optional[str] = None, summary: Optional[str] = None,
+    extras: Optional[dict] = None,
+) -> bool:
+    """Append schema-v3 baton event. Returns True if written, False if disabled.
+
+    Required v3 fields: ts, version, service, env, event.
+    Optional: ticket, from, to, signer, trace_id, session_id, _summary.
+    """
+    if not feature_enabled():
+        return False
+    record = {
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "version": SCHEMA_VERSION,
+        "service": SERVICE,
+        "env": os.environ.get("MEGINGJORD_ENV", DEFAULT_ENV),
+        "event": event,
+    }
+    if ticket is not None: record["ticket"] = int(ticket)
+    if from_role: record["from"] = from_role
+    if to_role: record["to"] = to_role
+    if signer: record["signer"] = signer
+    session_id = os.environ.get("MEGINGJORD_SESSION_ID", "").strip()
+    if session_id: record["session_id"] = session_id[:16]
+    if summary:
+        record["_summary"] = redact(summary[:SUMMARY_MAX])
+    if extras:
+        record.update(_redact_event(extras))
+    try:
+        EVENT_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with EVENT_LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+        return True
+    except OSError:
+        return False  # G6: never break the baton on log-write failure
+
+
+def emit_role_handoff(from_role: str, to_role: str, ticket: int, signer: str = "auto") -> bool:
+    """Convenience wrapper for the canonical role-transition event."""
+    return emit_baton_event(
+        "role-handoff", ticket=ticket,
+        from_role=from_role, to_role=to_role, signer=signer,
+        summary=f"{from_role} -> {to_role} on #{ticket}",
+    )

--- a/hooks/scripts/tool_activity.py
+++ b/hooks/scripts/tool_activity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from baton_event_emitter import emit_role_handoff
 from admin_patterns import (
     RE_GH_ISSUE_CLOSE, RE_GH_ISSUE_CREATE, RE_GH_RELEASE_CREATE,
     RE_GIT_COMMIT, RE_GIT_PUSH, RE_PR_CHECKS, RE_PR_CREATE,
@@ -95,4 +96,14 @@ def mark_tool_activity(state: dict[str, Any], payload: dict[str, Any]) -> None:
     repo_type = state.get("repo_type", "generic")
     required = required_admin_ops(flags, repo_type)
     if required and all(ops.get(k) for k in required):
+        if not roles.get("admin"):
+            # #2457: emit baton-event on role transition
+            try:
+                import re as _re
+                branch = state.get("active_branch") or ""
+                m = _re.match(r"^[a-z]+/(\d+)-", branch)
+                if m:
+                    emit_role_handoff("collaborator", "admin", int(m.group(1)))
+            except Exception:
+                pass  # never break the gate on emitter failure
         roles["admin"] = True

--- a/tests/hooks/test_baton_event_emitter.py
+++ b/tests/hooks/test_baton_event_emitter.py
@@ -1,0 +1,112 @@
+"""Tests for #2457: append-only baton-events.jsonl emitter (schema v3)."""
+from __future__ import annotations
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "hooks" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import baton_event_emitter as emitter  # noqa: E402
+
+
+class TestFeatureFlag(unittest.TestCase):
+    def test_disabled_by_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MEGINGJORD_BATON_EVENT_LOG", None)
+            self.assertFalse(emitter.feature_enabled())
+
+    def test_enabled_when_set(self):
+        with patch.dict(os.environ, {"MEGINGJORD_BATON_EVENT_LOG": "1"}):
+            self.assertTrue(emitter.feature_enabled())
+
+
+class TestRedaction(unittest.TestCase):
+    def test_redact_anthropic_key(self):
+        result = emitter.redact("token sk-ant-abc123def456ghi789jkl000")
+        self.assertIn("[REDACTED:anthropic-key]", result)
+
+    def test_redact_github_pat(self):
+        result = emitter.redact("ghp_AAABBBCCCDDDEEEFFFGGGHHHIIIJJJ")
+        self.assertIn("[REDACTED:github-pat]", result)
+
+    def test_redact_email(self):
+        result = emitter.redact("contact me at alice@example.com today")
+        self.assertIn("[REDACTED:email]", result)
+
+    def test_no_redaction_on_clean_text(self):
+        result = emitter.redact("plain governance text")
+        self.assertEqual(result, "plain governance text")
+
+
+class TestEmit(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.log_path = Path(self.tmp.name) / "baton-events.jsonl"
+        self.orig_path = emitter.EVENT_LOG_PATH
+        emitter.EVENT_LOG_PATH = self.log_path
+
+    def tearDown(self):
+        emitter.EVENT_LOG_PATH = self.orig_path
+        self.tmp.cleanup()
+
+    def test_emit_when_disabled_returns_false(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MEGINGJORD_BATON_EVENT_LOG", None)
+            self.assertFalse(emitter.emit_baton_event("test", ticket=2457))
+            self.assertFalse(self.log_path.exists())
+
+    def test_emit_when_enabled_writes_jsonl(self):
+        with patch.dict(os.environ, {"MEGINGJORD_BATON_EVENT_LOG": "1"}):
+            ok = emitter.emit_baton_event("role-handoff", ticket=2457,
+                                            from_role="collaborator", to_role="admin")
+            self.assertTrue(ok)
+            self.assertTrue(self.log_path.exists())
+            event = json.loads(self.log_path.read_text().strip())
+            self.assertEqual(event["version"], 3)
+            self.assertEqual(event["service"], "baton")
+            self.assertEqual(event["event"], "role-handoff")
+            self.assertEqual(event["ticket"], 2457)
+            self.assertEqual(event["from"], "collaborator")
+            self.assertEqual(event["to"], "admin")
+            self.assertIn("ts", event)
+            self.assertIn("env", event)
+
+    def test_emit_redacts_summary(self):
+        with patch.dict(os.environ, {"MEGINGJORD_BATON_EVENT_LOG": "1"}):
+            emitter.emit_baton_event("test", ticket=1, summary="token sk-ant-xxxxxxxxxxxxxxxxxxxx")
+            event = json.loads(self.log_path.read_text().strip())
+            self.assertIn("[REDACTED:anthropic-key]", event["_summary"])
+
+    def test_emit_append_only(self):
+        with patch.dict(os.environ, {"MEGINGJORD_BATON_EVENT_LOG": "1"}):
+            emitter.emit_baton_event("a", ticket=1)
+            emitter.emit_baton_event("b", ticket=2)
+            lines = self.log_path.read_text().strip().split("\n")
+            self.assertEqual(len(lines), 2)
+            self.assertEqual(json.loads(lines[0])["event"], "a")
+            self.assertEqual(json.loads(lines[1])["event"], "b")
+
+    def test_emit_role_handoff_wrapper(self):
+        with patch.dict(os.environ, {"MEGINGJORD_BATON_EVENT_LOG": "1"}):
+            self.assertTrue(emitter.emit_role_handoff("collaborator", "admin", 2457))
+            event = json.loads(self.log_path.read_text().strip())
+            self.assertEqual(event["from"], "collaborator")
+            self.assertEqual(event["to"], "admin")
+            self.assertIn("collaborator -> admin", event["_summary"])
+
+    def test_emit_handles_io_error_gracefully(self):
+        """G6: emitter MUST NOT break the baton on log-write failure."""
+        with patch.dict(os.environ, {"MEGINGJORD_BATON_EVENT_LOG": "1"}):
+            emitter.EVENT_LOG_PATH = Path("/nonexistent-dir-12345/baton-events.jsonl")
+            with patch.object(Path, "mkdir", side_effect=OSError("simulated")):
+                result = emitter.emit_baton_event("test", ticket=1)
+                self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phase-1 Move 2 of Epic #2451 — event-source baton transitions. Schema v3 compliant. PII redacted. Feature-flagged MEGINGJORD_BATON_EVENT_LOG (off by default).

Refs #2457
Refs Epic #2451
merge-evidence-deferred-final: #2457

[skip-changelog] — Feature-flagged off; behavioral change opt-in.

All 4 baton artifacts on #2457.