### PR TITLE
fix(governance): env-derive agent-signature identity #2579

### DIFF
--- a/.changes/unreleased/2579.md
+++ b/.changes/unreleased/2579.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `scripts/global/agent-signature.js` no longer hard-codes a `codex`/`gpt-5.4` identity default. Team and model now resolve from `--team`/`--model` flags or the `HAMR_TEAM`/`HAMR_MODEL` env signals, and the CLI fails loud (exit 2) when identity is unresolved instead of silently mis-attributing the signer to the codex team (#2579).

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -52,4 +52,5 @@ jobs:
           tests/no-network-errors.spec.js
           tests/api-smoke.spec.js
           tests/api-smoke-load.spec.js
+          tests/agent-signature-cli.spec.js
           --reporter=line

--- a/scripts/global/agent-signature.js
+++ b/scripts/global/agent-signature.js
@@ -9,8 +9,11 @@ const opt = {};
 for (let i = 0; i < args.length; i += 2) if (args[i]?.startsWith('--')) opt[args[i].slice(2)] = args[i + 1] || '';
 
 const registry = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'inventory', 'team-model-signatures.json'), 'utf8'));
-const team = (opt.team || 'codex').toLowerCase();
-const model = (opt.model || 'gpt-5.4').toLowerCase();
+// Identity is settings/substrate-derived, never hard-coded to one team (G5).
+// Resolve from explicit flag, then the established HAMR_TEAM/HAMR_MODEL env
+// signals; if unresolved we fail loud below rather than mis-attribute provenance.
+const team = (opt.team || process.env.HAMR_TEAM || process.env.MEGINGJORD_TEAM || '').toLowerCase();
+const model = (opt.model || process.env.HAMR_MODEL || process.env.MEGINGJORD_MODEL || '').toLowerCase();
 const role = (opt.role || 'collaborator').toLowerCase();
 const substrate = (opt.substrate || 'local').toLowerCase();
 const deviceName = (opt.device || '').toLowerCase();
@@ -18,6 +21,15 @@ const format = opt.format || 'json';
 const withCrypto = String(opt['include-crypto'] || '').toLowerCase() === 'true';
 const keyFile = opt['private-key-file'] ? path.resolve(opt['private-key-file']) : '';
 const device = deviceName ? `/${deviceName}` : '';
+
+if (!team || !model) {
+  process.stderr.write(
+    'agent-signature: unresolved identity. Pass --team and --model, or set '
+    + 'HAMR_TEAM and HAMR_MODEL. Refusing to emit a default signature so the '
+    + 'signer team/model is never silently mis-attributed (provenance integrity).\n'
+  );
+  process.exit(2);
+}
 
 function match(entry) {
   return (entry.team === '*' || entry.team === team)

--- a/tests/agent-signature-cli.spec.js
+++ b/tests/agent-signature-cli.spec.js
@@ -1,0 +1,57 @@
+// Regression coverage for #2579 — agent-signature.js identity resolution.
+// Asserts the CLI no longer hard-codes a codex/gpt-5.4 default: identity must
+// come from --team/--model flags or HAMR_TEAM/HAMR_MODEL env, else fail loud.
+'use strict';
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const CLI = path.join(__dirname, '..', 'scripts', 'global', 'agent-signature.js');
+
+function run(args, extraEnv) {
+  // Start from a clean slate so the host env can't leak identity into a test.
+  const env = { ...process.env };
+  delete env.HAMR_TEAM;
+  delete env.MEGINGJORD_TEAM;
+  delete env.HAMR_MODEL;
+  delete env.MEGINGJORD_MODEL;
+  const out = execFileSync('node', [CLI, ...args], {
+    encoding: 'utf8',
+    env: { ...env, ...(extraEnv || {}) },
+  });
+  return JSON.parse(out);
+}
+
+test('explicit flags resolve claude-code identity (AC2)', () => {
+  const r = run(['--team', 'claude-code', '--model', 'opus', '--role', 'manager']);
+  expect(r.signedBy).toBe('Orla Mason');
+  expect(r.teamModel).toBe('claude-code:opus@local');
+  expect(r.role).toBe('manager');
+});
+
+test('HAMR_TEAM/HAMR_MODEL env resolves identity without flags (AC3)', () => {
+  const r = run(['--role', 'manager'], { HAMR_TEAM: 'claude-code', HAMR_MODEL: 'opus' });
+  expect(r.signedBy).toBe('Orla Mason');
+  expect(r.teamModel).toBe('claude-code:opus@local');
+});
+
+test('codex still works with explicit flags — only the SILENT default is gone (AC1)', () => {
+  const r = run(['--team', 'codex', '--model', 'gpt-5.4', '--role', 'manager']);
+  expect(r.signedBy).toBe('Quill Mason');
+  expect(r.teamModel).toBe('codex:gpt-5.4@local');
+});
+
+test('no flags + no env fails loud instead of mis-attributing to codex (AC1)', () => {
+  let err;
+  try {
+    run(['--role', 'manager']);
+  } catch (e) {
+    err = e;
+  }
+  expect(err, 'CLI should exit non-zero when identity is unresolved').toBeTruthy();
+  expect(err.status).toBe(2);
+  expect(String(err.stderr)).toContain('unresolved identity');
+  // Must not have emitted any signature on the failure path.
+  expect(String(err.stdout || '')).not.toContain('Signed-by');
+  expect(String(err.stdout || '')).not.toContain('codex');
+});


### PR DESCRIPTION
Refs #2579
merge-evidence-deferred-final: #2579

## Summary
`scripts/global/agent-signature.js` hard-coded a `codex`/`gpt-5.4` identity default, so any non-codex runtime (Claude Code, Copilot) invoking it without `--team`/`--model` silently derived a **codex** signature — wrong provenance (G5 portability + G1/OA3 identity integrity).

This resolves identity from `--team`/`--model` flags, then `HAMR_TEAM`/`HAMR_MODEL` env, else **fails loud** (exit 2) rather than mis-attribute. Role/substrate defaults (collaborator/local) are preserved — they are role-neutral, not team-coupled.

## Changes
- `agent-signature.js`: env-driven identity + fail-loud guard.
- `tests/agent-signature-cli.spec.js`: explicit-flag, env-derived, codex-regression, and fail-loud cases (4/4 pass).
- `quality-gates.yml`: run the new spec in the deterministic unit set.
- `.changes/unreleased/2579.md`: changelog fragment.

## Validation
- eslint (devenv) exit 0; lint:md 0 errors; line-cap clean (62 lines).
- Playwright spec 4/4 pass locally.
- Cross-family review (two independent non-Anthropic families): fleet qwen2.5-coder:7b + cloud gemini-2.5-flash, ACCEPT at collaborator/admin/consultant gates.

## Baton artifacts (full set on #2579)
- COLLABORATOR_HANDOFF: posted — test_strategy tdd-pyramid, per-AC PASS, cross_family_rating 9/10.
- ADMIN_HANDOFF: posted — signer-independence-check PASS (Reyes != Harper), deploy-runtime-impact yes (sync verified post-merge).
- CONSULTANT_CLOSEOUT: posted — verdict approve_for_merge, rubric 9/10, cross_family_verdict ACCEPT.

Runtime parity (sync:codex + sync:claude + hamr:sync-verify) is run post-merge against merged main and cited on the ticket before terminal close.
