### PR TITLE
feat(governance): operationalize governance-bundle producer-push #2613

### DIFF
--- a/.changes/unreleased/2613.md
+++ b/.changes/unreleased/2613.md
@@ -1,0 +1,3 @@
+### Added
+
+- Orchestrator producer-push that operationalizes the #2094 governance bundle: `scripts/global/governance-bundle-push.js` (+ `npm run hamr:governance-bundle-push -- --issue N`) reads a per-issue governance-fields snapshot, builds the redacted + content-hashed bundle, signs it with the operator Ed25519 key, and POSTs it to the new HAMR `/governance-bundle` write route, which stores `governance-bundle:<issue>` in KV for the read-only `tool:governance-bundle` dispatch to serve. This makes fleet-consultant parity live — a fleet (free) model can self-attest a compliant CLOSEOUT instead of escalating to paid cloud (G3) (#2613).

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -59,4 +59,5 @@ jobs:
           tests/fleet-keepalive.spec.js
           tests/merge-gate-unknown-retry.spec.js
           tests/governance-bundle.spec.js
+          tests/governance-bundle-push.spec.js
           --reporter=line

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ npm run deploy:both:apply
 | `hamr:doctor` | `node scripts/global/hamr-doctor.js` |
 | `hamr:fleet-cascade-gate` | `node scripts/global/fleet-cascade-gate.js` |
 | `hamr:fleet-cascade-gate:test` | `node --test tests/fleet-cascade-gate.spec.js` |
+| `hamr:governance-bundle-push` | `node scripts/global/governance-bundle-push.js` |
 | `hamr:health` | `node scripts/global/substrate-health.js` |
 | `hamr:health-push` | `node scripts/global/substrate-health-push.js` |
 | `hamr:install-cron` | `bash scripts/global/install-cron.sh` |

--- a/cloudflare/hamr/routes/governance-bundle.ts
+++ b/cloudflare/hamr/routes/governance-bundle.ts
@@ -1,0 +1,59 @@
+// HAMR /governance-bundle — Worker KV writer for governance-bundle:<issue> (#2613).
+// Mirrors the /substrate-health producer pattern (#943): DPoP + Ed25519-signed
+// POST from the orchestrator; writes the bundle the read-only tool:governance-bundle
+// dispatch (#2094) serves to fleet consultants. Operationalizes Epic #2094.
+import type { Env } from '../worker';
+
+function unauthorized(reason: string): Response {
+  return new Response(JSON.stringify({ error: 'unauthorized', reason }), {
+    status: 401, headers: { 'content-type': 'application/json' },
+  });
+}
+
+function badRequest(reason: string): Response {
+  return new Response(JSON.stringify({ error: 'bad_request', reason }), {
+    status: 400, headers: { 'content-type': 'application/json' },
+  });
+}
+
+function decodeKeyring(env: Env): Record<string, string> | null {
+  if (!env.PUBLISHER_KEYRING) return null;
+  try { return JSON.parse(env.PUBLISHER_KEYRING) as Record<string, string>; } catch { return null; }
+}
+
+async function verifyEd25519(spkiB64: string, canonical: string, sigB64: string): Promise<boolean> {
+  try {
+    const spki = Uint8Array.from(atob(spkiB64), (c) => c.charCodeAt(0));
+    const data = new TextEncoder().encode(canonical);
+    const sig = Uint8Array.from(atob(sigB64), (c) => c.charCodeAt(0));
+    const key = await crypto.subtle.importKey('spki', spki, { name: 'Ed25519' }, false, ['verify']);
+    return await crypto.subtle.verify('Ed25519', key, sig, data);
+  } catch { return false; }
+}
+
+export async function governanceBundleWrite(request: Request, env: Env): Promise<Response> {
+  const auth = request.headers.get('authorization') ?? '';
+  if (!auth.startsWith('DPoP ')) return unauthorized('missing_dpop');
+  const sigHeader = request.headers.get('x-hamr-signature') ?? '';
+  const keyId = request.headers.get('x-hamr-key-id') ?? '';
+  const canonical = request.headers.get('x-hamr-canonical') ?? '';
+  if (!sigHeader || !keyId || !canonical) return unauthorized('missing_signature_headers');
+
+  const keyring = decodeKeyring(env);
+  if (!keyring) return unauthorized('no_publisher_keyring_configured');
+  const spkiB64 = keyring[keyId];
+  if (!spkiB64) return unauthorized('unknown_key_id');
+  if (!await verifyEd25519(spkiB64, canonical, sigHeader)) return unauthorized('bad_signature');
+
+  let bundle: { issue?: number; content_hash?: string; schema?: string };
+  try { bundle = await request.json(); } catch { return badRequest('invalid_json'); }
+  if (!Number.isInteger(bundle.issue)) return badRequest('issue_required');
+  if (!bundle.content_hash || !/^[0-9a-f]{64}$/.test(bundle.content_hash)) return badRequest('content_hash_required');
+  if (bundle.schema !== 'governance-bundle/v1') return badRequest('unsupported_schema');
+
+  const key = `governance-bundle:${bundle.issue}`;
+  await env.HAMR_KV.put(key, canonical);
+  return new Response(JSON.stringify({ ok: true, written: key, content_hash: bundle.content_hash }), {
+    status: 200, headers: { 'content-type': 'application/json' },
+  });
+}

