### PR TITLE
feat(megalint): blocking cross-family fields + family independence in collaborator-handoff #2439

### DIFF
--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -212,6 +212,8 @@ Conditional required fields:
 
 `test_strategy` selected per `instructions/test-methodology-matrix.instructions.md`; missing on legacy tickets defaults to `none` (advisory). New tickets with `none` on non-permitted lane fail `test-evidence`.
 
+**Cross-family preflight requirement** (lane:code-change, Refs #2439): Before posting `COLLABORATOR_HANDOFF`, run `npm run collaborator:preflight --ticket=N`. The handoff MUST include `cross_family_rating:`, `cross_family_reviewer:`, and `cross_family_findings:` from the preflight output. The reviewer model family MUST differ from the Collaborator's `Team&Model` family.
+
 ## Parent/child relationships (Sub-issues primitive)
 
 The canonical parent/child relationship uses GitHub's native **Sub-issues**

--- a/scripts/global/megalint/collaborator-handoff.js
+++ b/scripts/global/megalint/collaborator-handoff.js
@@ -2,12 +2,13 @@
 // collaborator-handoff — validates COLLABORATOR_HANDOFF signer + content.
 // Refs #2302: LIGHTWEIGHT imported from lane-enum.js (single source of truth).
 // #2424: doc-coverage block now blocking (not advisory).
+// #2439: cross_family_reviewer/rating/findings blocking; family independence check.
 
 const path = require('path');
 const { roleIdentity } = require(path.join(__dirname, '..', 'baton-independence.js'));
 const { LIGHTWEIGHT, laneSeverity } = require(path.join(__dirname, '..', 'lane-enum.js'));
 const docCoverage = require('./doc-coverage.js');
-const { KNOWN_FAMILIES } = require('./signer-fidelity.js');
+const { KNOWN_FAMILIES, extractAIFamily } = require('./signer-fidelity.js');
 
 function findCollaboratorHandoff(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?COLLABORATOR_HANDOFF\b/;
@@ -32,16 +33,25 @@ function checkSignerFields(body) {
 }
 
 function checkCrossFamily(body) {
-  const advisory = s => ({ rule: s, detail: `COLLABORATOR_HANDOFF missing ${s.replace('missing-', '').replace(/-/g, '_')}: field`, severity: 'advisory' });
-  const violations = [
-    /cross_family_reviewer:/i.test(body) ? null : advisory('missing-cross-family-reviewer'),
-    /cross_family_rating:/i.test(body) ? null : advisory('missing-cross-family-rating'),
-    /reviewer_family:/i.test(body) ? null : advisory('missing-reviewer-family'),
-  ].filter(Boolean);
+  const violations = [];
+  const block = s => ({ rule: `missing-${s}`, detail: `COLLABORATOR_HANDOFF missing ${s}: field` });
+  if (!/cross_family_reviewer:/i.test(body)) violations.push(block('cross-family-reviewer'));
+  if (!/cross_family_rating:/i.test(body)) violations.push(block('cross-family-rating'));
+  if (!/cross_family_findings:/i.test(body)) violations.push(block('cross-family-findings'));
   const fm = (body || '').match(/reviewer_family\s*:\s*(\S+)/i);
   if (fm && !KNOWN_FAMILIES.includes(fm[1].toLowerCase())) {
     violations.push({ rule: 'unknown-reviewer-family',
       detail: `reviewer_family "${fm[1]}" not in KNOWN_FAMILIES`, severity: 'advisory' });
+  }
+  const tmm = (body || '').match(/Team&Model\s*:\s*(\S+)/i);
+  const rvm = (body || '').match(/cross_family_reviewer\s*:\s*(\S+)/i);
+  if (tmm && rvm) {
+    const cf = extractAIFamily(tmm[1]);
+    const rf = extractAIFamily(rvm[1]);
+    if (cf !== 'unknown' && cf === rf) {
+      violations.push({ rule: 'cross-family-reviewer-same-family',
+        detail: `Reviewer family "${rf}" matches Collaborator Team&Model family` });
+    }
   }
   return violations;
 }

--- a/tests/collaborator-handoff-cross-family.spec.js
+++ b/tests/collaborator-handoff-cross-family.spec.js
@@ -1,0 +1,75 @@
+'use strict';
+// tests/collaborator-handoff-cross-family.spec.js
+// Refs #2439 — validates cross-family blocking fields + family independence check.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const { validate } = require(path.join(__dirname, '..', 'scripts', 'global',
+  'megalint', 'collaborator-handoff.js'));
+
+const validBody = `## COLLABORATOR_HANDOFF
+Signed-by: Soren Harper
+Team&Model: copilot:claude-sonnet-4-6@github
+Role: collaborator
+cross_family_reviewer: qwen2.5-coder:7b@fleet-tailscale
+cross_family_rating: 82/100
+cross_family_findings: No major issues found.
+reviewer_family: qwen
+doc-coverage:
+  N/A: all surfaces — lane test only`;
+
+const makeInput = body => ({
+  lane: 'lane:code-change',
+  comments: [{ body, user: { login: 'test' } }],
+  labels: [],
+});
+
+describe('collaborator-handoff cross-family fields (#2439)', () => {
+  test('valid cross-family handoff passes', () => {
+    const r = validate(makeInput(validBody));
+    const blocking = (r.violations || []).filter(v => v.severity !== 'advisory');
+    assert.ok(blocking.length === 0, `Expected no blocking violations; got: ${
+      blocking.map(v => v.rule).join(', ')}`);
+  });
+
+  test('missing cross_family_reviewer is blocking', () => {
+    const body = validBody.replace(/cross_family_reviewer:[^\n]+\n/, '');
+    const r = validate(makeInput(body));
+    const rules = r.violations.map(v => v.rule);
+    assert.ok(rules.includes('missing-cross-family-reviewer'), 'Expected missing-cross-family-reviewer');
+    assert.ok(!r.ok);
+  });
+
+  test('missing cross_family_rating is blocking', () => {
+    const body = validBody.replace(/cross_family_rating:[^\n]+\n/, '');
+    const r = validate(makeInput(body));
+    const rules = r.violations.map(v => v.rule);
+    assert.ok(rules.includes('missing-cross-family-rating'), 'Expected missing-cross-family-rating');
+    assert.ok(!r.ok);
+  });
+
+  test('missing cross_family_findings is blocking', () => {
+    const body = validBody.replace(/cross_family_findings:[^\n]+\n/, '');
+    const r = validate(makeInput(body));
+    const rules = r.violations.map(v => v.rule);
+    assert.ok(rules.includes('missing-cross-family-findings'), 'Expected missing-cross-family-findings');
+    assert.ok(!r.ok);
+  });
+
+  test('same-family reviewer is blocking', () => {
+    const body = validBody.replace('qwen2.5-coder:7b@fleet-tailscale',
+      'claude-haiku-3-5@anthropic');
+    const r = validate(makeInput(body));
+    const rules = r.violations.map(v => v.rule);
+    assert.ok(rules.includes('cross-family-reviewer-same-family'),
+      `Expected cross-family-reviewer-same-family; got: ${rules.join(', ')}`);
+    assert.ok(!r.ok);
+  });
+
+  test('cross-family fields optional on non-code-change lane', () => {
+    const input = { lane: 'lane:docs-research', comments: [{ body: validBody }], labels: [] };
+    const r = validate(input);
+    assert.ok(r.ok, `lane:docs-research should skip cross-family check`);
+  });
+});


### PR DESCRIPTION
Refs #2439

## Changes

- **collaborator-handoff.js**: `cross_family_reviewer:`, `cross_family_rating:`, `cross_family_findings:` are now **blocking** (not advisory) for lane:code-change. Added `cross-family-reviewer-same-family` blocking check when reviewer family matches Collaborator Team&Model family. Optional on other lanes.
- **tests/collaborator-handoff-cross-family.spec.js**: 6 unit tests — valid case, 3 missing-field cases, same-family case, non-code-change lane skip.
- **instructions/role-baton-routing.instructions.md**: Added cross-family preflight requirement note to MANAGER_HANDOFF schema section.

merge-evidence-deferred-final: #2439

Signed-by: Soren Harper
Team&Model: copilot:claude-sonnet-4-6@github
Role: collaborator