### PR TITLE
fix(governance): enforce blocking doc-coverage violations #2426

### DIFF
--- a/.changes/unreleased/2426.md
+++ b/.changes/unreleased/2426.md
@@ -1,0 +1,5 @@
+### Fixed
+- Updated doc-coverage required-surface validation to return blocking `doc-coverage-missing` violations for missing required entries.
+- Added blocking validation for bare `N/A` values without reason text in required doc-coverage surfaces.
+- Added lane bypass behavior for `lane:docs-research` and `lane:config-only` in direct doc-coverage validator execution.
+- Expanded validator test coverage to include bare `N/A` blocking behavior and consolidated blocking-rule expectations.

--- a/scripts/global/megalint/doc-coverage.js
+++ b/scripts/global/megalint/doc-coverage.js
@@ -1,13 +1,10 @@
 'use strict';
-// doc-coverage — validates doc-coverage: block in COLLABORATOR_HANDOFF.
-// Upgraded from advisory to blocking. Refs #2426.
-// Set DOC_COVERAGE_GATE_ADVISORY=1 for advisory-only mode (G5 escape hatch).
 
 const fs = require('fs');
 const path = require('path');
 
 const MATRIX_PATH = path.join(__dirname, '..', '..', '..', 'config', 'doc-coverage-matrix.yml');
