### PR TITLE
feat(scripts): signer-fidelity family independence check #2536

### DIFF
--- a/scripts/global/megalint/signer-fidelity.js
+++ b/scripts/global/megalint/signer-fidelity.js
@@ -49,21 +49,47 @@ function checkRegistryAlias(body, opts) {
   return [result.violation];
 }
 
+function extractAIFamily(teamModel) {
+  if (!teamModel) return 'unknown';
+  const m = (teamModel.match(/[^:]+:([^@]+)@/) || [])[1] || teamModel;
+  const s = m.toLowerCase();
+  if (s.includes('claude')) return 'anthropic';
+  if (/^gpt-|^o[0-9]/.test(s)) return 'openai';
+  if (s.includes('qwen')) return 'qwen';
+  if (s.includes('deepseek')) return 'deepseek';
+  if (s.includes('granite')) return 'granite';
+  return 'unknown';
+}
+
+function checkConsultantFamilyIndependence(body) {
+  if (!body) return [];
+  const blocks = [];
+  const pat = /Team&Model\s*:\s*([^\n]+)[\s\S]{0,120}?Role\s*:\s*(\w[\w-]*)/gi;
+  let match;
+  while ((match = pat.exec(body)) !== null) {
+    blocks.push({ teamModel: match[1].trim(), role: match[2].toLowerCase() });
+  }
+  const consult = blocks.find(b => b.role === 'consultant');
+  const collab = blocks.find(b => b.role === 'collaborator');
+  if (!consult || !collab) return [];
+  const cf = extractAIFamily(consult.teamModel);
+  const cc = extractAIFamily(collab.teamModel);
+  if (cf === 'unknown' || cc === 'unknown' || cf !== cc) return [];
+  return [{ rule: 'cross-family-mismatch', severity: 'advisory',
+    detail: `Consultant+Collaborator same AI family (${cf}); cross-family review required (#2511)` }];
+}
+
 function validate(input) {
   const body = input.body || '';
   const violations = checkSignedBy(body);
   const aiSig = findSignerField(body, 'AI-Signature');
-  if (isClientIdentity(aiSig)) {
-    violations.push({
-      rule: 'client-identity-as-ai-signature',
-      detail: `Issue body uses client identity "${aiSig}" as AI-Signature trailer`,
-    });
-  }
-  violations.push(...checkRegistryAlias(body, {
-    device: input.device, registryOverride: input.registryOverride,
-  }));
+  if (isClientIdentity(aiSig)) violations.push({ rule: 'client-identity-as-ai-signature',
+    detail: `Issue body uses client identity "${aiSig}" as AI-Signature trailer` });
+  violations.push(...checkRegistryAlias(body, { device: input.device, registryOverride: input.registryOverride }));
+  violations.push(...checkConsultantFamilyIndependence(body));
   const unique = dedupe(violations);
-  return { ok: unique.length === 0, violations: unique };
+  return { ok: unique.filter(v => v.severity !== 'advisory').length === 0, violations: unique };
 }
 
-module.exports = { validate, isClientIdentity, findSignerField, CLIENT_IDENTITIES };
+module.exports = { validate, isClientIdentity, findSignerField, extractAIFamily,
+  checkConsultantFamilyIndependence, CLIENT_IDENTITIES };

--- a/tests/signer-family-independence.spec.js
+++ b/tests/signer-family-independence.spec.js
@@ -1,0 +1,59 @@
+'use strict';
+// Tests for extractAIFamily + checkConsultantFamilyIndependence (#2536)
+const { test, expect } = require('@playwright/test');
+const { extractAIFamily, checkConsultantFamilyIndependence, validate } =
+  require('../scripts/global/megalint/signer-fidelity.js');
+
+test('extractAIFamily — claude model → anthropic', () => {
+  expect(extractAIFamily('copilot:claude-sonnet-4-6@github')).toBe('anthropic');
+});
+test('extractAIFamily — gpt model → openai', () => {
+  expect(extractAIFamily('codex:gpt-5.4@openai')).toBe('openai');
+});
+test('extractAIFamily — qwen model → qwen', () => {
+  expect(extractAIFamily('fleet:qwen2.5-coder:7b@ollama')).toBe('qwen');
+});
+test('extractAIFamily — unknown model → unknown', () => {
+  expect(extractAIFamily('team:llama3@local')).toBe('unknown');
+});
+test('same-family consultant+collaborator → advisory cross-family-mismatch', () => {
+  const body = [
+    'Team&Model: copilot:claude-sonnet-4-6@github',
+    'Role: collaborator',
+    '---',
+    'Team&Model: copilot:claude-sonnet-4-6@github',
+    'Role: consultant',
+  ].join('\n');
+  const violations = checkConsultantFamilyIndependence(body);
+  expect(violations).toHaveLength(1);
+  expect(violations[0].rule).toBe('cross-family-mismatch');
+  expect(violations[0].severity).toBe('advisory');
+});
+test('different-family consultant+collaborator → no violation', () => {
+  const body = [
+    'Team&Model: codex:gpt-5.4@openai',
+    'Role: collaborator',
+    '---',
+    'Team&Model: copilot:claude-sonnet-4-6@github',
+    'Role: consultant',
+  ].join('\n');
+  expect(checkConsultantFamilyIndependence(body)).toHaveLength(0);
+});
+test('validate: same-family advisory does not flip ok to false', () => {
+  const body = [
+    'Signed-by: Soren Harper',
+    'Team&Model: copilot:claude-sonnet-4-6@github',
+    'Role: collaborator',
+    '---',
+    'Signed-by: Soren Vale',
+    'Team&Model: copilot:claude-sonnet-4-6@github',
+    'Role: consultant',
+  ].join('\n');
+  const result = validate({ body });
+  const cf = result.violations.filter(v => v.rule === 'cross-family-mismatch');
+  expect(cf).toHaveLength(1);
+  expect(result.ok).toBe(true);
+});
+test('no consultant or collaborator → no cross-family violation', () => {
+  expect(checkConsultantFamilyIndependence('Team&Model: codex:gpt-5@openai\nRole: admin')).toHaveLength(0);
+});


### PR DESCRIPTION
Adds extractAIFamily() and checkConsultantFamilyIndependence() to signer-fidelity.js.

Advisory cross-family-mismatch emitted when Consultant+Collaborator share same AI family. Advisory violations do not flip ok to false (backward-compatible soak). validate() updated to filter advisory violations from ok (consistent with C2 #2537).

8 new tests in tests/signer-family-independence.spec.js — all pass.

merge-evidence-deferred-final: #2536
Refs #2536