### PR TITLE
fix(fleet): keep red-team model warm between reviews

### DIFF
--- a/.changes/unreleased/2601.md
+++ b/.changes/unreleased/2601.md
@@ -1,0 +1,2 @@
+### Fixed
+- Keep fleet red-team model warm by adding `keep_alive` to Ollama generate requests in `scripts/global/fleet-red-team-dispatch.js`, with `FLEET_KEEP_ALIVE` env override and safe default fallback (`30m`) when unset/invalid. Refs #2601.

--- a/scripts/global/fleet-red-team-dispatch.js
+++ b/scripts/global/fleet-red-team-dispatch.js
@@ -15,6 +15,7 @@ const DEFAULT_MODEL = 'qwen2.5-coder:32b';
 const TIER = 'fleet-local';
 const RETRY_DELAYS_MS = [1000, 4000];
 const REQUEST_TIMEOUT_MS = 600_000;
+const DEFAULT_KEEP_ALIVE = '30m';
 const TEMPLATES_PATH = path.join(__dirname, '..', '..', 'config', 'fleet-red-team-prompts.json');
 const MATRIX_PATH = path.join(__dirname, '..', '..', 'config', 'red-team-model-matrix.yml');
 const TOKEN_BUDGET_HEADROOM = 200;
@@ -100,14 +101,28 @@ function detectRefusal(text) {
   return REFUSAL_PATTERNS.some((re) => re.test(trimmed));
 }
 
+function resolveKeepAlive(raw = process.env.FLEET_KEEP_ALIVE) {
+  const value = String(raw || '').trim();
+  if (/^\d+[smhd]$/i.test(value)) return value.toLowerCase();
+  return DEFAULT_KEEP_ALIVE;
+}
+
 async function callOllamaOnce({ host, model, prompt, num_predict }) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  // Keep model warm between baton reviews to reduce cold-load paid fallbacks.
+  const keepAlive = resolveKeepAlive();
   try {
     const response = await fetch(`${host}/api/generate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model, prompt, stream: false, options: { temperature: 0.3, num_predict } }),
+      body: JSON.stringify({
+        model,
+        prompt,
+        stream: false,
+        keep_alive: keepAlive,
+        options: { temperature: 0.3, num_predict },
+      }),
       signal: controller.signal,
     });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -173,5 +188,5 @@ async function dispatchRedTeam({
 module.exports = {
   dispatchRedTeam, selectModel, loadMatrix, loadTemplate, buildPrompt,
   callWithRetry, parseFindings, stripArxivHallucinations, detectRefusal,
-  TIER, RETRY_DELAYS_MS, MATRIX_PATH,
+  resolveKeepAlive, TIER, RETRY_DELAYS_MS, MATRIX_PATH,
 };

--- a/tests/fleet-red-team-dispatch.spec.js
+++ b/tests/fleet-red-team-dispatch.spec.js
@@ -1,10 +1,18 @@
 // Refs #2175 - tests for fleet-red-team-dispatch
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const fs = require('fs');
-const os = require('os');
 const path = require('path');
-const { loadTemplate, buildPrompt, parseFindings, stripArxivHallucinations, detectRefusal, RETRY_DELAYS_MS, TIER } = require('../scripts/global/fleet-red-team-dispatch.js');
+const {
+  loadTemplate,
+  buildPrompt,
+  parseFindings,
+  stripArxivHallucinations,
+  detectRefusal,
+  callWithRetry,
+  resolveKeepAlive,
+  RETRY_DELAYS_MS,
+  TIER,
+} = require('../scripts/global/fleet-red-team-dispatch.js');
 
 const TEMPLATES_PATH = path.join(__dirname, '..', 'config', 'fleet-red-team-prompts.json');
 
@@ -68,4 +76,46 @@ test('TIER constant is "fleet-local" (per P1-7 #2178)', () => {
 
 test('RETRY_DELAYS_MS is [1000, 4000] per Phase-0 finding', () => {
   assert.deepEqual(RETRY_DELAYS_MS, [1000, 4000]);
+});
+
+test('resolveKeepAlive: defaults to 30m when env is unset/invalid', () => {
+  assert.equal(resolveKeepAlive(undefined), '30m');
+  assert.equal(resolveKeepAlive(''), '30m');
+  assert.equal(resolveKeepAlive('abc'), '30m');
+  assert.equal(resolveKeepAlive('12x'), '30m');
+});
+
+test('resolveKeepAlive: accepts valid env format', () => {
+  assert.equal(resolveKeepAlive('45m'), '45m');
+  assert.equal(resolveKeepAlive('2H'), '2h');
+  assert.equal(resolveKeepAlive('7d'), '7d');
+});
+
+test('callWithRetry: request body includes resolved keep_alive', async () => {
+  const oldFetch = global.fetch;
+  const oldKeepAlive = process.env.FLEET_KEEP_ALIVE;
+  try {
+    let seenPayload = null;
+    global.fetch = async (_url, init) => {
+      seenPayload = JSON.parse(String(init.body));
+      return { ok: true, json: async () => ({ response: 'ACCEPT: ok' }) };
+    };
+
+    delete process.env.FLEET_KEEP_ALIVE;
+    await callWithRetry({ host: 'http://x', model: 'm', prompt: 'p', num_predict: 123 });
+    assert.equal(seenPayload.keep_alive, '30m');
+
+    process.env.FLEET_KEEP_ALIVE = '55m';
+    await callWithRetry({ host: 'http://x', model: 'm', prompt: 'p', num_predict: 123 });
+    assert.equal(seenPayload.keep_alive, '55m');
+
+    process.env.FLEET_KEEP_ALIVE = 'not-valid';
+    await callWithRetry({ host: 'http://x', model: 'm', prompt: 'p', num_predict: 123 });
+    assert.equal(seenPayload.keep_alive, '30m');
+  } finally {
+    if (oldFetch) global.fetch = oldFetch;
+    else delete global.fetch;
+    if (typeof oldKeepAlive === 'undefined') delete process.env.FLEET_KEEP_ALIVE;
+    else process.env.FLEET_KEEP_ALIVE = oldKeepAlive;
+  }
 });


### PR DESCRIPTION
## Summary
- add `resolveKeepAlive()` with `FLEET_KEEP_ALIVE` env override and safe default (`30m`)
- include `keep_alive` in fleet red-team Ollama `/api/generate` payload
- add unit tests for default/override/invalid resolution and payload propagation
- add changelog fragment for #2601

## Validation
- node --test tests/fleet-red-team-dispatch.spec.js
- npm run lint

Refs #2601
merge-evidence-deferred-final: #2601
