### PR TITLE
feat(scripts): free-cloud usage report #2624

### DIFF
--- a/.changes/unreleased/2624.md
+++ b/.changes/unreleased/2624.md
@@ -1,0 +1,3 @@
+### Added
+
+- `npm run routing:free-cloud-report` surfaces the `lane:free-cloud` telemetry emitted by the fleet-down failover (#2621): free-cloud execution count (= paid-Haiku calls avoided), per-provider breakdown, average latency, and an estimated paid-$ avoided. Makes the G3 savings operator-visible and auditable against the premium-share governor; supports `--days N` and `--json`. New `scripts/global/free-cloud-usage-report.js` (#2624).

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -63,4 +63,5 @@ jobs:
           tests/wrapper-result-contract.spec.js
           tests/cascade-free-cloud-failover.spec.js
           tests/free-cloud-dispatch.spec.js
+          tests/free-cloud-usage-report.spec.js
           --reporter=line

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ npm run deploy:both:apply
 | `routing:baseline` | `node scripts/global/routing-baseline-report.js` |
 | `routing:calibrate` | `node scripts/global/cascade-calibrate.js` |
 | `routing:fallback-report` | `node scripts/global/routing-fallback-report.js` |
+| `routing:free-cloud-report` | `node scripts/global/free-cloud-usage-report.js` |
 | `routing:freshness` | `node scripts/global/matrix-freshness.js` |
 | `routing:reconcile` | `node scripts/global/token-telemetry-reconcile.js --json` |
 | `routing:refresh` | `node scripts/global/routing-refresh.js --update-matrix` |

--- a/instructions/hamr-routing.instructions.md
+++ b/instructions/hamr-routing.instructions.md
@@ -190,3 +190,21 @@ npm run it-ops:usage-report
 
 Tier-2 anneal is emitted when any marker's usage exceeds 5 events per week.
 Override threshold with env var `IT_BYPASS_THRESHOLD=10` (integer, default 5).
+
+### Free-cloud usage telemetry (#2624)
+
+When the fleet is unreachable and `cascade-dispatch` executes a free $0 cloud
+provider (#2621), it records a `lane:free-cloud` row to
+`logs/model-routing-telemetry.jsonl`. The aggregator surfaces the G3 savings —
+execution count (= paid-Haiku calls avoided), per-provider breakdown, average
+latency, and an estimated paid-$ avoided — so the failover is auditable against
+the premium-share governor:
+
+```bash
+npm run routing:free-cloud-report          # last 7 days, human-readable
+npm run routing:free-cloud-report -- --days 30 --json
+```
+
+No anneal threshold: high free-cloud usage is a G3 win, not a fault. The $-avoided
+estimate uses `policy.models.haiku.costPer1kTokens` and a documented assumed
+~1500 tokens/call (see `scripts/global/free-cloud-usage-report.js`).

--- a/package.json
+++ b/package.json
@@ -262,6 +262,7 @@
     "gov:extract": "node scripts/global/rule-card-extractor.js --all > /tmp/rule-cards.json",
     "gov:parity": "node scripts/global/megalint/parity-validator.js",
     "routing:fallback-report": "node scripts/global/routing-fallback-report.js",
+    "routing:free-cloud-report": "node scripts/global/free-cloud-usage-report.js",
     "it-ops:usage-report": "node scripts/global/it-bypass-usage-report.js",
     "test:collaborator-input-shape": "node --test tests/collaborator-handoff-input-shape.spec.js",
     "test:compatibility": "node --test tests/orchestrator-compatibility.spec.js",

--- a/scripts/global/free-cloud-usage-report.js
+++ b/scripts/global/free-cloud-usage-report.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+'use strict';
+// free-cloud-usage-report.js (#2624): surface lane:free-cloud usage + estimated paid-spend avoided.
+// Aggregates the telemetry emitted by #2621 (cascade-dispatch free-cloud executions) so the G3
+// savings are operator-visible + auditable against the premium-share governor. Read-only report.
+const { readTelemetry } = require('./model-routing-telemetry');
+const policy = require('./model-routing-policy.json');
+
+const DEFAULT_DAYS = 7;
+// Documented estimate for a routing-lane task: ~1k input + ~0.5k output tokens.
+const ASSUMED_TOKENS_PER_CALL = 1500;
+const DEFAULT_HAIKU_COST_PER_1K = 0.00088;
+
+/** Build the free-cloud usage report. @param {number} days @param {object[]|null} entries (test inject) */
+function buildReport(days = DEFAULT_DAYS, entries = null) {
+  const rows = (entries || readTelemetry(days)).filter((r) => r && r.lane === 'free-cloud');
+  const byProvider = {};
+  let latencySum = 0;
+  let latencyCount = 0;
+  for (const row of rows) {
+    const provider = row.model || 'unknown';
+    byProvider[provider] = (byProvider[provider] || 0) + 1;
+    const lat = row.latencyMs ?? row.latency_ms;
+    if (typeof lat === 'number') { latencySum += lat; latencyCount += 1; }
+  }
+  const executions = rows.length;
+  const haikuCostPer1k = policy?.models?.haiku?.costPer1kTokens ?? DEFAULT_HAIKU_COST_PER_1K;
+  const estPaidUsdAvoided = +(executions * (ASSUMED_TOKENS_PER_CALL / 1000) * haikuCostPer1k).toFixed(4);
+  return {
+    window_days: days,
+    free_cloud_executions: executions,
+    paid_haiku_calls_avoided: executions,
+    per_provider: byProvider,
+    avg_latency_ms: latencyCount ? Math.round(latencySum / latencyCount) : null,
+    est_paid_usd_avoided: estPaidUsdAvoided,
+    assumptions: { assumed_tokens_per_call: ASSUMED_TOKENS_PER_CALL, haiku_cost_per_1k: haikuCostPer1k },
+  };
+}
+
+/** Render a report object as human-readable text. @param {object} report */
+function formatReport(report) {
+  return [
+    `Free-cloud usage (last ${report.window_days}d):`,
+    `  executions: ${report.free_cloud_executions} (= paid-Haiku calls avoided)`,
+    `  per-provider: ${JSON.stringify(report.per_provider)}`,
+    `  avg latency: ${report.avg_latency_ms ?? 'n/a'} ms`,
+    `  est. paid $ avoided: $${report.est_paid_usd_avoided} ` +
+      `(@ ${report.assumptions.assumed_tokens_per_call} tok/call, $${report.assumptions.haiku_cost_per_1k}/1k)`,
+  ].join('\n');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const dayArg = args.indexOf('--days');
+  const days = dayArg >= 0 ? Number(args[dayArg + 1]) || DEFAULT_DAYS : DEFAULT_DAYS;
+  const report = buildReport(days);
+  console.log(args.includes('--json') ? JSON.stringify(report, null, 2) : formatReport(report));
+}
+
+if (require.main === module) main();
+module.exports = { buildReport, formatReport };

--- a/tests/free-cloud-usage-report.spec.js
+++ b/tests/free-cloud-usage-report.spec.js
@@ -1,0 +1,53 @@
+// #2624: free-cloud usage report — surfaces lane:free-cloud executions + paid-spend avoided.
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const REPORT = require(path.join(ROOT, 'scripts', 'global', 'free-cloud-usage-report.js'));
+
+const now = () => new Date().toISOString();
+
+test('buildReport aggregates free-cloud rows: count, per-provider, paid-avoided, latency', () => {
+  const entries = [
+    { lane: 'free-cloud', model: 'gemini', outcome: 'ok', latencyMs: 1200, ts: now() },
+    { lane: 'free-cloud', model: 'gemini', outcome: 'ok', latencyMs: 800, ts: now() },
+    { lane: 'free-cloud', model: 'openrouter-free', outcome: 'ok', latencyMs: 2000, ts: now() },
+    { lane: 'fleet', model: 'qwen2.5-coder', outcome: 'ok', latencyMs: 50, ts: now() }, // ignored
+    { lane: 'haiku', model: 'balanced-cloud', outcome: 'ok', ts: now() },               // ignored
+  ];
+  const r = REPORT.buildReport(7, entries);
+  expect(r.free_cloud_executions).toBe(3);
+  expect(r.paid_haiku_calls_avoided).toBe(3); // each free-cloud execution = one paid-Haiku call avoided
+  expect(r.per_provider).toEqual({ gemini: 2, 'openrouter-free': 1 });
+  expect(r.avg_latency_ms).toBe(1333); // round((1200+800+2000)/3)
+  expect(r.est_paid_usd_avoided).toBeGreaterThan(0);
+});
+
+test('buildReport handles latency-less rows and supports legacy latency_ms field', () => {
+  const entries = [
+    { lane: 'free-cloud', model: 'groq', outcome: 'ok', latency_ms: 600, ts: now() }, // snake_case
+    { lane: 'free-cloud', model: 'groq', outcome: 'ok', ts: now() },                   // no latency
+  ];
+  const r = REPORT.buildReport(7, entries);
+  expect(r.free_cloud_executions).toBe(2);
+  expect(r.per_provider.groq).toBe(2);
+  expect(r.avg_latency_ms).toBe(600); // only the one with a latency value is averaged
+});
+
+test('buildReport is graceful on empty telemetry (zero report, no crash)', () => {
+  const r = REPORT.buildReport(7, []);
+  expect(r.free_cloud_executions).toBe(0);
+  expect(r.paid_haiku_calls_avoided).toBe(0);
+  expect(r.per_provider).toEqual({});
+  expect(r.avg_latency_ms).toBeNull();
+  expect(r.est_paid_usd_avoided).toBe(0);
+});
+
+test('formatReport renders human-readable text with the key fields', () => {
+  const text = REPORT.formatReport(REPORT.buildReport(7, [
+    { lane: 'free-cloud', model: 'gemini', outcome: 'ok', latencyMs: 1000, ts: now() },
+  ]));
+  expect(text).toContain('Free-cloud usage (last 7d)');
+  expect(text).toContain('executions: 1');
+  expect(text).toContain('paid $ avoided');
+});


### PR DESCRIPTION
Refs #2624
Refs #2619 #2621
merge-evidence-deferred-final: #2624

## Summary (G8 in service of G3)
Surfaces the `lane:free-cloud` telemetry emitted by the fleet-down failover (#2621) so the G3 savings are operator-visible + auditable. New `scripts/global/free-cloud-usage-report.js` aggregates: free-cloud execution count (= paid-Haiku calls avoided), per-provider breakdown, avg latency, and an estimated paid-$ avoided (policy haiku cost × documented ~1500 tok/call). `npm run routing:free-cloud-report` (`--days N`, `--json`).

## Validation
- 4 specs pass (`free-cloud-usage-report.spec.js`: aggregation, latency-field handling, empty-log graceful, format).
- `npm run lint` 0 errors + 100-line cap PASS (module 61 lines); lint:js 0; readability 474 (<475); lint:md 0; README synced via docs:compile.
- Read-only report — zero runtime blast radius. No Copilot-Team dashboard files.
- Cross-family review (gemini-2.5-flash@google-ai-studio; fleet DOWN → dogfooded the free-cloud path): collaborator ACCEPT / admin ACCEPT / consultant approve_for_merge 9-10/10, all SECURITY OK.

## Baton (#2624)
MANAGER_HANDOFF / COLLABORATOR_HANDOFF / ADMIN_HANDOFF (Reyes != Harper) / CONSULTANT_CLOSEOUT posted on #2624.
