### PR TITLE
fix(hooks): block client arbitration leakage

### DIFF
--- a/.changes/unreleased/2578.md
+++ b/.changes/unreleased/2578.md
@@ -1,0 +1,4 @@
+### Fixed
+- Added blocking stop-hook guardrails that prevent delegating internal governance/worktree conflict decisions to clients.
+- Added deterministic internal-conflict policy classification and incident emission for sync residue, cross-team lease collisions, and worktree drift.
+- Added hook regression tests covering client-arbitration leakage detection and stop-hook blocking behavior.

--- a/governance/README.md
+++ b/governance/README.md
@@ -32,6 +32,19 @@ All four entry-point files MUST mention each invariant. `cross-team-contract-che
 3. **Ticket-first workflow** — no governed work without a linked GitHub issue per `instructions/ticket-driven-work.instructions.md`.
 4. **Dedicated-worktree protocol** — one live worktree per agent per `research/concurrent-agent-worktrees-2026-04-24.md`.
 
+## Client-Arbitration Prohibition (#2578)
+
+Internal conflicts are operator-owned and must never be delegated to the client:
+
+- sync residue / reverse-sync drift,
+- cross-team lease collisions,
+- worktree branch drift or baton-role collisions.
+
+Client input remains limited to design direction and UAT confirmation.
+
+Enforcement: `hooks/scripts/client_arbitration_guard.py` + `hooks/scripts/stop_reminder.py`.
+The Stop hook blocks leakage patterns and emits incidents for anneal follow-up.
+
 ## State taxonomy (Epic #1828)
 
 The harness uses an 11-state status taxonomy enforcing **single-status cardinality**:

--- a/hooks/scripts/client_arbitration_guard.py
+++ b/hooks/scripts/client_arbitration_guard.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Guardrail for client-arbitration leakage and internal conflict policy."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+
+INCIDENTS_LOG = Path.home() / ".megingjord" / "incidents.jsonl"
+
+CONFLICT_CONTEXT_RE = re.compile(
+    r"\b(governance|worktree|branch|drift|conflict|lease|sync(?:\s|-)?residue|team)\b",
+    re.IGNORECASE,
+)
+FORBIDDEN_ASK_RE = re.compile(
+    r"\b(how\s+would\s+you\s+like\s+(?:me\s+)?to\s+proceed|"
+    r"which\s+option\s+should\s+i\s+take|"
+    r"let\s+me\s+know\s+how\s+you\s+want\s+to\s+proceed|"
+    r"please\s+choose\s+(?:one|an?\s+option)|"
+    r"what\s+should\s+i\s+do\s+next)\b",
+    re.IGNORECASE,
+)
+DESIGN_UAT_RE = re.compile(
+    r"\b(design|layout|theme|color|typography|ux|ui|uat|visual\s+confirmation|look\s+and\s+feel)\b",
+    re.IGNORECASE,
+)
+
+SYNC_RESIDUE_FILES = {
+    "scripts/global/post-merge-sweep.js",
+}
+SYNC_RESIDUE_DIRS = (
+    "wiki/concepts/",
+    "wiki/entities/",
+    "wiki/skills/",
+    "wiki/sources/",
+    "wiki/syntheses/",
+)
+
+
+def extract_assistant_text(payload: dict) -> str:
+    """Best-effort extraction of assistant output from hook payload."""
+    keys = ("assistant_response", "response", "output", "final_response", "message")
+    for key in keys:
+        val = payload.get(key)
+        if isinstance(val, str) and val.strip():
+            return val
+    return ""
+
+
+def detect_client_arbitration(text: str) -> list[str]:
+    """Return violations when assistant delegates internal conflict decisions."""
+    if not text or DESIGN_UAT_RE.search(text):
+        return []
+    if FORBIDDEN_ASK_RE.search(text) and CONFLICT_CONTEXT_RE.search(text):
+        return ["delegated-internal-conflict-decision-to-client"]
+    return []
+
+
+def classify_internal_conflict(uncommitted: list[str]) -> dict:
+    """Deterministic classifier for common internal conflict classes."""
+    files = [f.strip() for f in (uncommitted or []) if f and f.strip()]
+    if not files:
+        return {"type": "none", "files": [], "policy": []}
+
+    if any(f in SYNC_RESIDUE_FILES for f in files) or any(
+        f.startswith(prefix) for f in files for prefix in SYNC_RESIDUE_DIRS
+    ):
+        return {
+            "type": "sync-residue",
+            "files": files,
+            "policy": [
+                "git restore scripts/global/post-merge-sweep.js",
+                "git clean -fd wiki/concepts wiki/entities wiki/skills wiki/sources wiki/syntheses",
+                "git status --short",
+            ],
+        }
+
+    if any("cross-team-leases.json" in f for f in files):
+        return {
+            "type": "cross-team-lease-collision",
+            "files": files,
+            "policy": [
+                "node scripts/global/cross-team-conflict-gate.js --post-comment 1",
+                "apply manager adjudication from issue thread",
+                "continue on lease owner decision without client escalation",
+            ],
+        }
+
+    return {
+        "type": "worktree-drift",
+        "files": files,
+        "policy": [
+            "preserve-first: commit to rescue branch OR revert local drift deterministically",
+            "record evidence in issue comment",
+            "continue delivery without client arbitration",
+        ],
+    }
+
+
+def emit_incident(pattern_id: str, evidence: list[str] | None = None, severity: str = "high") -> bool:
+    """Best-effort incident emission for anneal pipelines."""
+    event = {
+        "version": 3,
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "service": "stop-hook-client-arbitration-guard",
+        "env": "local",
+        "event": "governance.client_arbitration_block",
+        "pattern_id": pattern_id,
+        "severity": severity,
+        "evidence": evidence or [],
+    }
+    try:
+        INCIDENTS_LOG.parent.mkdir(parents=True, exist_ok=True)
+        with INCIDENTS_LOG.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event) + "\n")
+        return True
+    except Exception:
+        return False

--- a/hooks/scripts/stop_reminder.py
+++ b/hooks/scripts/stop_reminder.py
@@ -18,6 +18,12 @@ from governance_state import ensure_state, reset_on_branch_change, save_state
 from stop_checks import (
     check_admin_ops, check_uncommitted, post_merge_messages, wiki_pending_message,
 )
+from client_arbitration_guard import (
+    classify_internal_conflict,
+    detect_client_arbitration,
+    emit_incident,
+    extract_assistant_text,
+)
 
 
 def main() -> int:
@@ -48,9 +54,36 @@ def main() -> int:
     messages = []
     block_reason = None
 
-    block_reason, msg = check_uncommitted(uncommitted, roles)
+    assistant_text = extract_assistant_text(payload)
+    violations = detect_client_arbitration(assistant_text)
+    if violations:
+        emit_incident("client-arbitration-output-leak", evidence=violations)
+        block_reason = "Stop blocked: client-arbitration leakage detected."
+        messages.append(
+            "CLIENT-ARBITRATION GUARDRAIL BLOCK — internal governance/worktree/team "
+            "conflicts must be resolved by the operator, not delegated to the client."
+        )
+
+    if not block_reason:
+        block_reason, msg = check_uncommitted(uncommitted, roles)
+    else:
+        msg = None
     if msg:
         messages.append(msg)
+
+    conflict = classify_internal_conflict(uncommitted)
+    if conflict.get("type") != "none":
+        emit_incident(
+            "internal-conflict-auto-resolution-required",
+            evidence=[conflict["type"], *conflict.get("files", [])[:5]],
+            severity="medium",
+        )
+        if not block_reason:
+            block_reason = "Stop blocked: unresolved internal conflict requires deterministic operator resolution."
+        policy = " | ".join(conflict.get("policy", []))
+        messages.append(
+            f"INTERNAL-CONFLICT POLICY ({conflict['type']}): {policy}"
+        )
 
     if not block_reason:
         block_reason, msg = check_admin_ops(flags, ops, roles, repo_type, uncommitted)

--- a/tests/client-arbitration-guard.spec.js
+++ b/tests/client-arbitration-guard.spec.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+
+function runPython(code) {
+  const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+  assert.strictEqual(r.status, 0, r.stderr || 'python failed');
+  return (r.stdout || '').trim();
+}
+
+test('guard detects client arbitration leakage for internal conflict text', () => {
+  const out = runPython([
+    'import sys, json',
+    "sys.path.insert(0, 'hooks/scripts')",
+    'import client_arbitration_guard as g',
+    "print(json.dumps(g.detect_client_arbitration('worktree conflict: how would you like me to proceed?')))"
+  ].join(';'));
+  assert.match(out, /delegated-internal-conflict-decision-to-client/);
+});
+
+test('guard allows design-direction prompts', () => {
+  const out = runPython([
+    'import sys, json',
+    "sys.path.insert(0, 'hooks/scripts')",
+    'import client_arbitration_guard as g',
+    "print(json.dumps(g.detect_client_arbitration('Design direction: which color palette should we use?')))"
+  ].join(';'));
+  assert.strictEqual(out, '[]');
+});

--- a/tests/hooks/test_client_arbitration_guard.py
+++ b/tests/hooks/test_client_arbitration_guard.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "hooks" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import client_arbitration_guard as guard  # noqa: E402
+
+
+class TestClientArbitrationGuard(unittest.TestCase):
+    def test_blocks_internal_conflict_arbitration_phrase(self):
+        text = "Governance conflict in worktree drift. How would you like me to proceed?"
+        self.assertEqual(guard.detect_client_arbitration(text), ["delegated-internal-conflict-decision-to-client"])
+
+    def test_allows_design_or_uat_questions(self):
+        text = "For design direction, which color palette do you prefer for this UI?"
+        self.assertEqual(guard.detect_client_arbitration(text), [])
+
+    def test_classifies_sync_residue(self):
+        conflict = guard.classify_internal_conflict([
+            "scripts/global/post-merge-sweep.js",
+            "wiki/concepts/agent-drift.md",
+        ])
+        self.assertEqual(conflict["type"], "sync-residue")
+        self.assertTrue(any("git restore" in step for step in conflict["policy"]))
+
+    def test_classifies_lease_collision(self):
+        conflict = guard.classify_internal_conflict([".dashboard/cross-team-leases.json"])
+        self.assertEqual(conflict["type"], "cross-team-lease-collision")
+
+    def test_emits_incident(self):
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            log = home / ".megingjord" / "incidents.jsonl"
+            with patch.object(guard, "INCIDENTS_LOG", log):
+                self.assertTrue(guard.emit_incident("test-pattern", ["e1"], "high"))
+                self.assertTrue(log.is_file())
+                row = json.loads(log.read_text(encoding="utf-8").strip())
+                self.assertEqual(row["pattern_id"], "test-pattern")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hooks/test_stop_hook_client_arbitration.py
+++ b/tests/hooks/test_stop_hook_client_arbitration.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "hooks" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import stop_reminder  # noqa: E402
+
+
+class TestStopHookClientArbitrationBlock(unittest.TestCase):
+    def test_stop_hook_blocks_client_arbitration_leak(self):
+        with tempfile.TemporaryDirectory() as td:
+            payload = {
+                "cwd": td,
+                "assistant_response": "Worktree governance conflict detected. How would you like me to proceed?",
+            }
+            stdin = io.StringIO(json.dumps(payload))
+            stdout = io.StringIO()
+            with patch("sys.stdin", stdin), patch("sys.stdout", stdout):
+                rc = stop_reminder.main()
+            self.assertEqual(rc, 0)
+            out = json.loads(stdout.getvalue())
+            self.assertEqual(out.get("decision"), "block")
+            self.assertIn("client-arbitration", out.get("reason", "").lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `hooks/scripts/client_arbitration_guard.py` to detect and block client-arbitration leakage for internal conflicts
- integrate stop-hook blocking + deterministic internal-conflict policy messaging in `hooks/scripts/stop_reminder.py`
- emit incidents for leakage and unresolved internal conflict classes
- add regression tests for guardrail detection + stop-hook block integration
- add JS spec evidence test for lane `tdd-pyramid` policy compatibility
- document policy in `governance/README.md`
- add changelog fragment `.changes/unreleased/2578.md`

## Validation
- node --test tests/client-arbitration-guard.spec.js
- python3 -m unittest tests.hooks.test_client_arbitration_guard tests.hooks.test_stop_hook_client_arbitration
- npm run lint

## Cross-Model Review (fleet)
- collaborator self-review: qwen2.5-coder:7b (fleet-quality), starcoder2:3b (fleet-fast)
- admin review: qwen2.5-coder:1.5b (fleet-standard), qwen2.5-coder:7b (fleet-quality)
- consultant review: starcoder2:3b (fleet-fast), qwen2.5-coder:7b (fleet-quality)

Refs #2578
merge-evidence-deferred-final: #2578
