### PR TITLE
feat(governance): runtime detection + signer-team auto-resolution

### DIFF
--- a/.changes/unreleased/2665.md
+++ b/.changes/unreleased/2665.md
@@ -1,0 +1,7 @@
+### Added
+
+- `scripts/global/detect-runtime.js` (Epic #2659): precedence-based detection of the active agent runtime (claude-code/codex/copilot/antigravity/openclaw) — distinct from the model family. Deliberately ignores `COPILOT_OTEL_*` (injected into every workspace terminal by the extension, not a runtime signal); honest `unknown` fallback.
+
+### Changed
+
+- `scripts/global/agent-signature.js` (Epic #2659): when `HAMR_TEAM` is unset, the signer team now auto-resolves from a high-confidence `detectRuntime()` result — so each runtime attributes its own team correctly; `unknown` detection still fails loud (no guessing), preserving provenance integrity.

--- a/scripts/global/agent-signature.js
+++ b/scripts/global/agent-signature.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const sig = require('./governance-artifact-signature');
+const { detectRuntime } = require('./detect-runtime');
 
 const args = process.argv.slice(2);
 const opt = {};
@@ -10,9 +11,14 @@ for (let i = 0; i < args.length; i += 2) if (args[i]?.startsWith('--')) opt[args
 
 const registry = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'inventory', 'team-model-signatures.json'), 'utf8'));
 // Identity is settings/substrate-derived, never hard-coded to one team (G5).
-// Resolve from explicit flag, then the established HAMR_TEAM/HAMR_MODEL env
-// signals; if unresolved we fail loud below rather than mis-attribute provenance.
-const team = (opt.team || process.env.HAMR_TEAM || process.env.MEGINGJORD_TEAM || '').toLowerCase();
+// Resolve from explicit flag, then HAMR_TEAM/MEGINGJORD_TEAM env, then a HIGH-CONFIDENCE
+// runtime detection (#2659) — so each runtime auto-attributes its team even when HAMR_TEAM
+// is unset; 'unknown' detection still falls through to the fail-loud below (no guessing).
+let team = (opt.team || process.env.HAMR_TEAM || process.env.MEGINGJORD_TEAM || '').toLowerCase();
+if (!team) {
+  const detected = detectRuntime();
+  if (detected.confidence === 'high') team = detected.runtime;
+}
 const model = (opt.model || process.env.HAMR_MODEL || process.env.MEGINGJORD_MODEL || '').toLowerCase();
 const role = (opt.role || 'collaborator').toLowerCase();
 const substrate = (opt.substrate || 'local').toLowerCase();

--- a/scripts/global/detect-runtime.js
+++ b/scripts/global/detect-runtime.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+'use strict';
+// tier: 0
+// detect-runtime (Epic #2659 / #2665): precedence-based detection of the ACTIVE agent
+// runtime (the agent surface: claude-code / codex / copilot / antigravity / openclaw),
+// distinct from the model family. Used to (a) auto-resolve HAMR_TEAM / the signer team
+// when unset, and (b) attribute work to a runtime instead of guessing from process names.
+//
+// CRITICAL: `COPILOT_OTEL_*` env vars are injected into EVERY workspace terminal by the
+// Copilot VS Code extension — they are present even in a Claude Code session. They are
+// NOT evidence of a copilot RUNTIME and are deliberately ignored here.
+
+const KNOWN = ['claude-code', 'codex', 'copilot', 'antigravity', 'openclaw'];
+
+// Definitive per-runtime primary markers (NOT the workspace-injected COPILOT_OTEL_*).
+const PRIMARY = [
+  { runtime: 'claude-code', test: (env) => env.CLAUDECODE === '1' || Boolean(env.CLAUDE_CODE_ENTRYPOINT), signal: 'CLAUDECODE/CLAUDE_CODE_ENTRYPOINT' },
+  { runtime: 'codex', test: (env) => Boolean(env.CODEX_HOME || env.CODEX_SANDBOX || env.CODEX_CLI), signal: 'CODEX_*' },
+  { runtime: 'antigravity', test: (env) => Boolean(env.ANTIGRAVITY_AGENT || env.ANTIGRAVITY_HOME), signal: 'ANTIGRAVITY_*' },
+  { runtime: 'openclaw', test: (env) => Boolean(env.OPENCLAW_AGENT || env.OPENCLAW_HOME), signal: 'OPENCLAW_*' },
+];
+
+// detectRuntime(env) → { runtime, confidence, signal }.
+// Order: the AI_AGENT=<runtime>_<version> convention (highest), then per-runtime primaries.
+function detectRuntime(env = process.env) {
+  const aiAgent = String(env.AI_AGENT || '').toLowerCase();
+  for (const runtime of KNOWN) {
+    if (aiAgent === runtime || aiAgent.startsWith(`${runtime}_`) || aiAgent.startsWith(`${runtime}-`)) {
+      return { runtime, confidence: 'high', signal: `AI_AGENT=${runtime}*` };
+    }
+  }
+  for (const candidate of PRIMARY) {
+    if (candidate.test(env)) return { runtime: candidate.runtime, confidence: 'high', signal: candidate.signal };
+  }
+  return {
+    runtime: 'unknown', confidence: 'none',
+    signal: 'no primary runtime marker (COPILOT_OTEL_* ignored — workspace-injected, not a runtime signal)',
+  };
+}
+
+if (require.main === module) {
+  console.log(JSON.stringify(detectRuntime()));
+}
+
+module.exports = { detectRuntime, KNOWN };

