### PR TITLE
feat(governance): enforce overlap fields in manager handoff

### DIFF
--- a/.changes/unreleased/2617.md
+++ b/.changes/unreleased/2617.md
@@ -1,9 +1,5 @@
-# #2617
-
-## Changed
+### Changed
 - Enforced `related_tickets` and `overlap_decision` as required MANAGER_HANDOFF schema fields.
 - Added validation that `related_tickets` must contain issue references like `#123`.
 - Extended baton comment builder to emit overlap fields for manager artifacts.
-
-## Why
 - Prevent duplicate/conflicting ticket creation by requiring explicit overlap boundary decisions at manager handoff.

--- a/.changes/unreleased/2617.md
+++ b/.changes/unreleased/2617.md
@@ -1,0 +1,9 @@
+# #2617
+
+## Changed
+- Enforced `related_tickets` and `overlap_decision` as required MANAGER_HANDOFF schema fields.
+- Added validation that `related_tickets` must contain issue references like `#123`.
+- Extended baton comment builder to emit overlap fields for manager artifacts.
+
+## Why
+- Prevent duplicate/conflicting ticket creation by requiring explicit overlap boundary decisions at manager handoff.

--- a/docs/howto/baton-workflow.md
+++ b/docs/howto/baton-workflow.md
@@ -30,7 +30,14 @@ gh issue create \
 
 Title rules: plain imperative ≤72 chars. No `feat(scope):` prefix on issue titles.
 
-**Post scope comment** with objective, ACs, and constraints. End it with:
+**Post scope comment** with objective, ACs, constraints, and overlap boundary references. Include these required fields before the signature block:
+
+```
+related_tickets: [#N, #N, ...]
+overlap_decision: <boundary decision>
+```
+
+End it with:
 
 ```
 MANAGER_HANDOFF

--- a/docs/workflow/learnings.md
+++ b/docs/workflow/learnings.md
@@ -1,0 +1,5 @@
+# Workflow Learnings
+
+## 2026-06-02
+- #2617: Make overlap boundaries explicit at manager handoff (`related_tickets`, `overlap_decision`) so conflict prevention is enforced by schema, not operator memory.
+- #2626: Direct fleet model calls without bounded timeout can stall sessions; use guarded wrappers or explicit timeout flags.

--- a/governance/README.md
+++ b/governance/README.md
@@ -29,7 +29,7 @@ All four entry-point files MUST mention each invariant. `cross-team-contract-che
 
 1. **Team&Model signing** — every governed artifact carries `Signed-by:` + `Team&Model:` + `Role:` per `instructions/team-model-signing.instructions.md`.
 2. **Baton order** — Manager → Collaborator → Admin → Consultant single-thread per `instructions/role-baton-routing.instructions.md`.
-3. **Ticket-first workflow** — no governed work without a linked GitHub issue per `instructions/ticket-driven-work.instructions.md`.
+3. **Ticket-first workflow** — no governed work without a linked GitHub issue, and manager handoffs must carry overlap-boundary fields for related tickets and decisions per `instructions/ticket-driven-work.instructions.md`.
 4. **Dedicated-worktree protocol** — one live worktree per agent per `research/concurrent-agent-worktrees-2026-04-24.md`.
 
 ## Client-Arbitration Prohibition (#2578)

--- a/scripts/global/baton-comment-build.js
+++ b/scripts/global/baton-comment-build.js
@@ -7,15 +7,18 @@ function arg(name, fallback = '') {
   return i >= 0 ? (process.argv[i + 1] || '') : fallback;
 }
 
-function buildBatonComment({ artifact, ticket, role, teamModel, summary = '' }) {
+function buildBatonComment({ artifact, ticket, role, teamModel, summary = '', relatedTickets = '', overlapDecision = '' }) {
   const [team = '', modelSub = ''] = String(teamModel || '').split(':');
   const model = (modelSub.split('@')[0] || '').trim();
   const signer = canonicalSignerAlias(team, role, model);
   const head = `## ${artifact}\n\n`;
   const scope = summary ? `scope: ${summary}\n\n` : '';
   const refs = ticket ? `ticket: #${ticket}\n\n` : '';
+  const overlap = artifact === 'MANAGER_HANDOFF' && role === 'manager'
+    ? `${relatedTickets ? `related_tickets: ${relatedTickets}\n` : ''}${overlapDecision ? `overlap_decision: ${overlapDecision}\n` : ''}${relatedTickets || overlapDecision ? '\n' : ''}`
+    : '';
   const sig = `Signed-by: ${signer}\nTeam&Model: ${teamModel}\nRole: ${role}`;
-  return `${head}${scope}${refs}${sig}`;
+  return `${head}${scope}${refs}${overlap}${sig}`;
 }
 
 function main() {
@@ -24,11 +27,13 @@ function main() {
   const teamModel = arg('team-model', process.env.TEAM_MODEL || '');
   const ticket = arg('ticket', '');
   const summary = arg('summary', '');
+  const relatedTickets = arg('related-tickets', '');
+  const overlapDecision = arg('overlap-decision', '');
   if (!teamModel) {
     process.stderr.write('Missing --team-model (or TEAM_MODEL env).\n');
     process.exit(1);
   }
-  console.log(buildBatonComment({ artifact, ticket, role, teamModel, summary }));
+  console.log(buildBatonComment({ artifact, ticket, role, teamModel, summary, relatedTickets, overlapDecision }));
 }
 
 if (require.main === module) main();

--- a/scripts/global/megalint/manager-handoff.js
+++ b/scripts/global/megalint/manager-handoff.js
@@ -3,7 +3,7 @@
 
 const sig = require('../governance-artifact-signature');
 const { isValidStrategy } = require('../test-strategy-enum');
-const REQUIRED_FIELDS = ['scope', 'lane', 'test_strategy', 'acceptance', 'gates'];
+const REQUIRED_FIELDS = ['scope', 'lane', 'test_strategy', 'acceptance', 'gates', 'related_tickets', 'overlap_decision'];
 const PHASE_ONE_LABEL = process.env.PHASE_ONE_LABEL || 'phase-gate:phase-1';
 
 function findManagerHandoff(comments) {
@@ -22,6 +22,8 @@ function checkRequiredFields(body) {
         detail: `MANAGER_HANDOFF missing required field '${field}:' per role-baton-routing schema` });
     }
   }
