### PR TITLE
fix(governance): enforce no-code remediation eligibility guards #2265

### DIFF
--- a/.changes/unreleased/2265.md
+++ b/.changes/unreleased/2265.md
@@ -1,0 +1,5 @@
+## 2265
+- enforce issue-only protections for lane:no-code-remediation in pretool guards
+- block file edits and admin/implementation commands when no-code lane is active
+- block no-code issue closeout when repository has unresolved working tree diff
+- add hook unit tests for no-code lane deny behavior and reduced-path invariant coverage

--- a/.changes/unreleased/2265.md
+++ b/.changes/unreleased/2265.md
@@ -1,5 +1,5 @@
-## 2265
-- enforce issue-only protections for lane:no-code-remediation in pretool guards
-- block file edits and admin/implementation commands when no-code lane is active
-- block no-code issue closeout when repository has unresolved working tree diff
-- add hook unit tests for no-code lane deny behavior and reduced-path invariant coverage
+### Fixed
+- Enforced issue-only protections for `lane:no-code-remediation` in pretool guards.
+- Blocked file edits and admin/implementation commands when no-code lane is active.
+- Blocked no-code issue closeout when repository has unresolved working tree diff.
+- Added hook unit tests for no-code lane deny behavior and reduced-path invariant coverage.

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -22,6 +22,12 @@ RE_BRANCH_SWITCH = re.compile(
 BRANCH_VALID = re.compile(r"^(feat|fix|hotfix)/\d+-|^(chore|skill)/[a-z0-9]|^main$|^develop$")
 RE_PR_REF = re.compile(r"gh\s+pr\s+merge\s+(\S+)")
 IT_OPS_MARKERS_RE = re.compile(r"\[it-ops\]|chore\(it-ops\)\s*:", re.IGNORECASE)
+NO_CODE_ADMIN_RE = re.compile(
+    r"\bgit\s+add\b|\bgit\s+commit\b|\bgit\s+push\b|"
+    r"\bgh\s+pr\s+(?:create|merge)\b|\bnpm\s+run\s+deploy(?:[:\w-]*)?\b|"
+    r"\bnpx\s+vsce\s+publish\b|\bgh\s+release\s+create\b",
+    re.IGNORECASE,
+)
 
 def detect_it_ops_bypass(joined: str, env: dict | None = None) -> tuple[bool, str | None]:
     """#2142: IT-ops commit-gate bypass detector.
@@ -63,9 +69,28 @@ def _emit_it_bypass_telemetry(marker: str, cwd: str) -> None:
     except Exception:
         pass  # telemetry failure must not affect hook decision
 
+def _active_ticket_labels(state: dict, cwd: str) -> set[str]:
+    ticket = state.get("active_ticket")
+    if not ticket:
+        return set()
+    try:
+        res = subprocess.run(
+            ["gh", "issue", "view", str(ticket), "--json", "labels", "-q", ".labels[].name"],
+            cwd=cwd, check=False, capture_output=True, text=True, timeout=20,
+        )
+        return {line.strip() for line in (res.stdout or "").splitlines() if line.strip()}
+    except Exception:
+        return set()
+
+def active_ticket_is_no_code_lane(state: dict, cwd: str) -> bool:
+    return "lane:no-code-remediation" in _active_ticket_labels(state, cwd)
+
 def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
     flags, ops = state.get("flags", {}), state.get("admin_ops", {})
     repo_type = state.get("repo_type", "generic")
+    no_code_lane = active_ticket_is_no_code_lane(state, cwd)
+    if no_code_lane and NO_CODE_ADMIN_RE.search(joined):
+        return emit("deny", "No-code remediation lane is issue-only. Admin/implementation commands are blocked; re-route to lane:code-change.")
     if DANGEROUS_CMD_RE.search(joined): return emit("deny","Blocked dangerous terminal command.")
     if is_main_checkout(cwd):
         sw = RE_BRANCH_SWITCH.search(joined)
@@ -111,6 +136,13 @@ def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
     if RE_GH_RELEASE_CREATE.search(joined) and repo_type == "vscode-extension" and flags.get("extension_touched"):
         if not ops.get("publish"): return emit("deny","Release blocked: publish not recorded.")
     if RE_GH_ISSUE_CLOSE.search(joined):
+        if no_code_lane:
+            dirty = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=cwd, check=False, capture_output=True, text=True,
+            ).stdout.strip()
+            if dirty:
+                return emit("deny", "No-code remediation lane invalid: repository diff detected. Move ticket to lane:code-change before closeout.")
         if flags.get("code_touched") and not ops.get("merge"): return emit("deny","Issue close blocked: merge not recorded.")
         if repo_type == "vscode-extension" and flags.get("extension_touched") and not ops.get("release_integrity"):
             return emit("deny","Issue close blocked: integrity check not recorded.")
@@ -138,6 +170,8 @@ def main() -> int:
     from state_store import reset_on_branch_change
     state = reset_on_branch_change(cwd, current_branch(cwd))
     if tool in {"create_file","apply_patch","edit_notebook_file","create_new_jupyter_notebook","replace_string_in_file","multi_replace_string_in_file","Write","Edit","MultiEdit","write_to_file","replace_file_content","multi_replace_file_content"}:
+        if active_ticket_is_no_code_lane(state, cwd):
+            return emit("deny", "File edit blocked: lane:no-code-remediation is issue-only. Re-route ticket to lane:code-change.")
         if is_main_checkout(cwd):
             for path_val in iter_paths(payload.get("tool_input", {})):
                 if not (path_val.startswith("/") or path_val.startswith("./") or "/" in path_val):

--- a/tests/hooks/test_pretool_guard_no_code_lane.py
+++ b/tests/hooks/test_pretool_guard_no_code_lane.py
@@ -1,0 +1,64 @@
+"""No-code remediation lane deny rules (#2265)."""
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOKS_SCRIPTS = REPO_ROOT / "hooks" / "scripts"
+sys.path.insert(0, str(HOOKS_SCRIPTS))
+
+import pretool_guard  # noqa: E402
+
+
+class NoCodeLaneGuards(unittest.TestCase):
+    def test_denies_admin_command_in_no_code_lane(self):
+        state = {"flags": {}, "admin_ops": {}, "repo_type": "generic", "active_ticket": 2265}
+        out = {}
+
+        def fake_emit(decision, reason, extra=None):
+            out["decision"], out["reason"] = decision, reason
+            return 0
+
+        with patch("pretool_guard.active_ticket_is_no_code_lane", return_value=True), \
+             patch("pretool_guard.emit", side_effect=fake_emit):
+            pretool_guard.check_terminal("git commit -m 'x #2265'", state, str(REPO_ROOT))
+
+        self.assertEqual(out.get("decision"), "deny")
+        self.assertIn("issue-only", out.get("reason", ""))
+
+    def test_denies_file_edit_tool_in_no_code_lane(self):
+        payload = {
+            "tool_name": "apply_patch",
+            "tool_input": {"input": "*** Begin Patch\n*** End Patch"},
+            "cwd": str(REPO_ROOT),
+        }
+        state = {"flags": {}, "admin_ops": {}, "repo_type": "generic", "active_ticket": 2265}
+        out = {}
+
+        def fake_emit(decision, reason, extra=None):
+            out["decision"], out["reason"] = decision, reason
+            return 0
+
+        with patch("pretool_guard.ensure_state", return_value=state), \
+             patch("pretool_guard.current_branch", return_value="fix/2265-no-code-lane"), \
+             patch("pretool_guard.active_ticket_is_no_code_lane", return_value=True), \
+             patch("pretool_guard.emit", side_effect=fake_emit), \
+             patch("sys.stdin", io.StringIO(json.dumps(payload))):
+            pretool_guard.main()
+
+        self.assertEqual(out.get("decision"), "deny")
+        self.assertIn("File edit blocked", out.get("reason", ""))
+
+    def test_allows_issue_comment_command_in_no_code_lane(self):
+        state = {"flags": {}, "admin_ops": {}, "repo_type": "generic", "active_ticket": 2265}
+        with patch("pretool_guard.active_ticket_is_no_code_lane", return_value=True):
+            self.assertIsNone(pretool_guard.check_terminal(
+                "gh issue comment 2265 --body 'note'", state, str(REPO_ROOT)
+            ))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/megalint/baton-handoffs.spec.js
+++ b/tests/megalint/baton-handoffs.spec.js
@@ -33,6 +33,12 @@ test('collaborator: lightweight lane skips check', () => {
   expect(r.reason).toBe('lightweight-lane-skip');
 });
 
+test('collaborator: no-code-remediation lane skips collaborator handoff', () => {
+  const r = Coll.validate({ comments: [], lane: 'lane:no-code-remediation' });
+  expect(r.ok).toBe(true);
+  expect(r.reason).toBe('lightweight-lane-skip');
+});
+
 test('admin: no-code-remediation lane skips admin handoff requirement', () => {
   const r = Adm.validate({ comments: [], lane: 'lane:no-code-remediation' });
   expect(r.ok).toBe(true);


### PR DESCRIPTION
## Summary
- enforce issue-only protections for `lane:no-code-remediation` in pretool guards
- block file-edit tools for active no-code remediation tickets
- block admin/implementation terminal commands (`git add/commit/push`, `gh pr create/merge`, deploy/release)
- block no-code issue closeout when repository has unresolved diff
- add hook unit tests for no-code deny behavior and megalint invariant test for collaborator skip

## Validation
- python3 -m unittest tests/hooks/test_pretool_guard_no_code_lane.py
- npx playwright test tests/megalint/baton-handoffs.spec.js tests/lane-enum.spec.js
- npm run lint

Refs #2265
merge-evidence-deferred-final: #2265