--- a/tests/detect-runtime.spec.js
+++ b/tests/detect-runtime.spec.js
@@ -1,0 +1,43 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { detectRuntime } = require('../scripts/global/detect-runtime');
+
+test('AI_AGENT convention → high-confidence runtime', () => {
+  assert.deepStrictEqual(detectRuntime({ AI_AGENT: 'claude-code_2-1-162_agent' }).runtime, 'claude-code');
+  assert.strictEqual(detectRuntime({ AI_AGENT: 'copilot_1.2' }).runtime, 'copilot');
+  assert.strictEqual(detectRuntime({ AI_AGENT: 'codex-cli' }).runtime, 'codex');
+});
+test('claude-code primary markers (no AI_AGENT)', () => {
+  assert.strictEqual(detectRuntime({ CLAUDECODE: '1' }).runtime, 'claude-code');
+  assert.strictEqual(detectRuntime({ CLAUDE_CODE_ENTRYPOINT: 'claude-vscode' }).runtime, 'claude-code');
+});
+test('codex / antigravity primary markers', () => {
+  assert.strictEqual(detectRuntime({ CODEX_HOME: '/x' }).runtime, 'codex');
+  assert.strictEqual(detectRuntime({ ANTIGRAVITY_AGENT: '1' }).runtime, 'antigravity');
+});
+test('CRITICAL: COPILOT_OTEL_* alone is NOT a copilot runtime signal → unknown', () => {
+  const r = detectRuntime({ COPILOT_OTEL_ENABLED: 'true', COPILOT_OTEL_EXPORTER_TYPE: 'file' });
+  assert.strictEqual(r.runtime, 'unknown');
+  assert.match(r.signal, /workspace-injected/);
+});
+test('empty env → unknown (never guesses)', () => {
+  assert.strictEqual(detectRuntime({}).runtime, 'unknown');
+});
+
+const SIG = path.join(__dirname, '..', 'scripts', 'global', 'agent-signature.js');
+function runSig(env) {
+  try { return execFileSync('node', [SIG, '--model', 'opus', '--role', 'collaborator'], { env, encoding: 'utf8' }); }
+  catch (e) { return { code: e.status, stderr: String(e.stderr || '') }; }
+}
+test('agent-signature: auto-resolves team from runtime detection when HAMR_TEAM unset', () => {
+  const out = runSig({ PATH: process.env.PATH, CLAUDECODE: '1' }); // no HAMR_TEAM
+  assert.match(String(out), /claude-code:opus@local/); // team auto-resolved from runtime detection
+});
+test('agent-signature: unknown runtime still fails loud (no guessing)', () => {
+  const out = runSig({ PATH: process.env.PATH, COPILOT_OTEL_ENABLED: 'true' }); // OTEL only, no team
+  assert.strictEqual(out.code, 2);
+  assert.match(out.stderr, /unresolved identity/);
+});


### PR DESCRIPTION
Refs #2665
Closes #2665
merge-evidence-deferred-final: #2665
Refs Epic #2659

## Summary (Epic #2659 Phase-1 — lane:code-change)
`scripts/global/detect-runtime.js`: precedence-based detection of the active **agent runtime** (claude-code/codex/copilot/antigravity/openclaw), distinct from the model family. **Key correctness point:** `COPILOT_OTEL_*` env is injected into *every* workspace terminal by the Copilot extension (present even in a Claude Code session), so it is **not** a copilot-runtime signal — deliberately ignored; honest `unknown` fallback. `agent-signature.js` now auto-resolves the signer team from a high-confidence detection when `HAMR_TEAM` is unset; `unknown` still fails loud (no guessing).

This closes the *real* attribution gap from the AC-R1 audit (the original "team-from-model-family" premise was inaccurate — the harness already requires explicit runtime-team and fails loud; the gap was no runtime-detection + unset `HAMR_TEAM`, which forced the manual guessing behind the 2026-06-04 mis-attribution).

## Validation
7/7 unit tests (incl the COPILOT_OTEL false-signal + unknown→fail-loud); lint ≤100 LOC; readability green. Cross-family: qwen-7b@tailscale + gemini@cloud + qwen-32b@tailscale → ACCEPT (10/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)