### PR TITLE
feat(governance): Tier-1 GitHub-label fallback for merge-claim #2479

### DIFF
--- a/.changes/unreleased/2479.md
+++ b/.changes/unreleased/2479.md
@@ -1,0 +1,4 @@
+### Added
+
+- GitHub-label fallback mode in `merge_claim_client.py`: when HAMR is disabled or unreachable, uses `merge-claim:held:<team>` issue labels as the lock primitive (Tier-1/G5 portability fix). Claim IDs encode ticket+team for clean release. Refs #2479.
+- `merge-claim-gh-label-cleanup.yml`: scheduled GitHub Action (every 5 min) removes stale merge-claim labels beyond TTL. AC3 of #2479.

--- a/.github/workflows/merge-claim-gh-label-cleanup.yml
+++ b/.github/workflows/merge-claim-gh-label-cleanup.yml
@@ -1,0 +1,52 @@
+# Merge-claim GitHub-label cleanup — Tier-1 fallback TTL enforcement.
+# Removes stale merge-claim:held:<team> labels after TTL_MINUTES (default 5).
+# Companion to GitHub-label fallback mode in merge_claim_client.py #2479.
+name: merge-claim-gh-label-cleanup
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+    inputs:
+      ttl_minutes:
+        description: 'TTL in minutes (default 5)'
+        default: '5'
+permissions:
+  issues: write
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove stale merge-claim labels
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const PREFIX = 'merge-claim:held:';
+            const ttlMin = parseInt(core.getInput('ttl_minutes') || '5', 10);
+            const TTL_MS = ttlMin * 60 * 1000;
+            const now = Date.now();
+            const allLabels = await github.paginate(
+              github.rest.issues.listLabelsForRepo,
+              { ...context.repo, per_page: 100 }
+            );
+            const claimLabels = allLabels.filter(l => l.name.startsWith(PREFIX));
+            if (!claimLabels.length) { core.info('no merge-claim labels'); return; }
+            for (const label of claimLabels) {
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                ...context.repo, labels: label.name, state: 'open', per_page: 100
+              });
+              for (const issue of issues) {
+                const events = await github.rest.issues.listEvents({
+                  ...context.repo, issue_number: issue.number, per_page: 100
+                });
+                const ev = events.data.filter(e =>
+                  e.event === 'labeled' && e.label?.name === label.name
+                ).pop();
+                if (!ev) continue;
+                const age = now - new Date(ev.created_at).getTime();
+                if (age < TTL_MS) continue;
+                await github.rest.issues.removeLabel({
+                  ...context.repo, issue_number: issue.number, name: label.name
+                });
+                core.info(`removed stale ${label.name} from #${issue.number} (${Math.round(age/60000)}m)`);
+              }
+            }

--- a/docs/howto/state-authority-migration.md
+++ b/docs/howto/state-authority-migration.md
@@ -110,6 +110,34 @@ export HAMR_TEAM=claude-code   # or codex, copilot, antigravity
 
 Once Moves 1-3 are steady-state for ≥2 weeks, file the memory anchor cleanup per #2461 — `feedback_state_store_dual_variants` and 7 related anchors are then provably obsolete and should be retired with `superseded-by-#2451` notes.
 
+
+## Move 3 — Dual-mode merge-claim (HAMR + GitHub-label fallback) (#2479)
+
+`hooks/scripts/merge_claim_client.py` supports two backend modes:
+
+| Mode | Activation | Lock primitive |
+|---|---|---|
+| HAMR (Tier-2) | Default when `MEGINGJORD_HAMR_DISABLED` unset | CloudFlare Worker |
+| GitHub-label (Tier-1) | `MEGINGJORD_HAMR_DISABLED=1` or HAMR unreachable | Issue label |
+
+**GitHub-label lock format**: `merge-claim:held:<team>` added to the target issue.
+**claim_id format in fallback mode**: `gh-label:<ticket_n>:<team>` — pass this to
+`release()` and it removes the label instead of calling HAMR.
+
+### TTL cleanup
+
+A scheduled GitHub Action (`merge-claim-gh-label-cleanup.yml`) runs every 5 min
+and removes `merge-claim:held:*` labels that have been present longer than the TTL
+(default 5 min). This enforces the same lock-expiry guarantee as HAMR's built-in TTL.
+
+### GITHUB_TOKEN requirement
+
+The GitHub-label fallback requires `GITHUB_TOKEN` and `GITHUB_REPOSITORY`
+environment variables. Both are available in all GitHub Actions contexts.
+For local hook execution, operators must set these or use a personal access token.
+If either is absent, `acquire()` / `status()` return `None` (degrade to race-prone
+legacy behavior, same as HAMR-unreachable path).
+
 ## Related
 
 - Epic #2451 — parent

