### PR TITLE
feat(megalint): cross-family independence check in admin-handoff gate #2510

### DIFF
--- a/scripts/global/megalint/admin-handoff.js
+++ b/scripts/global/megalint/admin-handoff.js
@@ -2,10 +2,12 @@
 // admin-handoff — validates ADMIN_HANDOFF signer + independence vs Collaborator.
 // Refs #2302: LIGHTWEIGHT imported from lane-enum.js (single source of truth).
 // Updated to include lane:config-only and lane:research (were missing vs canonical set).
+// #2510: cross-family independence check using COLLABORATOR_HANDOFF fields.
 
 const path = require('path');
 const { roleIdentity } = require(path.join(__dirname, '..', 'baton-independence.js'));
 const { LIGHTWEIGHT, laneSeverity } = require(path.join(__dirname, '..', 'lane-enum.js'));
+const { extractAIFamily } = require('./signer-fidelity.js');
 
 function findAdminHandoff(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?ADMIN_HANDOFF\b/;
@@ -48,12 +50,28 @@ function checkIndependence(adminBody, collaboratorHandoff) {
   return [];
 }
 
-function checkCrossFamily(body) {
-  if (!/reviewer_family_verified:/i.test(body)) {
-    return [{ rule: 'missing-reviewer-family-verified',
-      detail: 'ADMIN_HANDOFF missing reviewer_family_verified: field', severity: 'advisory' }];
+function checkCrossFamily(adminBody, collaboratorHandoff) {
+  const advisory = process.env.CROSS_FAMILY_ADMIN_GATE_ADVISORY === '1';
+  const violations = [];
+  if (!/reviewer_family_verified:/i.test(adminBody)) {
+    violations.push({ rule: 'missing-reviewer-family-verified',
+      detail: 'ADMIN_HANDOFF missing reviewer_family_verified: field', severity: 'advisory' });
   }
-  return [];
+  if (!collaboratorHandoff) return violations;
+  const cb = collaboratorHandoff.body || '';
+  const tmm = cb.match(/Team&Model\s*:\s*(\S+)/i);
+  const rvm = cb.match(/cross_family_reviewer\s*:\s*(\S+)/i);
+  if (tmm && rvm) {
+    const cf = extractAIFamily(tmm[1]);
+    const rf = extractAIFamily(rvm[1]);
+    if (cf !== 'unknown' && cf === rf) {
+      const v = { rule: 'cross-family-reviewer-same-family',
+        detail: `Reviewer family "${rf}" matches Collaborator Team&Model family` };
+      if (advisory) v.severity = 'advisory';
+      violations.push(v);
+    }
+  }
+  return violations;
 }
 
 function validate(input) {
@@ -66,15 +84,17 @@ function validate(input) {
     return { ok: false, violations: [{ rule: 'missing-admin-handoff',
       detail: 'ADMIN_HANDOFF comment not found on issue' }], found: false };
   }
+  const collabHandoff = findCollaboratorHandoff(comments);
   const violations = [
     ...checkSignerFields(handoff.body || ''),
-    ...checkIndependence(handoff.body, findCollaboratorHandoff(comments)),
+    ...checkIndependence(handoff.body, collabHandoff),
   ];
   if (input.lane === 'lane:code-change') {
-    violations.push(...checkCrossFamily(handoff.body || ''));
+    violations.push(...checkCrossFamily(handoff.body || '', collabHandoff));
   }
   const signer = roleIdentity({ body: handoff.body, author: handoff.user && handoff.user.login });
-  return { ok: violations.length === 0, violations, found: true, signer };
+  const blocking = violations.filter(v => v.severity !== 'advisory');
+  return { ok: blocking.length === 0, violations, found: true, signer };
 }
 
 module.exports = { validate, findAdminHandoff, LIGHTWEIGHT };

--- a/tests/admin-handoff-cross-family.spec.js
+++ b/tests/admin-handoff-cross-family.spec.js
@@ -1,0 +1,80 @@
+'use strict';
+// tests/admin-handoff-cross-family.spec.js — Refs #2510
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const { validate } = require(path.join(__dirname, '..', 'scripts', 'global',
+  'megalint', 'admin-handoff.js'));
+
+const collabBody = `## COLLABORATOR_HANDOFF
+Signed-by: Soren Harper
+Team&Model: copilot:claude-sonnet-4-6@github
+Role: collaborator
+cross_family_reviewer: qwen2.5-coder:7b@fleet-tailscale
+cross_family_rating: 82/100
+cross_family_findings: ok`;
+
+const adminBody = `## ADMIN_HANDOFF
+Signed-by: Soren Reyes
+Team&Model: copilot:claude-sonnet-4-6@github
+Role: admin
+reviewer_family_verified: pass`;
+
+const makeInput = (aBody, cBody) => ({
+  lane: 'lane:code-change',
+  comments: [
+    { body: cBody || collabBody, user: { login: 'harper' } },
+    { body: aBody || adminBody, user: { login: 'reyes' } },
+  ],
+  labels: [],
+});
+
+describe('admin-handoff cross-family check (#2510)', () => {
+  beforeEach(() => { delete process.env.CROSS_FAMILY_ADMIN_GATE_ADVISORY; });
+  afterEach(() => { delete process.env.CROSS_FAMILY_ADMIN_GATE_ADVISORY; });
+
+  test('valid cross-family handoff passes', () => {
+    const r = validate(makeInput());
+    const blocking = (r.violations || []).filter(v => v.severity !== 'advisory');
+    assert.strictEqual(blocking.length, 0,
+      `Expected no blocking; got: ${blocking.map(v => v.rule).join(', ')}`);
+    assert.ok(r.ok);
+  });
+
+  test('same-family reviewer is blocking', () => {
+    const sameFamily = collabBody.replace('qwen2.5-coder:7b@fleet-tailscale',
+      'claude-haiku@anthropic');
+    const r = validate(makeInput(adminBody, sameFamily));
+    const rules = r.violations.map(v => v.rule);
+    assert.ok(rules.includes('cross-family-reviewer-same-family'),
+      `Expected cross-family-reviewer-same-family; got: ${rules.join(', ')}`);
+    assert.ok(!r.ok);
+  });
+
+  test('same-family becomes advisory with CROSS_FAMILY_ADMIN_GATE_ADVISORY=1', () => {
+    process.env.CROSS_FAMILY_ADMIN_GATE_ADVISORY = '1';
+    const sameFamily = collabBody.replace('qwen2.5-coder:7b@fleet-tailscale',
+      'claude-haiku@anthropic');
+    const r = validate(makeInput(adminBody, sameFamily));
+    const blocking = (r.violations || []).filter(v => v.severity !== 'advisory');
+    assert.strictEqual(blocking.length, 0, 'Feature-flag should make violation advisory');
+    assert.ok(r.ok);
+  });
+
+  test('cross-family check skipped on lightweight lane', () => {
+    const sameFamily = collabBody.replace('qwen2.5-coder:7b@fleet-tailscale', 'claude-haiku@anthropic');
+    const r = validate({ lane: 'lane:trivial', comments: makeInput(adminBody, sameFamily).comments });
+    assert.ok(r.ok, 'trivial lane should skip cross-family check');
+  });
+
+  test('no collaborator handoff does not cause crash', () => {
+    const input = {
+      lane: 'lane:code-change',
+      comments: [{ body: adminBody, user: { login: 'reyes' } }],
+      labels: [],
+    };
+    const r = validate(input);
+    assert.ok(r !== null);
+  });
+});


### PR DESCRIPTION
Refs #2510

## Changes

- **admin-handoff.js** (100 lines): Added cross-family independence check — extracts `Team&Model:` and `cross_family_reviewer:` from COLLABORATOR_HANDOFF, compares AI families via `extractAIFamily()`. Same-family match emits blocking `cross-family-reviewer-same-family`. Feature-flagged: `CROSS_FAMILY_ADMIN_GATE_ADVISORY=1` downgrades to advisory. Updated `validate()` to filter advisory violations from `ok` determination.
- **tests/admin-handoff-cross-family.spec.js** (80 lines): 5 unit tests — valid case, same-family blocking, feature-flag advisory mode, lightweight lane skip, no-collab-handoff no-crash.

merge-evidence-deferred-final: #2510

Signed-by: Soren Harper
Team&Model: copilot:claude-sonnet-4-6@github
Role: collaborator