### PR TITLE
feat(governance): cross-runtime canonical-main WIP guard

### DIFF
--- a/.changes/unreleased/2663.md
+++ b/.changes/unreleased/2663.md
@@ -1,0 +1,3 @@
+### Added
+
+- `scripts/global/canonical-main-wip-guard.js` + SessionStart hook `hooks/scripts/canonical_main_wip_check.py` (Epic #2658): runtime-AGNOSTIC detection + quarantine of stranded tracked WIP in the canonical main checkout. Where the #2091 C6 enforcer only catches Claude Code's tool writes, this reads git working-tree state so it catches residue from ANY runtime (Copilot/Codex/etc.). Scoped to canonical main (zero-tracked-WIP invariant); skips during in-progress git ops; advisory by default, auto-quarantine (backup patch+tgz + restore clean + recovery manifest) on `MEGINGJORD_CANONICAL_MAIN_ENFORCE=1`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,6 +44,11 @@
             "type": "command",
             "command": "python3 ~/.copilot/hooks/scripts/prune_file_history.py",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.copilot/hooks/scripts/canonical_main_wip_check.py",
+            "timeout": 10
           }
         ]
       }

--- a/hooks/scripts/canonical_main_wip_check.py
+++ b/hooks/scripts/canonical_main_wip_check.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""SessionStart hook (Epic #2658 #2663): runtime-agnostic advisory check for stranded
+tracked WIP in the canonical main checkout, left by ANY runtime. Non-blocking — emits
+an advisory only. Auto-quarantine is opt-in via MEGINGJORD_CANONICAL_MAIN_ENFORCE=1.
+"""
+import json
+import os
+import subprocess
+import sys
+
+CHECKOUT = os.path.join(os.path.expanduser("~"), "devenv-ops")
+GUARD = os.path.join(CHECKOUT, "scripts", "global", "canonical-main-wip-guard.js")
+
+
+def main() -> int:
+    if not os.path.isfile(GUARD):
+        return 0
+    try:
+        result = subprocess.run(
+            ["node", GUARD, CHECKOUT], capture_output=True, text=True, timeout=8, check=False,
+        )
+        message = (result.stderr or result.stdout).strip()
+        if message:
+            print(json.dumps({"hookEventName": "SessionStart", "additionalContext": message}))
+    except Exception:
+        pass  # advisory hook must never break session start
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/global/canonical-main-wip-guard.js
+++ b/scripts/global/canonical-main-wip-guard.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+'use strict';
+// tier: 1
+// canonical-main-wip-guard (Epic #2658 / #2663): runtime-AGNOSTIC detection + quarantine of
+// stranded tracked WIP in the canonical main checkout. The #2091 C6 enforcer only catches
+// Claude Code's tool writes; this reads git WORKING-TREE state, so it catches residue from ANY
+// runtime (Copilot/Codex/etc.). Scope: canonical main only (invariant: zero tracked WIP, #2107).
+// Advisory by default; enforce (auto-quarantine) on MEGINGJORD_CANONICAL_MAIN_ENFORCE=1.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const GIT_OP_MARKERS = ['index.lock', 'MERGE_HEAD', 'REBASE_HEAD', 'CHERRY_PICK_HEAD'];
+
+function isGitOpInProgress(gitDir) {
+  return GIT_OP_MARKERS.some((marker) => fs.existsSync(path.join(gitDir, marker)));
+}
+
+// Parse `git status --porcelain` → tracked-modified + untracked paths.
+function detectStrandedWip(porcelain) {
+  const modified = [];
+  const untracked = [];
+  for (const line of String(porcelain || '').split('\n')) {
+    if (!line.trim()) continue;
+    const code = line.slice(0, 2);
+    const file = line.slice(3);
+    if (code === '??') untracked.push(file);
+    else modified.push(file);
+  }
+  return { modified, untracked };
+}
+
+function git(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+function quarantineWip(cwd, wip, opts = {}) {
+  const stamp = opts.stamp || new Date().toISOString().replace(/[:.]/g, '-');
+  const dir = path.join(os.homedir(), '.megingjord');
+  fs.mkdirSync(dir, { recursive: true });
+  const patch = path.join(dir, `canonical-main-wip-${stamp}.patch`);
+  const tgz = path.join(dir, `canonical-main-untracked-${stamp}.tgz`);
+  fs.writeFileSync(patch, git(cwd, ['diff']), 'utf8');
+  if (wip.untracked.length) execFileSync('tar', ['czf', tgz, ...wip.untracked], { cwd });
+  if (opts.enforce) {
+    if (wip.modified.length) git(cwd, ['checkout', '--', ...wip.modified]);
+    for (const file of wip.untracked) fs.rmSync(path.join(cwd, file), { force: true });
+  }
+  const manifest = {
+    ts: stamp, modified: wip.modified, untracked: wip.untracked, enforced: Boolean(opts.enforce),
+    recover: `git worktree add ~/devenv-ops-recover -b recover/canonical-main-wip; git -C ~/devenv-ops-recover apply ${patch}; tar xzf ${tgz} -C ~/devenv-ops-recover`,
+  };
+  const manifestPath = path.join(dir, `canonical-main-quarantine-${stamp}.json`);
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+  return { patch, tgz, manifestPath, manifest };
+}
+
+// Returns {action, ...}. action: 'skip-not-main' | 'skip-git-op' | 'clean' | 'advisory' | 'quarantined'.
+function guard(cwd, opts = {}) {
+  const isMain = (opts.branch || git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']).trim()) === 'main';
+  if (!isMain) return { action: 'skip-not-main' };
+  if (isGitOpInProgress(opts.gitDir || path.join(cwd, '.git'))) return { action: 'skip-git-op' };
+  const porcelain = opts.porcelain !== undefined ? opts.porcelain : git(cwd, ['status', '--porcelain']);
+  const wip = detectStrandedWip(porcelain);
+  if (!wip.modified.length && !wip.untracked.length) return { action: 'clean' };
+  const enforce = opts.enforce ?? process.env.MEGINGJORD_CANONICAL_MAIN_ENFORCE === '1';
+  const backup = quarantineWip(cwd, wip, { ...opts, enforce });
+  return { action: enforce ? 'quarantined' : 'advisory', wip, backup };
+}
+
+if (require.main === module) {
+  const target = process.argv[2] || path.join(os.homedir(), 'devenv-ops');
+  try {
+    const result = guard(target, {});
+    if (result.action === 'advisory') {
+      console.warn(`[canonical-main-wip-guard] foreign stranded WIP in canonical main `
+        + `(${result.wip.modified.length} modified, ${result.wip.untracked.length} untracked) — `
+        + `backed up: ${result.backup.manifestPath}. Set MEGINGJORD_CANONICAL_MAIN_ENFORCE=1 to auto-quarantine.`);
+    } else if (result.action === 'quarantined') {
+      console.warn(`[canonical-main-wip-guard] quarantined stranded WIP; main restored. Recovery: ${result.backup.manifestPath}`);
+    }
+  } catch (err) { console.error(`[canonical-main-wip-guard] skipped: ${err.message}`); }
+}
+
+module.exports = { guard, detectStrandedWip, isGitOpInProgress, quarantineWip, GIT_OP_MARKERS };

--- a/tests/canonical-main-wip-guard.spec.js
+++ b/tests/canonical-main-wip-guard.spec.js
@@ -1,0 +1,52 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { guard, detectStrandedWip, isGitOpInProgress } = require('../scripts/global/canonical-main-wip-guard');
+
+test('detectStrandedWip: parses modified + untracked from porcelain', () => {
+  const wip = detectStrandedWip(' M scripts/a.js\n?? scripts/new.js\nA  staged.js\n');
+  assert.deepStrictEqual(wip.modified, ['scripts/a.js', 'staged.js']);
+  assert.deepStrictEqual(wip.untracked, ['scripts/new.js']);
+});
+test('isGitOpInProgress: true when index.lock present', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-op-'));
+  assert.strictEqual(isGitOpInProgress(dir), false);
+  fs.writeFileSync(path.join(dir, 'index.lock'), '');
+  assert.strictEqual(isGitOpInProgress(dir), true);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+test('guard: skip when not on main', () => {
+  assert.strictEqual(guard('/x', { branch: 'feat/1-x' }).action, 'skip-not-main');
+});
+test('guard: skip when a git op is in progress', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'guard-op-'));
+  fs.mkdirSync(path.join(dir, '.git'));
+  fs.writeFileSync(path.join(dir, '.git', 'MERGE_HEAD'), '');
+  assert.strictEqual(guard(dir, { branch: 'main' }).action, 'skip-git-op');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+test('guard: clean tree on main → action clean', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'guard-clean-'));
+  fs.mkdirSync(path.join(dir, '.git'));
+  assert.strictEqual(guard(dir, { branch: 'main', porcelain: '' }).action, 'clean');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+test('guard enforce: quarantines stranded WIP + restores main clean (integration)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'guard-enforce-'));
+  const g = (...a) => execFileSync('git', a, { cwd: dir });
+  g('init', '-q'); g('config', 'user.email', 't@t'); g('config', 'user.name', 't'); g('checkout', '-q', '-b', 'main');
+  fs.writeFileSync(path.join(dir, 'tracked.js'), 'v1\n'); g('add', 'tracked.js'); g('commit', '-qm', 'init');
+  fs.writeFileSync(path.join(dir, 'tracked.js'), 'v2-foreign\n');       // modified
+  fs.writeFileSync(path.join(dir, 'untracked.js'), 'stranded\n');        // untracked
+  const res = guard(dir, { branch: 'main', enforce: true, stamp: 'test' });
+  assert.strictEqual(res.action, 'quarantined');
+  assert.ok(fs.existsSync(res.backup.manifestPath));
+  assert.strictEqual(execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).trim(), '', 'main clean after enforce');
+  assert.strictEqual(fs.readFileSync(path.join(dir, 'tracked.js'), 'utf8'), 'v1\n', 'tracked reverted');
+  assert.strictEqual(fs.existsSync(path.join(dir, 'untracked.js')), false, 'untracked removed');
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
Refs #2663
Closes #2663
merge-evidence-deferred-final: #2663
Refs Epic #2658

## Summary (Epic #2658 Phase-1 — lane:code-change)
`scripts/global/canonical-main-wip-guard.js` + SessionStart hook: **runtime-agnostic** detection + quarantine of stranded tracked WIP in canonical main. Where the #2091 C6 enforcer catches only Claude Code's tool writes, this reads **git working-tree state**, catching residue from **any** runtime (Copilot/Codex/etc.) — the gap that stranded WIP in main and blocked Stop gates **twice this session**.

- Canonical-main-only (zero-tracked-WIP invariant → no false positives); skips during in-progress git ops.
- Advisory-default (back up + warn, non-destructive); enforce auto-quarantine (backup patch+tgz + restore clean + recovery manifest) on `MEGINGJORD_CANONICAL_MAIN_ENFORCE=1`; advisory→enforce promotion gated on sign-off.

## Validation
6/6 unit tests (incl temp-git enforce integration); lint ≤100 LOC; readability green. Cross-family: qwen-7b@tailscale + gemini@cloud + qwen-32b@tailscale → ACCEPT 9/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)