-
+const LANE_SKIP = new Set(['lane:docs-research', 'lane:config-only']);
 function parseYamlSurfaces(text) {
   const lines = text.split('\n');
   const out = {};
@@ -44,30 +41,50 @@ function parseDocBlock(body) {
   const lines = (body || '').split('\n');
   let inBlock = false; const entries = {};
   for (const line of lines) {
-    if (!inBlock) {
-      if (/^\s*doc-coverage\s*:/i.test(line)) { inBlock = true; continue; }
-    } else {
-      if (/^\S/.test(line)) break;
-      const m = line.match(/^\s+([^:]+):\s*(.+)/);
-      if (m) entries[m[1].trim()] = m[2].trim();
-    }
+    if (!inBlock && /^\s*doc-coverage\s*:/i.test(line)) { inBlock = true; continue; }
+    if (!inBlock) continue;
+    if (/^\S/.test(line)) break;
+    const m = line.match(/^\s+([^:]+):\s*(.+)/);
+    if (m) entries[m[1].trim()] = m[2].trim();
   }
   return inBlock ? entries : null;
+}
+
+function findSurfaceValue(block, surface) {
+  const key = block && Object.keys(block).find(k => k.startsWith(surface) || surface.startsWith(k));
+  return key ? block[key] : null;
+}
+
+function valueViolation(surface, value) {
+  if (/^DONE(?:\b|\s*[—:-])/i.test(value)) return null;
+  if (/^N\/A\b/i.test(value)) {
+    const reason = String(value).replace(/^N\/A\b\s*(?:[—:-]\s*)?/i, '').trim();
+    if (reason) return null;
+    return { rule: 'doc-coverage-missing', severity: 'error',
+      detail: `required surface "${surface}" has bare N/A without reason` };
+  }
+  return { rule: 'doc-coverage-missing', severity: 'error',
+    detail: `required surface "${surface}" must be DONE or N/A with reason` };
 }
 
 function checkBlock(body, labels, matrix) {
   const expected = surfacesForLabels(labels, matrix);
   if (!expected.required.length) return [];
   const block = parseDocBlock(body);
-  if (!block) return [{ rule: 'doc-coverage-missing-block',
-    detail: `COLLABORATOR_HANDOFF missing doc-coverage: block. Required: ${expected.required.join(', ')}` }];
-  return expected.required
-    .filter(s => !Object.keys(block).some(k => k.startsWith(s) || s.startsWith(k)))
-    .map(s => ({ rule: 'doc-coverage-surface-missing',
-      detail: `doc-coverage: required surface "${s}" not found in block` }));
+  if (!block) return [{ rule: 'doc-coverage-missing', severity: 'error',
+    detail: `missing doc-coverage block; required surfaces: ${expected.required.join(', ')}` }];
+  return expected.required.flatMap((surface) => {
+    const value = findSurfaceValue(block, surface);
+    if (!value) return [{ rule: 'doc-coverage-missing', severity: 'error',
+      detail: `required surface "${surface}" not found in doc-coverage block` }];
+    const violation = valueViolation(surface, value);
+    return violation ? [violation] : [];
+  });
 }
 
 function validate(input) {
+  const lane = input.lane || '';
+  if (LANE_SKIP.has(lane)) return { ok: true, violations: [], reason: 'lane-skip' };
   if (process.env.DOC_COVERAGE_GATE_ADVISORY === '1') {
     return { ok: true, violations: [], advisory: 'doc-coverage: advisory mode (DOC_COVERAGE_GATE_ADVISORY=1)' };
   }
@@ -80,5 +97,4 @@ function validate(input) {
   const violations = checkBlock(body, input.labels, matrix);
   return { ok: violations.length === 0, violations };
 }
-
 module.exports = { validate, loadMatrix, parseYamlSurfaces, surfacesForLabels, parseDocBlock, checkBlock };

--- a/tests/collaborator-handoff-doc-coverage.spec.js
+++ b/tests/collaborator-handoff-doc-coverage.spec.js
@@ -5,7 +5,7 @@ const { validate } = require('../scripts/global/megalint/collaborator-handoff.js
 const { checkBlock, parseDocBlock, loadMatrix } = require('../scripts/global/megalint/doc-coverage.js');
 
 const HANDOFF_SIGNED = (extra) =>
-  `## COLLABORATOR_HANDOFF\n${extra}\nSigned-by: Alex Harper\nTeam&Model: copilot:sonnet@anthropic\nRole: collaborator\n`;
+  `## COLLABORATOR_HANDOFF\n${extra}\ncross_family_reviewer: qwen2.5-coder:32b@100.91.113.16:11434\ncross_family_rating: 82/100\ncross_family_findings: none\nreviewer_family: Qwen\nSigned-by: Alex Harper\nTeam&Model: copilot:sonnet@anthropic\nRole: collaborator\n`;
 
 test('validate: blocking when doc-coverage: block missing on lane:code-change with governance label', () => {
   const matrix = loadMatrix();
@@ -15,7 +15,7 @@ test('validate: blocking when doc-coverage: block missing on lane:code-change wi
     comments: [{ body, user: { login: 'alex' } }],
   });
   assert.equal(result.ok, false);
-  assert.ok(result.violations.some(v => v.rule === 'doc-coverage-missing-block'), JSON.stringify(result.violations));
+  assert.ok(result.violations.some(v => v.rule === 'doc-coverage-missing'), JSON.stringify(result.violations));
 });
 
 test('validate: passes when doc-coverage: block has required surfaces', () => {
@@ -62,7 +62,13 @@ test('parseDocBlock: parses entries from indented block', () => {
 test('checkBlock: returns violation for missing required surface', () => {
   const matrix = loadMatrix();
   const violations = checkBlock('doc-coverage:\n  README.md: DONE\n', ['area:governance'], matrix);
-  assert.ok(violations.some(v => v.rule === 'doc-coverage-surface-missing'));
+  assert.ok(violations.some(v => v.rule === 'doc-coverage-missing'));
+});
+
+test('checkBlock: bare N/A without reason is blocking', () => {
+  const matrix = loadMatrix();
+  const violations = checkBlock('doc-coverage:\n  .changes/unreleased/: N/A\n', ['area:governance'], matrix);
+  assert.ok(violations.some(v => v.rule === 'doc-coverage-missing'));
 });
 
 test('checkBlock: passes when no required surfaces for given labels', () => {

--- a/tests/doc-coverage-blocking.spec.js
+++ b/tests/doc-coverage-blocking.spec.js
@@ -18,8 +18,8 @@ for (const label of Object.keys(matrix)) {
   if (!req || req.length === 0) continue;
   test(`checkBlock: violation on absent block for ${label}`, () => {
     const v = checkBlock('', [label], matrix);
-    assert.ok(v.some(x => x.rule === 'doc-coverage-missing-block'),
-      `expected missing-block violation for ${label}: ${JSON.stringify(v)}`);
+    assert.ok(v.some(x => x.rule === 'doc-coverage-missing'),
+      `expected blocking violation for ${label}: ${JSON.stringify(v)}`);
   });
   test(`checkBlock: passes with complete block for ${label}`, () => {
     const entries = Object.fromEntries(req.map(s => [s, 'DONE — test']));
@@ -33,6 +33,11 @@ test('surfacesForLabels: unions required from multiple labels', () => {
   const s = surfacesForLabels(['area:governance', 'area:hooks'], matrix);
   assert.ok(s.required.includes('.changes/unreleased/'));
   assert.ok(s.required.includes('docs/howto/hooks.md'));
+});
+
+test('checkBlock: bare N/A without reason is blocking', () => {
+  const v = checkBlock('doc-coverage:\n  .changes/unreleased/: N/A\n', ['area:governance'], matrix);
+  assert.ok(v.some(x => x.rule === 'doc-coverage-missing'));
 });
 
 // changelog-fragment-presence wired in megalint VALIDATORS


### PR DESCRIPTION
## Summary
- make doc-coverage required-surface checks blocking with `doc-coverage-missing` violations
- block bare `N/A` values without reason text for required surfaces
- preserve lane bypass for `lane:docs-research` and `lane:config-only`
- update doc-coverage tests to match blocking contract

## Validation
- node --test tests/doc-coverage-blocking.spec.js tests/collaborator-handoff-doc-coverage.spec.js tests/doc-coverage-matrix.spec.js
- npm run lint

Refs #2426
merge-evidence-deferred-final: #2426