### PR TITLE
fix(governance): collaborator-gate accepts object+string shapes

### DIFF
--- a/.changes/unreleased/2562.md
+++ b/.changes/unreleased/2562.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- collaborator-gate false-failed on every PR (#2562): `.github/workflows/baton-gates.yml` passed comment bodies as bare strings (`comments.map(c => c.body)`) to `scripts/global/megalint/collaborator-handoff.js#validate`, whose finder reads `c.body` and expects objects — so it reported `missing-collaborator-handoff` even when a valid COLLABORATOR_HANDOFF was present (regression from #2439 validator refactor). Fix: pass full comment objects at the call site, and harden `findCollaboratorHandoff`/`validate` (via a `bodyOf` helper) to accept string **or** `{body}` elements so the bug class cannot silently recur. admin-gate and consultant-gate were verified unaffected. Regression test: `tests/collaborator-handoff-input-shape.spec.js` (`npm run test:collaborator-input-shape`).
+
+Refs #2562.

--- a/.github/workflows/baton-gates.yml
+++ b/.github/workflows/baton-gates.yml
@@ -49,7 +49,9 @@ jobs:
               return;
             }
             const { validate } = require('./scripts/global/megalint/collaborator-handoff.js');
-            const result = validate({ comments: comments.map(c => c.body), labels });
+            // #2562: pass full comment objects (validator reads .body + .user); mapping
+            // to bare .body strings false-failed the gate on every PR.
+            const result = validate({ comments, labels });
             if (!result.ok) {
               const detail = (result.violations || []).map(v => v.rule + (v.detail ? ': ' + v.detail : '')).join('; ');
               core.setFailed(`collaborator-handoff violations in #${linkedIssue}: ${detail}`);

--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ npm run deploy:both:apply
 | `synthesis:snapshot` | `node scripts/global/synthesis-snapshot.js` |
 | `synthesis:status` | `node scripts/global/broker-synthesis-status.js` |
 | `test` | `npx playwright test` |
+| `test:collaborator-input-shape` | `node --test tests/collaborator-handoff-input-shape.spec.js` |
 | `test:compatibility` | `node --test tests/orchestrator-compatibility.spec.js` |
 | `test:headed` | `npx playwright test --headed` |
 | `test:post-merge-sweep` | `node --test tests/post-merge-sweep.spec.js` |

--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
     "gov:parity": "node scripts/global/megalint/parity-validator.js",
     "routing:fallback-report": "node scripts/global/routing-fallback-report.js",
     "it-ops:usage-report": "node scripts/global/it-bypass-usage-report.js",
+    "test:collaborator-input-shape": "node --test tests/collaborator-handoff-input-shape.spec.js",
     "test:compatibility": "node --test tests/orchestrator-compatibility.spec.js",
     "test:post-merge-sweep": "node --test tests/post-merge-sweep.spec.js",
     "synthesis:init": "node scripts/global/synthesis-init.js",

--- a/scripts/global/megalint/collaborator-handoff.js
+++ b/scripts/global/megalint/collaborator-handoff.js
@@ -10,9 +10,13 @@ const { LIGHTWEIGHT, laneSeverity } = require(path.join(__dirname, '..', 'lane-e
 const docCoverage = require('./doc-coverage.js');
 const { KNOWN_FAMILIES, extractAIFamily } = require('./signer-fidelity.js');
 
+// #2562: accept string OR {body} comment elements so a caller passing bare
+// bodies (the baton-gates.yml regression) cannot silently false-fail the gate.
+const bodyOf = (c) => (typeof c === 'string' ? c : (c && c.body) || '');
+
 function findCollaboratorHandoff(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?COLLABORATOR_HANDOFF\b/;
-  return [...(comments || [])].reverse().find(c => headerRe.test(c.body || ''));
+  return [...(comments || [])].reverse().find(c => headerRe.test(bodyOf(c)));
 }
 
 function checkSignerFields(body) {
@@ -65,7 +69,7 @@ function validate(input) {
     return { ok: false, violations: [{ rule: 'missing-collaborator-handoff',
       detail: 'COLLABORATOR_HANDOFF comment not found on issue' }], found: false };
   }
-  const body = handoff.body || '';
+  const body = bodyOf(handoff);
   const violations = checkSignerFields(body);
   if (input.lane === 'lane:code-change' && process.env.DOC_COVERAGE_GATE_ADVISORY !== '1') {
     let matrix;

--- a/tests/collaborator-handoff-input-shape.spec.js
+++ b/tests/collaborator-handoff-input-shape.spec.js
@@ -1,0 +1,38 @@
+'use strict';
+// @megalint:test-discoverability:opt-out — node:test CLI spec; registered via
+// `npm run test:collaborator-input-shape`.
+// #2562 — collaborator-gate input-shape regression: findCollaboratorHandoff/validate
+// must accept BOTH {body,user} objects AND bare string comment elements, so a caller
+// passing comment bodies (baton-gates.yml line 52) cannot false-fail the gate.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const ch = require(path.join(__dirname, '..', 'scripts', 'global', 'megalint', 'collaborator-handoff.js'));
+
+const HANDOFF = '## COLLABORATOR_HANDOFF\nticket: #2562\nSigned-by: X\nTeam&Model: t:m@s\nRole: collaborator';
+
+test('#2562: finds handoff in OBJECT-shaped comments', () => {
+  const found = ch.findCollaboratorHandoff([{ body: 'noise' }, { body: HANDOFF, user: { login: 'a' } }]);
+  assert.ok(found && found.body === HANDOFF);
+});
+
+test('#2562: finds handoff in STRING-shaped comments (the regression)', () => {
+  assert.strictEqual(ch.findCollaboratorHandoff(['noise', HANDOFF]), HANDOFF);
+});
+
+test('#2562: malformed elements (null/number/missing-body) do not throw', () => {
+  assert.doesNotThrow(() => ch.findCollaboratorHandoff([null, 42, {}, { body: undefined }]));
+  assert.strictEqual(ch.findCollaboratorHandoff([null, 42, {}]), undefined);
+});
+
+test('#2562: validate finds handoff (no missing-collaborator-handoff) under STRING shape', () => {
+  const r = ch.validate({ comments: ['noise', HANDOFF], labels: ['lane:code-change'], lane: 'lane:code-change' });
+  const rules = (r.violations || []).map((v) => v.rule);
+  assert.ok(!rules.includes('missing-collaborator-handoff'), `unexpected missing-handoff: ${rules}`);
+  assert.strictEqual(r.found, true);
+});
+
+test('#2562: validate finds handoff under OBJECT shape', () => {
+  const r = ch.validate({ comments: [{ body: HANDOFF, user: { login: 'a' } }], labels: ['lane:code-change'], lane: 'lane:code-change' });
+  assert.strictEqual(r.found, true);
+});


### PR DESCRIPTION
Refs #2562

merge-evidence-deferred-final: #2562

## Summary
Fixes collaborator-gate false-failing `missing-collaborator-handoff` on **every** PR. `.github/workflows/baton-gates.yml` passed comment bodies as bare strings (`comments.map(c => c.body)`) to `collaborator-handoff.js#validate`, whose finder reads `c.body` and expects objects (regression from the #2439 validator refactor).

## Fix
- baton-gates.yml: pass full comment objects at the collaborator-gate call site.
- `collaborator-handoff.js`: `bodyOf()` helper hardens `findCollaboratorHandoff` + `validate` to accept string **or** `{body}` elements — closes the bug class. Genuinely-absent handoffs still report missing (hardening does not mask).
- admin-gate / consultant-gate verified unaffected.

## Test
- `tests/collaborator-handoff-input-shape.spec.js` (`npm run test:collaborator-input-shape`) — 5/5: object shape, string shape (the regression), malformed elements no-throw, validate finds handoff under both shapes.
- `npm run lint` clean.

## Cross-family review
- L2: qwen2.5-coder:32b (fleet) ACCEPT + gemini-2.5-flash (cloud) ACCEPT.
- L4: qwen32b ACCEPT 9/10 + gemini 10/10 — both merge-safe.

Baton artifacts on issue #2562. Note: lint-required/quality-required are RED on pre-existing main baseline (readability 485>475 / MD018), not this diff — Admin baseline-drift override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
