### PR TITLE
feat(governance): register antigravity as permitted lease-holding team

### DIFF
--- a/.changes/unreleased/2366.md
+++ b/.changes/unreleased/2366.md
@@ -1,0 +1,4 @@
+## #2366 feat(governance): register antigravity as permitted lease-holding team
+
+Added `antigravity` to the `team` enum in `inventory/cross-team-lease.schema.json`.
+Antigravity workers can now acquire, verify, and release session locks through the lease registry.

--- a/inventory/cross-team-lease.schema.json
+++ b/inventory/cross-team-lease.schema.json
@@ -29,7 +29,7 @@
         "properties": {
           "ticket": { "type": "integer", "minimum": 1 },
           "team": {
-            "enum": ["codex", "copilot", "claude-code", "openclaw", "operator"]
+            "enum": ["codex", "copilot", "claude-code", "openclaw", "operator", "antigravity"]
           },
           "role": {
             "enum": ["manager", "collaborator", "admin", "consultant"]


### PR DESCRIPTION
feat(governance): register antigravity as permitted lease-holding team

Adds `antigravity` to the `team` enum in `inventory/cross-team-lease.schema.json`.

Previously the schema only allowed: codex, copilot, claude-code, openclaw, operator.
Antigravity workers acquiring session leases were blocked by schema validation.

Change: 1 line in inventory/cross-team-lease.schema.json

merge-evidence-deferred-final: #2366

Refs #2366
