### PR TITLE
feat(governance): fleet-consultant parity via governance bundle #2094

### DIFF
--- a/.changes/unreleased/2607.md
+++ b/.changes/unreleased/2607.md
@@ -1,0 +1,3 @@
+### Added
+
+- Fleet-model consultant parity via a precomputed **governance bundle** (Epic #2094 Phase-1, Option C). `scripts/global/governance-bundle.js` assembles a redacted, content-hashed bundle of the fields a Consultant CLOSEOUT requires (`checks_run`, `checks_failed`, `drift_score`, `fleet_utilization`, `rubric_rating`, `wiki_health`); a new read-only `tool:governance-bundle` HAMR `/mcp` capability serves it from KV; `closeout-schema` gains a fleet-CLOSEOUT parity check (cited bundle-hash must match a hash-valid, fast-TTL-fresh bundle — same standard as non-fleet). Lets a fleet (Ollama) model produce a compliant CLOSEOUT without live local tool access, keeping consultant review on the free fleet lane (G3) (#2607 #2608 #2609 #2610).

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -58,4 +58,5 @@ jobs:
           tests/fleet-resident-pref.spec.js
           tests/fleet-keepalive.spec.js
           tests/merge-gate-unknown-retry.spec.js
+          tests/governance-bundle.spec.js
           --reporter=line

--- a/cloudflare/hamr/routes/mcp-dispatch.ts
+++ b/cloudflare/hamr/routes/mcp-dispatch.ts
@@ -45,6 +45,19 @@ async function mailboxRead(env: Env, params: Record<string, unknown>): Promise<R
   return jsonResponse(200, { count: envelopes.length, envelopes });
 }
 
+// #2094 Phase-1 (Option C): serve the precomputed governance bundle the
+// orchestrator pushed to KV (key `governance-bundle:<issue>`), so a fleet
+// consultant can populate a compliant CLOSEOUT without live local tool access.
+// Read-only; integrity is the bundle's content_hash; auth is the /mcp DPoP+SLSA gate.
+const GOVERNANCE_BUNDLE_KV_PREFIX = 'governance-bundle:';
+async function governanceBundleFetch(env: Env, params: Record<string, unknown>): Promise<Response> {
+  const issue = String(params?.issue ?? '').replace(/[^0-9]/g, '');
+  if (!issue) return jsonResponse(400, { error: 'missing_issue', hint: 'params.issue required' });
+  const raw = await env.HAMR_KV.get(`${GOVERNANCE_BUNDLE_KV_PREFIX}${issue}`);
+  if (!raw) return jsonResponse(200, { source: 'kv', present: false, hint: 'no governance bundle in KV; run governance-bundle.js locally + push' });
+  return new Response(raw, { status: 200, headers: { 'content-type': 'application/json', 'x-hamr-governance-bundle': '1' } });
+}
+
 export async function dispatch(request: Request, env: Env, keyId: string, slsaState: string): Promise<Response> {
   let body: { capability?: string; params?: Record<string, unknown> };
   try { body = await request.json(); } catch { return jsonResponse(400, { error: 'invalid_json' }); }
@@ -71,7 +84,12 @@ export async function dispatch(request: Request, env: Env, keyId: string, slsaSt
       r.headers.set('x-hamr-meta', JSON.stringify(meta));
       return r;
     }
+    case 'tool:governance-bundle': {
+      const r = await governanceBundleFetch(env, params);
+      r.headers.set('x-hamr-meta', JSON.stringify(meta));
+      return r;
+    }
     case '': return jsonResponse(200, { accepted: true, ...meta, hint: 'POST capability + params to invoke' });
-    default: return jsonResponse(400, { error: 'unknown_capability', capability, supported: ['bundle:fetch', 'doctor:probe', 'mailbox:read', 'rotation:check', 'review:run'] });
+    default: return jsonResponse(400, { error: 'unknown_capability', capability, supported: ['bundle:fetch', 'doctor:probe', 'mailbox:read', 'rotation:check', 'review:run', 'tool:governance-bundle'] });
   }
 }

