### PR TITLE
feat(scripts): add cross_family_verdict to closeout.js #2537

### DIFF
--- a/scripts/global/megalint/consultant-closeout.js
+++ b/scripts/global/megalint/consultant-closeout.js
@@ -61,28 +61,17 @@ function checkGovTokenResolution(body, input) {
   return unresolved.map(t => ({ rule: 'unresolved-governance-token', detail: `Token ${t} has no catalog source in instructions/governance-controls.instructions.md` }));
 }
 
-function hasChildRef(body) {
-  const matches = (body || '').match(/(?:^|[\s(\[,;])#(\d{2,5})\b/g) || [];
-  return matches.length > 0;
-}
-
-function hasPrRef(body) {
-  return /\b(?:PR|pull[\/\\]|pull\s+request)\s*#?\d+|pull\/\d+/i.test(body || '');
-}
-
-function hasResearchRef(body) {
-  return /research\/[\w-]+\.md/i.test(body || '');
-}
-
 function checkSubstantiveContent(body, isEpic) {
   if (!isEpic) return [];
-  if (hasChildRef(body) || hasPrRef(body) || hasResearchRef(body)) return [];
-  return [{
-    rule: 'epic-closeout-no-substantive-evidence',
-    detail: 'CONSULTANT_CLOSEOUT on an Epic must reference substantive evidence: at least one of '
-      + '(a) #N child issue ref, (b) PR ref (PR #N or pull/N), (c) research/*.md path. '
-      + 'Schema-fields-only closeouts (rubric + verdict + timestamp + signer) are insufficient — see #1453.',
-  }];
+  const b = body || '';
+  if (/(?:^|[\s(\[,;])#\d{2,5}\b/.test(b) || /\b(?:PR|pull[\/\\]|pull\s+request)\s*#?\d+|pull\/\d+/i.test(b) || /research\/[\w-]+\.md/i.test(b)) return [];
+  return [{ rule: 'epic-closeout-no-substantive-evidence', detail: 'CONSULTANT_CLOSEOUT on an Epic must reference: (a) #N child ref, (b) PR ref, (c) research/*.md — see #1453.' }];
+}
+
+function checkCrossFamilyVerdict(body) {
+  if (!/cross_family_verdict:/i.test(body)) return [{ rule: 'cross-family-verdict-missing', severity: 'advisory', detail: 'CONSULTANT_CLOSEOUT: cross_family_verdict field missing (advisory; #2537)' }];
+  if (!/cross_family_verdict:\s*(ACCEPT|PARTIAL|REJECT)\s*[—–-]+\s*\S+@\S+\s*[—–-]+\s*.+/i.test(body)) return [{ rule: 'cross-family-verdict-malformed', detail: 'cross_family_verdict must be: ACCEPT|PARTIAL|REJECT — <model@host> — <rationale>' }];
+  return [];
 }
 
 function validate(input) {
@@ -98,8 +87,9 @@ function validate(input) {
     ...checkTier3Emission(body, input),
     ...checkGovTokenResolution(body, input),
     ...checkSubstantiveContent(body, input.isEpic === true),
+    ...checkCrossFamilyVerdict(body),
   ];
-  return { ok: violations.length === 0, violations, found: true };
+  return { ok: violations.filter(v => v.severity !== 'advisory').length === 0, violations, found: true };
 }
 
 module.exports = { validate, findConsultantCloseout };

--- a/tests/cross-family-verdict-field.spec.js
+++ b/tests/cross-family-verdict-field.spec.js
@@ -1,0 +1,62 @@
+// cross-family-verdict-field — tests for #2537 (Epic #2511 C2)
+// Validates checkCrossFamilyVerdict() in scripts/global/megalint/consultant-closeout.js
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const { validate } = require(path.resolve(__dirname, '..', 'scripts', 'global', 'megalint', 'consultant-closeout.js'));
+
+function makeInput(closeoutBody, extras = {}) {
+  return {
+    comments: [{
+      body: `## CONSULTANT_CLOSEOUT\nrubric: G1=9, G2=8\nverification-timestamp: 2026-05-31T00:00:00Z\nverdict: approved\nSigned-by: Soren Vale\nTeam&Model: copilot:claude-sonnet-4-6@github\nRole: consultant\n${closeoutBody}`,
+    }],
+    lane: 'lane:code-change', labels: [], state: 'open', body: '', prBody: '',
+    ...extras,
+  };
+}
+
+test('#2537 C2: missing cross_family_verdict emits advisory, ok stays true', () => {
+  const r = validate(makeInput(''));
+  expect(r.found).toBe(true);
+  expect(r.ok).toBe(true);
+  const advisory = r.violations.find(v => v.rule === 'cross-family-verdict-missing');
+  expect(advisory).toBeDefined();
+  expect(advisory.severity).toBe('advisory');
+});
+
+test('#2537 C2: malformed cross_family_verdict emits hard error, ok is false', () => {
+  const r = validate(makeInput('cross_family_verdict: ACCEPT missing-fields'));
+  expect(r.found).toBe(true);
+  expect(r.ok).toBe(false);
+  const err = r.violations.find(v => v.rule === 'cross-family-verdict-malformed');
+  expect(err).toBeDefined();
+  expect(err.severity).toBeUndefined();
+});
+
+test('#2537 C2: valid ACCEPT verdict — no cross-family violations', () => {
+  const r = validate(makeInput('cross_family_verdict: ACCEPT — qwen2.5-coder:7b@100.91.113.16 — No structural issues found'));
+  expect(r.found).toBe(true);
+  expect(r.ok).toBe(true);
+  const cfViolations = r.violations.filter(v => v.rule.startsWith('cross-family-verdict'));
+  expect(cfViolations).toHaveLength(0);
+});
+
+test('#2537 C2: valid PARTIAL verdict — no cross-family violations', () => {
+  const r = validate(makeInput('cross_family_verdict: PARTIAL — qwen2.5-coder:7b@100.91.113.16 — Advisory gaps in G5'));
+  expect(r.found).toBe(true);
+  expect(r.ok).toBe(true);
+  const cfViolations = r.violations.filter(v => v.rule.startsWith('cross-family-verdict'));
+  expect(cfViolations).toHaveLength(0);
+});
+
+test('#2537 C2: valid REJECT verdict — no cross-family violations', () => {
+  const r = validate(makeInput('cross_family_verdict: REJECT — qwen2.5-coder:7b@100.91.113.16 — Critical G1 violation'));
+  const cfViolations = r.violations.filter(v => v.rule.startsWith('cross-family-verdict'));
+  expect(cfViolations).toHaveLength(0);
+});
+
+test('#2537 C2: em-dash and en-dash separators both accepted', () => {
+  const r1 = validate(makeInput('cross_family_verdict: ACCEPT — qwen2.5-coder:7b@host — rationale'));
+  expect(r1.violations.filter(v => v.rule.startsWith('cross-family-verdict'))).toHaveLength(0);
+  const r2 = validate(makeInput('cross_family_verdict: PARTIAL – qwen2.5-coder:7b@host – rationale'));
+  expect(r2.violations.filter(v => v.rule.startsWith('cross-family-verdict'))).toHaveLength(0);
+});


### PR DESCRIPTION
feat(scripts): add cross_family_verdict field to consultant-closeout.js validator

Adds `checkCrossFamilyVerdict(body)` function to the consultant-closeout.js megalint validator, emitting:
- Advisory `cross-family-verdict-missing` when field absent (backward-compatible, ok stays true)
- Hard error `cross-family-verdict-malformed` when present but invalid format

Also updates `validate()` to filter advisory violations from the `ok` computation (non-advisory violations only block ok).

6 new tests in `tests/cross-family-verdict-field.spec.js` — all pass.

merge-evidence-deferred-final: #2537
Refs #2537