### PR TITLE
fix(governance): strict wait-for-green merge discipline #2573

### DIFF
--- a/.changes/unreleased/2573.md
+++ b/.changes/unreleased/2573.md
@@ -1,0 +1,5 @@
+### Fixed
+- Enforced strict wait-for-green merge gating in hook live checks by classifying CI state as `pending-only`, `failing`, `green`, or `unknown`.
+- Updated pre-tool merge guard to deny merge attempts when checks are pending or not fully green, with explicit pending-only guidance.
+- Added regression tests for pending-only, failing, and green-but-policy-blocked merge flow classification.
+- Documented wait-for-green discipline and policy-block reason capture requirements in completion governance guidance.

--- a/hooks/scripts/live_checks.py
+++ b/hooks/scripts/live_checks.py
@@ -3,22 +3,57 @@
 import json, re, subprocess
 
 RE_BRANCH_ISSUE = re.compile(r"(?:feat|fix|hotfix)/(\d+)-")
+PENDING_STATES = {"PENDING", "IN_PROGRESS", "QUEUED", "REQUESTED", "WAITING"}
+PASS_CONCLUSIONS = {"success", "skipped", "neutral"}
+FAIL_CONCLUSIONS = {"failure", "failed", "timed_out", "cancelled", "action_required", "startup_failure"}
 
 
-def ci_all_pass(pr_ref: str, cwd: str) -> bool:
-    """Return True if all non-pending CI checks for a PR are passing."""
+def classify_ci_checks(checks: list[dict]) -> str:
+    """Classify GH checks into pending-only, failing, green, or unknown."""
+    if not checks:
+        return "unknown"
+    has_pending = False
+    for c in checks:
+        state = str(c.get("state", "")).upper()
+        conclusion = str(c.get("conclusion", "")).lower()
+        if state in PENDING_STATES:
+            has_pending = True
+            continue
+        if conclusion and conclusion in FAIL_CONCLUSIONS:
+            return "failing"
+        if state in {"FAILURE", "FAILED", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "ERROR"}:
+            return "failing"
+        if conclusion and conclusion not in PASS_CONCLUSIONS:
+            return "failing"
+    if has_pending:
+        return "pending-only"
+    return "green"
+
+
+def classify_merge_flow_state(checks: list[dict], merge_policy_blocked: bool = False) -> str:
+    """Extend CI classification with policy-blocked merge outcome state."""
+    ci_state = classify_ci_checks(checks)
+    if ci_state == "green" and merge_policy_blocked:
+        return "green-but-policy-blocked"
+    return ci_state
+
+
+def ci_gate_status(pr_ref: str, cwd: str) -> str:
+    """Fetch and classify PR check status for merge gating."""
     try:
         r = subprocess.run(
             ["gh", "pr", "checks", pr_ref, "--json", "name,state,conclusion"],
             capture_output=True, text=True, cwd=cwd, timeout=20,
         )
         checks = json.loads(r.stdout or "[]")
-        return all(
-            c.get("conclusion", "") in ("success", "skipped", "neutral")
-            for c in checks if c.get("state", "") != "PENDING"
-        )
+        return classify_ci_checks(checks)
     except Exception:
-        return False
+        return "unknown"
+
+
+def ci_all_pass(pr_ref: str, cwd: str) -> bool:
+    """Compatibility helper: True only when checks are fully green."""
+    return ci_gate_status(pr_ref, cwd) == "green"
 
 
 def linked_issue_has_collab_handoff(cwd: str) -> bool:

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -10,7 +10,7 @@ from admin_patterns import (  # noqa: E501
     RE_RELEASE_INTEGRITY, RE_VSCE_PUBLISH, SECRET_FILE_RE, iter_paths, iter_strings)
 from canonical_main_enforcer import is_main_checkout, evaluate_path
 from governance_state import ensure_state
-from live_checks import ci_all_pass, linked_issue_has_collab_handoff
+from live_checks import ci_gate_status, linked_issue_has_collab_handoff
 from runtime_paths import runtime_hook_paths
 RE_ISSUE_REF = re.compile(r"#\d+")
 RE_BRANCH_TICKET = re.compile(r"^(feat|fix|hotfix)/(\d+)-")
@@ -98,8 +98,12 @@ def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
     if RE_PR_MERGE.search(joined):
         if not ops.get("pr_create"): return emit("deny","Merge blocked: PR creation not recorded.")
         pr_m = RE_PR_REF.search(joined)
