### PR TITLE
refactor(scripts): pay down readability warnings under budget

### DIFF
--- a/scripts/global/fleet-benchmark-runner.js
+++ b/scripts/global/fleet-benchmark-runner.js
@@ -3,7 +3,7 @@ const path = require('path');
 const PROMPT = 'Write a short Python fibonacci function and one-line complexity note.';
 
 function arg(name, d = '') { const i = process.argv.indexOf(`--${name}`); return i > -1 ? process.argv[i + 1] : d; }
-function num(v, d) { const n = Number(v); return Number.isFinite(n) ? n : d; }
+function num(v, d) { const parsed = Number(v); return Number.isFinite(parsed) ? parsed : d; }
 function classifyError(status, text = '', e = '') {
   if (/timed out|timeout|aborted/i.test(`${e}`)) return 'timeout';
   if (/requires more system memory/i.test(text)) return 'memory';
@@ -12,43 +12,43 @@ function classifyError(status, text = '', e = '') {
   return 'transport';
 }
 async function j(method, url, body, timeoutMs) {
-  const ac = new AbortController(); const t = setTimeout(() => ac.abort(), timeoutMs);
+  const ac = new AbortController(); const timer = setTimeout(() => ac.abort(), timeoutMs);
   const init = { method, signal: ac.signal, headers: { 'content-type': 'application/json' } };
   if (body != null) init.body = JSON.stringify(body);
-  try { const r = await fetch(url, init);
-    const text = await r.text(); let data = {}; try { data = JSON.parse(text); } catch { data = { raw: text }; }
-    return { ok: r.ok, status: r.status, data, text }; } finally { clearTimeout(t); }
+  try { const response = await fetch(url, init);
+    const text = await response.text(); let data = {}; try { data = JSON.parse(text); } catch { data = { raw: text }; }
+    return { ok: response.ok, status: response.status, data, text }; } finally { clearTimeout(timer); }
 }
 async function benchOnce(host, model, prompt, timeoutMs) {
   const t0 = Date.now();
   try {
-    const r = await j('POST', `http://${host}:11434/api/generate`, { model, prompt, stream: false }, timeoutMs);
-    const ms = Date.now() - t0; const c = r.data.eval_count || 0; const d = r.data.eval_duration || 0;
-    const tok = d ? Number((c / (d / 1e9)).toFixed(2)) : null;
-    if (!r.ok) return { ok: false, status: r.status, latency_ms: ms, reason: classifyError(r.status, r.text), error: r.data.error || r.text };
-    return { ok: true, status: r.status, latency_ms: ms, tok_s: tok };
+    const response = await j('POST', `http://${host}:11434/api/generate`, { model, prompt, stream: false }, timeoutMs);
+    const ms = Date.now() - t0; const evalCount = response.data.eval_count || 0; const evalDuration = response.data.eval_duration || 0;
+    const tok = evalDuration ? Number((evalCount / (evalDuration / 1e9)).toFixed(2)) : null;
+    if (!response.ok) return { ok: false, status: response.status, latency_ms: ms, reason: classifyError(response.status, response.text), error: response.data.error || response.text };
+    return { ok: true, status: response.status, latency_ms: ms, tok_s: tok };
   } catch (e) { return { ok: false, status: 0, latency_ms: Date.now() - t0, reason: classifyError(0, '', e.message), error: e.message }; }
 }
 async function run(opts = {}) {
   const inv = JSON.parse(fs.readFileSync(opts.devices || path.join(process.cwd(), 'inventory/devices.json'), 'utf8'));
   const devices = inv.devices.filter((d) => d.ollama && d.tailscaleIP).map((d) => ({ id: d.id, host: d.tailscaleIP }));
   const out = { ts: new Date().toISOString(), prompt: opts.prompt || PROMPT, timeout_ms: opts.timeoutMs || 90000, devices: [] };
-  for (const d of devices) {
-    const row = { id: d.id, host: d.host }; out.devices.push(row);
+  for (const device of devices) {
+    const row = { id: device.id, host: device.host }; out.devices.push(row);
     try {
-      const tags = await j('GET', `http://${d.host}:11434/api/tags`, null, 20000);
-      const cfg = inv.devices.find((x) => x.id === d.id) || {};
+      const tags = await j('GET', `http://${device.host}:11434/api/tags`, null, 20000);
+      const cfg = inv.devices.find((x) => x.id === device.id) || {};
       const preferred = cfg.benchmarks?.model || cfg.recommendedModels?.[0]?.model;
       const names = (tags.data.models || []).map((m) => m.name);
       const model = names.includes(preferred) ? preferred : names[0];
       row.model = model || null;
       if (!model) { row.error = { reason: 'no_model', message: 'no installed models' }; continue; }
-      row.cold = await benchOnce(d.host, model, out.prompt, out.timeout_ms);
-      row.warm = await benchOnce(d.host, model, out.prompt, out.timeout_ms);
+      row.cold = await benchOnce(device.host, model, out.prompt, out.timeout_ms);
+      row.warm = await benchOnce(device.host, model, out.prompt, out.timeout_ms);
     } catch (e) { row.error = { reason: 'transport', message: e.message }; }
   }
-  const p = opts.out || path.join(process.cwd(), 'test-results/fleet-benchmark-runner.json');
-  fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, `${JSON.stringify(out, null, 2)}\n`);
+  const outPath = opts.out || path.join(process.cwd(), 'test-results/fleet-benchmark-runner.json');
+  fs.mkdirSync(path.dirname(outPath), { recursive: true }); fs.writeFileSync(outPath, `${JSON.stringify(out, null, 2)}\n`);
   return out;
 }
 if (require.main === module) run({ devices: arg('devices'), out: arg('out'), prompt: arg('prompt', PROMPT), timeoutMs: num(arg('timeout-ms'), 90000) })

--- a/scripts/global/fleet-rollout-runner.js
+++ b/scripts/global/fleet-rollout-runner.js
@@ -2,26 +2,26 @@ const fs = require('fs');
 const path = require('path');
 
 function arg(name, d = '') { const i = process.argv.indexOf(`--${name}`); return i > -1 ? process.argv[i + 1] : d; }
-function num(v, d) { const n = Number(v); return Number.isFinite(n) ? n : d; }
+function num(v, d) { const parsed = Number(v); return Number.isFinite(parsed) ? parsed : d; }
 function reason(status, text = '', e = '') {
   if (/timed out|timeout|aborted/i.test(`${e}`)) return 'timeout';
   if (/requires more system memory/i.test(text)) return 'memory';
   if (status >= 500) return 'http_5xx'; if (status >= 400) return 'http_4xx'; return 'transport';
 }
 async function req(method, host, api, body, timeoutMs) {
-  const ac = new AbortController(); const t = setTimeout(() => ac.abort(), timeoutMs);
+  const ac = new AbortController(); const timer = setTimeout(() => ac.abort(), timeoutMs);
   try {
     // hamr-bypass-ok: diagnostic — fleet model-management endpoints (/api/pull etc.) not production inference; metrics excluded via tier='diagnostic' in upstream callers
-    const r = await fetch(`http://${host}:11434${api}`, { method, body: body ? JSON.stringify(body) : undefined, headers: { 'content-type': 'application/json' }, signal: ac.signal });
-    const text = await r.text(); let data = {}; try { data = JSON.parse(text); } catch { data = { raw: text }; }
-    return { ok: r.ok, status: r.status, data, text }; } finally { clearTimeout(t); }
+    const response = await fetch(`http://${host}:11434${api}`, { method, body: body ? JSON.stringify(body) : undefined, headers: { 'content-type': 'application/json' }, signal: ac.signal });
+    const text = await response.text(); let data = {}; try { data = JSON.parse(text); } catch { data = { raw: text }; }
+    return { ok: response.ok, status: response.status, data, text }; } finally { clearTimeout(timer); }
 }
 async function pullWithRetry(host, model, retries, timeoutMs) {
   for (let i = 0; i <= retries; i += 1) {
     try {
-      const r = await req('POST', host, '/api/pull', { name: model, stream: false }, timeoutMs);
-      if (r.ok) return { ok: true, attempts: i + 1, status: r.status };
-      if (i === retries) return { ok: false, attempts: i + 1, reason: reason(r.status, r.text), error: r.data.error || r.text };
+      const result = await req('POST', host, '/api/pull', { name: model, stream: false }, timeoutMs);
+      if (result.ok) return { ok: true, attempts: i + 1, status: result.status };
+      if (i === retries) return { ok: false, attempts: i + 1, reason: reason(result.status, result.text), error: result.data.error || result.text };
     } catch (e) { if (i === retries) return { ok: false, attempts: i + 1, reason: reason(0, '', e.message), error: e.message }; }
     await new Promise((x) => setTimeout(x, 1000 * (i + 1)));
   }
@@ -29,24 +29,24 @@ async function pullWithRetry(host, model, retries, timeoutMs) {
 }
 async function run(opts = {}) {
   const plan = JSON.parse(fs.readFileSync(opts.plan, 'utf8')); const out = { ts: new Date().toISOString(), dry_run: !opts.apply, devices: [] };
-  for (const d of plan.devices || []) {
-    const row = { id: d.id, host: d.host, pulls: [], deletes: [] }; out.devices.push(row);
-    const tags = await req('GET', d.host, '/api/tags', null, 20000); const have = new Set((tags.data.models || []).map((m) => m.name));
-    for (const m of d.pull || []) {
+  for (const device of plan.devices || []) {
+    const row = { id: device.id, host: device.host, pulls: [], deletes: [] }; out.devices.push(row);
+    const tags = await req('GET', device.host, '/api/tags', null, 20000); const have = new Set((tags.data.models || []).map((m) => m.name));
+    for (const m of device.pull || []) {
       if (!opts.apply) { row.pulls.push({ model: m, ok: true, dry_run: true }); continue; }
-      const p = await pullWithRetry(d.host, m, opts.retries, opts.timeoutMs); row.pulls.push({ model: m, ...p }); if (p.ok) have.add(m);
+      const pullResult = await pullWithRetry(device.host, m, opts.retries, opts.timeoutMs); row.pulls.push({ model: m, ...pullResult }); if (pullResult.ok) have.add(m);
     }
-    for (const m of d.delete || []) {
-      const safe = [...have].filter((x) => x !== m).length > 0 && !((d.keep || []).includes(m));
+    for (const m of device.delete || []) {
+      const safe = [...have].filter((x) => x !== m).length > 0 && !((device.keep || []).includes(m));
       if (!opts.apply) { row.deletes.push({ model: m, ok: safe, dry_run: true, skipped: !safe }); continue; }
       if (!safe) { row.deletes.push({ model: m, ok: false, skipped: true, reason: 'safety_guard' }); continue; }
-      const del = await req('DELETE', d.host, '/api/delete', { name: m }, 30000); row.deletes.push({ model: m, ok: del.ok, status: del.status, reason: del.ok ? null : reason(del.status, del.text) });
+      const del = await req('DELETE', device.host, '/api/delete', { name: m }, 30000); row.deletes.push({ model: m, ok: del.ok, status: del.status, reason: del.ok ? null : reason(del.status, del.text) });
       if (del.ok) have.delete(m);
     }
-    row.reconcile = { expected: d.expected || [...have], have: [...have], missing: (d.expected || [...have]).filter((m) => !have.has(m)) };
+    row.reconcile = { expected: device.expected || [...have], have: [...have], missing: (device.expected || [...have]).filter((m) => !have.has(m)) };
   }
-  const p = opts.out || path.join(process.cwd(), 'test-results/fleet-rollout-runner.json');
-  fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, `${JSON.stringify(out, null, 2)}\n`); return out;
+  const outPath = opts.out || path.join(process.cwd(), 'test-results/fleet-rollout-runner.json');
+  fs.mkdirSync(path.dirname(outPath), { recursive: true }); fs.writeFileSync(outPath, `${JSON.stringify(out, null, 2)}\n`); return out;
 }
 if (require.main === module) {
   const plan = arg('plan', path.join(process.cwd(), 'test-results/fleet-rollout-plan.json')); if (!fs.existsSync(plan)) { console.error('missing --plan'); process.exit(1); }

--- a/scripts/global/hamr-probes.js
+++ b/scripts/global/hamr-probes.js
@@ -4,13 +4,13 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 
-const T = 5000
-const _t = ms => new Promise((_, r) => setTimeout(() => r(new Error('timeout')), ms))
-async function _st(u, h) {
-  const c = new AbortController()
-  const t = setTimeout(() => c.abort(), T)
-  try { return (await fetch(u, { headers: h, signal: c.signal })).status } catch { return 0 }
-  finally { clearTimeout(t) }
+const TIMEOUT_MS = 5000
+const timeoutAfter = ms => new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), ms))
+async function statusOf(url, headers) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+  try { return (await fetch(url, { headers, signal: controller.signal })).status } catch { return 0 }
+  finally { clearTimeout(timer) }
 }
 
 /**
@@ -19,12 +19,12 @@ async function _st(u, h) {
  */
 async function probeCloudflare() {
   try {
-    const s = await Promise.race([_st('https://api.cloudflare.com/client/v4/ips', {}), _t(T)])
-    const base = { reachable: s >= 200 && s < 400 }
+    const status = await Promise.race([statusOf('https://api.cloudflare.com/client/v4/ips', {}), timeoutAfter(TIMEOUT_MS)])
+    const base = { reachable: status >= 200 && status < 400 }
     const tok = process.env.CLOUDFLARE_API_TOKEN
     if (!tok) return { ...base, authenticated: false, reason: 'no-token' }
-    const a = await Promise.race([_st('https://api.cloudflare.com/client/v4/accounts', { Authorization: `Bearer ${tok}` }), _t(T)])
-    return { ...base, authenticated: a === 200 }
+    const acctStatus = await Promise.race([statusOf('https://api.cloudflare.com/client/v4/accounts', { Authorization: `Bearer ${tok}` }), timeoutAfter(TIMEOUT_MS)])
+    return { ...base, authenticated: acctStatus === 200 }
   } catch { return { reachable: false, authenticated: false, reason: 'error' } }
 }
 
@@ -37,11 +37,11 @@ async function probeR2() {
   const acct = process.env.CLOUDFLARE_ACCOUNT_ID
   if (!tok || !acct) return { available: false, reason: 'no-token' }
   try {
-    const s = await Promise.race([
-      _st(`https://api.cloudflare.com/client/v4/accounts/${acct}/r2/buckets`, { Authorization: `Bearer ${tok}` }),
-      _t(T),
+    const status = await Promise.race([
+      statusOf(`https://api.cloudflare.com/client/v4/accounts/${acct}/r2/buckets`, { Authorization: `Bearer ${tok}` }),
+      timeoutAfter(TIMEOUT_MS),
     ])
-    return { available: s === 200 }
+    return { available: status === 200 }
   } catch { return { available: false, reason: 'error' } }
 }
 
@@ -51,11 +51,11 @@ async function probeR2() {
  */
 function probeWrangler() {
   try {
-    const v = execSync('wrangler --version', { timeout: T, stdio: 'pipe' }).toString().trim()
-    const m = v.match(/(\d+)\./)
-    if (m && parseInt(m[1], 10) >= 4) return { available: true, version: v }
-    const w = execSync('wrangler whoami', { timeout: T, stdio: 'pipe' }).toString()
-    return { available: w.includes('You are logged in'), reason: 'version-lt-4' }
+    const versionOut = execSync('wrangler --version', { timeout: TIMEOUT_MS, stdio: 'pipe' }).toString().trim()
+    const major = versionOut.match(/(\d+)\./)
+    if (major && parseInt(major[1], 10) >= 4) return { available: true, version: versionOut }
+    const whoamiOut = execSync('wrangler whoami', { timeout: TIMEOUT_MS, stdio: 'pipe' }).toString()
+    return { available: whoamiOut.includes('You are logged in'), reason: 'version-lt-4' }
   } catch { return { available: false, reason: 'not-installed-or-unauthenticated' } }
 }
 
@@ -65,8 +65,8 @@ function probeWrangler() {
  */
 async function probeGithubOidc() {
   try {
-    const { nameWithOwner } = JSON.parse(execSync('gh repo view --json nameWithOwner', { timeout: T, stdio: 'pipe' }).toString())
-    const perms = JSON.parse(execSync(`gh api repos/${nameWithOwner} --jq '.permissions'`, { timeout: T, stdio: 'pipe' }).toString())
+    const { nameWithOwner } = JSON.parse(execSync('gh repo view --json nameWithOwner', { timeout: TIMEOUT_MS, stdio: 'pipe' }).toString())
+    const perms = JSON.parse(execSync(`gh api repos/${nameWithOwner} --jq '.permissions'`, { timeout: TIMEOUT_MS, stdio: 'pipe' }).toString())
     return { eligible: !!(perms && (perms.admin || perms.maintain)), caveat: 'heuristic-only' }
   } catch { return { eligible: false, reason: 'gh-unavailable-or-no-access' } }
 }
@@ -79,7 +79,7 @@ function probeMcp() {
   const sdk = path.join(process.cwd(), 'node_modules', '@modelcontextprotocol', 'sdk')
   if (fs.existsSync(sdk)) return { available: true, source: 'node_modules' }
   const cfgs = ['.claude/mcp.json', '.codex/mcp.json'].map(f => path.join(os.homedir(), f))
-  const found = cfgs.find(c => fs.existsSync(c))
+  const found = cfgs.find(cfg => fs.existsSync(cfg))
   return found ? { available: true, source: 'config-file' } : { available: false, reason: 'MCP SDK not installed' }
 }
 
@@ -88,7 +88,7 @@ function probeMcp() {
  * @returns {object} Result with eligible field.
  */
 function probeNpmTrustedPublishing() {
-  try { execSync('npm whoami', { timeout: T, stdio: 'pipe' }) } catch { return { eligible: false, reason: 'npm-not-authenticated' } }
+  try { execSync('npm whoami', { timeout: TIMEOUT_MS, stdio: 'pipe' }) } catch { return { eligible: false, reason: 'npm-not-authenticated' } }
   try {
     const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'))
     if (pkg.publishConfig?.provenance === true) return { eligible: true }


### PR DESCRIPTION
Refs #2566

merge-evidence-deferred-final: #2566

## Summary
Pays down the readability-linter baseline so PRs stop needing the Admin override for that gate. Renames single-letter variables to descriptive names in three backend scripts — `hamr-probes.js`, `fleet-rollout-runner.js`, `fleet-benchmark-runner.js`. **`lint:readability:ci` 485 → 463** (under the 475 budget, 12 headroom).

## Safety
- Pure rename refactor: diff is **61 insertions / 61 deletions** (balanced).
- Existing specs `tests/hamr-probes.spec.js` + `tests/fleet-remediation-runners.spec.js` — **9/9 pass**.
- eslint: 0 errors, no `no-undef` (no missed renames). require-smoke exercises exports.
- No `dashboard/js` touched (no visual-QA surface). Budget unchanged at 475.

## Cross-family review (tailscale + cloud)
- L2: qwen2.5-coder:32b (fleet) ACCEPT + gemini-2.5-flash (cloud) ACCEPT — behavior preserved.
- L4: qwen32b ACCEPT 9/10 + gemini 10/10 — merge-safe.

Baton artifacts on issue #2566. The readability gate now PASSES; the only residual baseline RED is the MD018 issue in `cross-family-review.instructions.md` (tracked #2560, not this diff) — once that lands, PRs are fully override-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[skip-changelog] [skip-doc-gate] — pure internal variable-rename refactor; no user-facing, behavioral, or doc-relevant change.
