### PR TITLE
feat(megalint): cross-family field consistency #2541

### DIFF
--- a/scripts/global/megalint/admin-handoff.js
+++ b/scripts/global/megalint/admin-handoff.js
@@ -48,6 +48,14 @@ function checkIndependence(adminBody, collaboratorHandoff) {
   return [];
 }
 
+function checkCrossFamily(body) {
+  if (!/reviewer_family_verified:/i.test(body)) {
+    return [{ rule: 'missing-reviewer-family-verified',
+      detail: 'ADMIN_HANDOFF missing reviewer_family_verified: field', severity: 'advisory' }];
+  }
+  return [];
+}
+
 function validate(input) {
   if (LIGHTWEIGHT.includes(input.lane) || laneSeverity(input.lane) === 'issue-only') {
     return { ok: true, violations: [], reason: 'lightweight-lane-skip' };
@@ -62,6 +70,9 @@ function validate(input) {
     ...checkSignerFields(handoff.body || ''),
     ...checkIndependence(handoff.body, findCollaboratorHandoff(comments)),
   ];
+  if (input.lane === 'lane:code-change') {
+    violations.push(...checkCrossFamily(handoff.body || ''));
+  }
   const signer = roleIdentity({ body: handoff.body, author: handoff.user && handoff.user.login });
   return { ok: violations.length === 0, violations, found: true, signer };
 }

--- a/scripts/global/megalint/collaborator-handoff.js
+++ b/scripts/global/megalint/collaborator-handoff.js
@@ -7,6 +7,7 @@ const path = require('path');
 const { roleIdentity } = require(path.join(__dirname, '..', 'baton-independence.js'));
 const { LIGHTWEIGHT, laneSeverity } = require(path.join(__dirname, '..', 'lane-enum.js'));
 const docCoverage = require('./doc-coverage.js');
+const { KNOWN_FAMILIES } = require('./signer-fidelity.js');
 
 function findCollaboratorHandoff(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?COLLABORATOR_HANDOFF\b/;
@@ -32,11 +33,17 @@ function checkSignerFields(body) {
 
 function checkCrossFamily(body) {
   const advisory = s => ({ rule: s, detail: `COLLABORATOR_HANDOFF missing ${s.replace('missing-', '').replace(/-/g, '_')}: field`, severity: 'advisory' });
-  return [
+  const violations = [
     /cross_family_reviewer:/i.test(body) ? null : advisory('missing-cross-family-reviewer'),
     /cross_family_rating:/i.test(body) ? null : advisory('missing-cross-family-rating'),
     /reviewer_family:/i.test(body) ? null : advisory('missing-reviewer-family'),
   ].filter(Boolean);
+  const fm = (body || '').match(/reviewer_family\s*:\s*(\S+)/i);
+  if (fm && !KNOWN_FAMILIES.includes(fm[1].toLowerCase())) {
+    violations.push({ rule: 'unknown-reviewer-family',
+      detail: `reviewer_family "${fm[1]}" not in KNOWN_FAMILIES`, severity: 'advisory' });
+  }
+  return violations;
 }
 
 function validate(input) {

--- a/scripts/global/megalint/signer-fidelity.js
+++ b/scripts/global/megalint/signer-fidelity.js
@@ -91,5 +91,8 @@ function validate(input) {
   return { ok: unique.filter(v => v.severity !== 'advisory').length === 0, violations: unique };
 }
 
+const KNOWN_FAMILIES = ['anthropic', 'openai', 'qwen', 'deepseek', 'granite', 'unknown'];
+const normalizeFamily = s => { const n = (s || '').toLowerCase().trim(); return KNOWN_FAMILIES.includes(n) ? n : 'unknown'; };
+
 module.exports = { validate, isClientIdentity, findSignerField, extractAIFamily,
-  checkConsultantFamilyIndependence, CLIENT_IDENTITIES };
+  checkConsultantFamilyIndependence, CLIENT_IDENTITIES, KNOWN_FAMILIES, normalizeFamily };

--- a/tests/cross-family-field-consistency.spec.js
+++ b/tests/cross-family-field-consistency.spec.js
@@ -1,0 +1,61 @@
+'use strict';
+// Tests for C6 #2541: cross-family field consistency validators
+const { test, expect } = require('@playwright/test');
+const { KNOWN_FAMILIES, normalizeFamily } = require('../scripts/global/megalint/signer-fidelity.js');
+const { validate: validateCollab } = require('../scripts/global/megalint/collaborator-handoff.js');
+const { validate: validateAdmin } = require('../scripts/global/megalint/admin-handoff.js');
+
+test('KNOWN_FAMILIES contains the 6 canonical families', () => {
+  expect(KNOWN_FAMILIES).toEqual(['anthropic', 'openai', 'qwen', 'deepseek', 'granite', 'unknown']);
+});
+
+test('normalizeFamily returns canonical values for known families', () => {
+  for (const f of ['anthropic', 'openai', 'qwen', 'deepseek', 'granite']) {
+    expect(normalizeFamily(f)).toBe(f);
+    expect(normalizeFamily(f.toUpperCase())).toBe(f);
+  }
+});
+
+test('normalizeFamily returns unknown for unrecognised strings', () => {
+  expect(normalizeFamily('mistral')).toBe('unknown');
+  expect(normalizeFamily('')).toBe('unknown');
+  expect(normalizeFamily(null)).toBe('unknown');
+});
+
+function makeCollab(extra) {
+  return { lane: 'lane:code-change', labels: [], comments: [{ body: `COLLABORATOR_HANDOFF\nSigned-by: Soren Harper\nTeam&Model: copilot:claude-sonnet@github\nRole: collaborator\ncross_family_reviewer: Qwen/2.5-Coder\ncross_family_rating: ACCEPT\nreviewer_family: ${extra}` }] };
+}
+
+test('collaborator-handoff: known reviewer_family has no unknown-family advisory', () => {
+  const result = validateCollab(makeCollab('qwen'));
+  const unknown = (result.violations || []).filter(v => v.rule === 'unknown-reviewer-family');
+  expect(unknown).toHaveLength(0);
+});
+
+test('collaborator-handoff: unknown reviewer_family triggers advisory', () => {
+  const result = validateCollab(makeCollab('mistral'));
+  const unknown = (result.violations || []).filter(v => v.rule === 'unknown-reviewer-family');
+  expect(unknown).toHaveLength(1);
+  expect(unknown[0].severity).toBe('advisory');
+});
+
+function makeAdmin(includeVerified) {
+  const extra = includeVerified ? '\nreviewer_family_verified: qwen' : '';
+  return { lane: 'lane:code-change', comments: [
+    { body: 'COLLABORATOR_HANDOFF\nSigned-by: Soren Harper\nTeam&Model: copilot:claude@github\nRole: collaborator' },
+    { body: `ADMIN_HANDOFF\nSigned-by: Soren Reyes\nTeam&Model: copilot:claude@github\nRole: admin${extra}` },
+  ]};
+}
+
+test('admin-handoff: present reviewer_family_verified has no advisory', () => {
+  const result = validateAdmin(makeAdmin(true));
+  const missing = (result.violations || []).filter(v => v.rule === 'missing-reviewer-family-verified');
+  expect(missing).toHaveLength(0);
+});
+
+test('admin-handoff: absent reviewer_family_verified triggers advisory', () => {
+  const result = validateAdmin(makeAdmin(false));
+  const missing = (result.violations || []).filter(v => v.rule === 'missing-reviewer-family-verified');
+  expect(missing).toHaveLength(1);
+  expect(missing[0].severity).toBe('advisory');
+});


### PR DESCRIPTION
## Summary

Adds cross-family field consistency validators for Epic #2511 C6.

- `signer-fidelity.js`: exports `KNOWN_FAMILIES` + `normalizeFamily` for shared use
- `collaborator-handoff.js`: validates `reviewer_family:` is canonical (advisory)
- `admin-handoff.js`: validates `reviewer_family_verified:` presence (advisory)
- 7 new unit tests in `tests/cross-family-field-consistency.spec.js`

merge-evidence-deferred-final: #2541
Refs #2541, Epic #2511