### PR TITLE
feat(scripts): cross-family advisory bridge gate #2538

### DIFF
--- a/.github/workflows/baton-gates.yml
+++ b/.github/workflows/baton-gates.yml
@@ -114,7 +114,10 @@ jobs:
     name: consultant-gate
     needs: [admin-gate]
     runs-on: ubuntu-latest
+    env:
+      GATE_ADVISORY_MODE: '1'
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
@@ -132,6 +135,21 @@ jobs:
                 `CONSULTANT_CLOSEOUT not found in issue #${linkedIssue} comments. ` +
                 'Post artifact as a comment on the linked issue — PR body does not satisfy this gate.'
               );
+              return;
+            }
+            const advisory = process.env.GATE_ADVISORY_MODE === '1';
+            const { checkConsultantFamilyIndependence } =
+              require('./scripts/global/megalint/signer-fidelity.js');
+            const { checkCrossFamilyVerdict } =
+              require('./scripts/global/megalint/consultant-closeout.js');
+            const allViols = [
+              ...checkConsultantFamilyIndependence(trail),
+              ...checkCrossFamilyVerdict(trail),
+            ];
+            if (allViols.length > 0) {
+              const msg = allViols.map(v => `${v.rule}${v.detail ? ': ' + v.detail : ''}`).join('; ');
+              if (advisory) { core.warning(`[advisory] cross-family gate: ${msg}`); }
+              else { core.setFailed(`cross-family gate: ${msg}`); }
             }
 
   changelog-fragment:

--- a/scripts/global/megalint/consultant-closeout.js
+++ b/scripts/global/megalint/consultant-closeout.js
@@ -92,4 +92,4 @@ function validate(input) {
   return { ok: violations.filter(v => v.severity !== 'advisory').length === 0, violations, found: true };
 }
 
-module.exports = { validate, findConsultantCloseout };
+module.exports = { validate, findConsultantCloseout, checkCrossFamilyVerdict };

--- a/tests/cross-family-bridge-gate.spec.js
+++ b/tests/cross-family-bridge-gate.spec.js
@@ -1,0 +1,50 @@
+'use strict';
+// Integration tests for C3 (#2538): cross-family bridge gate advisory checks
+const { test, expect } = require('@playwright/test');
+const { checkCrossFamilyVerdict } = require('../scripts/global/megalint/consultant-closeout.js');
+const { checkConsultantFamilyIndependence } = require('../scripts/global/megalint/signer-fidelity.js');
+
+test('checkCrossFamilyVerdict exported from consultant-closeout.js', () => {
+  expect(typeof checkCrossFamilyVerdict).toBe('function');
+});
+
+test('missing cross_family_verdict → advisory violation', () => {
+  const body = `## CONSULTANT_CLOSEOUT
+verdict: approve_for_merge
+rubric_rating: 8/10.
+Signed-by: Soren Vale
+Team&Model: copilot:claude-sonnet-4-6@github
+Role: consultant`;
+  const viols = checkCrossFamilyVerdict(body);
+  expect(viols.length).toBe(1);
+  expect(viols[0].rule).toBe('cross-family-verdict-missing');
+  expect(viols[0].severity).toBe('advisory');
+});
+
+test('valid cross_family_verdict → no violation', () => {
+  const body = `cross_family_verdict: ACCEPT — qwen2.5-coder:7b@100.0.0.1 — all ACs satisfied`;
+  const viols = checkCrossFamilyVerdict(body);
+  expect(viols.length).toBe(0);
+});
+
+test('malformed cross_family_verdict → hard error', () => {
+  const body = `cross_family_verdict: ACCEPT incomplete`;
+  const viols = checkCrossFamilyVerdict(body);
+  expect(viols.length).toBe(1);
+  expect(viols[0].rule).toBe('cross-family-verdict-malformed');
+  expect(viols[0].severity).toBeUndefined();
+});
+
+test('same-family body → cross-family-mismatch advisory from checkConsultantFamilyIndependence', () => {
+  const body = `Team&Model: copilot:claude-sonnet@github\nRole: collaborator\n\nTeam&Model: copilot:claude-opus@github\nRole: consultant`;
+  const viols = checkConsultantFamilyIndependence(body);
+  expect(viols.length).toBe(1);
+  expect(viols[0].severity).toBe('advisory');
+});
+
+test('gate emits advisory array (no throw) for missing verdict', () => {
+  const trail = `## CONSULTANT_CLOSEOUT\nverdict: approve\nrubric_rating: 8/10.\nSigned-by: X\nTeam&Model: t:m@s\nRole: consultant`;
+  const viols = [...checkConsultantFamilyIndependence(trail), ...checkCrossFamilyVerdict(trail)];
+  expect(Array.isArray(viols)).toBe(true);
+  expect(viols.every(v => v.severity === 'advisory' || v.rule.includes('malformed'))).toBe(true);
+});


### PR DESCRIPTION
Adds advisory cross-family checks to consultant-gate job in baton-gates.yml.

Exports checkCrossFamilyVerdict from consultant-closeout.js (C2 function now public for CI use). GATE_ADVISORY_MODE=1 env flag; advisory emits core.warning, not setFailed. 6 integration tests pass.

Depends on C1 (#2536, merged PR #2544) + C2 (#2537, merged PR #2543).

merge-evidence-deferred-final: #2538
Refs #2538