--- a/cloudflare/hamr/worker.ts
+++ b/cloudflare/hamr/worker.ts
@@ -8,6 +8,7 @@ import { mailboxRead, mailboxWrite } from './routes/mailbox';
 import { quota } from './routes/quota';
 import { cacheStats } from './routes/cache-stats';
 import { substrateHealth } from './routes/substrate-health';
+import { governanceBundleWrite } from './routes/governance-bundle';
 import { mergeClaimAcquire, mergeClaimRelease, mergeClaimStatus } from './routes/merge-claim';
 import { fleetClaimAcquire, fleetClaimRelease, fleetInFlight } from './routes/fleet';
 import { scheduled as scheduledHandler } from './scheduled';
@@ -75,6 +76,7 @@ export default {
       }
       else if (url.pathname === '/cache-stats' && m === 'POST') res = await cacheStats(request, env);
       else if (url.pathname === '/substrate-health' && m === 'POST') res = await substrateHealth(request, env);
+      else if (url.pathname === '/governance-bundle' && m === 'POST') res = await governanceBundleWrite(request, env);
       else res = notFound();
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'internal_error';

--- a/instructions/hamr-routing.instructions.md
+++ b/instructions/hamr-routing.instructions.md
@@ -76,6 +76,8 @@ requires (`checks_run`, `checks_failed`, `drift_score`, `fleet_utilization`,
 `rubric_rating`, `wiki_health`) and pushes it to KV at `governance-bundle:<issue>`.
 `POST /mcp {capability:"tool:governance-bundle", params:{issue:N}}` returns it.
 
