### PR TITLE
fix(governance): exit-code fallback for ci_gate_status #2596

### DIFF
--- a/.changes/unreleased/2596.md
+++ b/.changes/unreleased/2596.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `live_checks.ci_gate_status` no longer false-blocks a merge when `gh pr checks --json` returns empty/unparseable stdout for an all-green PR (an observed gh quirk). It now falls back to gh's plain exit code (0 → green, 8 → pending-only, 1 → failing) instead of classifying "unknown". Anti-merge safety is preserved — green still requires an affirmative signal (#2596).

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -54,4 +54,5 @@ jobs:
           tests/api-smoke-load.spec.js
           tests/agent-signature-cli.spec.js
           tests/pretool-guard-worktree-gate.spec.js
+          tests/ci-gate-status-fallback.spec.js
           --reporter=line

--- a/hooks/scripts/live_checks.py
+++ b/hooks/scripts/live_checks.py
@@ -38,6 +38,22 @@ def classify_merge_flow_state(checks: list[dict], merge_policy_blocked: bool = F
     return ci_state
 
 
+# gh exit codes for `gh pr checks`: 0 = all pass, 8 = pending, 1 = failing.
+GH_CHECKS_EXIT = {0: "green", 8: "pending-only", 1: "failing"}
+
+
+def _exit_code_status(pr_ref: str, cwd: str) -> str:
+    """Fallback classifier using gh's plain exit code (no --json)."""
+    try:
+        r = subprocess.run(
+            ["gh", "pr", "checks", pr_ref],
+            capture_output=True, text=True, cwd=cwd, timeout=20,
+        )
+        return GH_CHECKS_EXIT.get(r.returncode, "unknown")
+    except Exception:
+        return "unknown"
+
+
 def ci_gate_status(pr_ref: str, cwd: str) -> str:
     """Fetch and classify PR check status for merge gating."""
     try:
@@ -45,10 +61,18 @@ def ci_gate_status(pr_ref: str, cwd: str) -> str:
             ["gh", "pr", "checks", pr_ref, "--json", "name,state,conclusion"],
             capture_output=True, text=True, cwd=cwd, timeout=20,
         )
-        checks = json.loads(r.stdout or "[]")
-        return classify_ci_checks(checks)
     except Exception:
         return "unknown"
+    try:
+        checks = json.loads(r.stdout or "[]")
+    except (ValueError, TypeError):
+        checks = []
+    # `gh pr checks --json` can exit non-zero with empty stdout for an all-green
+    # PR (observed #2595). An empty list would classify "unknown" and false-block
+    # the merge — fall back to gh's plain exit code instead.
+    if checks:
+        return classify_ci_checks(checks)
+    return _exit_code_status(pr_ref, cwd)
 
 
 def ci_all_pass(pr_ref: str, cwd: str) -> bool:

--- a/tests/ci-gate-status-fallback.spec.js
+++ b/tests/ci-gate-status-fallback.spec.js
@@ -1,0 +1,21 @@
+// #2596 — JS harness that runs the Python unittest for ci_gate_status's
+// exit-code fallback. The implementation under test is a Python hook helper
+// (live_checks.py), so the real assertions live in unittest; this spec
+// satisfies the JS-centric test-evidence gate while executing the Python
+// coverage in CI.
+'use strict';
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+test('live_checks ci_gate_status fallback Python suite passes (#2596)', () => {
+  const root = path.resolve(__dirname, '..');
+  try {
+    execFileSync('python3', ['-m', 'unittest', 'tests.hooks.test_live_checks_wait_gate'], {
+      cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (e) {
+    throw new Error(`Python unittest failed:\n${e.stdout || ''}\n${e.stderr || ''}`);
+  }
+  expect(true).toBe(true);
+});

--- a/tests/hooks/test_live_checks_wait_gate.py
+++ b/tests/hooks/test_live_checks_wait_gate.py
@@ -50,5 +50,40 @@ class PretToolMergeGate(unittest.TestCase):
         self.assertIn("not fully green", result[1])
 
 
+class CiGateStatusJsonFallback(unittest.TestCase):
+    """#2596 — empty `gh pr checks --json` must fall back to the plain exit code."""
+
+    def _status(self, json_stdout, plain_rc):
+        from unittest.mock import patch, MagicMock
+
+        def side_effect(cmd, **kw):
+            m = MagicMock()
+            if "--json" in cmd:
+                m.stdout = json_stdout
+                m.returncode = 0 if json_stdout.strip() not in ("", "[]") else 1
+            else:  # plain `gh pr checks <pr>` fallback
+                m.stdout = ""
+                m.returncode = plain_rc
+            return m
+
+        with patch("live_checks.subprocess.run", side_effect=side_effect):
+            return live_checks.ci_gate_status("99", ".")
+
+    def test_nonempty_json_unchanged(self):
+        self.assertEqual(self._status('[{"state": "COMPLETED", "conclusion": "success"}]', 1), "green")
+
+    def test_empty_json_exit0_green(self):
+        self.assertEqual(self._status("", 0), "green")
+
+    def test_empty_json_exit8_pending(self):
+        self.assertEqual(self._status("", 8), "pending-only")
+
+    def test_empty_json_exit1_failing(self):
+        self.assertEqual(self._status("", 1), "failing")
+
+    def test_empty_json_exit2_unknown(self):
+        self.assertEqual(self._status("", 2), "unknown")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refs #2596
merge-evidence-deferred-final: #2596

## Summary
`live_checks.ci_gate_status` classified an empty `gh pr checks --json` result as "unknown" and false-blocked the admin-merge step even when all checks pass — an observed gh quirk where `--json` exits 1 with empty stdout for some all-green PRs (firsthand: #2595 this session). It now falls back to gh's plain exit code (0 → green, 8 → pending-only, 1 → failing, else → unknown) when the `--json` list is empty. Non-empty `--json` is unchanged.

**Safety preserved (G1):** green still requires an affirmative signal (json-green OR plain exit 0); pending / failing / unknown still block.

## Validation
- `python3 -m unittest tests.hooks.test_live_checks_wait_gate` → 10 pass (5 new: non-empty unchanged, empty+exit{0,8,1,2}).
- JS harness `tests/ci-gate-status-fallback.spec.js` wired into quality-gates (runs the unittest in CI).
- ruff clean; live_checks.py at the 100-line cap.

## Baton artifacts (#2596)
- COLLABORATOR_HANDOFF / ADMIN_HANDOFF (signer-independent Reyes≠Harper) / CONSULTANT_CLOSEOUT posted.
- Cross-family review: gemini-2.5-flash ACCEPT at all gates (fleet qwen contended this round).

Forward runtime parity run post-merge; issue closed by Consultant after merge.
