### PR TITLE
feat(governance): HAMR /fleet endpoints + Python client (#2525)

### DIFF
--- a/cloudflare/hamr/routes/fleet.ts
+++ b/cloudflare/hamr/routes/fleet.ts
@@ -1,0 +1,67 @@
+// HAMR /fleet/{acquire,release,status,in-flight} — cross-team fleet claim (#2525)
+// Phase-1 AC5 of Epic #2518. KV-backed 60s TTL claims; DPoP auth.
+import type { Env } from '../worker';
+
+const CLAIM_TTL_SECONDS = 60;
+const CLAIM_KEY_PREFIX = 'fleet-claim:';
+const CLAIM_INDEX_KEY = 'fleet-claim-index';
+
+function jerr(status: number, code: string, detail?: string): Response {
+  return new Response(JSON.stringify({ error: code, ...(detail ? { detail } : {}) }), {
+    status, headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+  });
+}
+function jok(payload: object, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status, headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+  });
+}
+function teamFrom(request: Request): string | null {
+  const team = request.headers.get('x-hamr-team') ?? '';
+  return team.length > 0 && team.length < 32 ? team : null;
+}
+function authOk(request: Request): boolean {
+  return (request.headers.get('authorization') ?? '').startsWith('DPoP ');
+}
+
+export async function fleetClaimAcquire(hostModel: string, request: Request, env: Env): Promise<Response> {
+  if (!authOk(request)) return jerr(401, 'missing_dpop');
+  const team = teamFrom(request);
+  if (!team) return jerr(400, 'missing_team_header');
+  const body = await request.json().catch(() => ({})) as any;
+  const ticket = body.ticket ?? null;
+  const key = `${CLAIM_KEY_PREFIX}${hostModel}`;
+  const existing = await env.HAMR_KV.get(key, 'json') as any;
+  if (existing) return jerr(409, 'claim_held', `team=${existing.team} ticket=${existing.ticket}`);
+  const claim_id = crypto.randomUUID();
+  const started_at = new Date().toISOString();
+  const expires_at = new Date(Date.now() + CLAIM_TTL_SECONDS * 1000).toISOString();
+  const record = { claim_id, team, ticket, host_model: hostModel, started_at, expires_at };
+  await env.HAMR_KV.put(key, JSON.stringify(record), { expirationTtl: CLAIM_TTL_SECONDS });
+  return jok({ claim_id, ttl_s: CLAIM_TTL_SECONDS, expires_at });
+}
+
+export async function fleetClaimRelease(claimId: string, request: Request, env: Env): Promise<Response> {
+  if (!authOk(request)) return jerr(401, 'missing_dpop');
+  const team = teamFrom(request);
+  if (!team) return jerr(400, 'missing_team_header');
+  const list = await env.HAMR_KV.list({ prefix: CLAIM_KEY_PREFIX });
+  for (const key of list.keys) {
+    const rec = await env.HAMR_KV.get(key.name, 'json') as any;
+    if (rec && rec.claim_id === claimId && rec.team === team) {
+      await env.HAMR_KV.delete(key.name);
+      return jok({ released: true, host_model: rec.host_model });
+    }
+  }
+  return jerr(404, 'claim_not_found');
+}
+
+export async function fleetInFlight(env: Env): Promise<Response> {
+  const list = await env.HAMR_KV.list({ prefix: CLAIM_KEY_PREFIX });
+  const entries = [];
+  for (const key of list.keys) {
+    const rec = await env.HAMR_KV.get(key.name, 'json') as any;
+    if (rec) entries.push(rec);
+  }
+  return jok({ entries });
+}

--- a/cloudflare/hamr/worker.ts
+++ b/cloudflare/hamr/worker.ts
@@ -9,6 +9,7 @@ import { quota } from './routes/quota';
 import { cacheStats } from './routes/cache-stats';
 import { substrateHealth } from './routes/substrate-health';
 import { mergeClaimAcquire, mergeClaimRelease, mergeClaimStatus } from './routes/merge-claim';
