### PR TITLE
fix(scripts): fleet-down failover to free-cloud #2619

### DIFF
--- a/.changes/unreleased/2619.md
+++ b/.changes/unreleased/2619.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fleet-unavailable failover no longer escalates straight to the paid Haiku tier. `cascade-dispatch.js` and `task_router.py` now distinguish *availability* failures (fleet host down → no answer) from *capability* failures (fleet answered but quality/judge inadequate): availability failures fail over to a new `free-cloud` tier ($0 ordered providers — openrouter-free, gemini, groq, cerebras) before any paid tier, while capability failures still step up to Haiku. Closes a recurring G3 paid-spend leak when the local fleet host is unreachable. The `free-cloud` tier is defined in `model-routing-policy.json` and inserted into the cascade order between `fleet` and `haiku` (#2619).

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -61,4 +61,5 @@ jobs:
           tests/governance-bundle.spec.js
           tests/governance-bundle-push.spec.js
           tests/wrapper-result-contract.spec.js
+          tests/cascade-free-cloud-failover.spec.js
           --reporter=line

--- a/hooks/scripts/task_router.py
+++ b/hooks/scripts/task_router.py
@@ -51,10 +51,12 @@ def execute_cascade(prompt: str, model: str | None = None) -> dict:
             if isinstance(data, dict):
                 return data
         except Exception as exc:
+            # #2619: availability failure (cascade subprocess errored) -> free $0 cloud, not paid haiku.
             return {"ok": False, "tier": "local", "escalation_needed": True,
-                    "suggested_tier": "haiku", "reason": str(exc)}
+                    "suggested_tier": "free-cloud", "reason": str(exc)}
+    # #2619: availability failure (no cascade script) -> free $0 cloud, not paid haiku.
     return {"ok": False, "tier": "local", "escalation_needed": True,
-            "suggested_tier": "haiku", "reason": "cascade_script_not_found"}
+            "suggested_tier": "free-cloud", "reason": "cascade_script_not_found"}
 
 
 def apply_route(state: dict, route: dict | None) -> dict:

