### PR TITLE
feat(scripts): execute free-cloud failover #2621

### DIFF
--- a/.changes/unreleased/2621.md
+++ b/.changes/unreleased/2621.md
@@ -1,0 +1,3 @@
+### Added
+
+- Fleet-unavailable failover is now **executed**, not just signalled. New `scripts/global/free-cloud-dispatch.js` calls the policy `free-cloud` providers in order (gemini, openrouter-free, groq, cerebras — all $0), routed through `wrapProviderCall` for HAMR cost/observability. `cascade-dispatch.js` invokes it on an availability failure (fleet host down) and returns the cloud answer directly (`tier: free-cloud`); when no free-cloud key is configured or all providers fail, it degrades gracefully to the advisory `suggested_tier: free-cloud` signal from #2619 (no regression). Removes the manual free-cloud routing previously needed during a fleet outage (#2621).

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -62,4 +62,5 @@ jobs:
           tests/governance-bundle-push.spec.js
           tests/wrapper-result-contract.spec.js
           tests/cascade-free-cloud-failover.spec.js
+          tests/free-cloud-dispatch.spec.js
           --reporter=line

--- a/instructions/global-task-router.instructions.md
+++ b/instructions/global-task-router.instructions.md
@@ -23,7 +23,12 @@ the `free-cloud` tier (`$0` ordered providers: openrouter-free, gemini, groq,
 cerebras) **before** any paid tier. Only a *capability* failure (Fleet answered
 but quality/judge inadequate) steps up to paid Haiku. This preserves the
 cost-ascending mandate when the local fleet host is down — do not escalate
-straight to Haiku on a fleet outage. Free-cloud chain detail:
+straight to Haiku on a fleet outage. As of #2621 this failover is **executed**,
+not merely signalled: `cascade-dispatch` calls `free-cloud-dispatch.js`, which
+tries the policy `free-cloud` providers in order (via `wrapProviderCall`) and
+returns the answer directly (`tier: free-cloud`). If no free-cloud key is
+configured or all providers fail, it degrades gracefully to the advisory
+`suggested_tier: free-cloud` signal. Free-cloud chain detail:
 `skills/openrouter-free-failover`.
 
 Codex, Copilot, and Claude Code sessions all use the same lane policy. A lane

--- a/scripts/global/cascade-dispatch.js
+++ b/scripts/global/cascade-dispatch.js
@@ -8,6 +8,7 @@ const { getProfile } = require('./fleet-config');
 const { judgeResponse } = require('./local-judge');
 const policy = require('./model-routing-policy.json');
 const { backoff, isRateLimitError } = require('./backoff');
+const { dispatchFreeCloud } = require('./free-cloud-dispatch'); // #2621: execute $0 cloud on fleet-down
 
 // #2619: G3 lane-order. Availability failures (fleet down -> no answer) fail over to a
 // free $0 cloud tier BEFORE any paid tier; capability failures (fleet answered but