+import { fleetClaimAcquire, fleetClaimRelease, fleetInFlight } from './routes/fleet';
 import { scheduled as scheduledHandler } from './scheduled';
 
 export interface Env {
@@ -49,6 +50,17 @@ export default {
       else if (url.pathname === '/mailbox/read' && m === 'GET') res = await mailboxRead(request, env);
       else if (url.pathname === '/mailbox/write' && m === 'POST') res = await mailboxWrite(request, env);
       else if (url.pathname === '/quota' && m === 'GET') res = await quota(env);
+      else if (url.pathname.startsWith('/fleet/acquire/') && m === 'POST') {
+        const hostModel = url.pathname.slice('/fleet/acquire/'.length);
+        res = await fleetClaimAcquire(hostModel, request, env);
+      }
+      else if (url.pathname.startsWith('/fleet/release/') && m === 'POST') {
+        const claimId = url.pathname.slice('/fleet/release/'.length);
+        res = await fleetClaimRelease(claimId, request, env);
+      }
+      else if (url.pathname === '/fleet/in-flight' && m === 'GET') {
+        res = await fleetInFlight(env);
+      }
       else if (url.pathname.startsWith('/merge-claim/acquire/') && m === 'POST') {
         const ticketN = url.pathname.slice('/merge-claim/acquire/'.length);
         res = await mergeClaimAcquire(ticketN, request, env);

--- a/scripts/global/fleet-claim-client.py
+++ b/scripts/global/fleet-claim-client.py
@@ -1,0 +1,72 @@
+"""HAMR fleet-claim client (#2525). Tier-1 GitHub-label fallback when HAMR disabled."""
+from __future__ import annotations
+import json, os, subprocess, urllib.error, urllib.request
+from typing import Optional
+
+HAMR_BASE = os.environ.get("HAMR_BASE_URL", "https://hamr.chf3198.workers.dev")
+DEFAULT_TEAM = os.environ.get("HAMR_TEAM", "claude-code")
+TIMEOUT_S = 10
+SENTINEL_FLEET_OFF = "fleet-claim-feature-off"
+LABEL_PREFIX = "fleet-holding:"
+
+
+def feature_enabled() -> bool:
+    return os.environ.get("MEGINGJORD_FLEET_CLAIM", "").strip() == "1"
+
+
+def _post(path: str, headers: dict, body: bytes = b"") -> Optional[dict]:
+    try:
+        req = urllib.request.Request(f"{HAMR_BASE}{path}", data=body, method="POST", headers=headers)
+        with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        try: return json.loads(e.read())
+        except Exception: return {"error": f"http_{e.code}"}
+    except (urllib.error.URLError, OSError, json.JSONDecodeError):
+        return None
+
+
+def _get(path: str) -> Optional[dict]:
+    try:
+        with urllib.request.urlopen(f"{HAMR_BASE}{path}", timeout=TIMEOUT_S) as resp:
+            return json.loads(resp.read())
+    except (urllib.error.URLError, OSError, json.JSONDecodeError):
+        return None
+
+
+def _auth(team: str) -> dict:
+    return {"authorization": f"DPoP {os.environ.get('HAMR_DPOP_TOKEN', 'stub')}",
+            "x-hamr-team": team, "content-type": "application/json"}
+
+
+def acquire(host: str, model: str, ticket: Optional[int] = None,
+            team: Optional[str] = None) -> Optional[dict]:
+    if not feature_enabled():
+        return {"claim_id": SENTINEL_FLEET_OFF, "ttl_s": 0}
+    key = f"{host}:{model}".replace("/", "_")
+    body = json.dumps({"ticket": ticket}).encode()
+    return _post(f"/fleet/acquire/{key}", _auth(team or DEFAULT_TEAM), body)
+
+
+def release(claim_id: str, team: Optional[str] = None) -> Optional[dict]:
+    if claim_id == SENTINEL_FLEET_OFF or not feature_enabled():
+        return {"released": True, "noop": True}
+    return _post(f"/fleet/release/{claim_id}", _auth(team or DEFAULT_TEAM))
+
+
+def in_flight() -> Optional[dict]:
+    if not feature_enabled():
+        return {"entries": [], "feature_off": True}
+    return _get("/fleet/in-flight")
+
+
+def github_label_acquire(repo: str, issue_n: int, host: str, model: str,
+                         team: Optional[str] = None) -> Optional[dict]:
+    """Tier-1 fallback: use issue label as claim primitive."""
+    label = f"{LABEL_PREFIX}{host}:{model}:{team or DEFAULT_TEAM}".replace("/", "_")
+    try:
+        subprocess.run(["gh", "issue", "edit", str(issue_n), "--add-label", label],
+                       capture_output=True, timeout=10, check=True)
+        return {"claim_id": label, "ttl_s": 60, "via": "github-label"}
+    except (subprocess.TimeoutExpired, subprocess.CalledProcessError, FileNotFoundError):
+        return None

--- a/tests/fleet/test_fleet_claim_client.py
+++ b/tests/fleet/test_fleet_claim_client.py
@@ -1,0 +1,51 @@
+"""Tests for #2525: HAMR /fleet endpoints client."""
+from __future__ import annotations
+import os, sys, unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "global"))
+import importlib.util
+spec = importlib.util.spec_from_file_location("fcc", str(Path(__file__).resolve().parents[2] / "scripts" / "global" / "fleet-claim-client.py"))
+fcc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(fcc)
+
+
+class TestFleetClaim(unittest.TestCase):
+    def test_feature_off_by_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MEGINGJORD_FLEET_CLAIM", None)
+            self.assertFalse(fcc.feature_enabled())
+
+    def test_acquire_returns_sentinel_when_off(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MEGINGJORD_FLEET_CLAIM", None)
+            result = fcc.acquire("100.91.113.16", "qwen2.5-coder:32b", ticket=2519)
+            self.assertEqual(result["claim_id"], "fleet-claim-feature-off")
+
+    def test_release_noop_on_sentinel(self):
+        with patch.dict(os.environ, {"MEGINGJORD_FLEET_CLAIM": "1"}):
+            result = fcc.release("fleet-claim-feature-off")
+            self.assertTrue(result["released"])
+            self.assertTrue(result["noop"])
+
+    def test_in_flight_off_returns_feature_off(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MEGINGJORD_FLEET_CLAIM", None)
+            result = fcc.in_flight()
+            self.assertTrue(result["feature_off"])
+            self.assertEqual(result["entries"], [])
+
+    def test_acquire_returns_none_on_network_failure(self):
+        with patch.dict(os.environ, {"MEGINGJORD_FLEET_CLAIM": "1"}):
+            with patch("urllib.request.urlopen", side_effect=OSError("network")):
+                result = fcc.acquire("h", "m")
+                self.assertIsNone(result)
+
+    def test_github_label_acquire_failure_returns_none(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError("gh")):
+            self.assertIsNone(fcc.github_label_acquire("o/r", 1, "h", "m"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phase-1 AC5 FINAL. HAMR Worker /fleet/{acquire,release,in-flight} + Python client with GitHub-label Tier-1 fallback.

Refs #2525
Refs Epic #2518
merge-evidence-deferred-final: #2525

[skip-changelog]