### PR TITLE
feat(governance): fleet-decision-oracle for operator-internal decisions (#2509)

### DIFF
--- a/docs/howto/state-authority-migration.md
+++ b/docs/howto/state-authority-migration.md
@@ -110,7 +110,6 @@ export HAMR_TEAM=claude-code   # or codex, copilot, antigravity
 
 Once Moves 1-3 are steady-state for ≥2 weeks, file the memory anchor cleanup per #2461 — `feedback_state_store_dual_variants` and 7 related anchors are then provably obsolete and should be retired with `superseded-by-#2451` notes.
 
-
 ## Move 3 — Dual-mode merge-claim (HAMR + GitHub-label fallback) (#2479)
 
 `hooks/scripts/merge_claim_client.py` supports two backend modes:

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -309,3 +309,23 @@ When the GitHub-derived role resolver (#2456, feature-flagged via `MEGINGJORD_DE
 Manager: `role-manager-execution` | Collaborator: `role-collaborator-execution`
 Admin: `role-admin-execution` | Consultant: `role-consultant-critique`
 Orchestration: `role-baton-orchestrator`
+
+
+## Operator decision routing (#2509)
+
+When the operator (the AI agent running the baton) faces a routine yes/no dev decision (file follow-on ticket Y/N? two-ticket-or-one? accept fleet-rater verdict?), the DEFAULT routing is:
+
+1. Route to fleet decision oracle: `node scripts/global/fleet-decision-oracle.js` via `decideOnce(question, opts)`
+2. Fleet returns `{verdict: approve|reject|partial|inconclusive, rationale, model_used, escalate_to_client: bool}`
+3. If `escalate_to_client` is true (verdict inconclusive OR fleet unreachable) → THEN ask client
+4. Otherwise → operator executes per verdict; no client touch needed
+
+**Why:** per the harness's operator-identity contract (`instructions/operator-identity-context.instructions.md`), the client is design + UAT only. Asking the client to adjudicate routine dev decisions is governance-misalignment. The fleet rater (free, qwen-7b at ~30s) is the correct decision substrate.
+
+**When NOT to use fleet:**
+- Design direction (new architecture, scope expansion)
+- UAT confirmation (does the shipped behavior match user expectation)
+- Budget decisions (paid-provider lane authorization)
+- Memory has prior client preference on the specific class
+
+**Memory anchor:** `feedback_route_decisions_to_fleet_not_client` (operator-personal).

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -310,7 +310,6 @@ Manager: `role-manager-execution` | Collaborator: `role-collaborator-execution`
 Admin: `role-admin-execution` | Consultant: `role-consultant-critique`
 Orchestration: `role-baton-orchestrator`
 
-
 ## Operator decision routing (#2509)
 
 When the operator (the AI agent running the baton) faces a routine yes/no dev decision (file follow-on ticket Y/N? two-ticket-or-one? accept fleet-rater verdict?), the DEFAULT routing is:

--- a/scripts/global/fleet-decision-oracle.js
+++ b/scripts/global/fleet-decision-oracle.js
@@ -10,6 +10,10 @@ const FAST_MODEL = 'qwen2.5-coder:7b';
 const SLOW_MODEL = 'qwen2.5-coder:32b';
 const FAST_TIMEOUT_MS = 60_000;
 const SLOW_TIMEOUT_MS = 600_000;
+const SLOW_MODEL_LENGTH_THRESHOLD = 1500;
+const RATIONALE_SHORT_LEN = 200;
+const RATIONALE_FULL_LEN = 500;
+const DEFAULT_OLLAMA_PORT = 11434;
 
 const VERDICT_RE = /\b(yes|no|partial|approve|reject|revise)\b/i;
 
@@ -18,7 +22,7 @@ function pickModel(opts) {
   if (opts && opts.tier === 'fast') return FAST_MODEL;
   // Default by question length: longer → high-stakes
   const len = (opts && opts.question && opts.question.length) || 0;
-  return len > 1500 ? SLOW_MODEL : FAST_MODEL;
+  return len > SLOW_MODEL_LENGTH_THRESHOLD ? SLOW_MODEL : FAST_MODEL;
 }
 
 function timeoutFor(model) {
@@ -28,13 +32,13 @@ function timeoutFor(model) {
 function parseVerdict(text) {
   if (!text) return { verdict: 'inconclusive', rationale: 'empty response' };
   const match = text.match(VERDICT_RE);
-  if (!match) return { verdict: 'inconclusive', rationale: text.slice(0, 200) };
+  if (!match) return { verdict: 'inconclusive', rationale: text.slice(0, RATIONALE_SHORT_LEN) };
   const word = match[1].toLowerCase();
   const normalized = (word === 'yes' || word === 'approve') ? 'approve'
     : (word === 'no' || word === 'reject') ? 'reject'
     : (word === 'partial' || word === 'revise') ? 'partial'
     : 'inconclusive';
-  return { verdict: normalized, rationale: text.slice(0, 500) };
+  return { verdict: normalized, rationale: text.slice(0, RATIONALE_FULL_LEN) };
 }
 
 function dispatchOllama({ host, model, prompt, timeoutMs, httpImpl = http }) {
@@ -42,7 +46,7 @@ function dispatchOllama({ host, model, prompt, timeoutMs, httpImpl = http }) {
     const [hostname, portStr] = host.split(':');
     const body = JSON.stringify({ model, prompt, stream: false });
     const req = httpImpl.request({
-      hostname, port: parseInt(portStr, 10) || 11434,
+      hostname, port: parseInt(portStr, 10) || DEFAULT_OLLAMA_PORT,
       path: '/api/generate', method: 'POST',
       headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) },
       timeout: timeoutMs,

--- a/scripts/global/fleet-decision-oracle.js
+++ b/scripts/global/fleet-decision-oracle.js
@@ -1,0 +1,92 @@
+// fleet-decision-oracle.js — route routine dev decisions to fleet rater (#2509)
+// Wraps qwen-7b (fast) and qwen-32b (high-stakes) on Tailscale fleet for
+// operator-internal yes/no decisions; client-escalation only on inconclusive.
+'use strict';
+
+const http = require('node:http');
+
+const DEFAULT_HOST = process.env.HAMR_FLEET_HOST || '100.91.113.16:11434';
+const FAST_MODEL = 'qwen2.5-coder:7b';
+const SLOW_MODEL = 'qwen2.5-coder:32b';
+const FAST_TIMEOUT_MS = 60_000;
+const SLOW_TIMEOUT_MS = 600_000;
+
+const VERDICT_RE = /\b(yes|no|partial|approve|reject|revise)\b/i;
+
+function pickModel(opts) {
+  if (opts && opts.tier === 'high-stakes') return SLOW_MODEL;
+  if (opts && opts.tier === 'fast') return FAST_MODEL;
+  // Default by question length: longer → high-stakes
+  const len = (opts && opts.question && opts.question.length) || 0;
+  return len > 1500 ? SLOW_MODEL : FAST_MODEL;
+}
+
+function timeoutFor(model) {
+  return model === SLOW_MODEL ? SLOW_TIMEOUT_MS : FAST_TIMEOUT_MS;
+}
+
+function parseVerdict(text) {
+  if (!text) return { verdict: 'inconclusive', rationale: 'empty response' };
+  const match = text.match(VERDICT_RE);
+  if (!match) return { verdict: 'inconclusive', rationale: text.slice(0, 200) };
+  const word = match[1].toLowerCase();
+  const normalized = (word === 'yes' || word === 'approve') ? 'approve'
+    : (word === 'no' || word === 'reject') ? 'reject'
+    : (word === 'partial' || word === 'revise') ? 'partial'
+    : 'inconclusive';
+  return { verdict: normalized, rationale: text.slice(0, 500) };
+}
+
+function dispatchOllama({ host, model, prompt, timeoutMs, httpImpl = http }) {
+  return new Promise((resolve) => {
+    const [hostname, portStr] = host.split(':');
+    const body = JSON.stringify({ model, prompt, stream: false });
+    const req = httpImpl.request({
+      hostname, port: parseInt(portStr, 10) || 11434,
+      path: '/api/generate', method: 'POST',
+      headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) },
+      timeout: timeoutMs,
+    }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        try { resolve({ ok: true, response: JSON.parse(data).response || '' }); }
+        catch (err) { resolve({ ok: false, error: 'parse_error', detail: err.message }); }
+      });
+    });
+    req.on('error', (err) => resolve({ ok: false, error: 'network_error', detail: err.message }));
+    req.on('timeout', () => { req.destroy(); resolve({ ok: false, error: 'timeout' }); });
+    req.write(body); req.end();
+  });
+}
+
+async function decideOnce(question, opts = {}) {
+  const model = pickModel({ ...opts, question });
+  const host = (opts && opts.host) || DEFAULT_HOST;
+  const httpImpl = (opts && opts.httpImpl) || http;
+  const prompt = `You are an operator-internal decision oracle. Answer with one word (yes/no/partial) then a one-line rationale.
+
+QUESTION: ${question}
+
+Respond format:
+VERDICT: <yes|no|partial>
+RATIONALE: <one line>`;
+  const result = await dispatchOllama({
+    host, model, prompt, timeoutMs: timeoutFor(model), httpImpl,
+  });
+  if (!result.ok) {
+    return { verdict: 'inconclusive', rationale: `fleet ${result.error}`, model_used: model, escalate_to_client: true };
+  }
+  const parsed = parseVerdict(result.response);
+  return {
+    verdict: parsed.verdict,
+    rationale: parsed.rationale,
+    model_used: model,
+    escalate_to_client: parsed.verdict === 'inconclusive',
+  };
+}
+
+module.exports = {
+  decideOnce, parseVerdict, pickModel, timeoutFor, dispatchOllama,
+  FAST_MODEL, SLOW_MODEL, DEFAULT_HOST,
+};

--- a/tests/fleet-decision-oracle.spec.js
+++ b/tests/fleet-decision-oracle.spec.js
@@ -1,0 +1,89 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  decideOnce, parseVerdict, pickModel, timeoutFor,
+  FAST_MODEL, SLOW_MODEL,
+} = require('../scripts/global/fleet-decision-oracle');
+
+test('pickModel: fast tier explicit', () => {
+  assert.strictEqual(pickModel({ tier: 'fast' }), FAST_MODEL);
+});
+
+test('pickModel: high-stakes tier explicit', () => {
+  assert.strictEqual(pickModel({ tier: 'high-stakes' }), SLOW_MODEL);
+});
+
+test('pickModel: default routes by question length', () => {
+  assert.strictEqual(pickModel({ question: 'short q?' }), FAST_MODEL);
+  assert.strictEqual(pickModel({ question: 'x'.repeat(2000) }), SLOW_MODEL);
+});
+
+test('timeoutFor: slow model gets longer timeout', () => {
+  assert.ok(timeoutFor(SLOW_MODEL) > timeoutFor(FAST_MODEL));
+});
+
+test('parseVerdict: yes/approve normalize to approve', () => {
+  assert.strictEqual(parseVerdict('VERDICT: yes').verdict, 'approve');
+  assert.strictEqual(parseVerdict('VERDICT: approve - rationale').verdict, 'approve');
+});
+
+test('parseVerdict: no/reject normalize to reject', () => {
+  assert.strictEqual(parseVerdict('VERDICT: no').verdict, 'reject');
+  assert.strictEqual(parseVerdict('reject the proposal').verdict, 'reject');
+});
+
+test('parseVerdict: partial/revise normalize to partial', () => {
+  assert.strictEqual(parseVerdict('VERDICT: partial').verdict, 'partial');
+  assert.strictEqual(parseVerdict('revise then accept').verdict, 'partial');
+});
+
+test('parseVerdict: empty returns inconclusive', () => {
+  assert.strictEqual(parseVerdict('').verdict, 'inconclusive');
+  assert.strictEqual(parseVerdict(null).verdict, 'inconclusive');
+});
+
+test('parseVerdict: no verdict word returns inconclusive', () => {
+  assert.strictEqual(parseVerdict('this is just text without an answer').verdict, 'inconclusive');
+});
+
+test('decideOnce: returns inconclusive + escalate when fleet unreachable', async () => {
+  const mockHttp = {
+    request(opts, cb) {
+      const req = {
+        on(evt, handler) { if (evt === 'error') setImmediate(() => handler(new Error('network'))); return req; },
+        write() {}, end() {}, destroy() {},
+      };
+      return req;
+    },
+  };
+  const result = await decideOnce('Should I do X?', { httpImpl: mockHttp });
+  assert.strictEqual(result.verdict, 'inconclusive');
+  assert.strictEqual(result.escalate_to_client, true);
+  assert.match(result.rationale, /network/);
+});
+
+test('decideOnce: returns parsed verdict when fleet responds', async () => {
+  const mockHttp = {
+    request(opts, cb) {
+      const res = {
+        _handlers: {},
+        on(evt, h) { this._handlers[evt] = h; return this; },
+      };
+      setImmediate(() => {
+        cb(res);
+        setImmediate(() => {
+          res._handlers.data(JSON.stringify({ response: 'VERDICT: yes\nRATIONALE: looks good' }));
+          res._handlers.end();
+        });
+      });
+      const req = {
+        on(evt, handler) { return req; },
+        write() {}, end() {}, destroy() {},
+      };
+      return req;
+    },
+  };
+  const result = await decideOnce('Should I do X?', { httpImpl: mockHttp });
+  assert.strictEqual(result.verdict, 'approve');
+  assert.strictEqual(result.escalate_to_client, false);
+});


### PR DESCRIPTION
Implements decideOnce(question) → fleet rater (qwen-7b/32b) so operator stops asking client routine dev questions.

Refs #2509
merge-evidence-deferred-final: #2509

[skip-changelog]

All 4 baton artifacts on #2509.