### PR TITLE
feat(observability): worktree lifecycle event reporting (#2256)

### DIFF
--- a/.changes/unreleased/2256.md
+++ b/.changes/unreleased/2256.md
@@ -1,0 +1,2 @@
+### Added
+- feat(observability): worktree lifecycle event reporting — emits privacy-safe structured events for stale-safe, stale-risky, rescue-needed, stale-warning, and abandoned worktrees to .dashboard/events.jsonl (#2256)

--- a/scripts/global/worktree-lifecycle-events.js
+++ b/scripts/global/worktree-lifecycle-events.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+'use strict';
+// worktree-lifecycle-events.js — Emit lifecycle events for worktrees needing attention.
+// Observability only; no cleanup execution. Deploy to ~/.copilot/scripts/
+// Usage: node worktree-lifecycle-events.js [--json] [--dry-run]
+
+const { inventory } = require('./worktree-inventory');
+const { emit } = require('./emit-event');
+
+const ACTIONS = {
+  'stale-safe': 'remove-worktree-and-branch',
+  'stale-risky': 'rescue-branch-or-push-upstream',
+  'stale-warning': 'rebase-or-review',
+  'rescue-needed': 'create-draft-pr-or-rescue-branch',
+  'abandoned': 'remove-after-review',
+};
+
+// States that warrant an event emission
+const REPORT_STATES = new Set(Object.keys(ACTIONS));
+
+// Privacy-safe path redaction: remove home directory prefix
+function redactPath(p) {
+  const home = process.env.HOME || '';
+  return home && p.startsWith(home) ? p.replace(home, '~') : p;
+}
+
+// Build a privacy-safe event payload for one worktree entry
+function buildEvent(entry) {
+  const lifecycleState = entry.lifecycleState || 'unknown';
+  const proposedAction = ACTIONS[lifecycleState] || 'review';
+  const detail = JSON.stringify({
+    lifecycleState,
+    proposedAction,
+    branch: entry.branch || null,
+    path: redactPath(entry.path || ''),
+    ahead: entry.ahead ?? null,
+    behind: entry.behind ?? null,
+    dirty: entry.dirty ?? false,
+    mergedToMain: entry.mergedToMain ?? false,
+    lastActivity: entry.lastActivity || null,
+  });
+  return {
+    type: `worktree:${lifecycleState}`,
+    issue: entry.ticket || null,
+    title: entry.branch || null,
+    detail,
+  };
+}
+
+function emitLifecycleEvents(opts = {}) {
+  const inv = opts.inventory || inventory();
+  const results = [];
+  for (const entry of inv.worktrees) {
+    if (!REPORT_STATES.has(entry.lifecycleState)) continue;
+    const payload = buildEvent(entry);
+    if (!opts.dryRun) emit(payload);
+    results.push(payload);
+  }
+  return results;
+}
+
+if (require.main === module) {
+  const dryRun = process.argv.includes('--dry-run');
+  const json = process.argv.includes('--json');
+  const results = emitLifecycleEvents({ dryRun });
+  if (json) process.stdout.write(JSON.stringify(results, null, 2) + '\n');
+  else results.forEach(e => console.log(`${e.type} issue=${e.issue || '-'} ${e.title}`));
+}
+
+module.exports = { buildEvent, emitLifecycleEvents, redactPath, ACTIONS, REPORT_STATES };

--- a/tests/worktree-lifecycle-events.spec.js
+++ b/tests/worktree-lifecycle-events.spec.js
@@ -1,0 +1,89 @@
+// worktree-lifecycle-events.spec.js — Tests for worktree-lifecycle-events.js
+'use strict';
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const {
+  buildEvent, emitLifecycleEvents, redactPath, ACTIONS, REPORT_STATES,
+} = require(path.resolve(__dirname, '..', 'scripts', 'global', 'worktree-lifecycle-events'));
+
+function makeEntry(override = {}) {
+  return {
+    lifecycleState: 'stale-risky', branch: 'feat/1234-some-feature',
+    path: `${process.env.HOME}/devenv-ops-1234`, ticket: 1234,
+    ahead: 2, behind: 0, dirty: true, untracked: false,
+    mergedToMain: false, lastActivity: '2025-07-25T00:00:00Z', ...override,
+  };
+}
+
+test('REPORT_STATES covers 5 required states', () => {
+  const required = ['stale-safe', 'stale-risky', 'rescue-needed', 'stale-warning', 'abandoned'];
+  for (const s of required) expect(REPORT_STATES.has(s)).toBe(true);
+});
+
+test('buildEvent returns correct type for stale-risky', () => {
+  expect(buildEvent(makeEntry()).type).toBe('worktree:stale-risky');
+});
+
+test('buildEvent maps issue from ticket field', () => {
+  expect(buildEvent(makeEntry()).issue).toBe(1234);
+});
+
+test('buildEvent returns null issue when no ticket', () => {
+  expect(buildEvent(makeEntry({ ticket: null })).issue).toBeNull();
+});
+
+test('buildEvent detail is valid JSON', () => {
+  const e = buildEvent(makeEntry());
+  expect(() => JSON.parse(e.detail)).not.toThrow();
+});
+
+test('buildEvent detail contains required structured fields', () => {
+  const d = JSON.parse(buildEvent(makeEntry()).detail);
+  for (const f of ['lifecycleState', 'proposedAction', 'branch', 'path', 'ahead', 'behind', 'dirty']) {
+    expect(Object.hasOwn(d, f)).toBe(true);
+  }
+});
+
+test('buildEvent detail does not expose untracked file names', () => {
+  const text = buildEvent(makeEntry({ untracked: true })).detail;
+  expect(text).not.toContain('untrackedFiles');
+  expect(text).not.toContain('\.env');
+});
+
+test('buildEvent redacts home directory from path', () => {
+  const home = process.env.HOME || '/home/user';
+  const d = JSON.parse(buildEvent(makeEntry({ path: `${home}/devenv-ops-9999` })).detail);
+  expect(d.path).not.toContain(home);
+  expect(d.path.startsWith('~')).toBe(true);
+});
+
+test('emitLifecycleEvents only emits for REPORT_STATES entries', () => {
+  const inv = { worktrees: [
+    makeEntry({ lifecycleState: 'active' }),
+    makeEntry({ lifecycleState: 'stale-risky' }),
+    makeEntry({ lifecycleState: 'stale-safe', ticket: null }),
+  ] };
+  const results = emitLifecycleEvents({ dryRun: true, inventory: inv });
+  expect(results.length).toBe(2);
+});
+
+test('emitLifecycleEvents skips active worktrees', () => {
+  const inv = { worktrees: [makeEntry({ lifecycleState: 'active' })] };
+  expect(emitLifecycleEvents({ dryRun: true, inventory: inv }).length).toBe(0);
+});
+
+test('emitted events have required fields', () => {
+  const inv = { worktrees: [makeEntry()] };
+  const [e] = emitLifecycleEvents({ dryRun: true, inventory: inv });
+  expect(e.type).toBeTruthy();
+  expect(e.detail).toBeTruthy();
+});
+
+test('redactPath replaces home prefix with ~', () => {
+  const home = process.env.HOME || '/home/user';
+  expect(redactPath(`${home}/foo`)).toBe('~/foo');
+});
+
+test('redactPath passes through non-home paths unchanged', () => {
+  expect(redactPath('/tmp/foo')).toBe('/tmp/foo');
+});


### PR DESCRIPTION
feat(observability): worktree lifecycle event reporting (#2256)

Adds `scripts/global/worktree-lifecycle-events.js` — emits privacy-safe structured lifecycle events to `.dashboard/events.jsonl` for worktrees classified as stale-safe, stale-risky, rescue-needed, stale-warning, or abandoned.

- Events include issue number, branch, path (HOME-redacted), lifecycleState, proposedAction, ahead/behind counts, dirty flag, and lastActivity
- Observability only — no cleanup execution
- 13 passing tests covering event shape, privacy filtering, and dry-run mode
- Uses existing `emit-event.js` infrastructure; consistent with other governance events

Refs #2256
merge-evidence-deferred-final: #2256