+**Producer (#2613):** `npm run hamr:governance-bundle-push -- --issue N` (=`scripts/global/governance-bundle-push.js`) reads the per-issue fields snapshot at `~/.megingjord/governance-fields-<issue>.json`, builds + Ed25519-signs the bundle, and POSTs it to the HAMR `/governance-bundle` write route (DPoP + signed, mirrors `/substrate-health`), which stores `governance-bundle:<issue>` in KV. Run it before dispatching a fleet consultant for that issue.
+
 **Freshness contract:** the bundle carries `generated_at` + `content_hash`.
 A fleet-authored CLOSEOUT cites `governance-bundle-hash: <hash>`; `closeout-schema`
 parity (`governance-bundle.js#fleetCloseoutParity`) requires the hash to match a

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "hamr:fleet-cascade-gate:test": "node --test tests/fleet-cascade-gate.spec.js",
     "hamr:health": "node scripts/global/substrate-health.js",
     "hamr:health-push": "node scripts/global/substrate-health-push.js",
+    "hamr:governance-bundle-push": "node scripts/global/governance-bundle-push.js",
     "hamr:install-cron": "bash scripts/global/install-cron.sh",
     "hamr:log-rotate": "node scripts/global/log-rotate.js",
     "hamr:multi-judge:test": "node --test tests/multi-judge-prompts.spec.js tests/multi-judge-variance.spec.js tests/multi-judge-orchestrator.spec.js",

--- a/scripts/global/governance-bundle-push.js
+++ b/scripts/global/governance-bundle-push.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// governance-bundle-push.js — operationalizes Epic #2094. Reads a precomputed
+// per-issue governance-fields snapshot, builds the redacted + content-hashed
+// bundle (governance-bundle.js), signs it with the operator Ed25519 key, and
+// POSTs to HAMR for KV storage at `governance-bundle:<issue>` — so the
+// read-only tool:governance-bundle dispatch (#2094) serves real data and a
+// fleet model can self-attest a compliant Consultant CLOSEOUT (free-fleet, G3).
+// Mirrors the substrate-health-push.js producer pattern; graceful no-op (G6)
+// when the fields snapshot or operator key is unavailable.
+'use strict';
+require('dotenv').config({ quiet: true });
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { buildBundle } = require('./governance-bundle');
+const { loadEd25519Key } = require('./substrate-health-push');
+
+const DEFAULT_HAMR_URL = process.env.HAMR_URL || 'https://hamr.chf3198.workers.dev';
+const KEY_ID = process.env.OPERATOR_KEY_ID || 'operator-default';
+
+// Snapshot written by the orchestrator's consultant-checks + rubric-score run
+// for a given issue (the gathered FIELD_KEYS values). Mirrors substrate-health's
+// precomputed HEALTH_FILE rather than shelling out inline (keeps push pure).
+function fieldsFile(issue) {
+  return path.join(os.homedir(), '.megingjord', `governance-fields-${issue}.json`);
+}
+
+function readFields(issue) {
+  const f = fieldsFile(issue);
+  if (!fs.existsSync(f)) return null;
+  try { return JSON.parse(fs.readFileSync(f, 'utf8')); } catch { return null; }
+}
+
+async function pushBundle(opts = {}) {
+  const url = opts.url || DEFAULT_HAMR_URL;
+  const issue = opts.issue;
+  if (!issue) return { ok: false, reason: 'no_issue' };
+  const fields = opts.fields || readFields(issue);
+  if (!fields) return { ok: false, reason: 'no_fields_snapshot' };
+  const bundle = buildBundle({ issue, fields, nowMs: opts.nowMs || Date.now() });
+  // Deterministic serialization (buildBundle emits keys in a fixed order; the
+  // bundle's own content_hash anchors field integrity). NOT a replacer-array —
+  // that would strip nested `fields` values from the signed/pushed payload.
+  const canonical = JSON.stringify(bundle);
+  let sig;
+  try { sig = crypto.sign(null, Buffer.from(canonical), opts.key || loadEd25519Key()).toString('base64'); }
+  catch { return { ok: false, reason: 'no_operator_key' }; }
+  const doFetch = opts.fetchImpl || fetch;
+  const resp = await doFetch(`${url}/governance-bundle`, {
+    method: 'POST',
+    headers: {
+      authorization: 'DPoP governance-bundle-push', 'content-type': 'application/json',
+      'x-hamr-key-id': KEY_ID, 'x-hamr-signature': sig, 'x-hamr-canonical': canonical,
+    },
+    body: canonical,
+  });
+  const data = await resp.json().catch(() => ({}));
+  return { ok: resp.ok, status: resp.status, issue: Number(issue), content_hash: bundle.content_hash, response: data };
+}
+
+if (require.main === module) {
+  const i = process.argv.indexOf('--issue');
+  const issue = i >= 0 ? process.argv[i + 1] : null;
+  pushBundle({ issue }).then((r) => {
+    console.log(JSON.stringify(r, null, 2));
+    process.exit(r.ok ? 0 : 1);
+  }).catch((err) => { console.error(err.message); process.exit(1); });
+}
+
+module.exports = { pushBundle, readFields, fieldsFile };

--- a/tests/governance-bundle-push.spec.js
+++ b/tests/governance-bundle-push.spec.js
@@ -1,0 +1,41 @@
+// #2613 — governance-bundle producer-push (operationalizes #2094).
+'use strict';
+const { test, expect } = require('@playwright/test');
+const crypto = require('node:crypto');
+const path = require('path');
+const P = require(path.resolve(__dirname, '..', 'scripts', 'global', 'governance-bundle-push.js'));
+
+const FIELDS = {
+  checks_run: '15/16', checks_failed: 1, drift_score: '8/10',
+  fleet_utilization: '1/2', rubric_rating: '9/10', wiki_health: '163→163',
+  extra_secret: 'sk-ant-LEAK', // must be dropped by the bundle allow-list (G4)
+};
+
+test('graceful no-op: no issue / no fields snapshot (G6)', async () => {
+  expect((await P.pushBundle({})).reason).toBe('no_issue');
+  expect((await P.pushBundle({ issue: 999999321 })).reason).toBe('no_fields_snapshot');
+});
+
+test('builds + signs + POSTs the bundle to /governance-bundle; allow-list enforced', async () => {
+  const { privateKey } = crypto.generateKeyPairSync('ed25519');
+  let captured = null;
+  const fetchImpl = async (url, init) => {
+    captured = { url, init };
+    return { ok: true, status: 200, json: async () => ({ stored: true }) };
+  };
+  const r = await P.pushBundle({ issue: 2094, fields: FIELDS, key: privateKey, fetchImpl, nowMs: 1_700_000_000_000, url: 'https://hamr.test' });
+  expect(r.ok).toBe(true);
+  expect(r.content_hash).toMatch(/^[0-9a-f]{64}$/);
+  expect(captured.url).toBe('https://hamr.test/governance-bundle');
+  expect(captured.init.method).toBe('POST');
+  expect(captured.init.headers['x-hamr-signature']).toBeTruthy();
+  const body = JSON.parse(captured.init.body);
+  expect(body.content_hash).toBe(r.content_hash);
+  expect(body.fields.extra_secret).toBeUndefined();        // allow-list dropped it (G4)
+  expect(body.fields.rubric_rating).toBe('9/10');           // mandatory field carried
+  // signature verifies against the canonical body with the operator public key
+  const canonical = JSON.stringify(body);
+  const ok = crypto.verify(null, Buffer.from(canonical), crypto.createPublicKey(privateKey),
+    Buffer.from(captured.init.headers['x-hamr-signature'], 'base64'));
+  expect(ok).toBe(true);
+});


### PR DESCRIPTION
Refs #2613
merge-evidence-deferred-final: #2613

## Summary (G3 — operationalizes Epic #2094)
The #2094 bundle assembler + read-only `tool:governance-bundle` dispatch existed, but nothing produced/published a bundle — so fleet-consultant parity was dormant. This adds the producer-push that makes it live.

- `scripts/global/governance-bundle-push.js` — reads the per-issue fields snapshot (`~/.megingjord/governance-fields-<issue>.json`), builds the redacted + content-hashed bundle (reuses `governance-bundle.js`), Ed25519-signs it (reuses `substrate-health-push.loadEd25519Key`), and POSTs to HAMR.
- `cloudflare/hamr/routes/governance-bundle.ts` — `/governance-bundle` write route mirroring `/substrate-health` (DPoP + Ed25519 keyring verify + schema/hash checks → `KV.put('governance-bundle:<issue>')`); wired in `worker.ts`.
- `npm run hamr:governance-bundle-push -- --issue N`; `tests/governance-bundle-push.spec.js` (2) + producer doc note.

Net: a fleet (free) model can now self-attest a compliant Consultant CLOSEOUT instead of escalating to paid cloud.

## Validation
- 7 unit tests pass (push + bundle); eslint 0 errors; lint:md 0; README in sync.
- Fixed a real canonicalization bug (a replacer-array was stripping nested `fields` from the signed/pushed payload — caught by the signed-POST test which verifies the Ed25519 signature over the body).
- Cross-family review: gemini-2.5-flash ACCEPT at collaborator/admin/consultant (SECURITY_OK).
- The Cloudflare Worker write route validates live only on a Worker deploy (operator step); the orchestrator producer + signing + tests are fully local-verified.

[skip-changelog]

## Baton (#2613)
MANAGER_HANDOFF / COLLABORATOR_HANDOFF / ADMIN_HANDOFF (Reyes != Harper) / CONSULTANT_CLOSEOUT posted.
