### PR TITLE
feat(governance): megingjord-xteam-mcp server implementation (#2496)

### DIFF
--- a/inventory/team-perspectives.json
+++ b/inventory/team-perspectives.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": 1,
+  "teams": {
+    "claude-code": {
+      "lens": "Reasoning depth + multi-file refactor consequences",
+      "strengths": [
+        "long-context reasoning",
+        "cross-module impact analysis"
+      ]
+    },
+    "codex": {
+      "lens": "OpenAI-ecosystem compatibility + CLI ergonomics",
+      "strengths": [
+        "CLI tooling",
+        "OpenAI-compatible providers"
+      ]
+    },
+    "copilot": {
+      "lens": "VS Code + GitHub-native developer experience",
+      "strengths": [
+        "GitHub workflows",
+        "VS Code extensions"
+      ]
+    },
+    "antigravity": {
+      "lens": "Gemini long-context + Google Cloud integrations",
+      "strengths": [
+        "long-context windows",
+        "Google Cloud services"
+      ]
+    }
+  }
+}

--- a/scripts/xteam-mcp/bin.js
+++ b/scripts/xteam-mcp/bin.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('./index.js');

--- a/scripts/xteam-mcp/gh-client.js
+++ b/scripts/xteam-mcp/gh-client.js
@@ -1,0 +1,32 @@
+// gh-client.js — thin wrapper around `gh` CLI for testability + dependency injection
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+
+function shell(args) {
+  return execFileSync('gh', args, { encoding: 'utf8', timeout: 10000 });
+}
+
+async function viewLabels(ticket) {
+  const out = shell(['issue', 'view', String(ticket), '--json', 'labels']);
+  return JSON.parse(out).labels || [];
+}
+
+async function addLabel(ticket, label) {
+  shell(['issue', 'edit', String(ticket), '--add-label', label]);
+}
+
+async function removeLabel(ticket, label) {
+  shell(['issue', 'edit', String(ticket), '--remove-label', label]);
+}
+
+async function createEpic({ title, body, labels }) {
+  const labelArgs = (labels || []).flatMap(l => ['--label', l]);
+  const out = shell(['issue', 'create', '--title', title, '--body', body, ...labelArgs]);
+  const url = out.trim().split('\n').pop();
+  const match = url.match(/\/(\d+)$/);
+  if (!match) throw new Error(`could not parse created Epic URL: ${url}`);
+  return { number: parseInt(match[1], 10), url };
+}
+
+module.exports = { viewLabels, addLabel, removeLabel, createEpic };

--- a/scripts/xteam-mcp/handlers.js
+++ b/scripts/xteam-mcp/handlers.js
@@ -1,0 +1,55 @@
+// handlers.js — /xteam prompt handlers (pure logic, MCP-server-agnostic)
+// Each handler returns the chat-rendered prompt string for the caller.
+'use strict';
+
+const { attemptClaim } = require('./leader-election');
+
+function loadPerspectives(perspectivesPath, fs = require('fs')) {
+  return JSON.parse(fs.readFileSync(perspectivesPath, 'utf8')).teams;
+}
+
+function leadPrompt({ team, ticket, perspective, description }) {
+  return `You are LEAD on Epic #${ticket}.
+Your perspective: ${perspective.lens}
+Your strengths: ${perspective.strengths.join(', ')}
+Task: Coordinate cross-team synthesis. ${description ? 'Scope: ' + description : 'Read Epic body for scope.'}
+Write findings to artifacts/${team}-rd.md. Lead the convergence + final synthesis.`;
+}
+
+function participantPrompt({ team, ticket, perspective, leadTeam }) {
+  return `You are PARTICIPANT on Epic #${ticket}. Lead is ${leadTeam}.
+Your perspective: ${perspective.lens}
+Your strengths: ${perspective.strengths.join(', ')}
+Task: Read Epic body. Write findings to artifacts/${team}-rd.md from your perspective.`;
+}
+
+async function handleXteam({ ticket, team, perspectivesPath, ghClient, fs }) {
+  const teams = loadPerspectives(perspectivesPath, fs);
+  const perspective = teams[team];
+  if (!perspective) throw new Error(`unknown team: ${team}`);
+  const claim = await attemptClaim({ ticket, team, ghClient });
+  return claim.role === 'lead'
+    ? { role: 'lead', prompt: leadPrompt({ team, ticket, perspective }), ticket }
+    : { role: 'participant', prompt: participantPrompt({ team, ticket, perspective, leadTeam: claim.leadTeam }), ticket };
+}
+
+async function handleXteamCreate({ description, team, perspectivesPath, ghClient, fs }) {
+  if (!description || description.trim().length < 10) {
+    throw new Error('description must be at least 10 characters');
+  }
+  const epic = await ghClient.createEpic({
+    title: description.slice(0, 60),
+    body: `## Goal\n\n${description}\n\nCreated via /xteam ? by ${team}.`,
+    labels: ['type:epic', 'status:backlog', 'priority:P2', 'lane:docs-research', 'phase-gate:research-first'],
+  });
+  return handleXteam({ ticket: epic.number, team, perspectivesPath, ghClient, fs });
+}
+
+async function handleXteamStatus({ ticket, ghClient }) {
+  const labels = await ghClient.viewLabels(ticket);
+  const { parseExistingLeads } = require('./leader-election');
+  const leads = parseExistingLeads(labels);
+  return { ticket, leadTeam: leads[0] || null, status: leads.length > 0 ? 'in-flight' : 'no-claim' };
+}
+
+module.exports = { handleXteam, handleXteamCreate, handleXteamStatus, leadPrompt, participantPrompt, loadPerspectives };

