### PR TITLE
fix(governance): recognize merge-evidence-deferred-final form in reconciler #2372

### DIFF
--- a/.changes/unreleased/2372.md
+++ b/.changes/unreleased/2372.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- `merge-evidence-reconciler`: recognize `merge-evidence-deferred-final: #N` in
+  merged PR bodies as merge evidence; suppress false-positive
+  `governance:close-without-merge` advisory for tickets closed via the
+  deferred-finalize convention. Refs #2372.

--- a/.github/workflows/merge-evidence-check.yml
+++ b/.github/workflows/merge-evidence-check.yml
@@ -34,10 +34,10 @@ jobs:
               github.rest.search.issuesAndPullRequests,
               { q: `repo:${owner}/${repo} is:pr is:merged #${issue.number}`, per_page: 30 }
             );
-            const mergedPRRefs = results.map(r => ({ number: r.number, title: r.title }));
+            const mergedPRRefs = results.map(r => ({ number: r.number, title: r.title, body: r.body || '' }));
             const result = rule.validate({ state: 'closed', labels, mergedPRRefs });
-            if (result.ok) {
-              core.info(`pass: ${mergedPRRefs.length} merged PR(s) found`);
+            if (result.ok || reconciler.hasDeferredFinalEvidence(mergedPRRefs, issue.number)) {
+              core.info(`pass: ${mergedPRRefs.length} merged PR(s) found (or deferred-final evidence present)`);
               return;
             }
             // Check for existing advisory (idempotency)

--- a/.github/workflows/merge-evidence-cron.yml
+++ b/.github/workflows/merge-evidence-cron.yml
@@ -45,7 +45,7 @@ jobs:
               });
               items.push({
                 issue: { ...issue, state: 'closed' },
-                mergedPRRefs: prs.map(p => ({ number: p.number })),
+                mergedPRRefs: prs.map(p => ({ number: p.number, body: p.body || '' })),
               });
             }
             const plan = reconciler.reconcile(items, { batchSize });

--- a/scripts/global/merge-evidence-reconciler.js
+++ b/scripts/global/merge-evidence-reconciler.js
@@ -3,25 +3,38 @@
 // items through the merge-evidence rule and returns a remediation plan.
 // Pure(ish): callers provide GitHub data; this module produces decisions.
 // The caller (cron workflow) applies labels and posts comments.
+// Refs #2372: recognizes merge-evidence-deferred-final form as evidence-present.
 
 const rule = require('./megalint/merge-evidence.js');
 
 const DEFAULT_BATCH_SIZE = 20;
 const COMMENT_MARKER = '<!-- merge-evidence-reconciler -->';
 const VIOLATION_LABEL = 'governance:close-without-merge';