+  if (extractField(body, 'related_tickets') && !/#\d+/.test(extractField(body, 'related_tickets'))) {
+    violations.push({ rule: 'invalid-related_tickets', detail: "MANAGER_HANDOFF related_tickets must include one or more issue refs like '#123'" }); }
   if (!/Signed-by:/i.test(body)) violations.push({ rule: 'missing-signer', detail: 'MANAGER_HANDOFF missing Signed-by field' });
   if (!/Team&Model:/i.test(body)) violations.push({ rule: 'missing-team-model', detail: 'MANAGER_HANDOFF missing Team&Model field' });
   if (!/Role:\s*manager/i.test(body)) violations.push({ rule: 'missing-role-manager', detail: 'MANAGER_HANDOFF missing Role: manager field' });

--- a/tests/megalint/manager-handoff.spec.js
+++ b/tests/megalint/manager-handoff.spec.js
@@ -9,9 +9,9 @@ const fullHandoff = `**MANAGER_HANDOFF — Cole Mason**
 - test_strategy: tdd-pyramid
 - acceptance: AC1-5
 - gates: lint, test-evidence
-
+- related_tickets: [#2623, #2574, #2091, #2071]
+- overlap_decision: boundary-confirmed-no-redundancy
 Signed-by: Cole Mason · Team&Model: claude-code:opus-4-7@anthropic · Role: manager`;
-
 test('validate: full MANAGER_HANDOFF passes with all 5 fields', () => {
   const r = V.validate({ comments: [{ body: fullHandoff }] });
   expect(r.ok).toBe(true);
@@ -56,9 +56,28 @@ test('extractField: pulls value with various prefix formats', () => {
 });
 
 test('REQUIRED_FIELDS exposes 5 fields', () => {
-  expect(V.REQUIRED_FIELDS.length).toBe(5);
+  expect(V.REQUIRED_FIELDS.length).toBe(7);
   expect(V.REQUIRED_FIELDS).toContain('scope');
   expect(V.REQUIRED_FIELDS).toContain('test_strategy');
+  expect(V.REQUIRED_FIELDS).toContain('related_tickets');
+  expect(V.REQUIRED_FIELDS).toContain('overlap_decision');
+});
+
+test('validate: missing overlap fields reports violations', () => {
+  const body = fullHandoff
+    .replace(/related_tickets:.+\n/, '')
+    .replace(/overlap_decision:.+\n/, '');
+  const r = V.validate({ comments: [{ body }] });
+  expect(r.ok).toBe(false);
+  expect(r.violations.some(v => v.rule === 'missing-related_tickets')).toBe(true);
+  expect(r.violations.some(v => v.rule === 'missing-overlap_decision')).toBe(true);
+});
+
+test('validate: related_tickets must include issue references', () => {
+  const body = fullHandoff.replace(/- related_tickets:.+\n/, '- related_tickets: [none]\n');
+  const r = V.validate({ comments: [{ body }] });
+  expect(r.ok).toBe(false);
+  expect(r.violations.some(v => v.rule === 'invalid-related_tickets')).toBe(true);
 });
 
 test('phase-1: requires phase_gate_satisfied and phase_0_sources', () => {

--- a/wiki/wisdom/global/concepts/governance-enforcement.md
+++ b/wiki/wisdom/global/concepts/governance-enforcement.md
@@ -2,7 +2,7 @@
 title: "Governance Enforcement"
 type: concept
 created: 2026-04-14
-updated: 2026-04-14
+updated: 2026-06-02
 tags: [governance, architecture, copilot]
 sources: []
 related: ["[[baton-protocol]]", "[[agent-drift]]", "[[self-annealing]]", "[[linting-governance]]"]
@@ -31,7 +31,7 @@ status: draft
 - Branch name validation (pre-commit)
 - Event emission (mandatory per Admin skill)
 - Drift detection (Consultant CLOSEOUT)
-- Ticket lifecycle enforcement (Manager gates)
+- Ticket lifecycle enforcement (Manager gates, including overlap-boundary fields related_tickets + overlap_decision)
 
 See: [[workflow-design]], [[copilot-governance-actions]]
 


### PR DESCRIPTION
## Summary
- require `related_tickets` and `overlap_decision` in MANAGER_HANDOFF validation
- validate `related_tickets` contains issue references (`#N`)
- extend baton comment builder to emit overlap fields for manager artifact generation
- add regression tests for missing overlap fields and malformed related tickets

## Validation
- npm run lint
- npm test -- tests/megalint/manager-handoff.spec.js tests/baton-artifact-governance.spec.js

Refs #2617
merge-evidence-deferred-final: #2617