--- a/scripts/xteam-mcp/index.js
+++ b/scripts/xteam-mcp/index.js
@@ -1,0 +1,67 @@
+// index.js — megingjord-xteam-mcp server entrypoint (Epic #2486)
+// MCP server exposing /xteam, /xteam-status, /xteam-create as prompts.
+'use strict';
+
+const path = require('node:path');
+const { handleXteam, handleXteamCreate, handleXteamStatus } = require('./handlers');
+const ghClient = require('./gh-client');
+const fs = require('node:fs');
+
+const PERSPECTIVES_PATH = process.env.MEGINGJORD_XTEAM_PERSPECTIVES
+  || path.resolve(__dirname, '..', '..', 'inventory', 'team-perspectives.json');
+
+const TEAM = process.env.MEGINGJORD_XTEAM_TEAM || 'claude-code';
+
+const PROMPTS = [
+  {
+    name: 'xteam',
+    description: 'Join cross-team synthesis on an existing Epic',
+    arguments: [{ name: 'epic', description: 'Epic ticket number', required: true }],
+    handler: async ({ epic }) => handleXteam({
+      ticket: parseInt(epic, 10), team: TEAM, perspectivesPath: PERSPECTIVES_PATH, ghClient, fs,
+    }),
+  },
+  {
+    name: 'xteam-create',
+    description: 'Create new Epic and kick off cross-team synthesis',
+    arguments: [{ name: 'description', description: 'Epic description (10+ chars)', required: true }],
+    handler: async ({ description }) => handleXteamCreate({
+      description, team: TEAM, perspectivesPath: PERSPECTIVES_PATH, ghClient, fs,
+    }),
+  },
+  {
+    name: 'xteam-status',
+    description: 'Query progress of an in-flight synthesis',
+    arguments: [{ name: 'epic', description: 'Epic ticket number', required: true }],
+    handler: async ({ epic }) => handleXteamStatus({
+      ticket: parseInt(epic, 10), ghClient,
+    }),
+  },
+];
+
+async function main() {
+  try {
+    const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
+    const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
+    const server = new Server({ name: 'megingjord-xteam-mcp', version: '0.1.0' },
+      { capabilities: { prompts: {} } });
+    server.setRequestHandler('prompts/list', async () => ({
+      prompts: PROMPTS.map(p => ({ name: p.name, description: p.description, arguments: p.arguments })),
+    }));
+    server.setRequestHandler('prompts/get', async (req) => {
+      const prompt = PROMPTS.find(p => p.name === req.params.name);
+      if (!prompt) throw new Error(`unknown prompt: ${req.params.name}`);
+      const result = await prompt.handler(req.params.arguments || {});
+      return { messages: [{ role: 'user', content: { type: 'text', text: JSON.stringify(result, null, 2) } }] };
+    });
+    await server.connect(new StdioServerTransport());
+  } catch (err) {
+    process.stderr.write(`[xteam-mcp] startup failed: ${err.message}\n`);
+    process.stderr.write('Install @modelcontextprotocol/sdk: npm install @modelcontextprotocol/sdk\n');
+    process.exit(1);
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { PROMPTS, PERSPECTIVES_PATH, TEAM };

--- a/scripts/xteam-mcp/leader-election.js
+++ b/scripts/xteam-mcp/leader-election.js
@@ -1,0 +1,53 @@
+// leader-election.js — GitHub-label-based atomic leader claim (#2486 #2479)
+// Pure functions; gh CLI invocation injected for testability.
+'use strict';
+
+const TEAM_NAMESPACE = 'xteam-lead:';
+const VALID_TEAMS = ['claude-code', 'codex', 'copilot', 'antigravity'];
+
+function leadLabel(team) {
+  if (!VALID_TEAMS.includes(team)) {
+    throw new Error(`unknown team: ${team}; valid: ${VALID_TEAMS.join(', ')}`);
+  }
+  return `${TEAM_NAMESPACE}${team}`;
+}
+
+function parseExistingLeads(labels) {
+  return (labels || [])
+    .map(l => (typeof l === 'string' ? l : l.name))
+    .filter(name => name && name.startsWith(TEAM_NAMESPACE))
+    .map(name => name.slice(TEAM_NAMESPACE.length));
+}
+
+async function attemptClaim({ ticket, team, ghClient }) {
+  if (!Number.isInteger(ticket) || ticket <= 0) {
+    throw new Error('ticket must be positive integer');
+  }
+  const label = leadLabel(team);
+  const beforeLabels = await ghClient.viewLabels(ticket);
+  const existingLeads = parseExistingLeads(beforeLabels);
+  if (existingLeads.length > 0) {
+    return { role: 'participant', leadTeam: existingLeads[0], reason: 'lead-already-claimed' };
+  }
+  await ghClient.addLabel(ticket, label);
+  const afterLabels = await ghClient.viewLabels(ticket);
+  const finalLeads = parseExistingLeads(afterLabels);
+  if (finalLeads.length === 0) {
+    throw new Error('claim race: label not present after add');
+  }
+  if (finalLeads.length === 1 && finalLeads[0] === team) {
+    return { role: 'lead', leadTeam: team, reason: 'claimed' };
+  }
+  // Tiebreaker: alphabetical (stable, deterministic)
+  const winner = [...finalLeads].sort()[0];
+  if (winner === team) {
+    return { role: 'lead', leadTeam: team, reason: 'tiebreaker-winner' };
+  }
+  await ghClient.removeLabel(ticket, label);
+  return { role: 'participant', leadTeam: winner, reason: 'tiebreaker-loser' };
+}
+
+module.exports = {
+  TEAM_NAMESPACE, VALID_TEAMS,
+  leadLabel, parseExistingLeads, attemptClaim,
+};

--- a/scripts/xteam-mcp/package.json
+++ b/scripts/xteam-mcp/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@megingjord/xteam-mcp",
+  "version": "0.1.0",
+  "description": "Cross-runtime /xteam MCP slash-command server for Megingjord harness (Epic #2486)",
+  "type": "commonjs",
+  "main": "index.js",
+  "bin": {
+    "megingjord-xteam-mcp": "./bin.js"
+  },
+  "scripts": {
+    "test": "node --test ../../tests/xteam-mcp/"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/tests/xteam-mcp/handlers.spec.js
+++ b/tests/xteam-mcp/handlers.spec.js
@@ -1,0 +1,116 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { TEAM_NAMESPACE, VALID_TEAMS, leadLabel, parseExistingLeads, attemptClaim } =
+  require('../../scripts/xteam-mcp/leader-election');
+const { handleXteam, handleXteamStatus, leadPrompt, participantPrompt, loadPerspectives } =
+  require('../../scripts/xteam-mcp/handlers');
+
+const PERSPECTIVES = path.resolve(__dirname, '..', '..', 'inventory', 'team-perspectives.json');
+
+function mockGhClient(initialLabels = []) {
+  const state = { labels: [...initialLabels], created: [] };
+  return {
+    state,
+    async viewLabels() { return state.labels.map(name => ({ name })); },
+    async addLabel(_t, label) { state.labels.push(label); },
+    async removeLabel(_t, label) { state.labels = state.labels.filter(l => l !== label); },
+    async createEpic({ title, body, labels }) {
+      const number = 9000 + state.created.length;
+      state.created.push({ number, title, body, labels });
+      return { number, url: `https://example.com/${number}` };
+    },
+  };
+}
+
+test('leader-election: leadLabel namespaces team correctly', () => {
+  assert.strictEqual(leadLabel('claude-code'), 'xteam-lead:claude-code');
+  assert.strictEqual(leadLabel('codex'), 'xteam-lead:codex');
+});
+
+test('leader-election: leadLabel rejects unknown team', () => {
+  assert.throws(() => leadLabel('unknown'), /unknown team/);
+});
+
+test('leader-election: parseExistingLeads extracts team from xteam-lead labels', () => {
+  const labels = [{ name: 'status:in-progress' }, { name: 'xteam-lead:codex' }];
+  assert.deepStrictEqual(parseExistingLeads(labels), ['codex']);
+});
+
+test('leader-election: attemptClaim wins when no existing lead', async () => {
+  const gh = mockGhClient([]);
+  const result = await attemptClaim({ ticket: 100, team: 'claude-code', ghClient: gh });
+  assert.strictEqual(result.role, 'lead');
+  assert.strictEqual(result.leadTeam, 'claude-code');
+  assert.ok(gh.state.labels.includes('xteam-lead:claude-code'));
+});
+
+test('leader-election: attemptClaim yields when lead already claimed', async () => {
+  const gh = mockGhClient(['xteam-lead:codex']);
+  const result = await attemptClaim({ ticket: 100, team: 'claude-code', ghClient: gh });
+  assert.strictEqual(result.role, 'participant');
+  assert.strictEqual(result.leadTeam, 'codex');
+});
+
+test('leader-election: attemptClaim rejects non-positive ticket', async () => {
+  const gh = mockGhClient([]);
+  await assert.rejects(() => attemptClaim({ ticket: 0, team: 'claude-code', ghClient: gh }),
+    /positive integer/);
+});
+
+test('handlers: loadPerspectives returns 4 teams', () => {
+  const teams = loadPerspectives(PERSPECTIVES);
+  assert.ok(teams['claude-code']);
+  assert.ok(teams['codex']);
+  assert.ok(teams['copilot']);
+  assert.ok(teams['antigravity']);
+});
+
+test('handlers: leadPrompt includes team perspective + ticket', () => {
+  const perspective = { lens: 'L', strengths: ['s1', 's2'] };
+  const prompt = leadPrompt({ team: 'codex', ticket: 42, perspective });
+  assert.match(prompt, /LEAD on Epic #42/);
+  assert.match(prompt, /Your perspective: L/);
+  assert.match(prompt, /artifacts\/codex-rd\.md/);
+});
+
+test('handlers: participantPrompt mentions lead team', () => {
+  const perspective = { lens: 'L', strengths: ['s'] };
+  const prompt = participantPrompt({ team: 'copilot', ticket: 42, perspective, leadTeam: 'codex' });
+  assert.match(prompt, /PARTICIPANT on Epic #42/);
+  assert.match(prompt, /Lead is codex/);
+});
+
+test('handlers: handleXteam returns lead role on fresh Epic', async () => {
+  const gh = mockGhClient([]);
+  const result = await handleXteam({
+    ticket: 100, team: 'claude-code',
+    perspectivesPath: PERSPECTIVES, ghClient: gh, fs: require('fs'),
+  });
+  assert.strictEqual(result.role, 'lead');
+  assert.match(result.prompt, /LEAD on Epic #100/);
+});
+
+test('handlers: handleXteam returns participant role on claimed Epic', async () => {
+  const gh = mockGhClient(['xteam-lead:codex']);
+  const result = await handleXteam({
+    ticket: 100, team: 'claude-code',
+    perspectivesPath: PERSPECTIVES, ghClient: gh, fs: require('fs'),
+  });
+  assert.strictEqual(result.role, 'participant');
+  assert.match(result.prompt, /Lead is codex/);
+});
+
+test('handlers: handleXteamStatus reports no claim when empty', async () => {
+  const gh = mockGhClient([]);
+  const result = await handleXteamStatus({ ticket: 100, ghClient: gh });
+  assert.strictEqual(result.status, 'no-claim');
+  assert.strictEqual(result.leadTeam, null);
+});
+
+test('handlers: handleXteamStatus reports in-flight when lead claimed', async () => {
+  const gh = mockGhClient(['xteam-lead:antigravity']);
+  const result = await handleXteamStatus({ ticket: 100, ghClient: gh });
+  assert.strictEqual(result.status, 'in-flight');
+  assert.strictEqual(result.leadTeam, 'antigravity');
+});


### PR DESCRIPTION
Phase-1 Move 1 of Epic #2486. MCP server + leader-election + 13 unit tests.

Refs #2496
Refs Epic #2486
merge-evidence-deferred-final: #2496

[skip-changelog]

All 4 baton artifacts on #2496. Install docs are Child #2497.