@@ -63,6 +64,16 @@ async function cascade(prompt, opts = {}) {
 
   if (!local.ok) {
     const esc = escalationTier(local.reason); // #2619: fleet-down -> free-cloud, not paid haiku
+    if (esc === 'free-cloud' && opts.executeFreeCloud !== false) {
+      // #2621: actually execute a $0 cloud provider; graceful fall-through to advisory signal.
+      const fc = await dispatchFreeCloud(prompt, opts.freeCloud || {});
+      if (fc.ok) {
+        recordTelemetry({ lane: 'free-cloud', model: fc.provider, outcome: 'ok', escalation: null,
+          escalation_reason: local.reason, latency_ms: Date.now() - start, execute: true });
+        return { ok: true, content: fc.content, tier: 'free-cloud', confidence: 'medium',
+          escalation_needed: false, provider: fc.provider };
+      }
+    }
     recordTelemetry({ lane: 'fleet', model, outcome: 'fail', escalation: esc,
       escalation_reason: local.reason, latency_ms: latency, execute: true });
     return { ok: false, tier: 'local', escalation_needed: true,

--- a/scripts/global/cascade-dispatch.js
+++ b/scripts/global/cascade-dispatch.js
@@ -8,7 +8,7 @@ const { getProfile } = require('./fleet-config');
 const { judgeResponse } = require('./local-judge');
 const policy = require('./model-routing-policy.json');
 const { backoff, isRateLimitError } = require('./backoff');
-const { dispatchFreeCloud } = require('./free-cloud-dispatch'); // #2621: execute $0 cloud on fleet-down
+const { dispatchFreeCloud } = require('./free-cloud-dispatch'); // execute free $0 cloud on fleet-down
 
 // #2619: G3 lane-order. Availability failures (fleet down -> no answer) fail over to a
 // free $0 cloud tier BEFORE any paid tier; capability failures (fleet answered but
@@ -112,8 +112,8 @@ async function main() {
   const json = args.includes('--json');
   if (!prompt) { console.error('--prompt required'); process.exit(1); }
   if (getProfile().mode === 'solo') {
-    const r = { ok: false, tier: 'local', escalation_needed: true, suggested_tier: escalationTier('fleet_unavailable'), reason: 'fleet_unavailable' };
-    console.log(json ? JSON.stringify(r) : `escalation_needed=true reason=fleet_unavailable suggested_tier=${r.suggested_tier}`);
+    const soloResult = { ok: false, tier: 'local', escalation_needed: true, suggested_tier: escalationTier('fleet_unavailable'), reason: 'fleet_unavailable' };
+    console.log(json ? JSON.stringify(soloResult) : `escalation_needed=true reason=fleet_unavailable suggested_tier=${soloResult.suggested_tier}`);
     return;
   }
   const result = await cascade(prompt, { model });

--- a/scripts/global/free-cloud-dispatch.js
+++ b/scripts/global/free-cloud-dispatch.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+'use strict';
+// free-cloud-dispatch.js (#2621): execute a $0 cloud provider when the fleet is unreachable.
+// Tries the policy free-cloud providers in order; routes through wrapProviderCall (#1160) for
+// HAMR cost/observability; gracefully no-ops (no_key / all-fail) so callers fall back to the
+// advisory escalation signal (#2619). All providers below are free-tier; never a paid model.
+const policy = require('./model-routing-policy.json');
+let wrapProviderCall;
+try { ({ wrapProviderCall } = require('./hamr-provider-wrapper')); }
+catch { wrapProviderCall = async (_p, fn) => ({ ok: true, value: await fn({}) }); }
+
+// provider -> { envKey, url(key), body(prompt), headers(key), parse(json) }. OpenAI-compatible or REST.
+const PROVIDERS = {
+  gemini: {
+    envKey: 'GOOGLE_AI_STUDIO_API_KEY',
+    url: (k) => `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${k}`,
+    body: (p) => ({ contents: [{ parts: [{ text: p }] }] }),
+    headers: () => ({ 'content-type': 'application/json' }),
+    parse: (j) => j?.candidates?.[0]?.content?.parts?.[0]?.text,
+  },
+  'openrouter-free': {
+    envKey: 'OPENROUTER_API_KEY',
+    url: () => 'https://openrouter.ai/api/v1/chat/completions',
+    body: (p) => ({ model: 'meta-llama/llama-3.3-70b-instruct:free', messages: [{ role: 'user', content: p }] }),
+    headers: (k) => ({ 'content-type': 'application/json', authorization: `Bearer ${k}` }),
+    parse: (j) => j?.choices?.[0]?.message?.content,
+  },
+  groq: {
+    envKey: 'GROQ_API_KEY',
+    url: () => 'https://api.groq.com/openai/v1/chat/completions',
+    body: (p) => ({ model: 'llama-3.3-70b-versatile', messages: [{ role: 'user', content: p }] }),
+    headers: (k) => ({ 'content-type': 'application/json', authorization: `Bearer ${k}` }),
+    parse: (j) => j?.choices?.[0]?.message?.content,
+  },
+  cerebras: {
+    envKey: 'CEREBRAS_API_KEY',
+    url: () => 'https://api.cerebras.ai/v1/chat/completions',
+    body: (p) => ({ model: 'llama-3.3-70b', messages: [{ role: 'user', content: p }] }),
+    headers: (k) => ({ 'content-type': 'application/json', authorization: `Bearer ${k}` }),
+    parse: (j) => j?.choices?.[0]?.message?.content,
+  },
+};
+
+/** Ordered free-cloud providers from policy (falls back to all known). @returns {string[]} */
+function providerOrder() {
+  const list = policy?.models?.['free-cloud']?.providers;
+  return Array.isArray(list) && list.length ? list.filter((n) => PROVIDERS[n]) : Object.keys(PROVIDERS);
+}
+
+/** Call one free-cloud provider. @returns {Promise<{ok,content?,provider?,reason?}>} */
+async function callProvider(name, prompt, opts = {}) {
+  const spec = PROVIDERS[name];
+  if (!spec) return { ok: false, reason: `unknown_provider:${name}` };
+  const key = (opts.env || process.env)[spec.envKey];
+  if (!key) return { ok: false, reason: 'no_key' };
+  const fetchImpl = opts.fetchImpl || (typeof fetch === 'function' ? fetch : null);
+  if (!fetchImpl) return { ok: false, reason: 'no_fetch' };
+  const wrapProvider = name === 'gemini' ? 'gemini' : 'openai-compatible';
+  const wrapped = await wrapProviderCall(wrapProvider, async () => {
+    const ac = new AbortController();
+    const t = setTimeout(() => ac.abort(), opts.timeoutMs || 30000);
+    try {
+      const res = await fetchImpl(spec.url(key), { method: 'POST', headers: spec.headers(key),
+        body: JSON.stringify(spec.body(prompt)), signal: ac.signal });
+      return await res.json();
+    } finally { clearTimeout(t); }
+  }, { tier: 'free-cloud' });
+  if (!wrapped.ok) return { ok: false, reason: wrapped.meta?.error || 'provider_error' };
+  const content = spec.parse(wrapped.value);
+  return content ? { ok: true, content, provider: name } : { ok: false, reason: 'empty_response' };
+}
+
+/** Try free-cloud providers in policy order until one returns content. @returns {Promise<object>} */
+async function dispatchFreeCloud(prompt, opts = {}) {
+  if (!prompt) return { ok: false, reason: 'no_prompt' };
+  const tried = [];
+  for (const name of providerOrder()) {
+    const r = await callProvider(name, prompt, opts);
+    if (r.ok) return r;
+    tried.push(`${name}:${r.reason}`);
+  }
+  return { ok: false, reason: 'no_free_cloud_available', tried };
+}
+
+module.exports = { dispatchFreeCloud, callProvider, providerOrder, PROVIDERS };

--- a/scripts/global/free-cloud-dispatch.js
+++ b/scripts/global/free-cloud-dispatch.js
@@ -9,6 +9,8 @@ let wrapProviderCall;
 try { ({ wrapProviderCall } = require('./hamr-provider-wrapper')); }
 catch { wrapProviderCall = async (_p, fn) => ({ ok: true, value: await fn({}) }); }
 
+const DEFAULT_TIMEOUT_MS = 30000; // per-provider abort budget
+
 // provider -> { envKey, url(key), body(prompt), headers(key), parse(json) }. OpenAI-compatible or REST.
 const PROVIDERS = {
   gemini: {
@@ -58,12 +60,12 @@ async function callProvider(name, prompt, opts = {}) {
   const wrapProvider = name === 'gemini' ? 'gemini' : 'openai-compatible';
   const wrapped = await wrapProviderCall(wrapProvider, async () => {
     const ac = new AbortController();
-    const t = setTimeout(() => ac.abort(), opts.timeoutMs || 30000);
+    const timer = setTimeout(() => ac.abort(), opts.timeoutMs || DEFAULT_TIMEOUT_MS);
     try {
       const res = await fetchImpl(spec.url(key), { method: 'POST', headers: spec.headers(key),
         body: JSON.stringify(spec.body(prompt)), signal: ac.signal });
       return await res.json();
-    } finally { clearTimeout(t); }
+    } finally { clearTimeout(timer); }
   }, { tier: 'free-cloud' });
   if (!wrapped.ok) return { ok: false, reason: wrapped.meta?.error || 'provider_error' };
   const content = spec.parse(wrapped.value);
@@ -75,9 +77,9 @@ async function dispatchFreeCloud(prompt, opts = {}) {
   if (!prompt) return { ok: false, reason: 'no_prompt' };
   const tried = [];
   for (const name of providerOrder()) {
-    const r = await callProvider(name, prompt, opts);
-    if (r.ok) return r;
-    tried.push(`${name}:${r.reason}`);
+    const attempt = await callProvider(name, prompt, opts);
+    if (attempt.ok) return attempt;
+    tried.push(`${name}:${attempt.reason}`);
   }
   return { ok: false, reason: 'no_free_cloud_available', tried };
 }

--- a/tests/free-cloud-dispatch.spec.js
+++ b/tests/free-cloud-dispatch.spec.js
@@ -1,0 +1,76 @@
+// #2621: free-cloud execution on fleet-down (not just an advisory signal).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const FC = require(path.join(ROOT, 'scripts', 'global', 'free-cloud-dispatch.js'));
+const CASCADE = require(path.join(ROOT, 'scripts', 'global', 'cascade-dispatch.js'));
+
+// injected fetch that returns an OpenAI-compatible (and gemini-shaped) success body
+function okFetch(text) {
+  return async () => ({
+    status: 200,
+    json: async () => ({
+      candidates: [{ content: { parts: [{ text }] } }],          // gemini shape
+      choices: [{ message: { content: text } }],                  // openai-compatible shape
+    }),
+  });
+}
+
+test('providerOrder uses policy free-cloud provider list (known providers only)', () => {
+  const order = FC.providerOrder();
+  expect(order.length).toBeGreaterThan(0);
+  for (const p of order) expect(FC.PROVIDERS[p]).toBeTruthy();
+});
+
+test('callProvider returns no_key when the provider key is absent', async () => {
+  const r = await FC.callProvider('gemini', 'hello', { env: {} });
+  expect(r.ok).toBe(false);
+  expect(r.reason).toBe('no_key');
+});
+
+test('callProvider succeeds with an injected fetch + configured key', async () => {
+  const r = await FC.callProvider('gemini', 'hello', {
+    env: { GOOGLE_AI_STUDIO_API_KEY: 'k' }, fetchImpl: okFetch('FC-ANSWER'),
+  });
+  expect(r.ok).toBe(true);
+  expect(r.content).toBe('FC-ANSWER');
+  expect(r.provider).toBe('gemini');
+});
+
+test('dispatchFreeCloud falls through unconfigured providers to the first that answers', async () => {
+  // only the 2nd-in-order provider has a key; earlier ones return no_key and are skipped
+  const order = FC.providerOrder();
+  const env = { [FC.PROVIDERS[order[1]].envKey]: 'k' };
+  const r = await FC.dispatchFreeCloud('hello', { env, fetchImpl: okFetch('SECOND') });
+  expect(r.ok).toBe(true);
+  expect(r.provider).toBe(order[1]);
+  expect(r.content).toBe('SECOND');
+});
+
+test('dispatchFreeCloud returns no_free_cloud_available when no key is configured', async () => {
+  const r = await FC.dispatchFreeCloud('hello', { env: {} });
+  expect(r.ok).toBe(false);
+  expect(r.reason).toBe('no_free_cloud_available');
+  expect(Array.isArray(r.tried)).toBe(true);
+});
+
+test('cascade fleet-down executes free-cloud and returns its content', async () => {
+  // no Ollama in CI -> tryOllama reports ollama_unreachable -> availability failure -> free-cloud
+  const order = FC.providerOrder();
+  const env = { [FC.PROVIDERS[order[0]].envKey]: 'k' };
+  const r = await CASCADE.cascade('summarize this short fleet-lane prompt', {
+    freeCloud: { env, fetchImpl: okFetch('CLOUD-OK') },
+  });
+  expect(r.tier).toBe('free-cloud');
+  expect(r.ok).toBe(true);
+  expect(r.content).toBe('CLOUD-OK');
+  expect(r.escalation_needed).toBe(false);
+});
+
+test('cascade fleet-down falls back to advisory free-cloud signal when execution disabled', async () => {
+  const r = await CASCADE.cascade('summarize this short fleet-lane prompt', { executeFreeCloud: false });
+  expect(r.ok).toBe(false);
+  expect(r.escalation_needed).toBe(true);
+  expect(r.suggested_tier).toBe('free-cloud'); // #2619 advisory signal preserved
+});


### PR DESCRIPTION
Refs #2621
Refs #2619 #1160 #771
merge-evidence-deferred-final: #2621

## Summary (G3 — complete #2619's value)
#2619 made `free-cloud` an advisory signal on fleet-down; this **executes** it. New `scripts/global/free-cloud-dispatch.js` calls the policy `free-cloud` providers in order (gemini / openrouter-free / groq / cerebras — all $0) via `wrapProviderCall` (#1160). `cascade-dispatch` invokes it on an availability failure and returns the cloud answer (`tier: free-cloud`); on no-key / all-fail it degrades gracefully to the #2619 advisory signal (no regression). Ends the manual free-cloud routing this session required on every fleet outage.

## Validation
- 11 specs pass (7 new `free-cloud-dispatch.spec.js` incl 2 cascade-integration + existing cascade specs → no regression).
- `npm run lint` 0 errors + 100-line cap PASS (module 85 lines); lint:js 0; lint:md 0.
- Bounded: 30s per-provider timeout; graceful no-key/all-fail fallback so CI without keys is unchanged.
- Boundary preserved — `scripts/global/`, `instructions/`, `tests/`, `.changes/`, `quality-gates.yml`. No Copilot-Team dashboard files.
- Cross-family review (gemini-2.5-flash@google-ai-studio; **fleet DOWN — reviews dogfooded this exact path**): collaborator ACCEPT / admin ACCEPT / consultant approve_for_merge 10/10, all SECURITY OK.

## Baton (#2621)
MANAGER_HANDOFF / COLLABORATOR_HANDOFF / ADMIN_HANDOFF (Reyes != Harper) / CONSULTANT_CLOSEOUT posted on #2621.
