### PR TITLE
fix(governance): line-anchor baton artifact detection #2564

### DIFF
--- a/.changes/unreleased/2564.md
+++ b/.changes/unreleased/2564.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `baton-artifact-governance.js` now classifies baton artifacts by a line-anchored header match (mirroring the canonical per-validator finders) instead of a bare `body.includes()` substring scan. A comment that merely mentions a sibling artifact token in prose (e.g. a MANAGER_HANDOFF noting "the COLLABORATOR_HANDOFF will follow") is no longer misclassified and no longer trips a false `artifact-role-mismatch` (#2564).

--- a/scripts/global/baton-artifact-governance.js
+++ b/scripts/global/baton-artifact-governance.js
@@ -23,12 +23,20 @@ function roleFromBody(body) {
   return extractArtifactFields(body).role;
 }
 
+// Line-anchored header match, mirroring the canonical per-validator finders
+// (megalint/manager-handoff.js, collaborator-handoff.js). A bare body.includes()
+// over-matches when one artifact mentions a sibling token in prose (#2564),
+// misclassifying it and tripping a false artifact-role-mismatch.
+function artifactHeaderRe(artifact) {
+  return new RegExp(`(^|\\n)\\s*(?:\\*\\*|##\\s+)?${artifact}\\b`);
+}
+
 function entries(comments) {
   const out = [];
   for (const c of comments || []) {
     const body = String((c && c.body) || c || '');
     for (const [artifact, role] of Object.entries(ARTIFACT_ROLE)) {
-      if (body.includes(artifact)) out.push({ artifact, role, body });
+      if (artifactHeaderRe(artifact).test(body)) out.push({ artifact, role, body });
     }
   }
   return out;

--- a/tests/baton-artifact-governance.spec.js
+++ b/tests/baton-artifact-governance.spec.js
@@ -52,3 +52,31 @@ test('source-fixable role mismatch carries source-edit-first guidance', () => {
   expect(v.remediation.mode).toBe('source-edit-first');
   expect(v.remediation.suggestedFix).toContain('Edit the offending issue comment');
 });
+
+// #2564 — entries() classifies by line-anchored header, not bare substring.
+// A valid artifact that merely mentions sibling tokens in prose must NOT be
+// misclassified as those siblings (which would trip a false artifact-role-mismatch).
+test('prose mention of sibling artifact tokens does not misclassify (#2564)', () => {
+  const comments = [{
+    body: buildBatonComment({
+      artifact: 'MANAGER_HANDOFF', role: 'manager', teamModel: 'codex:gpt-5.4@codex-cli', ticket: 2564,
+      summary: 'Note: the COLLABORATOR_HANDOFF and ADMIN_HANDOFF will follow once work starts.',
+    }),
+  }];
+  const r = G.analyzeComments(comments);
+  expect(r.count).toBe(1); // only MANAGER_HANDOFF, not the two prose-mentioned siblings
+  expect(r.ok).toBe(true);
+  expect(r.violations.some(v => v.rule === 'artifact-role-mismatch')).toBe(false);
+});
+
+test('real ## header is still classified — no false negative (#2564)', () => {
+  const comments = [{
+    body: buildBatonComment({
+      artifact: 'CONSULTANT_CLOSEOUT', role: 'consultant', teamModel: 'codex:gpt-5.4@codex-cli', ticket: 2564,
+      summary: 'Verified; the COLLABORATOR_HANDOFF was posted earlier in the thread.',
+    }),
+  }];
+  const r = G.analyzeComments(comments);
+  expect(r.count).toBe(1); // CONSULTANT_CLOSEOUT header classified; prose mention ignored
+  expect(r.ok).toBe(true);
+});


### PR DESCRIPTION
Refs #2564
merge-evidence-deferred-final: #2564

## Summary
`baton-artifact-governance.js` `entries()` classified a comment as a baton artifact via `body.includes(artifact)` — a bare substring scan. Any artifact that merely *mentioned* a sibling token in prose (e.g. a MANAGER_HANDOFF noting "the COLLABORATOR_HANDOFF will follow") was misclassified, tripping a false `artifact-role-mismatch` (hit live on #2562; the documented prose-collision operator trap).

This detects artifacts by a line-anchored header match — `(^|\n)\s*(?:\*\*|##\s+)?<ARTIFACT>\b` — mirroring the canonical per-validator finders (`megalint/manager-handoff.js`, `collaborator-handoff.js`).

## Changes
- `baton-artifact-governance.js`: line-anchored `artifactHeaderRe()` replaces `body.includes()` in `entries()`.
- `tests/baton-artifact-governance.spec.js`: +2 regression tests (prose-mention not misclassified; real `##` header still classified). 6/6 pass.
- `.changes/unreleased/2564.md`: changelog fragment.

## Validation
- eslint 0 errors; lint:md 0 errors; 90-line file under cap.
- Cross-family review (two independent non-Anthropic families): cloud gemini-2.5-flash + fleet qwen2.5-coder:32b — ACCEPT at collaborator/admin/consultant gates.

## Baton artifacts (full set on #2564)
- COLLABORATOR_HANDOFF: test_strategy tdd-pyramid, per-AC PASS, cross_family_rating 10/10.
- ADMIN_HANDOFF: signer-independence PASS (Reyes != Harper), deploy-runtime-impact yes (sync post-merge).
- CONSULTANT_CLOSEOUT: verdict approve_for_merge, rubric 9/10, cross_family_verdict ACCEPT (two families).

Forward runtime parity (deploy.sh --apply + hamr:sync-verify) is run post-merge and cited before terminal close.
