### PR TITLE
fix(governance): enforce deferred-final terminal close #2575

### DIFF
--- a/.changes/unreleased/2575.md
+++ b/.changes/unreleased/2575.md
@@ -1,0 +1,6 @@
+# #2575
+
+- Added automated deferred-final terminal reconcile on consultant closeout comments so merged deferred-final PR evidence no longer leaves issues open.
+- Added `scripts/global/deferred-final-terminal-close.js` with observability marker emission (`event:goal-failure-escalation`) for this drift pattern.
+- Added unit tests for drift detection and remediation in `tests/deferred-final-terminal-close.spec.js`.
+- Updated completion-governance instruction text to explicitly forbid stopping while recoverable terminal-finalize work remains.

--- a/.changes/unreleased/2575.md
+++ b/.changes/unreleased/2575.md
@@ -1,5 +1,4 @@
-# #2575
-
+### Fixed
 - Added automated deferred-final terminal reconcile on consultant closeout comments so merged deferred-final PR evidence no longer leaves issues open.
 - Added `scripts/global/deferred-final-terminal-close.js` with observability marker emission (`event:goal-failure-escalation`) for this drift pattern.
 - Added unit tests for drift detection and remediation in `tests/deferred-final-terminal-close.spec.js`.

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -3,12 +3,14 @@ on:
   pull_request:
     branches: [main]
     types: [closed]
+  issue_comment:
+    types: [created]
   schedule:
     - cron: '30 8 * * *'
   workflow_dispatch:
 
 concurrency:
