### PR TITLE
fix(governance): promote wiki/wisdom surfaces to required in doc-coverage matrix #2464

### DIFF
--- a/.changes/unreleased/2464.md
+++ b/.changes/unreleased/2464.md
@@ -1,0 +1,9 @@
+# #2464 Promote Wiki C surfaces to required in doc-coverage matrix
+
+**config/doc-coverage-matrix.yml**:
+- `area:instructions`: `wiki/wisdom/project/` promoted from suggested → required
+- `area:governance`: `wiki/wisdom/global/concepts/` promoted from suggested → required
+- `wiki/code/*` surfaces remain suggested (auto-updated by merge pipeline; no manual gate)
+
+**tests/collaborator-handoff-doc-coverage.spec.js**: test fixture updated to declare
+`wiki/wisdom/global/concepts/: N/A` in the area:governance passing case.

--- a/config/doc-coverage-matrix.yml
+++ b/config/doc-coverage-matrix.yml
@@ -34,8 +34,8 @@ surfaces:
       - AGENTS.md
       - .github/copilot-instructions.md
       - .codex/AGENTS.md
-    suggested:
       - wiki/wisdom/project/
+    suggested:
       - instructions/
 
   area:governance:
@@ -44,12 +44,12 @@ surfaces:
       - docs/workflow/learnings.md
       - governance/README.md
       - docs/howto/baton-workflow.md
+      - wiki/wisdom/global/concepts/
     suggested:
       - CONTRIBUTING.md
       - .github/CONTRIBUTING.md
       - governance-carve-outs/index.md
       - docs/decisions.md
-      - wiki/wisdom/global/concepts/
       - .github/SECURITY.md
 
   area:dashboard:

--- a/tests/collaborator-handoff-doc-coverage.spec.js
+++ b/tests/collaborator-handoff-doc-coverage.spec.js
@@ -20,7 +20,7 @@ test('validate: blocking when doc-coverage: block missing on lane:code-change wi
 
 test('validate: passes when doc-coverage: block has required surfaces', () => {
   const body = HANDOFF_SIGNED(
-    'doc-coverage:\n  .changes/unreleased/: DONE — #2424.md\n  docs/workflow/learnings.md: N/A — no new pattern\n  governance/README.md: DONE\n  docs/howto/baton-workflow.md: DONE\n'
+    'doc-coverage:\n  .changes/unreleased/: DONE — #2424.md\n  docs/workflow/learnings.md: N/A — no new pattern\n  governance/README.md: DONE\n  docs/howto/baton-workflow.md: DONE\n  wiki/wisdom/global/concepts/: N/A — no concept change\n'
   );
   const result = validate({
     lane: 'lane:code-change', labels: ['area:governance'],


### PR DESCRIPTION
Promotes Wiki C (manually authored) surfaces from suggested to required in the doc-coverage gate. Wiki A (auto-pipeline) surfaces remain suggested.

- area:instructions: wiki/wisdom/project/ → required
- area:governance: wiki/wisdom/global/concepts/ → required
- Test fixture updated for new required surface

merge-evidence-deferred-final: #2464

Refs #2464