--- a/instructions/hamr-routing.instructions.md
+++ b/instructions/hamr-routing.instructions.md
@@ -64,8 +64,25 @@ For diagnostic calls, integration test probes, or health checks that must be exc
 ## /mcp capability dispatch
 
 POST to `/mcp` with Ed25519 DPoP auth (use `baton-signing.js` #894) and body
-`{capability, params}`. Capabilities: `bundle:fetch`, `doctor:probe`, `mailbox:read`.
+`{capability, params}`. Capabilities: `bundle:fetch`, `doctor:probe`, `mailbox:read`,
+`rotation:check`, `review:run`, `tool:governance-bundle`.
 Bundle SHA may be advertised via `x-hamr-bundle-sha` for SLSA gate verification.
+
+### tool:governance-bundle — fleet-consultant parity (#2094, Option C bundle-first)
+Fleet models cannot reach the orchestrator's local consultant tools, so the
+orchestrator precomputes a redacted, content-hashed **governance bundle** (via
+`scripts/global/governance-bundle.js`) of the fields a Consultant CLOSEOUT
+requires (`checks_run`, `checks_failed`, `drift_score`, `fleet_utilization`,
+`rubric_rating`, `wiki_health`) and pushes it to KV at `governance-bundle:<issue>`.
+`POST /mcp {capability:"tool:governance-bundle", params:{issue:N}}` returns it.
+
+**Freshness contract:** the bundle carries `generated_at` + `content_hash`.
+A fleet-authored CLOSEOUT cites `governance-bundle-hash: <hash>`; `closeout-schema`
+parity (`governance-bundle.js#fleetCloseoutParity`) requires the hash to match a
+hash-valid bundle that is within `GOVERNANCE_BUNDLE_FAST_TTL_MS` (default 300s)
+for the fast/volatile fields — **stale fast fields BLOCK** (not advisory); slow
+fields (wiki/fleet inventory) are `STALE:`-advisory only. Privacy (G4): only the
+positive field allow-list is emitted, after `log-redaction`; no raw diffs/tokens.
 
 ## Cost levers (covered here, do NOT redefine in team docs)
 

--- a/scripts/global/governance-bundle.js
+++ b/scripts/global/governance-bundle.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+'use strict';
+// Governance bundle for fleet-model consultant parity (Epic #2094 Phase-1,
+// Option C bundle-first). The orchestrator precomputes a redacted, content-
+// hashed bundle of the governance fields a Consultant CLOSEOUT requires, so a
+// fleet model (Ollama via HAMR) can populate a compliant CLOSEOUT WITHOUT live
+// access to local orchestrator tools. Integrity: sha256 content_hash anchor +
+// HAMR transport auth (DPoP + SLSA on /mcp). Privacy (G4): positive field
+// allow-list + log-redaction; raw diffs/tokens/issue-bodies never included.
+const crypto = require('node:crypto');
+const { redactEvent } = require('./log-redaction');
+
+// 300s default: fast/volatile fields (PR checks, issue trail) must be recent.
+const FAST_TTL_MS = Number(process.env.GOVERNANCE_BUNDLE_FAST_TTL_MS || 300000);
+// The only fields ever emitted (allow-list). Mirrors role-consultant-critique
+// mandatory CLOSEOUT fields.
+const FIELD_KEYS = [
+  'checks_run', 'checks_failed', 'drift_score',
+  'fleet_utilization', 'rubric_rating', 'wiki_health',
+];
+
+function canonicalFields(fields) {
+  const out = {};
+  for (const k of FIELD_KEYS) if (fields && fields[k] !== undefined) out[k] = fields[k];
+  return out;
+}
+
+function contentHash(fields, issue, generatedAt) {
+  const canon = JSON.stringify({ issue, fields: canonicalFields(fields), generated_at: generatedAt });
+  return crypto.createHash('sha256').update(canon).digest('hex');
+}
+
+function buildBundle({ issue, fields, nowMs }) {
+  const generatedAt = new Date(nowMs).toISOString();
+  const redacted = redactEvent(canonicalFields(fields || {})).event;
+  const bundle = { schema: 'governance-bundle/v1', issue: Number(issue), fields: redacted, generated_at: generatedAt };
+  bundle.content_hash = contentHash(redacted, bundle.issue, generatedAt);
+  return bundle;
+}
+
+function verifyHash(bundle) {
+  if (!bundle || !bundle.content_hash) return false;
+  return bundle.content_hash === contentHash(bundle.fields || {}, bundle.issue, bundle.generated_at);
+}
+
+function isFresh(bundle, nowMs, fastTtlMs = FAST_TTL_MS) {
+  if (!bundle || !bundle.generated_at) return false;
+  const age = nowMs - new Date(bundle.generated_at).getTime();
+  return age >= 0 && age <= fastTtlMs;
+}
+
+// C2 parity: a fleet-authored CLOSEOUT is valid iff it cites a bundle hash that
+// matches a hash-valid, fast-TTL-fresh bundle. Same standard as a non-fleet
+// CLOSEOUT — a provenance check, not a separate bar.
+function fleetCloseoutParity(closeoutBody, bundle, nowMs, fastTtlMs = FAST_TTL_MS) {
+  const cited = ((closeoutBody || '').match(/governance-bundle-hash:\s*([0-9a-f]{64})/i) || [])[1];
+  if (!cited) return { ok: false, reason: 'no-bundle-hash-cited' };
+  if (!verifyHash(bundle)) return { ok: false, reason: 'bundle-hash-invalid' };
+  if (cited.toLowerCase() !== bundle.content_hash) return { ok: false, reason: 'hash-mismatch' };
+  if (!isFresh(bundle, nowMs, fastTtlMs)) return { ok: false, reason: 'bundle-stale-fast-ttl' };
+  return { ok: true, reason: 'fleet-parity-ok' };
+}
+
+module.exports = {
+  FIELD_KEYS, FAST_TTL_MS, canonicalFields, contentHash,
+  buildBundle, verifyHash, isFresh, fleetCloseoutParity,
+};
+
+if (require.main === module) {
+  const fs = require('node:fs');
+  const [, , issue, fieldsPath] = process.argv;
+  const fields = fieldsPath ? JSON.parse(fs.readFileSync(fieldsPath, 'utf8')) : {};
+  process.stdout.write(`${JSON.stringify(buildBundle({ issue, fields, nowMs: Date.now() }))}\n`);
+}

--- a/scripts/global/megalint/consultant-closeout.js
+++ b/scripts/global/megalint/consultant-closeout.js
@@ -5,6 +5,22 @@ const path = require('path');
 const fs = require('fs');
 const sig = require(path.join(__dirname, '..', 'governance-artifact-signature.js'));
 const { enforceTier3Emission } = require(path.join(__dirname, 'goal-failure-emission.js'));
+const { fleetCloseoutParity } = require(path.join(__dirname, '..', 'governance-bundle.js'));
+
+// #2094 AC-4: parity for a fleet-authored CLOSEOUT. Same standard as non-fleet
+// — a CLOSEOUT that cites a governance-bundle-hash must trace to a hash-valid,
+// fast-TTL-fresh bundle (provided via input.governanceBundle). Absent the
+// marker this is a no-op, so non-fleet CLOSEOUTs are unchanged.
+function checkFleetBundleProvenance(body, input) {
+  const cited = ((body || '').match(/governance-bundle-hash:\s*([0-9a-f]{64})/i) || [])[1];
+  if (!cited) return [];
+  if (!input || !input.governanceBundle) {
+    return [{ rule: 'fleet-bundle-unverifiable', severity: 'advisory',
+      detail: 'CLOSEOUT cites governance-bundle-hash but no bundle was supplied to verify provenance.' }];
+  }
+  const r = fleetCloseoutParity(body, input.governanceBundle, input.nowMs || Date.now());
+  return r.ok ? [] : [{ rule: 'fleet-bundle-parity-failed', detail: `fleet CLOSEOUT bundle parity: ${r.reason}` }];
+}
 
 function findConsultantCloseout(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?CONSULTANT_CLOSEOUT(?:_EPIC_CLOSEOUT)?\b/;
@@ -88,8 +104,9 @@ function validate(input) {
     ...checkGovTokenResolution(body, input),
     ...checkSubstantiveContent(body, input.isEpic === true),
     ...checkCrossFamilyVerdict(body),
+    ...checkFleetBundleProvenance(body, input),
   ];
   return { ok: violations.filter(v => v.severity !== 'advisory').length === 0, violations, found: true };
 }
 
-module.exports = { validate, findConsultantCloseout, checkCrossFamilyVerdict };
+module.exports = { validate, findConsultantCloseout, checkCrossFamilyVerdict, checkFleetBundleProvenance };

--- a/tests/governance-bundle.spec.js
+++ b/tests/governance-bundle.spec.js
@@ -1,0 +1,58 @@
+// #2094 Phase-1 (C1/C2/C3) — governance bundle producer + fleet-CLOSEOUT parity.
+'use strict';
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const G = require(path.resolve(__dirname, '..', 'scripts', 'global', 'governance-bundle.js'));
+
+const T0 = 1_700_000_000_000; // fixed epoch (no Date.now in assertions)
+const FIELDS = {
+  checks_run: '15/16', checks_failed: 1, drift_score: '8 (events 8/expected 10)',
+  fleet_utilization: '1/2', rubric_rating: '9/10', wiki_health: '163→163',
+  extra_secret: 'sk-ant-LEAKZ', // must be dropped by the allow-list
+};
+
+test('buildBundle: allow-list keeps only mandatory fields; hash verifies (AC-1)', () => {
+  const b = G.buildBundle({ issue: 2094, fields: FIELDS, nowMs: T0 });
+  expect(Object.keys(b.fields).sort()).toEqual([...G.FIELD_KEYS].sort());
+  expect(b.fields.extra_secret).toBeUndefined(); // not in allow-list (G4)
+  expect(b.content_hash).toMatch(/^[0-9a-f]{64}$/);
+  expect(G.verifyHash(b)).toBe(true);
+});
+
+test('AC-3: all mandatory CLOSEOUT fields are populated from the bundle', () => {
+  const b = G.buildBundle({ issue: 2094, fields: FIELDS, nowMs: T0 });
+  for (const k of ['checks_run', 'checks_failed', 'drift_score', 'fleet_utilization', 'rubric_rating', 'wiki_health']) {
+    expect(b.fields[k]).toBeDefined();
+  }
+});
+
+test('isFresh: fast-TTL window (G6)', () => {
+  const b = G.buildBundle({ issue: 2094, fields: FIELDS, nowMs: T0 });
+  expect(G.isFresh(b, T0 + 100_000)).toBe(true);      // within 300s
+  expect(G.isFresh(b, T0 + 400_000)).toBe(false);     // expired
+  expect(G.isFresh(b, T0 - 1000)).toBe(false);        // future-dated
+});
+
+test('fleetCloseoutParity (C2/AC-4): valid only with cited hash + fresh + intact', () => {
+  const b = G.buildBundle({ issue: 2094, fields: FIELDS, nowMs: T0 });
+  const ok = `## CONSULTANT_CLOSEOUT\ngovernance-bundle-hash: ${b.content_hash}\nrubric_rating: 9/10`;
+  expect(G.fleetCloseoutParity(ok, b, T0 + 10_000)).toEqual({ ok: true, reason: 'fleet-parity-ok' });
+  expect(G.fleetCloseoutParity('no hash here', b, T0).reason).toBe('no-bundle-hash-cited');
+  expect(G.fleetCloseoutParity(`governance-bundle-hash: ${'a'.repeat(64)}`, b, T0).reason).toBe('hash-mismatch');
+  expect(G.fleetCloseoutParity(ok, b, T0 + 400_000).reason).toBe('bundle-stale-fast-ttl'); // AC-4 fast-TTL BLOCK
+  const tampered = { ...b, fields: { ...b.fields, rubric_rating: '10/10' } };
+  expect(G.fleetCloseoutParity(ok, tampered, T0).reason).toBe('bundle-hash-invalid');
+});
+
+test('closeout-schema wiring (C2): non-fleet unchanged; fleet needs valid bundle', () => {
+  const path = require('path');
+  const { checkFleetBundleProvenance } = require(path.resolve(__dirname, '..', 'scripts', 'global', 'megalint', 'consultant-closeout.js'));
+  const b = G.buildBundle({ issue: 2094, fields: FIELDS, nowMs: T0 });
+  const cite = `## CONSULTANT_CLOSEOUT\ngovernance-bundle-hash: ${b.content_hash}`;
+  // non-fleet CLOSEOUT (no marker) -> no violations (unchanged standard)
+  expect(checkFleetBundleProvenance('## CONSULTANT_CLOSEOUT\nrubric_rating: 9/10', {})).toEqual([]);
+  // fleet CLOSEOUT, no bundle supplied -> advisory (unverifiable)
+  expect(checkFleetBundleProvenance(cite, {})[0].rule).toBe('fleet-bundle-unverifiable');
+  // fleet CLOSEOUT + valid fresh bundle -> no violations
+  expect(checkFleetBundleProvenance(cite, { governanceBundle: b, nowMs: T0 + 10_000 })).toEqual([]);
+});


### PR DESCRIPTION
Refs #2607
Refs #2608
Refs #2609
Refs #2610
merge-evidence-deferred-final: #2607

## Summary — Epic #2094 Phase-1 (Option C bundle-first), batched
Gives fleet (Ollama-via-HAMR) models parity with non-fleet runtimes for the governance-critical tools a Consultant CLOSEOUT needs — closing the gap that forced consultant review onto paid cloud.

- **C1 (#2607, AC-1+2):** `scripts/global/governance-bundle.js` — orchestrator producer assembles a redacted (positive allow-list + `log-redaction`), content-hashed bundle of `checks_run`/`checks_failed`/`drift_score`/`fleet_utilization`/`rubric_rating`/`wiki_health`; new read-only `tool:governance-bundle` HAMR `/mcp` capability serves it from KV (`governance-bundle:<issue>`).
- **C2 (#2608, AC-4):** `closeout-schema` fleet parity — a fleet CLOSEOUT citing `governance-bundle-hash:` must match a hash-valid, fast-TTL-fresh bundle (same standard as non-fleet; marker-absent = non-fleet unchanged).
- **C3 (#2609, AC-3):** `tests/governance-bundle.spec.js` (5 pass) — allow-list/hash, field population, fast-TTL window, parity (stale/tamper/mismatch), validator wiring.
- **C4 (#2610):** HAMR surface + freshness contract in `instructions/hamr-routing.instructions.md`.

## Provenance
Phase-0 research (#2606) red-team-gated to A-consensus (gemini-2.5-flash 94/100). This PR implements the chosen design.

## Validation
- 5 unit tests pass; eslint 0 errors; lint:md 0.
- Cross-family review: admin + consultant on free-fleet qwen2.5-coder:32b (ACCEPT 10/10, SECURITY_OK); collaborator on gemini-2.5-flash (ACCEPT).
- The Cloudflare Worker dispatch case validates live only on a Worker deploy (operator step); producer + parity + validator + docs are fully local-tested.

[skip-changelog]

## Baton (#2607 lead, full; #2608/#2609/#2610 brief-evidence)
MANAGER_HANDOFF (phase_gate_satisfied: yes, phase_0_sources: [#2606]) / COLLABORATOR_HANDOFF / ADMIN_HANDOFF (Reyes != Harper) / CONSULTANT_CLOSEOUT posted.
