### PR TITLE
fix(ci): clear 5 ruff baseline errors blocking pre-push gate #2588

### DIFF
--- a/hooks/scripts/admin_patterns.py
+++ b/hooks/scripts/admin_patterns.py
@@ -71,7 +71,8 @@ RE_GIT_TAG = re.compile(r"\bgit\s+tag\b")
 
 def required_admin_ops(flags: dict, repo_type: str) -> list[str]:
     """Admin op keys required for completion. Stays in sync with
-    stop_checks.check_admin_ops base/ext logic (#2444)."""
+    stop_checks.check_admin_ops base/ext logic (#2444).
+    """
     base = (["commit", "push", "pr_create", "ci_green", "merge"]
             if flags.get("code_touched") else [])
     ext: list[str] = []

--- a/hooks/scripts/antigravity_signer_guard.py
+++ b/hooks/scripts/antigravity_signer_guard.py
@@ -66,7 +66,8 @@ def emit_incident(pattern_id: str, evidence: dict) -> bool:
 
 def check_commit_message(message: str, branch: str = "") -> dict:
     """Return decision dict. 'allow' always True (advisory mode).
-    If detection fires AND branch == 'main', incident is logged."""
+    If detection fires AND branch == 'main', incident is logged.
+    """
     if not feature_enabled():
         return {"allow": True, "advisory": False, "reason": "guard-disabled"}
     if not is_antigravity_signed(message):

--- a/hooks/scripts/github_role_resolver.py
+++ b/hooks/scripts/github_role_resolver.py
@@ -65,7 +65,7 @@ def _gh_view(ticket_n: int, timeout: float = 10.0) -> Optional[dict]:
 def _parse_roles(issue: dict) -> dict:
     """Project issue labels to canonical role-state dict."""
     roles = _empty_roles()
-    labels = {l.get("name", "") for l in issue.get("labels", [])}
+    labels = {lbl.get("name", "") for lbl in issue.get("labels", [])}
     for label, key in ROLE_LABELS.items():
         if label in labels:
             roles[key] = True

--- a/hooks/scripts/merge_claim_client.py
+++ b/hooks/scripts/merge_claim_client.py
@@ -79,8 +79,8 @@ def _gh_status(ticket_n: int) -> Optional[dict]:
     result = _gh_api("GET", f"/issues/{ticket_n}/labels")
     if result is None:
         return None
-    labels = [l["name"] for l in (result if isinstance(result, list) else [])
-              if l.get("name", "").startswith(GH_LABEL_PREFIX)]
+    labels = [lbl["name"] for lbl in (result if isinstance(result, list) else [])
+              if lbl.get("name", "").startswith(GH_LABEL_PREFIX)]
     return {"held": bool(labels), "labels": labels, "mode": "gh-label"}
 
 

--- a/hooks/scripts/stop_checks.py
+++ b/hooks/scripts/stop_checks.py
@@ -43,7 +43,8 @@ def ticket_from_branch(branch: str | None) -> int | None:
 
 def effective_roles(state_roles: dict, branch: str | None) -> dict:
     """Resolve effective roles. When feature flag set, GitHub-derived overrides
-    local-state. Falls back to local-state on offline or feature-off (#2456)."""
+    local-state. Falls back to local-state on offline or feature-off (#2456).
+    """
     if not _resolver_enabled():
         return state_roles
     ticket_n = ticket_from_branch(branch)


### PR DESCRIPTION
Refs #2588
merge-evidence-deferred-final: #2588

Clears 5 pre-existing ruff errors (fresh #2578-era drift) blocking the whole-repo pre-push gate: 3 D209 closing-quote auto-fixes + 2 E741 `l`->`lbl` renames. No behavior change (ast-verified).

manual-verify evidence — before: lint:py = 5 errors; after: 0 errors. Rationale: pure formatting + rename.

[skip-changelog]
[skip-doc-gate]

## Baton artifacts (full set on #2588)
- COLLABORATOR_HANDOFF / ADMIN_HANDOFF (signer-independent Reyes!=Harper) / CONSULTANT_CLOSEOUT posted; cross-family gemini-2.5-flash ACCEPT 10/10.