### PR TITLE
fix(governance): predate-ordering replaces 60s planting window #1433

### DIFF
--- a/.changes/unreleased/1433.md
+++ b/.changes/unreleased/1433.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The retroactive-planting check now uses predate-**ordering** instead of an arbitrary 60-second window, in both the `evidence-completeness` CI gate and the local `pre-pr-gate.js`. A `COLLABORATOR_HANDOFF` posted any time before the PR passes; only a handoff timestamped *after* the PR (genuine planting) fails. This removes the false-positive PR close/recreate churn that hit machine-speed operators who post the handoff and open the PR within 60s (#1433).

--- a/.github/workflows/evidence-completeness.yml
+++ b/.github/workflows/evidence-completeness.yml
@@ -75,7 +75,10 @@ jobs:
               violations.push(`Branch #${branchMatch[1]} ≠ Refs #${linkedNum} — branch must be for the linked issue`);
             }
 
-            // 4. COLLABORATOR_HANDOFF must predate PR creation by ≥60s
+            // 4. COLLABORATOR_HANDOFF must predate PR creation (ordering, not a
+            //    calendar window) — #1433. Retroactive planting = handoff posted
+            //    AFTER the PR (negative lag). PR.created_at and comment.created_at
+            //    share one server clock, so ordering is exact; no 60s buffer needed.
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo,
               issue_number: linkedNum, per_page: 100,
@@ -87,10 +90,10 @@ jobs:
               violations.push(`COLLABORATOR_HANDOFF not found on issue #${linkedNum}`);
             } else {
               const lagMs = prCreatedAt - new Date(handoff.created_at);
-              if (lagMs < 60_000) {
+              if (lagMs < 0) {
                 violations.push(
-                  `COLLABORATOR_HANDOFF posted ${Math.round(lagMs / 1000)}s before PR — ` +
-                  'must predate PR creation by ≥60s (retroactive planting check)'
+                  `COLLABORATOR_HANDOFF posted ${Math.round(-lagMs / 1000)}s AFTER PR creation — ` +
+                  'it must predate the PR (retroactive planting check)'
                 );
               }
             }

--- a/scripts/global/pre-pr-gate.js
+++ b/scripts/global/pre-pr-gate.js
@@ -6,7 +6,6 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 
-const PREDATE_WINDOW_SECONDS = 60;
 const ARTIFACTS = ['MANAGER_HANDOFF', 'COLLABORATOR_HANDOFF', 'ADMIN_HANDOFF', 'CONSULTANT_CLOSEOUT'];
 
 const gh = args => { try { return execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }); } catch (e) { return e.stdout?.toString('utf8') || ''; } };