-        if pr_m and not ci_all_pass(pr_m.group(1), cwd):
-            return emit("deny","Merge blocked: not all required CI checks pass (live API check).")
+        if pr_m:
+            ci_state = ci_gate_status(pr_m.group(1), cwd)
+            if ci_state == "pending-only":
+                return emit("deny", "Merge blocked: required CI checks are still pending. Wait and re-check status only.")
+            if ci_state in {"failing", "unknown"}:
+                return emit("deny", "Merge blocked: required CI checks are not fully green (live API check).")
         elif not pr_m and not ops.get("ci_green"):
             return emit("deny","Merge blocked: CI-green not recorded.")
     if RE_VSCE_PUBLISH.search(joined) and repo_type == "vscode-extension" and flags.get("extension_touched"):

--- a/instructions/feature-completion-governance.instructions.md
+++ b/instructions/feature-completion-governance.instructions.md
@@ -19,6 +19,13 @@ Completion intent semantics are strict:
 - Do not end a session while recoverable terminal-finalize work remains (for example, merged deferred-final evidence with closeout but issue still open).
 - When deferred-final evidence and CONSULTANT_CLOSEOUT coexist, perform or verify explicit issue closure before claiming completion.
 
+## Wait-For-Green Discipline
+
+- If required checks are pending and none are failing, do not run merge/branch-modifying commands.
+- In pending-only state, allowed actions are read-only check polling and evidence updates.
+- Attempt merge only when required checks are fully green.
+- If checks are green but merge is blocked by policy, use one explicit escalation path and capture the block reason in `ADMIN_HANDOFF` (for example under `merge_block_reason:`).
+
 ## Admin completion contract (required before claiming done)
 
 - Version collision check (Marketplace/tag/package alignment)

--- a/tests/hooks/test_live_checks_wait_gate.py
+++ b/tests/hooks/test_live_checks_wait_gate.py
@@ -1,0 +1,54 @@
+"""Regression tests for wait-for-green merge discipline (#2573)."""
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "hooks" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import live_checks  # noqa: E402
+import pretool_guard  # noqa: E402
+
+
+class ClassifyChecks(unittest.TestCase):
+    def test_pending_only(self):
+        checks = [{"state": "IN_PROGRESS", "conclusion": ""}]
+        self.assertEqual(live_checks.classify_ci_checks(checks), "pending-only")
+
+    def test_failing(self):
+        checks = [{"state": "COMPLETED", "conclusion": "failure"}]
+        self.assertEqual(live_checks.classify_ci_checks(checks), "failing")
+
+    def test_green_but_policy_blocked(self):
+        checks = [{"state": "COMPLETED", "conclusion": "success"}]
+        self.assertEqual(
+            live_checks.classify_merge_flow_state(checks, merge_policy_blocked=True),
+            "green-but-policy-blocked",
+        )
+
+
+class PretToolMergeGate(unittest.TestCase):
+    def _state(self):
+        return {
+            "repo_type": "generic",
+            "flags": {},
+            "admin_ops": {"pr_create": True},
+        }
+
+    def test_pending_blocks_merge(self):
+        pretool_guard.emit = lambda decision, reason, extra=None: (decision, reason, extra)
+        pretool_guard.ci_gate_status = lambda _pr, _cwd: "pending-only"
+        result = pretool_guard.check_terminal("gh pr merge 99", self._state(), ".")
+        self.assertEqual(result[0], "deny")
+        self.assertIn("still pending", result[1])
+
+    def test_failing_blocks_merge(self):
+        pretool_guard.emit = lambda decision, reason, extra=None: (decision, reason, extra)
+        pretool_guard.ci_gate_status = lambda _pr, _cwd: "failing"
+        result = pretool_guard.check_terminal("gh pr merge 99", self._state(), ".")
+        self.assertEqual(result[0], "deny")
+        self.assertIn("not fully green", result[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enforce strict CI state classification for merge gating (`pending-only`, `failing`, `green`, `unknown`)
- block `gh pr merge` when checks are pending-only or otherwise not fully green
- add regression tests covering pending-only, failing, and green-but-policy-blocked states
- document wait-for-green discipline and policy-block reason capture in completion governance guidance

## Validation
- python3 -m unittest tests/hooks/test_live_checks_wait_gate.py
- python3 -m unittest tests/hooks/test_pretool_guard_regex.py tests/hooks/test_admin_role_auto_emit.py
- npm run lint

Refs #2573
merge-evidence-deferred-final: #2573
