### PR TITLE
fix(hooks): offline contract + chaos tests for resolver (#2460)

### DIFF
--- a/hooks/scripts/github_role_resolver.py
+++ b/hooks/scripts/github_role_resolver.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import threading
 import time
 from typing import Optional
@@ -36,6 +37,16 @@ def feature_enabled() -> bool:
 def _empty_roles() -> dict:
     return {"manager": False, "collaborator": False, "admin": False, "consultant": False}
 
+
+
+def _warn_degraded(reason: str, ticket_n: int) -> None:
+    """G8 observability: emit user-visible degradation note to stderr (#2460)."""
+    if os.environ.get("MEGINGJORD_QUIET_RESOLVER", "").strip() == "1":
+        return
+    sys.stderr.write(
+        f"[role-resolver] degraded: {reason} for #{ticket_n}; "
+        f"falling back to {'stale cache' if reason != 'cold-miss' else 'local-state'}\n"
+    )
 
 def _gh_view(ticket_n: int, timeout: float = 10.0) -> Optional[dict]:
     """Call gh CLI; return parsed JSON or None on failure (G6 fallback)."""
@@ -80,7 +91,9 @@ def derive_roles_from_github(ticket_n: int) -> Optional[dict]:
     if issue is None:
         # G6 with bound: serve stale only if within MAX_STALE_SECONDS
         if cached and (now - cached[0]) < MAX_STALE_SECONDS:
+            _warn_degraded("gh-fetch-failed-using-stale", ticket_n)
             return cached[1]
+        _warn_degraded("cold-miss", ticket_n)
         return None
 
     roles = _parse_roles(issue)

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -285,6 +285,27 @@ When a MANAGER_HANDOFF involves writing files consumed by another team's runtime
 the `cross_runtime_writes` field is required and must include `target_team_sign_off`
 before the baton advances. See `instructions/cross-team-artifact-write.instructions.md`.
 
+
+
+## Offline contract for derive_roles_from_github (#2460, Epic #2451 Move 5)
+
+When the GitHub-derived role resolver (#2456, feature-flagged via `MEGINGJORD_DERIVE_ROLES_FROM_GH`) cannot reach GitHub:
+
+| Condition | Behavior | Operator-visible signal |
+|---|---|---|
+| First call (cold-miss): gh CLI unreachable or returns non-zero | Returns `None`; callers fall back to local-state | stderr: `[role-resolver] degraded: cold-miss for #N; falling back to local-state` |
+| Subsequent call (warm cache + gh fail) within 300s MAX_STALE | Returns last-cached value | stderr: `[role-resolver] degraded: gh-fetch-failed-using-stale for #N; falling back to stale cache` |
+| Subsequent call beyond MAX_STALE_SECONDS | Returns `None`; callers fall back to local-state | stderr: cold-miss line |
+| `gh` CLI absent (FileNotFoundError) | Same as above per cache state | same stderr lines |
+| Subprocess timeout (10s default) | Same as above per cache state | same stderr lines |
+
+**Quiet mode** for CI/cron contexts: set `MEGINGJORD_QUIET_RESOLVER=1` to suppress stderr output.
+
+**Goal-lens justification**:
+- **G6 resilience**: G6 is preserved via stale-cache fallback bounded by MAX_STALE_SECONDS=300; legacy `roles{}` continues to function when feature flag off
+- **G8 observability**: each degraded path emits a labeled stderr line so operators can diagnose; not silent
+- **G3 zero-cost in CI**: quiet-mode env flag suppresses noise without disabling the fallback path
+
 ## Skill Mapping
 
 Manager: `role-manager-execution` | Collaborator: `role-collaborator-execution`

--- a/tests/hooks/test_github_role_resolver.py
+++ b/tests/hooks/test_github_role_resolver.py
@@ -177,3 +177,69 @@ class TestMaxStaleBound(unittest.TestCase):
                 self.assertIsNone(result, "G6 bound: should not serve cache beyond MAX_STALE")
                 resolver.CACHE_TTL_SECONDS = 60
                 resolver.MAX_STALE_SECONDS = 300
+
+
+class TestChaosOffline(unittest.TestCase):
+    """#2460: chaos paths for offline behavior."""
+
+    def setUp(self):
+        resolver.clear_cache()
+
+    def test_chaos_gh_cli_not_found_no_cache(self):
+        """gh CLI absent (FileNotFoundError) returns None when no cache."""
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1",
+                                       "MEGINGJORD_QUIET_RESOLVER": "1"}):
+            with patch("subprocess.run", side_effect=FileNotFoundError("gh not found")):
+                self.assertIsNone(resolver.derive_roles_from_github(2460))
+
+    def test_chaos_gh_cli_not_found_with_cache(self):
+        """gh CLI absent serves stale cache within max-stale (G6)."""
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1",
+                                       "MEGINGJORD_QUIET_RESOLVER": "1"}):
+            with patch.object(resolver, "_gh_view") as mock_gh:
+                mock_gh.return_value = {"labels": [{"name": "role:admin"}]}
+                resolver.derive_roles_from_github(2460)
+                # Force expiry + simulate gh CLI absent
+                resolver.CACHE_TTL_SECONDS = 0
+                with patch("subprocess.run", side_effect=FileNotFoundError("gh not found")):
+                    result = resolver.derive_roles_from_github(2460)
+                self.assertIsNotNone(result)
+                self.assertTrue(result["admin"])
+                resolver.CACHE_TTL_SECONDS = 60
+
+    def test_chaos_rate_limit_returns_none_no_cache(self):
+        """Simulated rate-limit (subprocess returncode != 0) returns None."""
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1",
+                                       "MEGINGJORD_QUIET_RESOLVER": "1"}):
+            mock_result = type("R", (), {"returncode": 1, "stdout": "", "stderr": "rate limit"})
+            with patch("subprocess.run", return_value=mock_result):
+                self.assertIsNone(resolver.derive_roles_from_github(2460))
+
+    def test_chaos_timeout_returns_none_no_cache(self):
+        """Subprocess timeout returns None."""
+        import subprocess as _sp
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1",
+                                       "MEGINGJORD_QUIET_RESOLVER": "1"}):
+            with patch("subprocess.run", side_effect=_sp.TimeoutExpired("gh", 10)):
+                self.assertIsNone(resolver.derive_roles_from_github(2460))
+
+    def test_user_visible_warning_emitted(self):
+        """G8: stderr message on degraded path unless MEGINGJORD_QUIET_RESOLVER set."""
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1"}):
+            os.environ.pop("MEGINGJORD_QUIET_RESOLVER", None)
+            import io as _io
+            with patch("sys.stderr", new=_io.StringIO()) as stderr:
+                with patch.object(resolver, "_gh_view", return_value=None):
+                    resolver.derive_roles_from_github(99999)
+                self.assertIn("degraded", stderr.getvalue())
+                self.assertIn("#99999", stderr.getvalue())
+
+    def test_quiet_mode_suppresses_warning(self):
+        """G3: cron/CI mode can suppress stderr noise."""
+        with patch.dict(os.environ, {"MEGINGJORD_DERIVE_ROLES_FROM_GH": "1",
+                                       "MEGINGJORD_QUIET_RESOLVER": "1"}):
+            import io as _io
+            with patch("sys.stderr", new=_io.StringIO()) as stderr:
+                with patch.object(resolver, "_gh_view", return_value=None):
+                    resolver.derive_roles_from_github(99999)
+                self.assertEqual(stderr.getvalue(), "")


### PR DESCRIPTION
Phase-1 Move 5 of Epic #2451 — G6+G8 resilience hardening + offline contract documentation.

Refs #2460
Refs Epic #2451
merge-evidence-deferred-final: #2460

[skip-changelog] — feature-flagged behavior.

All 4 baton artifacts on #2460.