### PR TITLE
docs(agents): add diff-presence detection to doc-coverage sub-agent #2437

### DIFF
--- a/agents/pre-merge-review/doc-coverage.md
+++ b/agents/pre-merge-review/doc-coverage.md
@@ -1,8 +1,9 @@
 # doc-coverage sub-agent (#2437 — Epic #2414)
 
-Cross-family review of doc-coverage block completeness for the diff.
+Cross-family adversarial review of doc surface presence in the PR diff.
+Errs toward flagging missing surfaces (complement to programmatic doc-coverage.js).
 
-## Output contract (per #1739)
+## Output contract
 
 ```json
 {"severity": "low|medium|high", "category": "doc-coverage", "file": "...",
@@ -12,28 +13,44 @@ Cross-family review of doc-coverage block completeness for the diff.
 
 ## Detection focus
 
-- `COLLABORATOR_HANDOFF` on `lane:code-change` missing `doc-coverage:` block
-- Required surfaces (per `config/doc-coverage-matrix.yml`) not declared as
-  `UPDATED: <path>` or `N/A: <surface> — <reason>`
-- `N/A:` entries missing a reason string after `—`
-- Surface paths that don't match any configured `area:*` label for the ticket
+**Diff-presence checks** (evaluate what is actually in the PR diff, not just declared):
 
-## Auto-escalate triggers
+- `.changes/unreleased/<ticket-N>.md` absent from diff when `lane:code-change` →
+  `trigger: "missing-changelog-fragment"`, severity: medium
+- `docs/workflow/learnings.md` not modified when diff changes user-visible behavior →
+  `trigger: "missing-learnings-entry"`, severity: low
+- No wiki page (`wiki/wisdom/` or `wiki/code/`) added/modified when diff introduces
+  a new concept, entity, or architectural change →
+  `trigger: "missing-wiki-entry"`, severity: low
+- `doc-coverage:` block in COLLABORATOR_HANDOFF declares `UPDATED: <path>` for a
+  surface that is **not present in the diff** (declared but not written) →
+  `trigger: "declared-surface-not-in-diff"`, severity: high
 
-- Missing `doc-coverage:` block on `lane:code-change` →
+**Schema checks** (COLLABORATOR_HANDOFF structure):
+
+- `lane:code-change` COLLABORATOR_HANDOFF missing `doc-coverage:` block entirely →
   `trigger: "missing-doc-coverage-block"`, severity: high
 - Required surface absent (neither UPDATED nor N/A) →
   `trigger: "missing-required-surface"`, severity: medium
 
+## Auto-escalate triggers
+
+- Any `area:governance` label change without a corresponding doc surface (instruction,
+  wiki page, or learnings entry) in the diff →
+  `trigger: "governance-change-no-docs"`, severity: high
+
 ## Confidence calibration
 
-- 0.9-1.0: `lane:code-change` COLLABORATOR_HANDOFF with no `doc-coverage:` block
-- 0.7-0.89: block present but required surface(s) missing
-- 0.5-0.69: surfaces declared but N/A reason absent
-- <0.3: noise or non-code-change lane
+- 0.9-1.0: `lane:code-change` COLLABORATOR_HANDOFF missing `doc-coverage:` block; or
+  declared surface verifiably absent from diff
+- 0.7-0.89: changelog fragment or required surface absent; governance change without docs
+- 0.5-0.69: learnings/wiki entry absent but behavior change is ambiguous
+- 0.3-0.49: doc surface may be in a related (not directly reviewed) commit
+- <0.3: do not emit — noise threshold
 
 ## Out of scope
 
 - Whether documentation content is accurate (operator responsibility)
 - Non-COLLABORATOR_HANDOFF comments
 - Lanes other than `lane:code-change`
+- Code quality, test coverage, security posture


### PR DESCRIPTION
Refs #2437

Updates agents/pre-merge-review/doc-coverage.md to fully meet #2437 AC:

- Added diff-presence detection focus: changelog fragments, learnings.md, wiki entries
- Added declared-but-not-in-diff surface detection
- Added governance-change-no-docs auto-escalate trigger
- Retained confidence calibration and out-of-scope sections

merge-evidence-deferred-final: #2437

Signed-by: Soren Harper
Team&Model: copilot:claude-sonnet-4-6@github
Role: collaborator