@@ -23,8 +22,13 @@ const checkBatonCompleteness = comments => {
 function checkPredateWindow(comments, nowMs) {
   const collab = findArtifact(comments, 'COLLABORATOR_HANDOFF');
   if (!collab) return null;
+  // #1433: anti-retroactive-planting is an ORDERING property, not a calendar
+  // window. The handoff must PREDATE the PR (proxied here by push time). A
+  // handoff posted any time before the PR is legitimate, regardless of how few
+  // seconds — machine-speed AI operators post-then-push in <60s routinely.
+  // Fail only when the handoff is timestamped AFTER push (planted / clock anomaly).
   const age = (nowMs - new Date(collab.createdAt).getTime()) / 1000;
-  return age >= PREDATE_WINDOW_SECONDS ? null : { rule: 'predate-window-not-elapsed', detail: `COLLAB posted ${age.toFixed(1)}s ago; need >=${PREDATE_WINDOW_SECONDS}s. Wait ${(PREDATE_WINDOW_SECONDS - age).toFixed(1)}s.` };
+  return age >= 0 ? null : { rule: 'handoff-not-predating', detail: `COLLABORATOR_HANDOFF is timestamped ${(-age).toFixed(1)}s after push — it must predate the PR.` };
 }
 
 function checkClosesKeyword(prBodyDraft, leadTicket) {
@@ -90,4 +94,4 @@ if (require.main === module) {
   process.exit(result.ok ? 0 : 1);
 }
 
-module.exports = { check, checkBatonCompleteness, checkPredateWindow, checkClosesKeyword, extractLeadTicket, ARTIFACTS, PREDATE_WINDOW_SECONDS };
+module.exports = { check, checkBatonCompleteness, checkPredateWindow, checkClosesKeyword, extractLeadTicket, ARTIFACTS };

--- a/tests/pre-pr-gate.spec.js
+++ b/tests/pre-pr-gate.spec.js
@@ -1,4 +1,5 @@
 'use strict';
+// @megalint:test-discoverability:opt-out -- node:test CLI suite (run via `node --test`)
 process.env.NODE_ENV = 'test';
 const test = require('node:test');
 const assert = require('node:assert/strict');
@@ -39,11 +40,18 @@ test('checkPredateWindow: COLLAB >60s ago passes', () => {
   assert.equal(G.checkPredateWindow(comments, Date.now()), null);
 });
 
-test('checkPredateWindow: COLLAB <60s ago fails with wait time', () => {
-  const comments = [mkComment('COLLABORATOR_HANDOFF', 30)];
+test('checkPredateWindow: COLLAB 40s before PR passes (#1433 — no 60s window)', () => {
+  // The exact recurrence: handoff posted 40s before the PR was a false-positive
+  // under the old >=60s rule (forced PR close/recreate). Predate-ordering passes.
+  const comments = [mkComment('COLLABORATOR_HANDOFF', 40)];
+  assert.equal(G.checkPredateWindow(comments, Date.now()), null);
+});
+
+test('checkPredateWindow: COLLAB timestamped AFTER push fails (#1433 planting)', () => {
+  const comments = [mkComment('COLLABORATOR_HANDOFF', -30)]; // 30s in the future
   const result = G.checkPredateWindow(comments, Date.now());
-  assert.equal(result.rule, 'predate-window-not-elapsed');
-  assert.match(result.detail, /Wait/);
+  assert.equal(result.rule, 'handoff-not-predating');
+  assert.match(result.detail, /must predate/);
 });
 
 test('checkPredateWindow: no COLLAB returns null (covered by baton check)', () => {
@@ -86,14 +94,13 @@ test('check: feat branch + all 4 baton + COLLAB old + body OK = PASS', () => {
   assert.deepEqual(result.violations, []);
 });
 
-test('check: missing artifacts AND short predate AND missing Closes = 3 violations', () => {
+test('check: missing artifacts AND missing Closes = 2 violations (#1433: 30s predate is NOT a violation)', () => {
   const comments = [mkComment('MANAGER_HANDOFF'), mkComment('COLLABORATOR_HANDOFF', 30)];
   const result = G.check({ branch: 'feat/1234-x', comments, prBodyDraft: 'Refs #1234' });
   assert.equal(result.ok, false);
-  assert.equal(result.violations.length, 3);
+  assert.equal(result.violations.length, 2);
 });
 
 test('constants are sane', () => {
-  assert.equal(G.PREDATE_WINDOW_SECONDS, 60);
   assert.deepEqual(G.ARTIFACTS, ['MANAGER_HANDOFF', 'COLLABORATOR_HANDOFF', 'ADMIN_HANDOFF', 'CONSULTANT_CLOSEOUT']);
 });


### PR DESCRIPTION
Refs #1433
merge-evidence-deferred-final: #1433

Replaces the retroactive-planting check's arbitrary >=60s calendar threshold with strict predate-ordering in both the evidence-completeness CI gate (lagMs<0) and local pre-pr-gate.js (age>=0). Handoff posted any time before the PR passes; only one timestamped after the PR fails. Eliminates false-positive PR close/recreate churn (firsthand: #2589->#2590).

test: node --test tests/pre-pr-gate.spec.js -> 23 pass (40s-before PASS + after-PR FAIL).

## Baton (#1433)
COLLABORATOR_HANDOFF / ADMIN_HANDOFF (Reyes!=Harper) / CONSULTANT_CLOSEOUT posted; cross-family gemini-2.5-flash ACCEPT, anti-planting preserved.