-  group: post-merge-${{ github.event.pull_request.number || github.run_id }}
+  group: post-merge-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -28,14 +30,10 @@ jobs:
             const refsMatch = body.match(/Refs\s+#(\d+)/i);
             if (!refsMatch) return;
             const linkedNum = parseInt(refsMatch[1]);
-
             const { data: issue } = await github.rest.issues.get({
               owner: context.repo.owner, repo: context.repo.repo, issue_number: linkedNum,
             });
             const labels = issue.labels.map(l => l.name);
-            // #1541: fetch comments + apply pure decision to avoid racing
-            // label-lint's auto-transition. Skip when issue is already
-            // terminal OR CONSULTANT_CLOSEOUT exists in trail.
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo,
               issue_number: linkedNum, per_page: 100,
@@ -43,13 +41,12 @@ jobs:
             const result = decision.decide({ state: issue.state, labels, comments });
             console.log(`#${linkedNum}: consultant-activation decision=${result.action} reason=${result.reason}`);
             if (result.action !== 'activate') return;
-
             const remove = labels.filter(l => result.removeLabelsMatching.test(l));
             for (const l of remove) {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: linkedNum, name: l,
-              }).catch(() => {}); // catch-empty: removeLabel throws 404 if label absent
+              }).catch(() => {});
             }
             await github.rest.issues.addLabels({
               owner: context.repo.owner, repo: context.repo.repo,
@@ -59,8 +56,30 @@ jobs:
             const prUrl = context.payload.pull_request.html_url;
             await github.rest.issues.createComment({
               owner: context.repo.owner, repo: context.repo.repo, issue_number: linkedNum,
-              body: `**Consultant action required** — PR merged (${sha}, ${prUrl})\n\nIssue is now \`status:review\`. Consultant must:\n1. Independently critique the implementation\n2. Post \`CONSULTANT_CLOSEOUT\` as a comment on this issue\n3. Run \`gh issue close ${linkedNum}\` after closeout\n\nTimestamp: ${new Date().toISOString()}`,
+              body: `**Consultant action required** — PR merged (${sha}, ${prUrl})\n\nIssue is now \`status:review\`. Consultant must:\n1. Independently critique the implementation\n2. Post \`CONSULTANT_CLOSEOUT\` as a comment on this issue\n3. Ensure terminal issue closure after closeout\n\nTimestamp: ${new Date().toISOString()}`,
             });
+
+  deferred-final-terminal-close:
+    name: deferred-final-terminal-close
+    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, 'CONSULTANT_CLOSEOUT')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const mod = require('./scripts/global/deferred-final-terminal-close.js');
+            const result = await mod.reconcile({
+              github: { issues: github.rest.issues, search: github.rest.search },
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issueNumber: context.payload.issue.number,
+              commentBody: context.payload.comment.body || '',
+            });
+            core.info(`deferred-final-terminal-close: #${context.payload.issue.number} => ${result.action}`);
 
   stale-review-check:
     name: stale-review-check

--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -46,7 +46,7 @@ jobs:
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: linkedNum, name: l,
-              }).catch(() => {});
+              }).catch(() => {}); // catch-empty: removeLabel may return 404 when label is already absent.
             }
             await github.rest.issues.addLabels({
               owner: context.repo.owner, repo: context.repo.repo,

--- a/instructions/feature-completion-governance.instructions.md
+++ b/instructions/feature-completion-governance.instructions.md
@@ -16,6 +16,8 @@ Completion intent semantics are strict:
 - "complete", "finish", or "ship" means terminal workflow delivery in one session when feasible once the active role identifies that intent in task scope.
 - Do not pause after implementation to wait for another user nudge to run Admin or Consultant phases.
 - Escalate only for blockers, missing evidence, or explicit design/UAT decisions.
+- Do not end a session while recoverable terminal-finalize work remains (for example, merged deferred-final evidence with closeout but issue still open).
+- When deferred-final evidence and CONSULTANT_CLOSEOUT coexist, perform or verify explicit issue closure before claiming completion.
 
 ## Admin completion contract (required before claiming done)
 

--- a/scripts/global/deferred-final-terminal-close.js
+++ b/scripts/global/deferred-final-terminal-close.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const CLOSEOUT_HEADER_RE = /(^|\n)\s*(?:\*\*|##\s+)?CONSULTANT_CLOSEOUT(?:_EPIC_CLOSEOUT)?\b/;
+const DEFERRED_TOKEN = 'merge-evidence-deferred-final:';
+const MARKER = '<!-- deferred-final-terminal-close -->';
+
+function hasCloseoutHeader(text) {
+  return CLOSEOUT_HEADER_RE.test(String(text || ''));
+}
+
+function buildSearchQuery(owner, repo, issueNumber) {
+  return `repo:${owner}/${repo} is:pr is:merged in:body "${DEFERRED_TOKEN} #${issueNumber}"`;
+}
+
+function pickMergedPr(items) {
+  const pr = (items || []).find((it) => it && it.pull_request);
+  if (!pr) return null;
+  return { number: pr.number, url: pr.html_url };
+}
+
+function buildRemediationComment({ issueNumber, prNumber, prUrl }) {
+  return `${MARKER}\n`
+    + 'event:goal-failure-escalation\n'
+    + 'pattern: merged-deferred-final-open-after-closeout\n\n'
+    + `Auto-remediation applied for issue #${issueNumber}: merged deferred-final evidence `
+    + `detected from PR #${prNumber} (${prUrl}) after CONSULTANT_CLOSEOUT. `
+    + 'Issue was closed to enforce terminal-finalize discipline.';
+}
+
+async function reconcile({ github, owner, repo, issueNumber, commentBody }) {
+  if (!hasCloseoutHeader(commentBody)) return { action: 'skip-non-closeout' };
+  const issue = await github.issues.get({ owner, repo, issue_number: issueNumber });
+  if (issue.data.state === 'closed') return { action: 'already-closed' };
+
+  const query = buildSearchQuery(owner, repo, issueNumber);
+  const search = await github.search.issuesAndPullRequests({ q: query, per_page: 5 });
+  const pr = pickMergedPr(search.data.items || []);
+  if (!pr) return { action: 'no-merged-deferred-final' };
+
+  await github.issues.update({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    state: 'closed',
+    state_reason: 'completed',
+  });
+  await github.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body: buildRemediationComment({ issueNumber, prNumber: pr.number, prUrl: pr.url }),
+  });
+  return { action: 'closed-after-closeout', prNumber: pr.number, prUrl: pr.url };
+}
+
+module.exports = {
+  hasCloseoutHeader,
+  buildSearchQuery,
+  pickMergedPr,
+  buildRemediationComment,
+  reconcile,
+  CLOSEOUT_HEADER_RE,
+  DEFERRED_TOKEN,
+  MARKER,
+};

--- a/tests/deferred-final-terminal-close.spec.js
+++ b/tests/deferred-final-terminal-close.spec.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const mod = require('../scripts/global/deferred-final-terminal-close.js');
+
+function mock({ issueState = 'open', mergedPr = null } = {}) {
+  const calls = { update: [], comment: [], query: [] };
+  return {
+    calls,
+    issues: {
+      async get() { return { data: { state: issueState } }; },
+      async update(args) { calls.update.push(args); },
+      async createComment(args) { calls.comment.push(args); },
+    },
+    search: {
+      async issuesAndPullRequests({ q }) {
+        calls.query.push(q);
+        const items = mergedPr ? [{ number: mergedPr.number, html_url: mergedPr.url, pull_request: {} }] : [];
+        return { data: { items } };
+      },
+    },
+  };
+}
+
+test('detects closeout header variants', () => {
+  assert.equal(mod.hasCloseoutHeader('## CONSULTANT_CLOSEOUT\nverdict: approve'), true);
+  assert.equal(mod.hasCloseoutHeader('**CONSULTANT_CLOSEOUT** inline'), true);
+  assert.equal(mod.hasCloseoutHeader('plain progress note'), false);
+});
+
+test('skip when comment is not a closeout marker', async () => {
+  const gh = mock();
+  const r = await mod.reconcile({ github: gh, owner: 'o', repo: 'r', issueNumber: 10, commentBody: 'note' });
+  assert.equal(r.action, 'skip-non-closeout');
+  assert.equal(gh.calls.update.length, 0);
+});
+
+test('drift detection: merged deferred-final absent -> no remediation', async () => {
+  const gh = mock();
+  const r = await mod.reconcile({
+    github: gh,
+    owner: 'o',
+    repo: 'r',
+    issueNumber: 11,
+    commentBody: '## CONSULTANT_CLOSEOUT\nverdict: approve',
+  });
+  assert.equal(r.action, 'no-merged-deferred-final');
+  assert.equal(gh.calls.update.length, 0);
+});
+
+test('remediation: merged deferred-final present -> close + event comment', async () => {
+  const gh = mock({ mergedPr: { number: 88, url: 'https://example/pr/88' } });
+  const r = await mod.reconcile({
+    github: gh,
+    owner: 'o',
+    repo: 'r',
+    issueNumber: 12,
+    commentBody: '## CONSULTANT_CLOSEOUT\nverdict: approve',
+  });
+  assert.equal(r.action, 'closed-after-closeout');
+  assert.equal(gh.calls.update[0].state, 'closed');
+  assert.match(gh.calls.comment[0].body, /event:goal-failure-escalation/);
+  assert.match(gh.calls.query[0], /merge-evidence-deferred-final/);
+});


### PR DESCRIPTION
## Summary
- add deferred-final terminal reconcile module to close open issues when closeout arrives after merged deferred-final evidence
- wire post-merge automation to run reconcile on closeout comments
- add unit coverage for drift detection/remediation and observability marker emission
- document explicit non-stop terminal-finalize expectation

## Validation
- `node --test tests/deferred-final-terminal-close.spec.js tests/post-merge-sweep.spec.js`
- `npm run lint`

Refs #2575
merge-evidence-deferred-final: #2575