--- a/hooks/scripts/merge_claim_client.py
+++ b/hooks/scripts/merge_claim_client.py
@@ -1,16 +1,15 @@
-"""HAMR merge-claim client (#2458).
+"""HAMR merge-claim client with GitHub-label fallback (#2458 #2479).
 
-Phase-1 Move 3 of Epic #2451: cross-team merge serialization.
-Wraps POST /merge-claim/acquire, POST /merge-claim/release, GET /merge-claim/status.
-
-Feature-flagged via MEGINGJORD_MERGE_CLAIM. When off, acquire returns sentinel
-'feature-off' claim that release ignores (no-op pattern preserves admin flow).
+Phase-1 Move 3: HAMR-backed merge serialization.
+GitHub-label fallback (Tier-1): used when MEGINGJORD_HAMR_DISABLED=1 or HAMR
+unreachable. Label format: merge-claim:held:<team>. Refs #2479.
 """
 from __future__ import annotations
 
 import json
 import os
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Optional
 
@@ -18,10 +17,71 @@ HAMR_BASE = os.environ.get("HAMR_BASE_URL", "https://hamr.chf3198.workers.dev")
 DEFAULT_TEAM = os.environ.get("HAMR_TEAM", "claude-code")
 TIMEOUT_S = 10
 SENTINEL_CLAIM_FEATURE_OFF = "feature-off"
+SENTINEL_CLAIM_GH_PREFIX = "gh-label"
+GH_LABEL_PREFIX = "merge-claim:held:"
 
 
 def feature_enabled() -> bool:
     return os.environ.get("MEGINGJORD_MERGE_CLAIM", "").strip() == "1"
+
+
+def _hamr_disabled() -> bool:
+    return os.environ.get("MEGINGJORD_HAMR_DISABLED", "").strip() == "1"
+
+
+def _gh_api(method: str, path: str, body: Optional[dict] = None) -> Optional[dict]:
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    if not token or not repo:
+        return None
+    url = f"https://api.github.com/repos/{repo}{path}"
+    data = json.dumps(body).encode() if body else None
+    hdrs: dict = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if data:
+        hdrs["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, method=method, headers=hdrs)
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        if e.code in (204, 404):
+            return {}
+        try:
+            return json.loads(e.read())
+        except Exception:
+            return {"error": f"http_{e.code}"}
+    except (urllib.error.URLError, OSError, json.JSONDecodeError):
+        return None
+
+
+def _gh_acquire(ticket_n: int, team: str) -> Optional[dict]:
+    label = f"{GH_LABEL_PREFIX}{team}"
+    _gh_api("POST", "/labels", {"name": label, "color": "e11d48"})
+    result = _gh_api("POST", f"/issues/{ticket_n}/labels", {"labels": [label]})
+    if result is None:
+        return None
+    claim_id = f"{SENTINEL_CLAIM_GH_PREFIX}:{ticket_n}:{team}"
+    return {"claim_id": claim_id, "ttl_s": 300, "mode": "gh-label"}
+
+
+def _gh_release(ticket_n: int, team: str) -> Optional[dict]:
+    label = urllib.parse.quote(f"{GH_LABEL_PREFIX}{team}", safe="")
+    result = _gh_api("DELETE", f"/issues/{ticket_n}/labels/{label}")
+    return {"released": True, "mode": "gh-label"} if result is not None else None
+
+
+def _gh_status(ticket_n: int) -> Optional[dict]:
+    result = _gh_api("GET", f"/issues/{ticket_n}/labels")
+    if result is None:
+        return None
+    labels = [l["name"] for l in (result if isinstance(result, list) else [])
+              if l.get("name", "").startswith(GH_LABEL_PREFIX)]
+    return {"held": bool(labels), "labels": labels, "mode": "gh-label"}
 
 
 def _post(path: str, headers: dict, body: bytes = b"") -> Optional[dict]:
@@ -49,7 +109,6 @@ def _get(path: str) -> Optional[dict]:
 
 
 def _auth_headers(team: str) -> dict:
-    # DPoP token sourced from env; production-mode token rotation is HAMR concern (#894)
     token = os.environ.get("HAMR_DPOP_TOKEN", "stub")
     return {
         "authorization": f"DPoP {token}",
@@ -59,29 +118,34 @@ def _auth_headers(team: str) -> dict:
 
 
 def acquire(ticket_n: int, team: Optional[str] = None) -> Optional[dict]:
-    """Acquire merge-claim for ticket. Returns {claim_id, ttl_s, expires_at} on success.
-    Returns sentinel {claim_id: 'feature-off'} when feature flag off (no-op admin pass-through).
-    Returns None on network failure; {'error': ...} on HAMR rejection."""
+    """Acquire merge-claim. HAMR primary, GitHub-label fallback (G5/G6)."""
     if not feature_enabled():
         return {"claim_id": SENTINEL_CLAIM_FEATURE_OFF, "ttl_s": 0}
-    return _post(
-        f"/merge-claim/acquire/{ticket_n}",
-        _auth_headers(team or DEFAULT_TEAM),
-    )
+    t = team or DEFAULT_TEAM
+    if not _hamr_disabled():
+        result = _post(f"/merge-claim/acquire/{ticket_n}", _auth_headers(t))
+        if result is not None:
+            return result
+    return _gh_acquire(ticket_n, t)
 
 
 def release(claim_id: str, team: Optional[str] = None) -> Optional[dict]:
-    """Release a claim by ID. No-op on sentinel."""
+    """Release a claim. Handles HAMR, GitHub-label, and sentinel forms."""
     if claim_id == SENTINEL_CLAIM_FEATURE_OFF or not feature_enabled():
         return {"released": True, "noop": True}
-    return _post(
-        f"/merge-claim/release/{claim_id}",
-        _auth_headers(team or DEFAULT_TEAM),
-    )
+    if claim_id.startswith(f"{SENTINEL_CLAIM_GH_PREFIX}:"):
+        parts = claim_id.split(":", 2)
+        t = parts[2] if len(parts) > 2 else (team or DEFAULT_TEAM)
+        return _gh_release(int(parts[1]), t)
+    return _post(f"/merge-claim/release/{claim_id}", _auth_headers(team or DEFAULT_TEAM))
 
 
 def status(ticket_n: int) -> Optional[dict]:
-    """Query current claim status; no auth required."""
+    """Query current claim status; GH-label fallback when HAMR disabled."""
     if not feature_enabled():
         return {"held": False, "feature_off": True}
-    return _get(f"/merge-claim/status/{ticket_n}")
+    if not _hamr_disabled():
+        result = _get(f"/merge-claim/status/{ticket_n}")
+        if result is not None:
+            return result
+    return _gh_status(ticket_n)

--- a/tests/merge-claim-gh-fallback.spec.js
+++ b/tests/merge-claim-gh-fallback.spec.js
@@ -1,0 +1,120 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const HOOKS = path.resolve(__dirname, '..', 'hooks', 'scripts');
+
+function runPy(script, env = {}) {
+  const proc = spawnSync('python3', ['-c', script], {
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { status: proc.status, stdout: proc.stdout, stderr: proc.stderr };
+}
+
+function callMcc(fn, args, env = {}) {
+  const script = `
+import sys, json
+sys.path.insert(0, "${HOOKS}")
+import merge_claim_client as mcc
+result = mcc.${fn}(${args})
+print(json.dumps(result))
+`;
+  return runPy(script, env);
+}
+
+// --- Existing HAMR sentinel tests (ensure no regression) ---
+
+test('HAMR sentinel: acquire returns feature-off when flag off', () => {
+  const r = callMcc('acquire', '2458', { MEGINGJORD_MERGE_CLAIM: '' });
+  assert.strictEqual(r.status, 0);
+  assert.deepStrictEqual(JSON.parse(r.stdout), { claim_id: 'feature-off', ttl_s: 0 });
+});
+
+test('HAMR sentinel: status returns feature_off when flag off', () => {
+  const r = callMcc('status', '2458', { MEGINGJORD_MERGE_CLAIM: '' });
+  assert.strictEqual(r.status, 0);
+  assert.deepStrictEqual(JSON.parse(r.stdout), { held: false, feature_off: true });
+});
+
+test('HAMR sentinel: release noop on feature-off claim', () => {
+  const r = callMcc("release", "'feature-off'", { MEGINGJORD_MERGE_CLAIM: '' });
+  assert.strictEqual(r.status, 0);
+  const out = JSON.parse(r.stdout);
+  assert.strictEqual(out.released, true);
+  assert.strictEqual(out.noop, true);
+});
+
+// --- GitHub-label fallback mode tests (AC1, AC2) ---
+
+test('GH-label: _hamr_disabled returns true when MEGINGJORD_HAMR_DISABLED=1', () => {
+  const script = `
+import sys
+sys.path.insert(0, "${HOOKS}")
+import merge_claim_client as mcc
+print(mcc._hamr_disabled())
+`;
+  const r = runPy(script, { MEGINGJORD_HAMR_DISABLED: '1' });
+  assert.strictEqual(r.status, 0);
+  assert.ok(r.stdout.trim() === 'True');
+});
+
+test('GH-label: _hamr_disabled returns false by default', () => {
+  const script = `
+import sys
+sys.path.insert(0, "${HOOKS}")
+import merge_claim_client as mcc
+print(mcc._hamr_disabled())
+`;
+  const r = runPy(script, {});
+  assert.strictEqual(r.status, 0);
+  assert.ok(r.stdout.trim() === 'False');
+});
+
+test('GH-label: acquire returns None when feature on, HAMR disabled, no GITHUB_TOKEN', () => {
+  const r = callMcc('acquire', '2479', {
+    MEGINGJORD_MERGE_CLAIM: '1',
+    MEGINGJORD_HAMR_DISABLED: '1',
+    GITHUB_TOKEN: '',
+    GITHUB_REPOSITORY: '',
+  });
+  assert.strictEqual(r.status, 0);
+  assert.strictEqual(r.stdout.trim(), 'null');
+});
+
+test('GH-label: status returns gh-label mode when feature on, HAMR disabled, no token', () => {
+  const r = callMcc('status', '2479', {
+    MEGINGJORD_MERGE_CLAIM: '1',
+    MEGINGJORD_HAMR_DISABLED: '1',
+    GITHUB_TOKEN: '',
+    GITHUB_REPOSITORY: '',
+  });
+  assert.strictEqual(r.status, 0);
+  assert.strictEqual(r.stdout.trim(), 'null');
+});
+
+test('GH-label: release handles gh-label claim_id prefix correctly', () => {
+  const r = callMcc("release", "'gh-label:2479:codex'", {
+    MEGINGJORD_MERGE_CLAIM: '1',
+    GITHUB_TOKEN: '',
+    GITHUB_REPOSITORY: '',
+  });
+  assert.strictEqual(r.status, 0);
+  assert.strictEqual(r.stdout.trim(), 'null');
+});
+
+test('GH-label: constants correct — prefix and sentinel', () => {
+  const script = `
+import sys
+sys.path.insert(0, "${HOOKS}")
+import merge_claim_client as mcc
+import json
+print(json.dumps({'prefix': mcc.GH_LABEL_PREFIX, 'sentinel': mcc.SENTINEL_CLAIM_GH_PREFIX}))
+`;
+  const r = runPy(script, {});
+  assert.strictEqual(r.status, 0);
+  const out = JSON.parse(r.stdout);
+  assert.strictEqual(out.prefix, 'merge-claim:held:');
+  assert.strictEqual(out.sentinel, 'gh-label');
+});


### PR DESCRIPTION
Refs #2479
merge-evidence-deferred-final: #2479

Adds GitHub-label fallback to merge_claim_client.py: when HAMR is disabled or
unreachable, uses issue labels as the lock primitive. Includes scheduled cleanup
Action for TTL enforcement. Fixes G5 portability gap from Epic #2451 Move 3.

Refs Epic #2451 #2458