### PR TITLE
feat(governance): prefer resident fleet model in review dispatch #2599

### DIFF
--- a/.changes/unreleased/2599.md
+++ b/.changes/unreleased/2599.md
@@ -1,3 +1,7 @@
 ### Changed
 
 - Fleet review dispatch (`fleet-red-team-dispatch.js`) now prefers an already-**resident** cross-family model (queried via `/api/ps`, new `scripts/global/fleet-resident.js` helper) for non-high-stakes reviews, instead of cold-loading a stakes-default model that may time out and force a paid cloud fallback. High-stakes selection is unchanged (best model first). This keeps more governed review work on the free fleet lane (G3) (#2599).
+
+### Fixed
+
+- `fleet-red-team-dispatch.js` imported `hamr-provider-wrapper` via a hard-coded absolute path (`/home/<user>/devenv-ops/...`) that broke the module on CI and any non-default checkout; changed to a relative require so the dispatcher is importable everywhere (G5 portability) (#2599).

--- a/.changes/unreleased/2599.md
+++ b/.changes/unreleased/2599.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Fleet review dispatch (`fleet-red-team-dispatch.js`) now prefers an already-**resident** cross-family model (queried via `/api/ps`, new `scripts/global/fleet-resident.js` helper) for non-high-stakes reviews, instead of cold-loading a stakes-default model that may time out and force a paid cloud fallback. High-stakes selection is unchanged (best model first). This keeps more governed review work on the free fleet lane (G3) (#2599).

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -55,4 +55,5 @@ jobs:
           tests/agent-signature-cli.spec.js
           tests/pretool-guard-worktree-gate.spec.js
           tests/ci-gate-status-fallback.spec.js
+          tests/fleet-resident-pref.spec.js
           --reporter=line

--- a/scripts/global/fleet-red-team-dispatch.js
+++ b/scripts/global/fleet-red-team-dispatch.js
@@ -8,6 +8,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { wrapProviderCall } = require('/home/curtisfranks/devenv-ops/scripts/global/hamr-provider-wrapper');
+const { residentModels } = require('./fleet-resident');
 
 const DEFAULT_HOST = 'http://100.91.113.16:11434';
 const DEFAULT_MODEL = 'qwen2.5-coder:32b';
@@ -56,6 +57,13 @@ function selectModel(taskContext = {}, opts = {}) {
   const { models, fallbackChain } = loadMatrix(opts.matrixPath);
   const stakes = (taskContext.stakes || 'low').toLowerCase();
   const candidates = models.filter((m) => !m.blocked && m.cross_family_ok !== false);
+  // #2599 (G3): for non-high stakes, prefer an already-resident cross-family
+  // model so the review stays on the free fleet instead of cold-loading and
+  // falling back to a paid cloud reviewer. High stakes keeps the best model.
+  if (stakes !== 'high' && Array.isArray(opts.residentModels) && opts.residentModels.length) {
+    const resident = candidates.find((m) => opts.residentModels.includes(m.id));
+    if (resident) return { modelId: resident.id, rationale: `resident-preferred-${stakes}` };
+  }
   const match = candidates.find(
     (m) => Array.isArray(m.default_for_stakes) && m.default_for_stakes.includes(stakes),
   );
@@ -135,7 +143,12 @@ async function dispatchRedTeam({
   artifactType, content, model, host = DEFAULT_HOST,
   templatesPath = TEMPLATES_PATH, taskContext = {}, matrixPath,
 } = {}) {
-  const resolved = model ? { modelId: model, rationale: 'caller-arg' } : selectModel(taskContext, { matrixPath });
+  // #2599 (G3): tell selectModel which models are already resident on the host
+  // so non-high-stakes reviews prefer the free-fleet resident over a cold-load.
+  const resident = model ? [] : await residentModels(host);
+  const resolved = model
+    ? { modelId: model, rationale: 'caller-arg' }
+    : selectModel(taskContext, { matrixPath, residentModels: resident });
   const activeModel = resolved.modelId;
   const template = loadTemplate(artifactType, templatesPath);
   const prompt = buildPrompt(template, content);

--- a/scripts/global/fleet-red-team-dispatch.js
+++ b/scripts/global/fleet-red-team-dispatch.js
@@ -7,7 +7,7 @@
 'use strict';
 const fs = require('node:fs');
 const path = require('node:path');
-const { wrapProviderCall } = require('/home/curtisfranks/devenv-ops/scripts/global/hamr-provider-wrapper');
+const { wrapProviderCall } = require('./hamr-provider-wrapper');
 const { residentModels } = require('./fleet-resident');
 
 const DEFAULT_HOST = 'http://100.91.113.16:11434';

--- a/scripts/global/fleet-resident.js
+++ b/scripts/global/fleet-resident.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+'use strict';
+// Resident-model preference for fleet review dispatch (#2599, G3). Prefer a
+// model already loaded on the Ollama host (/api/ps) so cross-family reviews
+// stay on the FREE fleet instead of cold-loading a different model, timing
+// out, and falling back to a paid cloud reviewer. Fetch is injectable for
+// unit tests; every path degrades gracefully (returns []/null) on error.
+
+/**
+ * Names of models currently resident (loaded) on the Ollama host.
+ * @param {string} host e.g. "http://100.91.113.16:11434"
+ * @param {Function} [fetchImpl] injectable fetch (defaults to global fetch)
+ * @returns {Promise<string[]>} resident model names; [] on any error
+ */
+async function residentModels(host, fetchImpl) {
+  const doFetch = fetchImpl || (typeof fetch !== 'undefined' ? fetch : null);
+  if (!host || !doFetch) return [];
+  try {
+    const res = await doFetch(`${String(host).replace(/\/$/, '')}/api/ps`,
+      { signal: AbortSignal.timeout(5000) });
+    if (!res || !res.ok) return [];
+    const data = await res.json();
+    return (data.models || [])
+      .map((m) => m && (m.name || m.model))
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * First candidate id currently resident on the host, else null.
+ * @param {string[]} candidateIds
+ * @param {string} host
+ * @param {Function} [fetchImpl]
+ * @returns {Promise<string|null>}
+ */
+async function preferResident(candidateIds, host, fetchImpl) {
+  if (!Array.isArray(candidateIds) || candidateIds.length === 0) return null;
+  const resident = await residentModels(host, fetchImpl);
+  if (resident.length === 0) return null;
+  return candidateIds.find((id) => resident.includes(id)) || null;
+}
+
+module.exports = { residentModels, preferResident };
+
+if (require.main === module) {
+  const host = process.argv[2] || 'http://100.91.113.16:11434';
+  residentModels(host).then((m) => process.stdout.write(`${JSON.stringify(m)}\n`));
+}

--- a/tests/fleet-resident-pref.spec.js
+++ b/tests/fleet-resident-pref.spec.js
@@ -1,0 +1,46 @@
+// #2599 (G3) — resident-model preference keeps fleet reviews on the free lane.
+'use strict';
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const G = path.resolve(__dirname, '..', 'scripts', 'global');
+const { residentModels, preferResident } = require(path.join(G, 'fleet-resident.js'));
+const { selectModel } = require(path.join(G, 'fleet-red-team-dispatch.js'));
+
+const fakeFetch = (payload, ok = true) => async () => ({
+  ok, json: async () => payload,
+});
+const throwFetch = async () => { throw new Error('network'); };
+
+test('residentModels parses /api/ps name/model fields', async () => {
+  const f = fakeFetch({ models: [{ name: 'qwen2.5-coder:32b' }, { model: 'llama3:8b' }, {}] });
+  expect(await residentModels('http://h:11434', f)).toEqual(['qwen2.5-coder:32b', 'llama3:8b']);
+});
+
+test('residentModels degrades to [] on error / not-ok / no-host', async () => {
+  expect(await residentModels('http://h:11434', throwFetch)).toEqual([]);
+  expect(await residentModels('http://h:11434', fakeFetch({}, false))).toEqual([]);
+  expect(await residentModels('', fakeFetch({ models: [{ name: 'x' }] }))).toEqual([]);
+});
+
+test('preferResident returns first resident candidate, else null', async () => {
+  const f = fakeFetch({ models: [{ name: 'z' }, { name: 'b' }] });
+  expect(await preferResident(['a', 'b', 'z'], 'http://h:11434', f)).toBe('b');
+  expect(await preferResident(['a', 'c'], 'http://h:11434', f)).toBeNull();
+  expect(await preferResident([], 'http://h:11434', f)).toBeNull();
+});
+
+test('selectModel: non-high stakes prefers a resident cross-family model (#2599)', () => {
+  const r = selectModel({ stakes: 'low' }, { residentModels: ['qwen2.5-coder:32b'] });
+  expect(r.modelId).toBe('qwen2.5-coder:32b');
+  expect(r.rationale).toBe('resident-preferred-low');
+});
+
+test('selectModel: high stakes ignores residency (quality first)', () => {
+  const r = selectModel({ stakes: 'high' }, { residentModels: ['qwen2.5-coder:7b'] });
+  expect(r.rationale).toBe('matrix-stakes-high');
+});
+
+test('selectModel: no residentModels → unchanged matrix selection', () => {
+  const r = selectModel({ stakes: 'low' }, {});
+  expect(r.rationale).toMatch(/^matrix-stakes-|^fallback-chain$|^hardcoded-default$/);
+});


### PR DESCRIPTION
Refs #2599
merge-evidence-deferred-final: #2599

## Summary (G3 — Zero Cost)
Cross-family review dispatch was residency-blind: `selectModel` picked by stakes and cold-loaded a model that could time out, forcing a **paid cloud** fallback (~100% fleet→paid for review work this session). Now it prefers an already-**resident** cross-family model (queried via `/api/ps`) for non-high stakes, keeping reviews on the **free fleet**. High-stakes selection unchanged (best model first); absent resident info → unchanged behavior (graceful, G6).

## Changes
- `scripts/global/fleet-resident.js` (new): `residentModels(host, fetchImpl?)`, `preferResident(...)` — fetch-injectable, graceful.
- `fleet-red-team-dispatch.js`: `selectModel` honors `opts.residentModels` (non-high stakes); `dispatchRedTeam` populates it via `residentModels(host)`.
- `tests/fleet-resident-pref.spec.js` (6 pass) + quality-gates wiring; changelog fragment.

## Validation
- 6 unit tests pass; eslint clean.
- **Dogfooded:** all three gate reviews ran on the resident `qwen2.5-coder:32b` (free fleet) — ACCEPT 9/10, no paid-cloud fallback.

## Baton (#2599)
COLLABORATOR_HANDOFF / ADMIN_HANDOFF (Reyes≠Harper) / CONSULTANT_CLOSEOUT posted; cross-family qwen2.5-coder:32b ACCEPT at all gates.
