### PR TITLE
feat(governance): per-runtime session registry + foreign-WIP attribution

### DIFF
--- a/.changes/unreleased/2667.md
+++ b/.changes/unreleased/2667.md
@@ -1,0 +1,3 @@
+### Added
+
+- `scripts/global/runtime-session-registry.js` + SessionStart hook `runtime_session_register.py` (#2667, closes the #2658+#2659 attribution arc): each runtime registers its active session (runtime via #2659 detect-runtime; self-cleaning via pid-liveness + TTL). The #2658 `canonical-main-wip-guard` now NAMES the foreign runtime that stranded WIP (via `attributeForeignWriter`) — or `undetermined` — in its advisory/quarantine heads-up and manifest, ending the process-name guessing.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -49,6 +49,11 @@
             "type": "command",
             "command": "python3 ~/.copilot/hooks/scripts/canonical_main_wip_check.py",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.copilot/hooks/scripts/runtime_session_register.py",
+            "timeout": 8
           }
         ]
       }

--- a/hooks/scripts/runtime_session_register.py
+++ b/hooks/scripts/runtime_session_register.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""SessionStart hook (#2667): register THIS runtime's active session so the
+canonical-main-wip-guard can attribute stranded WIP to a runtime instead of guessing.
+Runtime is detected via #2659 detect-runtime.js; registration self-cleans (pid + TTL).
+Non-blocking; never breaks session start.
+"""
+import os
+import subprocess
+
+ROOT = os.path.join(os.path.expanduser("~"), "devenv-ops")
+DETECT = os.path.join(ROOT, "scripts", "global", "detect-runtime.js")
+REGISTER = os.path.join(ROOT, "scripts", "global", "runtime-session-registry.js")
+
+
+def main() -> int:
+    if not (os.path.isfile(DETECT) and os.path.isfile(REGISTER)):
+        return 0
+    try:
+        import json
+        detected = json.loads(subprocess.run(["node", DETECT], capture_output=True, text=True, timeout=6, check=False).stdout or "{}")
+        runtime = detected.get("runtime", "unknown")
+        if runtime and runtime != "unknown" and detected.get("confidence") == "high":
+            subprocess.run(["node", REGISTER, "register", runtime], capture_output=True, text=True, timeout=6, check=False)
+    except Exception:
+        pass  # advisory registration must never break session start
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/global/canonical-main-wip-guard.js
+++ b/scripts/global/canonical-main-wip-guard.js
@@ -11,6 +11,8 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
+const { detectRuntime } = require('./detect-runtime');
+const { attributeForeignWriter } = require('./runtime-session-registry');
 
 const GIT_OP_MARKERS = ['index.lock', 'MERGE_HEAD', 'REBASE_HEAD', 'CHERRY_PICK_HEAD'];
 
@@ -49,7 +51,8 @@ function quarantineWip(cwd, wip, opts = {}) {
     for (const file of wip.untracked) fs.rmSync(path.join(cwd, file), { force: true });
   }
   const manifest = {
-    ts: stamp, modified: wip.modified, untracked: wip.untracked, enforced: Boolean(opts.enforce),
+    ts: stamp, writer: opts.writer || 'undetermined',
+    modified: wip.modified, untracked: wip.untracked, enforced: Boolean(opts.enforce),
     recover: `git worktree add ~/devenv-ops-recover -b recover/canonical-main-wip; git -C ~/devenv-ops-recover apply ${patch}; tar xzf ${tgz} -C ~/devenv-ops-recover`,
   };
   const manifestPath = path.join(dir, `canonical-main-quarantine-${stamp}.json`);
@@ -66,8 +69,10 @@ function guard(cwd, opts = {}) {
   const wip = detectStrandedWip(porcelain);
   if (!wip.modified.length && !wip.untracked.length) return { action: 'clean' };
   const enforce = opts.enforce ?? process.env.MEGINGJORD_CANONICAL_MAIN_ENFORCE === '1';
-  const backup = quarantineWip(cwd, wip, { ...opts, enforce });
-  return { action: enforce ? 'quarantined' : 'advisory', wip, backup };
+  const writer = opts.writer !== undefined ? opts.writer
+    : attributeForeignWriter(detectRuntime().runtime, {});
+  const backup = quarantineWip(cwd, wip, { ...opts, enforce, writer });
+  return { action: enforce ? 'quarantined' : 'advisory', wip, writer, backup };
 }
 
 if (require.main === module) {
@@ -75,7 +80,7 @@ if (require.main === module) {
   try {
     const result = guard(target, {});
     if (result.action === 'advisory') {
-      console.warn(`[canonical-main-wip-guard] foreign stranded WIP in canonical main `
+      console.warn(`[canonical-main-wip-guard] stranded WIP in canonical main from runtime '${result.writer}' `
         + `(${result.wip.modified.length} modified, ${result.wip.untracked.length} untracked) — `
         + `backed up: ${result.backup.manifestPath}. Set MEGINGJORD_CANONICAL_MAIN_ENFORCE=1 to auto-quarantine.`);
     } else if (result.action === 'quarantined') {

--- a/scripts/global/runtime-session-registry.js
+++ b/scripts/global/runtime-session-registry.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+'use strict';
+// tier: 0
+// runtime-session-registry (#2667; closes the #2658+#2659 attribution arc): records each
+// active agent runtime's session so the canonical-main-wip-guard can NAME which foreign
+// runtime stranded WIP — instead of guessing.
+//
+// Concurrency-safe by construction: each session owns ONE file (`<session_id>.json`) written
+// atomically (temp+rename), so concurrent registrations from different runtimes never race on
+// a shared file. Self-cleaning: a session counts as active only while its pid is alive AND its
+// TTL has not lapsed; dead/expired files are pruned on read — no SessionEnd hook required.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const REG_DIR = path.join(os.homedir(), '.megingjord', 'runtime-sessions');
+const TTL_MS = 12 * 3600 * 1000; // 12h heartbeat ceiling
+
+function sessionFile(dir, sessionId) {
+  return path.join(dir, `${String(sessionId).replace(/[^A-Za-z0-9_-]/g, '_')}.json`);
+}
+
+// EPERM = process exists but isn't ours (still alive); ESRCH = no such process.
+function pidAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch (err) { return err.code === 'EPERM'; }
+}
+
+function registerSession(runtime, opts = {}) {
+  const dir = opts.dir || REG_DIR;
+  fs.mkdirSync(dir, { recursive: true });
+  const pid = opts.pid || process.pid;
+  const sessionId = opts.sessionId || process.env.CLAUDE_CODE_SESSION_ID || String(pid);
+  const nowMs = opts.now || Date.now();
+  const entry = {
+    runtime, session_id: sessionId, cwd: opts.cwd || process.cwd(), pid,
+    ts: opts.ts || new Date(nowMs).toISOString(), expires_at: new Date(nowMs + TTL_MS).toISOString(),
+  };
+  const file = sessionFile(dir, sessionId);
+  const tmp = `${file}.tmp.${pid}`;
+  fs.writeFileSync(tmp, `${JSON.stringify(entry, null, 2)}\n`);
+  fs.renameSync(tmp, file); // atomic per-session write — no shared-file race
+  return entry;
+}
+
+function readEntries(dir) {
+  let names;
+  try { names = fs.readdirSync(dir); } catch { return []; }
+  const out = [];
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    const file = path.join(dir, name);
+    try { out.push({ file, entry: JSON.parse(fs.readFileSync(file, 'utf8')) }); } catch { /* skip unreadable */ }
+  }
+  return out;
+}
+
+// Active sessions; prunes (unlinks) dead-pid / expired files unless opts.prune === false.
+function activeSessions(opts = {}) {
+  const at = opts.at || new Date().toISOString();
+  const alive = opts.pidAlive || pidAlive;
+  const active = [];
+  for (const { file, entry } of readEntries(opts.dir || REG_DIR)) {
+    if (entry.expires_at > at && alive(entry.pid)) active.push(entry);
+    else if (opts.prune !== false) { try { fs.unlinkSync(file); } catch { /* already gone */ } }
+  }
+  return active;
+}
+
+// Best-effort: the active runtime(s) other than the current one. Never guesses.
+function attributeForeignWriter(currentRuntime, opts = {}) {
+  const others = [...new Set(activeSessions(opts).map((s) => s.runtime).filter((r) => r && r !== currentRuntime))];
+  if (others.length === 0) return 'undetermined';
+  return others.length === 1 ? others[0] : `multiple:${others.join(',')}`;
+}
+
+if (require.main === module) {
+  const [cmd, runtime] = process.argv.slice(2);
+  if (cmd === 'register' && runtime) console.log(JSON.stringify(registerSession(runtime)));
+  else console.log(JSON.stringify(activeSessions()));
+}
+
+module.exports = { registerSession, activeSessions, attributeForeignWriter, pidAlive, REG_DIR };

--- a/tests/runtime-session-registry.spec.js
+++ b/tests/runtime-session-registry.spec.js
@@ -1,0 +1,60 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { registerSession, activeSessions, attributeForeignWriter } = require('../scripts/global/runtime-session-registry');
+
+const NOW = Date.parse('2026-06-05T00:00:00Z');
+const aliveAll = () => true;
+function tmpdir() { return fs.mkdtempSync(path.join(os.tmpdir(), 'rsr-')); }
+
+test('registerSession: writes one per-session file; re-register overwrites (no dup)', () => {
+  const dir = tmpdir();
+  registerSession('copilot', { dir, sessionId: 's1', pid: 111, now: NOW });
+  registerSession('copilot', { dir, sessionId: 's1', pid: 111, now: NOW });
+  assert.strictEqual(fs.readdirSync(dir).filter((f) => f.endsWith('.json')).length, 1);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+test('concurrency: two runtimes registering different sessions never lose entries', () => {
+  const dir = tmpdir();
+  registerSession('claude-code', { dir, sessionId: 'A', pid: 1, now: NOW });
+  registerSession('copilot', { dir, sessionId: 'B', pid: 2, now: NOW }); // "concurrent" — own file
+  const act = activeSessions({ dir, at: '2026-06-05T00:00:00Z', pidAlive: aliveAll });
+  assert.deepStrictEqual(act.map((s) => s.runtime).sort(), ['claude-code', 'copilot']);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+test('activeSessions: prunes expired and dead-pid files from disk', () => {
+  const dir = tmpdir();
+  registerSession('copilot', { dir, sessionId: 'live', pid: 1, now: NOW });
+  registerSession('codex', { dir, sessionId: 'expired', pid: 1, now: NOW - 13 * 3600 * 1000 });
+  registerSession('antigravity', { dir, sessionId: 'dead', pid: 2, now: NOW });
+  const act = activeSessions({ dir, at: '2026-06-05T00:00:00Z', pidAlive: (pid) => pid === 1 });
+  assert.deepStrictEqual(act.map((s) => s.runtime), ['copilot']);
+  // expired + dead files pruned from disk:
+  assert.strictEqual(fs.readdirSync(dir).filter((f) => f.endsWith('.json')).length, 1);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+test('attributeForeignWriter: names the single foreign runtime', () => {
+  const dir = tmpdir();
+  registerSession('claude-code', { dir, sessionId: 'A', pid: 1, now: NOW });
+  registerSession('copilot', { dir, sessionId: 'B', pid: 1, now: NOW });
+  assert.strictEqual(attributeForeignWriter('claude-code', { dir, at: '2026-06-05T00:00:00Z', pidAlive: aliveAll }), 'copilot');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+test('attributeForeignWriter: undetermined when no foreign active session', () => {
+  const dir = tmpdir();
+  registerSession('claude-code', { dir, sessionId: 'A', pid: 1, now: NOW });
+  assert.strictEqual(attributeForeignWriter('claude-code', { dir, at: '2026-06-05T00:00:00Z', pidAlive: aliveAll }), 'undetermined');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+test('attributeForeignWriter: multiple:<list> when >1 foreign runtime', () => {
+  const dir = tmpdir();
+  registerSession('copilot', { dir, sessionId: 'B', pid: 1, now: NOW });
+  registerSession('codex', { dir, sessionId: 'C', pid: 1, now: NOW });
+  const r = attributeForeignWriter('claude-code', { dir, at: '2026-06-05T00:00:00Z', pidAlive: aliveAll });
+  assert.match(r, /^multiple:/);
+  assert.ok(r.includes('copilot') && r.includes('codex'));
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
Refs #2667
Closes #2667
merge-evidence-deferred-final: #2667
Refs #2658 #2659

## Summary (closes the #2658+#2659 attribution arc — lane:code-change)
`scripts/global/runtime-session-registry.js`: each runtime registers its active session so the #2658 `canonical-main-wip-guard` can **name which foreign runtime stranded WIP** (via `attributeForeignWriter`) instead of guessing from process names.

- **Concurrency-safe by construction:** each session owns one file (`<session_id>.json`) written atomically (temp+rename) — concurrent registrations never contend on a shared file.
- **Self-cleaning:** active only while pid is alive AND TTL valid; dead/expired files pruned on read (no SessionEnd hook needed).
- SessionStart hook registers via #2659 `detect-runtime`; guard heads-up/manifest now report the writer (or `undetermined`/`multiple`).

## Validation
12/12 unit tests (incl a **concurrency-no-loss** test + a dead/expired **prune** test); lint ≤100 LOC; readability green.

**Cross-family, optimal fleet, ≥93-or-fail:** iter-1 admin (gemini) **REJECTED at 70** for a shared-file read-modify-write race + no pruning → **failed and remediated** structurally → iter-2 collaborator/admin/consultant all **95/100** (qwen-7b@tailscale + gemini@cloud + qwen-32b@tailscale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)