### PR TITLE
fix(governance): reject mixed role fields

### DIFF
--- a/.changes/unreleased/2348.md
+++ b/.changes/unreleased/2348.md
@@ -1,0 +1,2 @@
+### Fixed
+- Reject duplicate canonical Role: fields in baton artifacts so mixed semantic-role misuse is caught by the signer registry path and surfaced through baton artifact governance.

--- a/scripts/global/baton-artifact-governance.js
+++ b/scripts/global/baton-artifact-governance.js
@@ -47,6 +47,7 @@ function fixable(rule) {
     'artifact-role-mismatch',
     'signer-alias-not-registry-derived',
     'signer-fields-invalid',
+    'mixed-semantic-role-fields',
   ].includes(rule);
 }
 

--- a/scripts/global/megalint/signer-registry-check.js
+++ b/scripts/global/megalint/signer-registry-check.js
@@ -47,23 +47,39 @@ function expectedAliasFor({ team, model, role, device, registryOverride }) {
 
 function extractArtifactFields(body) {
   const text = body || '';
-  const field = (label, value) => {
-    const pattern = new RegExp(`(?:^|[·,\\n])\\s*${label}\\s*:\\s*(${value})`, 'gm');
-    const matches = [...text.matchAll(pattern)];
-    return matches.length ? matches[matches.length - 1][1] : null;
-  };
-  const signedBy = field('Signed-by', '[^·,\\n]+');
-  const teamModel = field('Team&Model', '\\S+');
-  const role = field('Role', '\\w+');
+  const signedByMatches = [...text.matchAll(/(?:^|[·,\n])\s*Signed-by\s*:\s*([^·,\n]+)/gm)].map(match => match[1].trim());
+  const teamModelMatches = [...text.matchAll(/(?:^|[·,\n])\s*Team&Model\s*:\s*([^·,\n]+)/gm)].map(match => match[1].trim());
+  const roleMatches = [...text.matchAll(/(?:^|[·,\n])\s*Role\s*:\s*(\w+)/gm)].map(match => match[1].trim().toLowerCase());
   return {
-    signedBy: signedBy ? signedBy.trim() : null,
-    teamModel,
-    role: role ? role.toLowerCase() : null,
+    signedBy: signedByMatches.length ? signedByMatches[signedByMatches.length - 1] : null,
+    teamModel: teamModelMatches.length ? teamModelMatches[teamModelMatches.length - 1] : null,
+    role: roleMatches.length ? roleMatches[roleMatches.length - 1] : null,
+    roleMatches,
   };
 }
 
 function validateArtifactAlias(body, opts = {}) {
   const fields = extractArtifactFields(body);
+  if (fields.roleMatches.length > 1) {
+    return {
+      ok: false,
+      fields,
+      violation: {
+        rule: 'mixed-semantic-role-fields',
+        detail: `Multiple Role: fields found (${fields.roleMatches.join(', ')}) — keep one execution role per baton artifact.`,
+      },
+    };
+  }
+  if (fields.roleMatches.length > 1) {
+    return {
+      ok: false,
+      fields,
+      violation: {
+        rule: 'mixed-semantic-role-fields',
+        detail: `Multiple Role: fields found (${fields.roleMatches.join(', ')}) — keep one execution role per baton artifact.`,
+      },
+    };
+  }
   if (!fields.signedBy || !fields.teamModel || !fields.role) {
     return { ok: true, skipped: 'missing-required-fields', fields };
   }

--- a/tests/baton-artifact-governance.spec.js
+++ b/tests/baton-artifact-governance.spec.js
@@ -37,6 +37,28 @@ test('fails on artifact-role mismatch', () => {
   expect(r.violations.some(v => v.rule === 'artifact-role-mismatch')).toBe(true);
 });
 
+test('fails on duplicate Role fields as mixed semantic-role misuse', () => {
+  const comments = [{
+    body: [
+      '## MANAGER_HANDOFF',
+      'Signed-by: Orla Mason',
+      'Team&Model: codex:gpt-5.4@codex-cli',
+      'Role: manager',
+      'Role: collaborator',
+    ].join('\n'),
+  }];
+  const r = G.analyzeComments(comments);
+  expect(r.ok).toBe(false);
+  expect(r.violations.some(v => v.rule === 'mixed-semantic-role-fields')).toBe(true);
+});
+
+test('fails on duplicate Role fields without signer metadata', () => {
+  const comments = [{ body: '## MANAGER_HANDOFF\nRole: manager\nRole: collaborator' }];
+  const r = G.analyzeComments(comments);
+  expect(r.ok).toBe(false);
+  expect(r.violations.some(v => v.rule === 'mixed-semantic-role-fields')).toBe(true);
+});
+
 test('source-fixable role mismatch carries source-edit-first guidance', () => {
   const comments = [{
     body: [

--- a/tests/megalint/signer-registry-check.spec.js
+++ b/tests/megalint/signer-registry-check.spec.js
@@ -74,6 +74,28 @@ test('extractArtifactFields: ignores prose lowercase role before signature', () 
   ].join('\n');
   const fields = R.extractArtifactFields(body);
   expect(fields.role).toBe('manager');
+  expect(fields.roleMatches).toEqual(['manager']);
+});
+
+test('validateArtifactAlias: duplicate Role fields are rejected as mixed semantic-role misuse', () => {
+  const file = makeRegistry();
+  const body = [
+    'Signed-by: Orla Mason',
+    'Team&Model: claude-code:opus-4-7@anthropic',
+    'Role: manager',
+    'Role: collaborator',
+  ].join('\n');
+  const result = R.validateArtifactAlias(body, { registryOverride: file });
+  expect(result.ok).toBe(false);
+  expect(result.violation.rule).toBe('mixed-semantic-role-fields');
+  expect(result.violation.detail).toContain('Multiple Role: fields found');
+  fs.unlinkSync(file);
+});
+
+test('validateArtifactAlias: duplicate Role fields without signer metadata still reject', () => {
+  const result = R.validateArtifactAlias('Role: manager\nRole: collaborator');
+  expect(result.ok).toBe(false);
+  expect(result.violation.rule).toBe('mixed-semantic-role-fields');
 });
 
 test('validateArtifactAlias: drift "Cole Mason" on claude-code:opus → violation with expected="Orla Mason"', () => {


### PR DESCRIPTION
Refs #2348
merge-evidence-deferred-final: #2348

## Summary
- reject duplicate canonical `Role:` fields as `mixed-semantic-role-fields` in signer-registry validation
- keep duplicate-role detection independent of signer metadata presence to close the missing-fields bypass
- propagate the new rule as source-edit-first remediation in baton artifact governance
- add regression coverage for duplicate-role misuse with and without signer metadata
- add changelog fragment `.changes/unreleased/2348.md`

## Validation
- `npx playwright test tests/megalint/signer-registry-check.spec.js tests/baton-artifact-governance.spec.js --reporter=line` (pass)
- `npm run lint` (pass)
- `npm test` currently has unrelated baseline stress failures in this branch context:
  - `stress: full admin baton across 50 iterations auto-emits roles.admin every time`
  - `stress: 50 sequential invocations all return null when feature off, p99 < 200ms`
  - `stress: 4 teams competing — sentinel fast-path when feature off, no contention`

## Fleet/Cross-model Review
- fleet dispatcher invoked for collaborator/admin/consultant review contexts; host path unavailable in-session (`hostOk=false`), model fallback `qwen2.5-coder:7b`
- independent runtime probes confirmed duplicate-role rejection for both mixed-role and same-role duplicates
