### PR TITLE
fix(governance): clear MD018 baseline + gitignore hook-state file #2560

### DIFF
--- a/.changes/unreleased/2560.md
+++ b/.changes/unreleased/2560.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Added `.megingjord-state.json` to `.gitignore` so transient hook state does not appear as untracked drift in ticket branches.
+- Preserved markdownlint compliance for cross-family review instruction references (no MD018 heading-style drift).

--- a/.changes/unreleased/2560.md
+++ b/.changes/unreleased/2560.md
@@ -1,4 +1,4 @@
-## Fixed
+### Fixed
 
 - Added `.megingjord-state.json` to `.gitignore` so transient hook state does not appear as untracked drift in ticket branches.
 - Preserved markdownlint compliance for cross-family review instruction references (no MD018 heading-style drift).

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ tmp/
 
 # Refs #2153 — doc-graph artifact (rebuilt on demand)
 generated/doc-graph.json
+
+# Refs #2560 — hook-generated transient baton state (never committed)
+.megingjord-state.json

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -6,3 +6,4 @@ CHANGELOG-archive.md
 .dashboard/
 generated/
 tests/fixtures/governance/golden/
+scripts/xteam-mcp/node_modules/

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ npm run deploy:both:apply
 | `lint:coverage-metric` | `node scripts/global/lint-coverage-metric.js` |
 | `lint:decisions` | `node scripts/global/decisions-md-validator.js` |
 | `lint:js` | `eslint -c lint-configs/eslint.config.devenv.js --max-warnings 9999 dashboard/js scripts/global scripts/wiki` |
-| `lint:md` | `markdownlint-cli2 '**/*.md' '!node_modules/**' '!.claude/**' '!research/**' '!wiki/wisdom/global/sources/**' '!wiki/wisdom/global/syntheses/**' '!raw/**' '!.dashboard/**' '!CHANGELOG-archive.md' '!tickets/**' '!planning/**' '!generated/**' '!tests/fixtures/governance/golden/**' '!tests/fixtures/changelog-fragments-invalid/**'` |
+| `lint:md` | `markdownlint-cli2 '**/*.md' '!node_modules/**' '!scripts/xteam-mcp/node_modules/**' '!.claude/**' '!research/**' '!wiki/wisdom/global/sources/**' '!wiki/wisdom/global/syntheses/**' '!raw/**' '!.dashboard/**' '!CHANGELOG-archive.md' '!tickets/**' '!planning/**' '!generated/**' '!tests/fixtures/governance/golden/**' '!tests/fixtures/changelog-fragments-invalid/**'` |
 | `lint:py` | `ruff check --config lint-configs/ruff.devenv.toml hooks/scripts/` |
 | `lint:readability` | `node scripts/lint-readability.js` |
 | `lint:readability:ci` | `node scripts/lint-readability.js --max-warnings=475` |

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "lint:coverage-metric": "node scripts/global/lint-coverage-metric.js",
     "lint:decisions": "node scripts/global/decisions-md-validator.js",
     "lint:js": "eslint -c lint-configs/eslint.config.devenv.js --max-warnings 9999 dashboard/js scripts/global scripts/wiki",
-    "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules/**' '!scripts/xteam-mcp/node_modules/**' '!.claude/**' '!research/**' '!wiki/wisdom/global/sources/**' '!wiki/wisdom/global/syntheses/**' '!raw/**' '!.dashboard/**' '!CHANGELOG-archive.md' '!tickets/**' '!planning/**' '!generated/**' '!tests/fixtures/governance/golden/**' '!tests/fixtures/changelog-fragments-invalid/**'",
+    "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules/**' '!.claude/**' '!research/**' '!wiki/wisdom/global/sources/**' '!wiki/wisdom/global/syntheses/**' '!raw/**' '!.dashboard/**' '!CHANGELOG-archive.md' '!tickets/**' '!planning/**' '!generated/**' '!tests/fixtures/governance/golden/**' '!tests/fixtures/changelog-fragments-invalid/**'",
     "lint:py": "ruff check --config lint-configs/ruff.devenv.toml hooks/scripts/",
     "lint:readability": "node scripts/lint-readability.js",
     "lint:readability:ci": "node scripts/lint-readability.js --max-warnings=475",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "lint:coverage-metric": "node scripts/global/lint-coverage-metric.js",
     "lint:decisions": "node scripts/global/decisions-md-validator.js",
     "lint:js": "eslint -c lint-configs/eslint.config.devenv.js --max-warnings 9999 dashboard/js scripts/global scripts/wiki",
-    "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules/**' '!.claude/**' '!research/**' '!wiki/wisdom/global/sources/**' '!wiki/wisdom/global/syntheses/**' '!raw/**' '!.dashboard/**' '!CHANGELOG-archive.md' '!tickets/**' '!planning/**' '!generated/**' '!tests/fixtures/governance/golden/**' '!tests/fixtures/changelog-fragments-invalid/**'",
+    "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules/**' '!scripts/xteam-mcp/node_modules/**' '!.claude/**' '!research/**' '!wiki/wisdom/global/sources/**' '!wiki/wisdom/global/syntheses/**' '!raw/**' '!.dashboard/**' '!CHANGELOG-archive.md' '!tickets/**' '!planning/**' '!generated/**' '!tests/fixtures/governance/golden/**' '!tests/fixtures/changelog-fragments-invalid/**'",
     "lint:py": "ruff check --config lint-configs/ruff.devenv.toml hooks/scripts/",
     "lint:readability": "node scripts/lint-readability.js",
     "lint:readability:ci": "node scripts/lint-readability.js --max-warnings=475",


### PR DESCRIPTION
## Summary
- Add `.megingjord-state.json` to `.gitignore` as transient hook runtime state.
- This completes the remaining #2560 fold-in on top of current `main`.

## Validation
- `npm run lint:md` -> 0 errors.

[skip-changelog]
merge-evidence-deferred-final: #2560
Refs #2560
