### PR TITLE
feat(governance): keep fleet review model warm via keep_alive #2601

### DIFF
--- a/.changes/unreleased/2601.md
+++ b/.changes/unreleased/2601.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Fleet review dispatch (`fleet-red-team-dispatch.js`) now sends a configurable `keep_alive` (default `30m`, override via `FLEET_KEEP_ALIVE`) on its Ollama `/api/generate` calls, so the review model stays resident between back-to-back baton reviews. This sustains the resident-model preference added in #2599 — fewer cold-load timeouts, less paid-cloud fallback, more review work on the free fleet (G3) (#2601).

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -56,4 +56,5 @@ jobs:
           tests/pretool-guard-worktree-gate.spec.js
           tests/ci-gate-status-fallback.spec.js
           tests/fleet-resident-pref.spec.js
+          tests/fleet-keepalive.spec.js
           --reporter=line

--- a/scripts/global/fleet-red-team-dispatch.js
+++ b/scripts/global/fleet-red-team-dispatch.js
@@ -100,6 +100,15 @@ function detectRefusal(text) {
   return REFUSAL_PATTERNS.some((re) => re.test(trimmed));
 }
 
+// #2601 (G3): keep the review model resident between back-to-back baton
+// reviews so resident-preference (#2599) keeps finding a warm model and review
+// work stays on the free fleet instead of cold-loading and falling to paid
+// cloud. Settings-driven (G5); default 30m balances warmth vs. shared-host VRAM.
+function keepAliveValue() {
+  const v = String(process.env.FLEET_KEEP_ALIVE || '').trim();
+  return v || '30m';
+}
+
 async function callOllamaOnce({ host, model, prompt, num_predict }) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -107,7 +116,11 @@ async function callOllamaOnce({ host, model, prompt, num_predict }) {
     const response = await fetch(`${host}/api/generate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model, prompt, stream: false, options: { temperature: 0.3, num_predict } }),
+      body: JSON.stringify({
+        model, prompt, stream: false,
+        keep_alive: keepAliveValue(),
+        options: { temperature: 0.3, num_predict },
+      }),
       signal: controller.signal,
     });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -172,6 +185,7 @@ async function dispatchRedTeam({
 
 module.exports = {
   dispatchRedTeam, selectModel, loadMatrix, loadTemplate, buildPrompt,
-  callWithRetry, parseFindings, stripArxivHallucinations, detectRefusal,
+  callWithRetry, callOllamaOnce, keepAliveValue, parseFindings,
+  stripArxivHallucinations, detectRefusal,
   TIER, RETRY_DELAYS_MS, MATRIX_PATH,
 };

--- a/tests/fleet-keepalive.spec.js
+++ b/tests/fleet-keepalive.spec.js
@@ -1,0 +1,46 @@
+// #2601 (G3) — fleet review dispatch keeps the model warm via keep_alive.
+'use strict';
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const D = require(path.resolve(__dirname, '..', 'scripts', 'global', 'fleet-red-team-dispatch.js'));
+
+function withEnv(value, fn) {
+  const prev = process.env.FLEET_KEEP_ALIVE;
+  if (value === undefined) delete process.env.FLEET_KEEP_ALIVE;
+  else process.env.FLEET_KEEP_ALIVE = value;
+  try { return fn(); } finally {
+    if (prev === undefined) delete process.env.FLEET_KEEP_ALIVE;
+    else process.env.FLEET_KEEP_ALIVE = prev;
+  }
+}
+
+async function captureBody(env, args) {
+  return withEnv(env, async () => {
+    const realFetch = global.fetch;
+    let body;
+    global.fetch = async (_url, opts) => { body = JSON.parse(opts.body); return { ok: true, json: async () => ({ response: 'ok' }) }; };
+    try { await D.callOllamaOnce(args); } finally { global.fetch = realFetch; }
+    return body;
+  });
+}
+
+test('keepAliveValue defaults to 30m (incl. empty/whitespace)', () => {
+  expect(withEnv(undefined, () => D.keepAliveValue())).toBe('30m');
+  expect(withEnv('   ', () => D.keepAliveValue())).toBe('30m');
+});
+
+test('keepAliveValue honors FLEET_KEEP_ALIVE override', () => {
+  expect(withEnv('1h', () => D.keepAliveValue())).toBe('1h');
+});
+
+test('callOllamaOnce sends default keep_alive in the request body (#2601)', async () => {
+  const body = await captureBody(undefined, { host: 'http://h:11434', model: 'qwen2.5-coder:32b', prompt: 'p', num_predict: 10 });
+  expect(body.keep_alive).toBe('30m');
+  expect(body.model).toBe('qwen2.5-coder:32b');
+  expect(body.options.num_predict).toBe(10);
+});
+
+test('callOllamaOnce reflects FLEET_KEEP_ALIVE override in body', async () => {
+  const body = await captureBody('45m', { host: 'http://h:11434', model: 'm', prompt: 'p', num_predict: 5 });
+  expect(body.keep_alive).toBe('45m');
+});


### PR DESCRIPTION
Refs #2601
merge-evidence-deferred-final: #2601

## Summary (G3 — Zero Cost)
`fleet-red-team-dispatch.js` `callOllamaOnce` sent no `keep_alive`, so the review model unloaded (~5min default TTL) and cold-loaded on the next review → timeout → **paid cloud** fallback. Now it sends a configurable `keep_alive` (default `30m`, `FLEET_KEEP_ALIVE` override) on its `/api/generate` calls, keeping the model resident across back-to-back baton reviews. Completes the free-fleet-sustain pair with #2599 (prefer-resident + keep-resident).

## Changes
- `fleet-red-team-dispatch.js`: `keepAliveValue()` (env || `30m`) + top-level `keep_alive` in the request body.
- `tests/fleet-keepalive.spec.js` (4 pass) + quality-gates wiring; changelog fragment.

## Validation
- 4 unit tests pass; eslint 0 errors. Selection/cross-family/retry unchanged.
- Cross-family review: collaborator on the **resident free-fleet** qwen-32b (ACCEPT 9/10); admin + consultant on gemini-2.5-flash (ACCEPT).

## Baton (#2601)
COLLABORATOR_HANDOFF / ADMIN_HANDOFF (Reyes≠Harper) / CONSULTANT_CLOSEOUT posted.