--- a/instructions/global-task-router.instructions.md
+++ b/instructions/global-task-router.instructions.md
@@ -17,6 +17,15 @@ Policy source: `scripts/global/model-routing-policy.json` (capability_matrix fie
 4. **Premium** — `frontier-reasoning`. Multi-file architecture, security,
    ambiguous debugging.
 
+**Fleet-unavailable failover (#2619)**: when Fleet is **unreachable** (an
+*availability* failure — no answer produced), `cascade-dispatch` fails over to
+the `free-cloud` tier (`$0` ordered providers: openrouter-free, gemini, groq,
+cerebras) **before** any paid tier. Only a *capability* failure (Fleet answered
+but quality/judge inadequate) steps up to paid Haiku. This preserves the
+cost-ascending mandate when the local fleet host is down — do not escalate
+straight to Haiku on a fleet outage. Free-cloud chain detail:
+`skills/openrouter-free-failover`.
+
 Codex, Copilot, and Claude Code sessions all use the same lane policy. A lane
 selects required capability and cost tier. Runtime, provider, model family, and
 lane are separate concepts:

--- a/scripts/global/cascade-dispatch.js
+++ b/scripts/global/cascade-dispatch.js
@@ -9,6 +9,18 @@ const { judgeResponse } = require('./local-judge');
 const policy = require('./model-routing-policy.json');
 const { backoff, isRateLimitError } = require('./backoff');
 
+// #2619: G3 lane-order. Availability failures (fleet down -> no answer) fail over to a
+// free $0 cloud tier BEFORE any paid tier; capability failures (fleet answered but
+// quality/judge inadequate) step up to paid haiku. suggested_tier is an advisory signal.
+const AVAILABILITY_REASONS = new Set(['ollama_unreachable', 'fleet_unavailable', 'cascade_script_not_found']);
+function escalationTier(reason) {
+  if (!reason) return 'haiku';
+  if (AVAILABILITY_REASONS.has(reason)) return 'free-cloud';
+  // connection-style provider errors are availability failures too (no usable answer produced).
+  if (/econnrefused|fetch failed|timeout|network|enotfound|socket hang|connect/i.test(String(reason))) return 'free-cloud';
+  return 'haiku'; // quality_reason / judge_low_score / unknown -> capability step-up
+}
+
 function hints(prompt) {
   const t = prompt.toLowerCase();
   return {
@@ -50,31 +62,34 @@ async function cascade(prompt, opts = {}) {
   const latency = Date.now() - start;
 
   if (!local.ok) {
-    recordTelemetry({ lane: 'fleet', model, outcome: 'fail', escalation: 'haiku',
+    const esc = escalationTier(local.reason); // #2619: fleet-down -> free-cloud, not paid haiku
+    recordTelemetry({ lane: 'fleet', model, outcome: 'fail', escalation: esc,
       escalation_reason: local.reason, latency_ms: latency, execute: true });
     return { ok: false, tier: 'local', escalation_needed: true,
-      suggested_tier: 'haiku', reason: local.reason };
+      suggested_tier: esc, reason: local.reason };
   }
 
   const quality = assessQuality(local.content, h);
   if (!quality.pass) {
-    recordTelemetry({ lane: 'fleet', model, outcome: 'escalate', escalation: 'haiku',
+    const esc = escalationTier(quality.reason); // capability failure -> haiku
+    recordTelemetry({ lane: 'fleet', model, outcome: 'escalate', escalation: esc,
       quality_reason: quality.reason, response_length: local.content.length, latency_ms: latency, execute: true });
     return { ok: true, content: local.content, tier: 'local', confidence: 'low',
-      escalation_needed: true, suggested_tier: 'haiku', quality_reason: quality.reason };
+      escalation_needed: true, suggested_tier: esc, quality_reason: quality.reason };
   }
 
   const jcfg = policy.judge; // Layer 2: judge gate (semantic quality, independent model)
   const j = jcfg?.enabled ? await judgeResponse(prompt, local.content, { threshold: jcfg.threshold, judgeModel: jcfg.model }) : null;
   const judgePass = !j || !j.ok || j.decision === 'return';
+  const judgeEsc = escalationTier('judge_low_score'); // capability failure -> haiku
   recordTelemetry({ lane: 'fleet', model, outcome: judgePass ? 'ok' : 'escalate',
-    escalation: judgePass ? null : 'haiku', quality_reason: quality.reason,
+    escalation: judgePass ? null : judgeEsc, quality_reason: quality.reason,
     ...(j?.ok && { judge_model: j.judge_model, judge_score: j.judge_score,
       judge_decision: j.decision, judge_latency_ms: j.latency_ms }),
     response_length: local.content.length, latency_ms: latency, execute: true });
   if (!judgePass)
     return { ok: true, content: local.content, tier: 'local', confidence: 'low',
-      escalation_needed: true, suggested_tier: 'haiku', quality_reason: 'judge_low_score' };
+      escalation_needed: true, suggested_tier: judgeEsc, quality_reason: 'judge_low_score' };
   return { ok: true, content: local.content, tier: 'local', confidence: 'high',
     escalation_needed: false, model };
 }
@@ -86,8 +101,8 @@ async function main() {
   const json = args.includes('--json');
   if (!prompt) { console.error('--prompt required'); process.exit(1); }
   if (getProfile().mode === 'solo') {
-    const r = { ok: false, tier: 'local', escalation_needed: true, suggested_tier: 'haiku', reason: 'fleet_unavailable' };
-    console.log(json ? JSON.stringify(r) : `escalation_needed=true reason=fleet_unavailable`);
+    const r = { ok: false, tier: 'local', escalation_needed: true, suggested_tier: escalationTier('fleet_unavailable'), reason: 'fleet_unavailable' };
+    console.log(json ? JSON.stringify(r) : `escalation_needed=true reason=fleet_unavailable suggested_tier=${r.suggested_tier}`);
     return;
   }
   const result = await cascade(prompt, { model });
@@ -97,4 +112,4 @@ async function main() {
 }
 
 if (require.main === module) main().catch(e => { console.error(e.message); process.exit(1); });
-module.exports = { cascade, assessQuality, hints };
+module.exports = { cascade, assessQuality, hints, escalationTier };

--- a/scripts/global/model-routing-policy.json
+++ b/scripts/global/model-routing-policy.json
@@ -66,6 +66,14 @@
       "costPer1kTokens": 0,
       "endpoint": "ollama"
     },
+    "free-cloud": {
+      "id": "free-cloud-failover",
+      "mult": 0,
+      "costPer1kTokens": 0,
+      "endpoint": "openai-compatible",
+      "_doc": "#2619: $0 cloud failover used when fleet is UNREACHABLE (availability failure), before any paid tier. Ordered free providers; see skills/openrouter-free-failover.",
+      "providers": ["openrouter-free", "gemini", "groq", "cerebras"]
+    },
     "haiku": {
       "id": "balanced-cloud",
       "mult": 0.08,
@@ -148,6 +156,7 @@
     "enabled": true,
     "tiers": [
       "fleet",
+      "free-cloud",
       "haiku",
       "premium"
     ],

--- a/tests/cascade-free-cloud-failover.spec.js
+++ b/tests/cascade-free-cloud-failover.spec.js
@@ -1,0 +1,51 @@
+// #2619: fleet-unavailable failover routes to free-cloud before paid Haiku.
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const { escalationTier } = require(path.join(ROOT, 'scripts', 'global', 'cascade-dispatch.js'));
+const POLICY = require(path.join(ROOT, 'scripts', 'global', 'model-routing-policy.json'));
+
+test('availability failures escalate to free-cloud (not paid haiku)', () => {
+  expect(escalationTier('ollama_unreachable')).toBe('free-cloud');
+  expect(escalationTier('fleet_unavailable')).toBe('free-cloud');
+  expect(escalationTier('cascade_script_not_found')).toBe('free-cloud');
+  expect(escalationTier('connect ECONNREFUSED 100.91.113.16:11434')).toBe('free-cloud');
+  expect(escalationTier('fetch failed')).toBe('free-cloud');
+});
+
+test('capability failures step up to paid haiku', () => {
+  expect(escalationTier('too_short')).toBe('haiku');
+  expect(escalationTier('no_code_structure')).toBe('haiku');
+  expect(escalationTier('judge_low_score')).toBe('haiku');
+  expect(escalationTier(null)).toBe('haiku'); // unknown -> conservative capability step-up
+});
+
+test('policy defines free-cloud as a $0 tier ordered between fleet and haiku', () => {
+  const fc = POLICY.models['free-cloud'];
+  expect(fc).toBeTruthy();
+  expect(fc.costPer1kTokens).toBe(0);
+  expect(fc.mult).toBe(0);
+  expect(Array.isArray(fc.providers)).toBe(true);
+  expect(fc.providers.length).toBeGreaterThan(0);
+  const tiers = POLICY.cascade.tiers;
+  expect(tiers).toContain('free-cloud');
+  // cost-ascending: free-cloud sits after fleet and before haiku
+  expect(tiers.indexOf('free-cloud')).toBeGreaterThan(tiers.indexOf('fleet'));
+  expect(tiers.indexOf('free-cloud')).toBeLessThan(tiers.indexOf('haiku'));
+});
+
+test('task_router.py: cascade-script-not-found availability failure suggests free-cloud', () => {
+  const py = [
+    'import sys; sys.path.insert(0, "hooks/scripts")',
+    'import task_router',
+    'task_router._cascade_candidates = lambda: []',  // force availability failure (no script)
+    'import json; print(json.dumps(task_router.execute_cascade("hello world test prompt")))',
+  ].join('\n');
+  const out = execFileSync('python3', ['-c', py], { cwd: ROOT, encoding: 'utf8' });
+  const result = JSON.parse(out.trim().split('\n').pop());
+  expect(result.escalation_needed).toBe(true);
+  expect(result.suggested_tier).toBe('free-cloud');
+  expect(result.reason).toBe('cascade_script_not_found');
+});


### PR DESCRIPTION
Refs #2619
Refs #1130
merge-evidence-deferred-final: #2619

## Summary (G3 lane-order fix)
When the local fleet (Ollama) is **unreachable**, `cascade-dispatch.js` and `task_router.py` escalated straight to the **paid** Haiku tier — skipping free cloud. This violated the cost-ascending lane order: a fleet *availability* failure produced no answer, so the next-cheapest lane is a **$0 cloud** provider, not paid Haiku.

- New `escalationTier(reason)` distinguishes **availability** failures (`ollama_unreachable`, `fleet_unavailable`, `cascade_script_not_found`, connection errors) → `free-cloud`, from **capability** failures (`quality_reason`, `judge_low_score`, unknown) → `haiku`. Applied at all 4 cascade-dispatch escalation sites + `task_router.py` parity.
- New `free-cloud` tier in `model-routing-policy.json` ($0; providers openrouter-free/gemini/groq/cerebras), inserted into `cascade.tiers` between `fleet` and `haiku`.
- `suggested_tier` is advisory — `routing_context.py` passes the new value through unchanged (non-breaking).

## Validation
- 10 specs pass (4 new `cascade-free-cloud-failover.spec.js` incl a Python `execute_cascade` harness + existing cascade specs → no regression).
- `npm run lint` 0 errors + 100-line cap PASS; lint:js 0; lint:py pass; lint:md 0.
- Boundary preserved — only `scripts/global/`, `hooks/scripts/`, `instructions/`, `tests/`, `.changes/`, `quality-gates.yml`. No Copilot-Team dashboard files.
- Cross-family review (gemini-2.5-flash@google-ai-studio; **fleet was DOWN — reviews dogfooded the free-cloud path this PR adds**): collaborator ACCEPT / admin ACCEPT / consultant approve_for_merge rubric 9/10, all SECURITY OK.

## Scope note
This corrects the escalation **signal** + policy tier-ordering at the level cascade-dispatch already operated (it emitted a `suggested_tier` signal; it never auto-executed Haiku either). Auto-executing the free-cloud provider chain inside cascade-dispatch would be a new capability beyond prior behavior — out of scope here.

## Baton (#2619)
MANAGER_HANDOFF / COLLABORATOR_HANDOFF / ADMIN_HANDOFF (Reyes != Harper) / CONSULTANT_CLOSEOUT posted on #2619.
