### PR TITLE
feat(governance): add Antigravity as fifth orchestrator target #2016

### DIFF
--- a/.antigravity/instructions.md
+++ b/.antigravity/instructions.md
@@ -1,0 +1,23 @@
+# Megingjord — Global Governance Harness
+
+Cross-team contract entry point: `governance/README.md` (4 invariants:
+Team&Model signing, baton order, ticket-first workflow, dedicated worktree per
+concurrent agent). This file is the Antigravity adapter.
+
+## Invariants
+
+1. **Team&Model signing** — all governed artifacts carry `Signed-by` + `Team&Model` provenance.
+2. **Baton order** — Manager → Collaborator → Admin → Consultant; one role active per ticket.
+3. **Ticket-first** — no code or config work without a linked GitHub issue; every commit refs `#N`.
+4. **Dedicated worktree** — each concurrent agent session uses an isolated worktree + branch.
+
+## Harness goals (priority order)
+
+Governance > Quality > Zero Cost > Privacy > Portability > Resilience >
+Throughput > Observability > Interoperability > Maintainability.
+
+## Adapter notes
+
+- Use `governance/README.md` as the canonical contract source.
+- Repo-local governance files may extend or tighten this baseline.
+- Runtime home for Antigravity assets: deploy through governed workflow only.

--- a/.changes/unreleased/2016.md
+++ b/.changes/unreleased/2016.md
@@ -1,0 +1,9 @@
+### Added
+- `.antigravity/instructions.md`: Antigravity orchestrator adapter entry point with the 4 governance invariants. Refs #2016.
+- `scripts/global/cross-team-contract-check.js`: `.antigravity/instructions.md` added to `ENTRY_POINTS` for cross-team contract validation coverage.
+
+### Changed
+- `inventory/governance-manifest.schema.json`: `antigravity` added to `targets` enum.
+- `scripts/global/governance-manifest-validate.js`: `antigravity` added to `allowedTargets` Set.
+- `scripts/global/governance-adapter-emit.js`: `antigravity` added to `targets` list and target path shim added.
+- `tests/cross-team-contract-check.spec.js`: Entry-point list length check updated from 4 to 5; Antigravity label assertion added.

--- a/inventory/governance-manifest.schema.json
+++ b/inventory/governance-manifest.schema.json
@@ -31,7 +31,7 @@
             "minItems": 1,
             "items": {
               "type": "string",
-              "enum": ["copilot", "cline", "claude-code", "continue"]
+              "enum": ["copilot", "cline", "claude-code", "continue", "antigravity"]
             }
           },
           "tags": {

--- a/scripts/global/cross-team-contract-check.js
+++ b/scripts/global/cross-team-contract-check.js
@@ -12,6 +12,7 @@ const ENTRY_POINTS = [
   { path: 'CLAUDE.md', label: 'CLAUDE.md (Claude Code)' },
   { path: '.github/copilot-instructions.md', label: 'Copilot entry' },
   { path: '.codex/AGENTS.md', label: 'Codex project doc' },
+  { path: '.antigravity/instructions.md', label: 'Antigravity entry' },
 ];
 
 const INVARIANTS = [

--- a/scripts/global/governance-adapter-emit.js
+++ b/scripts/global/governance-adapter-emit.js
@@ -8,7 +8,7 @@ const { validate } = require('./governance-manifest-validate');
 const root = path.resolve(__dirname, '..', '..');
 const manifestPath = path.join(root, 'inventory', 'governance-manifest.sample.json');
 const defaultOutRoot = path.join(root, 'generated', 'governance-adapters');
-const targets = ['copilot', 'cline', 'claude-code', 'continue'];
+const targets = ['copilot', 'cline', 'claude-code', 'continue', 'antigravity'];
 
 function readJson(file) { return JSON.parse(fs.readFileSync(file, 'utf8')); }
 function write(file, content) { fs.mkdirSync(path.dirname(file), { recursive: true }); fs.writeFileSync(file, `${content}\n`); }
@@ -34,6 +34,7 @@ function targetPath(target, unit, outRoot = defaultOutRoot) {
   if (target === 'cline') return path.join(base, '.clinerules', `${unit.id}.md`);
   if (target === 'claude-code') return path.join(base, 'CLAUDE.md');
   if (target === 'continue') return path.join(base, '.continue', 'rules', `${unit.id}.md`);
+  if (target === 'antigravity') return path.join(base, '.antigravity', `${unit.id}.md`);
   throw new Error(`unsupported target: ${target}`);
 }
 function frontmatter(target, unit) {

--- a/scripts/global/governance-manifest-validate.js
+++ b/scripts/global/governance-manifest-validate.js
@@ -7,7 +7,7 @@ const path = require('path');
 const root = path.resolve(__dirname, '..', '..');
 const schemaPath = path.join(root, 'inventory', 'governance-manifest.schema.json');
 const defaultManifestPath = path.join(root, 'inventory', 'governance-manifest.sample.json');
-const allowedTargets = new Set(['copilot', 'cline', 'claude-code', 'continue']);
+const allowedTargets = new Set(['copilot', 'cline', 'claude-code', 'continue', 'antigravity']);
 const allowedPriority = new Set(['P0', 'P1', 'P2', 'P3']);
 
 function fail(msg) { process.stderr.write(`manifest-validate: ${msg}\n`); }

--- a/tests/cross-team-contract-check.spec.js
+++ b/tests/cross-team-contract-check.spec.js
@@ -45,13 +45,14 @@ test('detects missing invariant in synthetic entry-point file', () => {
   assert.equal(hit, false);
 });
 
-test('entry-point list covers exactly 4 runtimes', () => {
-  assert.equal(ENTRY_POINTS.length, 4);
+test('entry-point list covers exactly 5 runtimes', () => {
+  assert.equal(ENTRY_POINTS.length, 5);
   const labels = ENTRY_POINTS.map(e => e.label);
   assert.ok(labels.some(l => l.includes('AGENTS')));
   assert.ok(labels.some(l => l.includes('CLAUDE')));
   assert.ok(labels.some(l => l.includes('Copilot')));
   assert.ok(labels.some(l => l.includes('Codex')));
+  assert.ok(labels.some(l => l.includes('Antigravity')));
 });
 
 test('invariant patterns recognize full-body example', () => {


### PR DESCRIPTION
## Summary

Integrates Antigravity as a fifth first-class orchestrator target in the Megingjord harness.

Refs #2016

## Changes

- `inventory/governance-manifest.schema.json`: Added `antigravity` to targets enum
- `scripts/global/governance-manifest-validate.js`: Added `antigravity` to `allowedTargets`
- `scripts/global/governance-adapter-emit.js`: Added target + path shim
- `.antigravity/instructions.md`: New adapter entry point with 4 invariants
- `scripts/global/cross-team-contract-check.js`: Added to `ENTRY_POINTS`
- `tests/cross-team-contract-check.spec.js`: Entry-point length 4→5, Antigravity label assertion

## Evidence

`node --test tests/cross-team-contract-check.spec.js`: 6/6 pass
`npm run lint`: all files within 100-line limit

merge-evidence-deferred-final: #2016