+const DEFERRED_FINAL_TOKEN = 'merge-evidence-deferred-final:';
+
+// Returns true if any PR body contains the deferred-final token for issueNumber.
+// mergedPRRefs entries should include a `body` property (empty string if absent).
+function hasDeferredFinalEvidence(mergedPRRefs, issueNumber) {
+  const token = `${DEFERRED_FINAL_TOKEN} #${issueNumber}`.toLowerCase();
+  return (mergedPRRefs || []).some(pr => (pr.body || '').toLowerCase().includes(token));
+}
 
 function classifyItem(item, buckets) {
   if (!item || typeof item.issue !== 'object') return;
   const issue = item.issue;
+  const refs = item.mergedPRRefs || [];
   const result = rule.validate({
     state: issue.state,
     labels: (issue.labels || []).map(l => typeof l === 'string' ? l : l.name),
-    mergedPRRefs: item.mergedPRRefs || [],
+    mergedPRRefs: refs,
   });
   const entry = { number: issue.number, title: issue.title };
   if (result.skipped) buckets.skipped.push({ ...entry, reason: result.skipped });
-  else if (!result.ok) buckets.violations.push({ ...entry, violations: result.violations });
-  else buckets.passed.push({ ...entry, mergedPRCount: result.mergedPRCount });
+  else if (!result.ok && !hasDeferredFinalEvidence(refs, issue.number)) {
+    buckets.violations.push({ ...entry, violations: result.violations });
+  } else {
+    buckets.passed.push({ ...entry, mergedPRCount: result.mergedPRCount || 0 });
+  }
 }
 
 function reconcile(items, opts = {}) {
@@ -50,5 +63,6 @@ function buildComment(item) {
 }
 
 module.exports = {
-  reconcile, buildComment, DEFAULT_BATCH_SIZE, COMMENT_MARKER, VIOLATION_LABEL,
+  reconcile, buildComment, hasDeferredFinalEvidence,
+  DEFAULT_BATCH_SIZE, COMMENT_MARKER, VIOLATION_LABEL, DEFERRED_FINAL_TOKEN,
 };

--- a/tests/merge-evidence-reconciler.spec.js
+++ b/tests/merge-evidence-reconciler.spec.js
@@ -112,3 +112,34 @@ test('#1500: malformed items silently skipped (no throw)', () => {
   expect(plan.violations).toHaveLength(0);
   expect(plan.passed).toHaveLength(0);
 });
+
+// #2372: deferred-final form tests
+test('#2372 AC3: deferred-final token in merged PR body treated as passed', () => {
+  const plan = reconciler.reconcile([
+    {
+      issue: issue(999),
+      mergedPRRefs: [{ number: 888, body: 'merge-evidence-deferred-final: #999\nRefs #999' }],
+    },
+  ]);
+  expect(plan.passed).toHaveLength(1);
+  expect(plan.violations).toHaveLength(0);
+});
+
+test('#2372 AC3: hasDeferredFinalEvidence returns false for wrong issue number', () => {
+  const refs = [{ body: 'merge-evidence-deferred-final: #998' }];
+  expect(reconciler.hasDeferredFinalEvidence(refs, 999)).toBe(false);
+  expect(reconciler.hasDeferredFinalEvidence(refs, 998)).toBe(true);
+});
+
+test('#2372 AC3: hasDeferredFinalEvidence is case-insensitive', () => {
+  const refs = [{ body: 'MERGE-EVIDENCE-DEFERRED-FINAL: #42' }];
+  expect(reconciler.hasDeferredFinalEvidence(refs, 42)).toBe(true);
+  expect(reconciler.hasDeferredFinalEvidence(refs, 43)).toBe(false);
+});
+
+test('#2372 AC3: empty mergedPRRefs with no body = violation (cannot detect)', () => {
+  const plan = reconciler.reconcile([
+    { issue: issue(888), mergedPRRefs: [] },
+  ]);
+  expect(plan.violations).toHaveLength(1);
+});


### PR DESCRIPTION
Refs #2372
merge-evidence-deferred-final: #2372

## Summary

Fixes false-positive `governance:close-without-merge` advisory on tickets
closed via the deferred-finalize convention (`merge-evidence-deferred-final: #N`).

## Changes

- **`scripts/global/merge-evidence-reconciler.js`**: Add `DEFERRED_FINAL_TOKEN`
  constant + `hasDeferredFinalEvidence(mergedPRRefs, issueNumber)` helper;
  suppress violation when merged PR body contains the deferred-final token.
- **`.github/workflows/merge-evidence-check.yml`**: Include `body` field in
  mergedPRRefs; skip advisory if `hasDeferredFinalEvidence` returns true.
- **`.github/workflows/merge-evidence-cron.yml`**: Include `body` field in
  mergedPRRefs for cron path.
- **`tests/merge-evidence-reconciler.spec.js`**: 4 new AC3 test cases.
- **`.changes/unreleased/2372.md`**: Changelog fragment.

## Test evidence

```
node_modules/.bin/playwright test tests/merge-evidence-reconciler.spec.js
16 passed (1.6s)
```

## Post-merge

After merge: remove `governance:close-without-merge` label from #2355 and #2360.