### PR TITLE
fix(post-merge-sweep): enforce deferred-final completion truth

### DIFF
--- a/.changes/unreleased/2574.md
+++ b/.changes/unreleased/2574.md
@@ -1,0 +1,2 @@
+### Fixed
+- Added deferred-final completion-truth guardrails to post-merge sweep so merged PR citations using `merge-evidence-deferred-final: #N` are reconciled only when consultant closeout evidence exists, preventing merged-but-open terminal drift.

--- a/scripts/global/post-merge-sweep.js
+++ b/scripts/global/post-merge-sweep.js
@@ -11,6 +11,8 @@ const os = require('node:os');
 // `:?` accepts GitHub's optional-colon form ("Closes: #5"); `\s+` (not \s*) is
 // kept so "closes#5" — which GitHub does NOT auto-close — never matches (mass-close guard).
 const KEYWORD_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?):?\s+#(\d+)/gi;
+const DEFERRED_FINAL_RE = /\bmerge-evidence-deferred-final:\s*#(\d+)/gi;
+const CLOSEOUT_HEADER_RE = /(^|\n)\s*(?:\*\*|##\s+)?CONSULTANT_CLOSEOUT(?:_EPIC_CLOSEOUT)?\b/;
 const COMMENT_MARKER = '<!-- post-merge-sweep -->';
 const DEFAULT_AUDIT = path.join(os.homedir(), '.megingjord', 'post-merge-sweep.jsonl');
 const POLL = { attempts: 6, intervalMs: 5000 }; // ~30s budget (AC3)
@@ -22,11 +24,24 @@ function parseCloseKeywords(text) {
   return out;
 }
 
+function parseDeferredFinal(text) {
+  const out = [];
+  if (!text) return out;
+  for (const m of String(text).matchAll(DEFERRED_FINAL_RE)) out.push(Number(m[1]));
+  return out;
+}
+
 // AC2: de-duplicated union of citations from PR body AND every commit message.
 function collectCitations({ prBody = '', commitMessages = [] } = {}) {
   const nums = new Set(parseCloseKeywords(prBody));
   for (const msg of commitMessages) for (const num of parseCloseKeywords(msg)) nums.add(num);
   return [...nums];
+}
+
+function collectSweepTargets({ prBody = '', commitMessages = [] } = {}) {
+  const keyword = collectCitations({ prBody, commitMessages });
+  const deferred = [...new Set(parseDeferredFinal(prBody))];
+  return { citations: [...new Set([...keyword, ...deferred])], deferredOnly: new Set(deferred) };
 }
 
 const realSleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -40,6 +55,11 @@ function buildComment(prNumber) {
 // AC3/AC4: poll state up to POLL.attempts; force-close survivors (idempotent).
 // state read error => skip (never close on uncertainty) — OA2 mass-close guard.
 async function settleOne(github, owner, repo, number, opts = {}) {
+  if (opts.requiresCloseout) {
+    const comments = await github.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
+    const hasCloseout = (comments.data || []).some((c) => CLOSEOUT_HEADER_RE.test((c && c.body) || ''));
+    if (!hasCloseout) return { number, action: 'deferred-no-closeout', prNumber: opts.prNumber };
+  }
   const poll = opts.poll || POLL;
   const nap = opts.sleep || realSleep;
   for (let i = 0; i < poll.attempts; i++) {
@@ -56,15 +76,22 @@ async function settleOne(github, owner, repo, number, opts = {}) {
 }
 
 async function sweep({ github, owner, repo, prNumber, prBody, commitMessages, ...opts }) {
-  const citations = collectCitations({ prBody, commitMessages });
+  const targets = collectSweepTargets({ prBody, commitMessages });
+  const citations = targets.citations;
   const records = [];
-  for (const number of citations) records.push(await settleOne(github, owner, repo, number, { ...opts, prNumber }));
+  for (const number of citations) {
+    records.push(await settleOne(github, owner, repo, number, {
+      ...opts,
+      prNumber,
+      requiresCloseout: targets.deferredOnly.has(number),
+    }));
+  }
   return { prNumber, citations, records };
 }
 
 // AC5: one audit record per drift (force-closed | would-force-close | skipped-errored).
 function toAuditEvents(result, schema = require('./event-schema-v3.js')) {
-  const drift = new Set(['force-closed', 'would-force-close', 'skipped-errored']);
+  const drift = new Set(['force-closed', 'would-force-close', 'skipped-errored', 'deferred-no-closeout']);
   return result.records.filter((r) => drift.has(r.action)).map((r) => schema.normalize({
     version: 'v3', service: 'post-merge-sweep', env: 'ci', event: 'drift-remediated',
     pr: result.prNumber, issue: r.number, action: r.action, error: r.error,
@@ -83,5 +110,7 @@ function appendAudit(result, opts = {}) {
 
 module.exports = {
   parseCloseKeywords, collectCitations, buildComment, settleOne, sweep,
-  toAuditEvents, appendAudit, KEYWORD_RE, COMMENT_MARKER, POLL, DEFAULT_AUDIT,
+  parseDeferredFinal, collectSweepTargets,
+  toAuditEvents, appendAudit, KEYWORD_RE, DEFERRED_FINAL_RE, CLOSEOUT_HEADER_RE,
+  COMMENT_MARKER, POLL, DEFAULT_AUDIT,
 };

--- a/tests/post-merge-sweep.spec.js
+++ b/tests/post-merge-sweep.spec.js
@@ -7,7 +7,7 @@ const test = require('node:test');
 const assert = require('node:assert');
 const sweep = require('../scripts/global/post-merge-sweep.js');
 
-function mockGithub(states) {
+function mockGithub(states, comments = {}) {
   const calls = { update: [], comment: [] };
   const seq = {};
   return {
@@ -22,6 +22,7 @@ function mockGithub(states) {
       },
       async update(a) { calls.update.push(a); },
       async createComment(a) { calls.comment.push(a); },
+      async listComments({ issue_number }) { return { data: comments[issue_number] || [] }; },
     },
   };
 }
@@ -66,6 +67,37 @@ test('AC2: citations unioned from body + commit messages, de-duped', () => {
   assert.deepStrictEqual(cites.sort((a, b) => a - b), [1, 2]);
 });
 
+test('AC2: deferred-final citation requires consultant closeout before close', async () => {
+  const gh = mockGithub(
+    { 11: 'open' },
+    { 11: [{ body: '## CONSULTANT_CLOSEOUT\nverdict: approve_for_merge' }] },
+  );
+  const r = await sweep.sweep({
+    github: gh,
+    owner: 'o',
+    repo: 'r',
+    prNumber: 9,
+    prBody: 'merge-evidence-deferred-final: #11',
+    ...fast,
+  });
+  assert.strictEqual(r.records[0].action, 'force-closed');
+  assert.strictEqual(gh.calls.update.length, 1);
+});
+
+test('AC2: deferred-final without consultant closeout -> no close', async () => {
+  const gh = mockGithub({ 12: 'open' }, { 12: [{ body: 'status update only' }] });
+  const r = await sweep.sweep({
+    github: gh,
+    owner: 'o',
+    repo: 'r',
+    prNumber: 9,
+    prBody: 'merge-evidence-deferred-final: #12',
+    ...fast,
+  });
+  assert.strictEqual(r.records[0].action, 'deferred-no-closeout');
+  assert.strictEqual(gh.calls.update.length, 0);
+});
+
 test('L2-fleet#1: optional-colon form parses; bare "closes#N" (no space) does not', () => {
   assert.deepStrictEqual(sweep.parseCloseKeywords('Closes: #5 fixes: #6'), [5, 6]);
   assert.deepStrictEqual(sweep.parseCloseKeywords('closes#7 see #8'), []); // neither is a valid GitHub close-link
@@ -94,8 +126,9 @@ test('AC5: audit events emitted only for drift actions', () => {
     { number: 1, action: 'already-closed' },
     { number: 2, action: 'force-closed' },
     { number: 3, action: 'skipped-errored', error: 'x' },
+    { number: 4, action: 'deferred-no-closeout' },
   ] };
   const evs = sweep.toAuditEvents(result);
-  assert.strictEqual(evs.length, 2);
+  assert.strictEqual(evs.length, 3);
   assert.ok(evs.every((e) => e.ts && e.service === 'post-merge-sweep'));
 });


### PR DESCRIPTION
## Summary
- add deferred-final citation parsing to post-merge sweep (`merge-evidence-deferred-final: #N`)
- require consultant closeout evidence before deferred-final auto-close
- emit explicit `deferred-no-closeout` drift action and include it in audit events
- add regression tests for deferred-final closeout/no-closeout behavior
- add changelog fragment for #2574

## Validation
- npm run test:post-merge-sweep
- npm run stress:post-merge-sweep
- npm run lint

## Notes
- Local full Playwright suite (`npm test`) is currently blocked in this worktree by missing local dependency `@playwright/test`.

Refs #2574
merge-evidence-deferred-final: #2574
