### PR TITLE
feat(governance): stale worktree rescue workflow #2253

### DIFF
--- a/.changes/unreleased/2253.md
+++ b/.changes/unreleased/2253.md
@@ -1,0 +1,4 @@
+### Added
+
+- Stale worktree rescue/quarantine workflow (`scripts/global/worktree-rescue.js`) with 8 rescue sub-states (dirty, untracked, unpushed, detached, locked, permanent, missing-ticket, unknown), rescue report emitter, preserve-only commands, and quarantine path for abandoned worktrees (#2253).
+- 28 tests covering all rescue states, safety invariant (no delete/remove commands), and rescue report exclusion of safe-to-remove worktrees (#2253).

--- a/scripts/global/worktree-rescue.js
+++ b/scripts/global/worktree-rescue.js
@@ -1,0 +1,148 @@
+'use strict';
+// Rescue/quarantine workflow for stale-risky worktrees (Epic #2248, Refs #2253).
+// Classifies worktrees into 8 rescue sub-states, emits rescue report with
+// owner/ticket inference, risk reason, next action, UAT flag, and preserve cmds.
+// No destructive operations — preservation only.
+
+function ticketFrom(branch = '') {
+  const hit = (branch || '').match(/(?:feat|fix|chore|docs|refactor|hotfix)\/(\d+)-/);
+  return hit ? Number(hit[1]) : null;
+}
+
+// AC1: Eight rescue sub-states for risky worktrees that cannot be proven safe.
+const RESCUE_CONFIGS = {
+  locked: {
+    riskReason: () => 'explicitly locked: removal requires manual lock release',
+    nextAction: 'unlock via worktree-active-session-lock, then re-evaluate',
+    requiresUAT: false,
+    preserve: () => [],
+  },
+  permanent: {
+    riskReason: () => 'sandbox/launcher branch: permanent infrastructure, never remove',
+    nextAction: 'no action; launcher branches are permanent by policy',
+    requiresUAT: false,
+    preserve: () => [],
+  },
+  detached: {
+    riskReason: () => 'detached HEAD: no branch; commits at risk of GC',
+    nextAction: 'create rescue branch and draft PR for ticket reconciliation',
+    requiresUAT: true,
+    preserve: (entry) => [
+      `git -C "${entry.path}" switch -c rescue/detached-${Date.now()}-preserve`,
+      `gh pr create --draft --title "rescue: detached HEAD at ${entry.path}" --body "Quarantine: detached HEAD. Assign ticket and reconcile."`,
+    ],
+  },
+  'missing-ticket': {
+    riskReason: () => 'no ticket number in branch name: cannot infer ownership',
+    nextAction: 'rename branch to feat/<N>-desc and file reconciliation ticket',
+    requiresUAT: true,
+    preserve: (entry) => [
+      `git -C "${entry.path}" push origin HEAD:refs/heads/rescue/${entry.branch}-preserve --force-with-lease`,
+    ],
+  },
+  dirty: {
+    riskReason: (entry) => `${entry.dirtyCount} modified file(s): uncommitted changes`,
+    nextAction: 'commit or stash changes, then re-evaluate',
+    requiresUAT: false,
+    preserve: (entry) => {
+      const t = ticketFrom(entry.branch) || 'unknown';
+      return [
+        `git -C "${entry.path}" switch -c rescue/${t}-preserve`,
+        `git -C "${entry.path}" add -A && git -C "${entry.path}" commit -m "rescue: preserve dirty state for #${t}"`,
+        `git -C "${entry.path}" push origin rescue/${t}-preserve`,
+      ];
+    },
+  },
+  untracked: {
+    riskReason: (entry) => `${entry.untrackedCount} untracked file(s): not in git history`,
+    nextAction: 'add and commit untracked files or archive them before cleanup',
+    requiresUAT: false,
+    preserve: (entry) => {
+      const t = ticketFrom(entry.branch) || 'unknown';
+      return [
+        `git -C "${entry.path}" switch -c rescue/${t}-preserve`,
+        `tar -czf /tmp/rescue-${t}-untracked-$(date +%s).tar.gz -C "${entry.path}" .`,
+      ];
+    },
+  },
+  unpushed: {
+    riskReason: (entry) => `${entry.mainAhead ?? entry.ahead ?? 0} commit(s) ahead of main: not on remote`,
+    nextAction: 'push to a rescue branch or open a draft PR to preserve commits',
+    requiresUAT: false,
+    preserve: (entry) => {
+      const t = ticketFrom(entry.branch) || 'unknown';
+      return [
+        `git -C "${entry.path}" push origin HEAD:refs/heads/rescue/${t}-preserve --force-with-lease`,
+      ];
+    },
+  },
+  unknown: {
+    riskReason: () => 'classification unclear: ambiguous merge status or unexpected state',
+    nextAction: 'run worktree-cleanup-plan with --json for full analysis; escalate to Manager',
+    requiresUAT: true,
+    preserve: (entry) => {
+      const t = ticketFrom(entry.branch) || 'unknown';
+      return [
+        `git -C "${entry.path}" push origin HEAD:refs/heads/rescue/${t}-preserve --force-with-lease`,
+      ];
+    },
+  },
+};
+
+// AC1: classify a worktree entry into one of the 8 rescue sub-states.
+function rescueState(entry) {
+  if (entry.locked) return 'locked';
+  if ((entry.branch || '').startsWith('sandbox/')) return 'permanent';
+  if (!entry.branch) return 'detached';
+  if (!ticketFrom(entry.branch)) return 'missing-ticket';
+  if ((entry.dirtyCount || 0) > 0) return 'dirty';
+  if ((entry.untrackedCount || 0) > 0) return 'untracked';
+  if ((entry.mainAhead ?? entry.ahead ?? 0) > 0) return 'unpushed';
+  return 'unknown';
+}
+
+// AC2: build a rescue report entry with owner/ticket inference, risk reason,
+// next action, UAT flag, and preserve commands. Never recommends deletion.
+function rescueEntry(entry) {
+  const state = rescueState(entry);
+  const cfg = RESCUE_CONFIGS[state];
+  const ticket = ticketFrom(entry.branch);
+  return {
+    path: entry.path,
+    branch: entry.branch || null,
+    ticket,
+    rescueState: state,
+    riskReason: cfg.riskReason(entry),
+    nextAction: cfg.nextAction,
+    requiresUAT: cfg.requiresUAT,
+    preserveCommands: cfg.preserve(entry), // AC3: preservation commands only
+  };
+}
+
+// AC4: quarantine path for detached or abandoned worktrees needing ticket reconciliation.
+function quarantinePath(entry) {
+  const ticket = ticketFrom(entry.branch) || 'unknown';
+  const ts = Date.now();
+  return {
+    branch: `quarantine/${ticket}-abandoned-${ts}`,
+    reconciliationNote: `Worktree at ${entry.path} needs ticket reconciliation. Branch: ${entry.branch || 'DETACHED'}.`,
+    commands: [
+      `git -C "${entry.path}" switch -c quarantine/${ticket}-abandoned-${ts}`,
+      `gh pr create --draft --title "quarantine: ${entry.branch || 'DETACHED'}" --body "Needs ticket reconciliation. Path: ${entry.path}"`,
+    ],
+  };
+}
+
+// Generate the full rescue report for an array of worktree entries.
+// Only includes entries that are rescue candidates (not confirmed-safe for removal).
+function rescueReport(entries) {
+  const candidates = entries.filter(e => e.cleanupState !== 'remove' && e.cleanupState !== 'prune-metadata');
+  return {
+    generatedAt: new Date().toISOString(),
+    mode: 'rescue-report',
+    requiresUAT: candidates.some(e => RESCUE_CONFIGS[rescueState(e)].requiresUAT),
+    entries: candidates.map(rescueEntry),
+  };
+}
+
+module.exports = { rescueState, rescueEntry, rescueReport, quarantinePath, ticketFrom, RESCUE_CONFIGS };

--- a/scripts/global/worktree-rescue.js
+++ b/scripts/global/worktree-rescue.js
@@ -45,11 +45,11 @@ const RESCUE_CONFIGS = {
     nextAction: 'commit or stash changes, then re-evaluate',
     requiresUAT: false,
     preserve: (entry) => {
-      const t = ticketFrom(entry.branch) || 'unknown';
+      const ticket = ticketFrom(entry.branch) || 'unknown';
       return [
-        `git -C "${entry.path}" switch -c rescue/${t}-preserve`,
-        `git -C "${entry.path}" add -A && git -C "${entry.path}" commit -m "rescue: preserve dirty state for #${t}"`,
-        `git -C "${entry.path}" push origin rescue/${t}-preserve`,
+        `git -C "${entry.path}" switch -c rescue/${ticket}-preserve`,
+        `git -C "${entry.path}" add -A && git -C "${entry.path}" commit -m "rescue: preserve dirty state for #${ticket}"`,
+        `git -C "${entry.path}" push origin rescue/${ticket}-preserve`,
       ];
     },
   },
@@ -58,10 +58,10 @@ const RESCUE_CONFIGS = {
     nextAction: 'add and commit untracked files or archive them before cleanup',
     requiresUAT: false,
     preserve: (entry) => {
-      const t = ticketFrom(entry.branch) || 'unknown';
+      const ticket = ticketFrom(entry.branch) || 'unknown';
       return [
-        `git -C "${entry.path}" switch -c rescue/${t}-preserve`,
-        `tar -czf /tmp/rescue-${t}-untracked-$(date +%s).tar.gz -C "${entry.path}" .`,
+        `git -C "${entry.path}" switch -c rescue/${ticket}-preserve`,
+        `tar -czf /tmp/rescue-${ticket}-untracked-$(date +%s).tar.gz -C "${entry.path}" .`,
       ];
     },
   },
@@ -70,9 +70,9 @@ const RESCUE_CONFIGS = {
     nextAction: 'push to a rescue branch or open a draft PR to preserve commits',
     requiresUAT: false,
     preserve: (entry) => {
-      const t = ticketFrom(entry.branch) || 'unknown';
+      const ticket = ticketFrom(entry.branch) || 'unknown';
       return [
-        `git -C "${entry.path}" push origin HEAD:refs/heads/rescue/${t}-preserve --force-with-lease`,
+        `git -C "${entry.path}" push origin HEAD:refs/heads/rescue/${ticket}-preserve --force-with-lease`,
       ];
     },
   },
@@ -81,9 +81,9 @@ const RESCUE_CONFIGS = {
     nextAction: 'run worktree-cleanup-plan with --json for full analysis; escalate to Manager',
     requiresUAT: true,
     preserve: (entry) => {
-      const t = ticketFrom(entry.branch) || 'unknown';
+      const ticket = ticketFrom(entry.branch) || 'unknown';
       return [
-        `git -C "${entry.path}" push origin HEAD:refs/heads/rescue/${t}-preserve --force-with-lease`,
+        `git -C "${entry.path}" push origin HEAD:refs/heads/rescue/${ticket}-preserve --force-with-lease`,
       ];
     },
   },

--- a/tests/worktree-rescue.spec.js
+++ b/tests/worktree-rescue.spec.js
@@ -1,0 +1,180 @@
+'use strict';
+// Tests for worktree-rescue.js (Refs #2253).
+// Verifies: rescue state taxonomy, report emission, preserve commands,
+// quarantine path, and the core safety invariant — no rescue entry ever
+// produces a delete/remove command.
+
+const { test, describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const rescue = require('../scripts/global/worktree-rescue');
+
+function entry(overrides = {}) {
+  return {
+    path: '/tmp/devenv-ops-test',
+    branch: overrides.branch !== undefined ? overrides.branch : 'feat/1700-demo',
+    dirtyCount: 0,
+    untrackedCount: 0,
+    ahead: 0,
+    mainAhead: 0,
+    locked: false,
+    mergedToMain: false,
+    cleanupState: 'quarantine',
+    ...overrides,
+  };
+}
+
+// ── AC1: rescue sub-state taxonomy ───────────────────────────────────────────
+
+test('classifies locked worktree as locked', () => {
+  assert.equal(rescue.rescueState(entry({ locked: true })), 'locked');
+});
+
+test('classifies sandbox branch as permanent', () => {
+  assert.equal(rescue.rescueState(entry({ branch: 'sandbox/copilot' })), 'permanent');
+});
+
+test('classifies null branch (detached HEAD) as detached', () => {
+  assert.equal(rescue.rescueState(entry({ branch: null })), 'detached');
+});
+
+test('classifies branch without ticket number as missing-ticket', () => {
+  assert.equal(rescue.rescueState(entry({ branch: 'my-ad-hoc-feature' })), 'missing-ticket');
+});
+
+test('classifies dirty worktree (dirtyCount > 0) as dirty', () => {
+  assert.equal(rescue.rescueState(entry({ dirtyCount: 3 })), 'dirty');
+});
+
+test('classifies untracked worktree (untrackedCount > 0) as untracked', () => {
+  assert.equal(rescue.rescueState(entry({ untrackedCount: 2 })), 'untracked');
+});
+
+test('classifies worktree with unpushed commits as unpushed', () => {
+  assert.equal(rescue.rescueState(entry({ mainAhead: 5 })), 'unpushed');
+});
+
+test('classifies ambiguous clean worktree as unknown', () => {
+  assert.equal(rescue.rescueState(entry({ mergedToMain: false, mainAhead: 0 })), 'unknown');
+});
+
+// ── AC2: rescue report fields ─────────────────────────────────────────────────
+
+test('rescue entry includes required report fields', () => {
+  const e = rescue.rescueEntry(entry({ dirtyCount: 1 }));
+  assert.ok(typeof e.rescueState === 'string');
+  assert.ok(typeof e.riskReason === 'string' && e.riskReason.length > 0);
+  assert.ok(typeof e.nextAction === 'string' && e.nextAction.length > 0);
+  assert.ok(typeof e.requiresUAT === 'boolean');
+  assert.ok(Array.isArray(e.preserveCommands));
+  assert.equal(e.ticket, 1700);
+});
+
+test('rescue entry infers ticket from branch name', () => {
+  assert.equal(rescue.rescueEntry(entry({ branch: 'feat/9999-x' })).ticket, 9999);
+  assert.equal(rescue.rescueEntry(entry({ branch: 'my-branch' })).ticket, null);
+});
+
+test('rescueReport includes generatedAt, mode, and requiresUAT fields', () => {
+  const report = rescue.rescueReport([entry({ dirtyCount: 1 })]);
+  assert.ok(typeof report.generatedAt === 'string');
+  assert.equal(report.mode, 'rescue-report');
+  assert.ok(typeof report.requiresUAT === 'boolean');
+  assert.ok(Array.isArray(report.entries));
+});
+
+test('rescueReport flags requiresUAT true when any entry needs it', () => {
+  const entries = [
+    entry({ branch: null }),           // detached → requiresUAT: true
+    entry({ dirtyCount: 1 }),          // dirty → requiresUAT: false
+  ];
+  const report = rescue.rescueReport(entries);
+  assert.equal(report.requiresUAT, true);
+});
+
+// ── AC3: preserve commands — non-destructive only ────────────────────────────
+
+test('dirty worktree preserve commands reference rescue/ branch, not deletion', () => {
+  const e = rescue.rescueEntry(entry({ dirtyCount: 2 }));
+  assert.ok(e.preserveCommands.length > 0);
+  for (const cmd of e.preserveCommands) {
+    assert.ok(!cmd.includes('worktree remove'), `unexpected remove cmd: ${cmd}`);
+    assert.ok(!cmd.includes('branch -d'), `unexpected delete cmd: ${cmd}`);
+  }
+  assert.ok(e.preserveCommands.some(cmd => cmd.includes('rescue/')));
+});
+
+test('unpushed worktree preserve commands push to rescue/ ref', () => {
+  const e = rescue.rescueEntry(entry({ mainAhead: 3 }));
+  assert.ok(e.preserveCommands.some(cmd => cmd.includes('rescue/')));
+  assert.ok(e.preserveCommands.every(cmd => !cmd.includes('branch -D') && !cmd.includes('worktree remove')));
+});
+
+test('locked and permanent worktrees have empty preserve commands (no action needed)', () => {
+  assert.deepEqual(rescue.rescueEntry(entry({ locked: true })).preserveCommands, []);
+  assert.deepEqual(rescue.rescueEntry(entry({ branch: 'sandbox/codex' })).preserveCommands, []);
+});
+
+// ── AC4: quarantine path for detached/abandoned ───────────────────────────────
+
+test('quarantinePath returns a quarantine branch name', () => {
+  const q = rescue.quarantinePath(entry({ branch: null }));
+  assert.ok(q.branch.startsWith('quarantine/'));
+  assert.ok(typeof q.reconciliationNote === 'string' && q.reconciliationNote.length > 0);
+  assert.ok(Array.isArray(q.commands) && q.commands.length > 0);
+});
+
+test('quarantinePath uses ticket number when available', () => {
+  const q = rescue.quarantinePath(entry({ branch: 'feat/42-feature' }));
+  assert.ok(q.branch.includes('42'), `expected ticket 42 in ${q.branch}`);
+});
+
+test('quarantinePath uses unknown for detached HEAD', () => {
+  const q = rescue.quarantinePath(entry({ branch: null }));
+  assert.ok(q.branch.includes('unknown'));
+});
+
+// ── AC5: safety invariant — rescue candidates are NEVER auto-deleted ──────────
+
+const allRescueInputs = [
+  ['dirty',          entry({ dirtyCount: 2 })],
+  ['untracked',      entry({ untrackedCount: 1 })],
+  ['unpushed',       entry({ mainAhead: 4 })],
+  ['detached',       entry({ branch: null })],
+  ['locked',         entry({ locked: true })],
+  ['permanent',      entry({ branch: 'sandbox/copilot' })],
+  ['missing-ticket', entry({ branch: 'ad-hoc-branch' })],
+  ['unknown',        entry({ mergedToMain: false, mainAhead: 0 })],
+];
+
+for (const [label, e] of allRescueInputs) {
+  test(`safety invariant: ${label} worktree preserve commands never contain delete/remove`, () => {
+    const r = rescue.rescueEntry(e);
+    for (const cmd of r.preserveCommands) {
+      assert.ok(!cmd.includes('worktree remove'), `[${label}] found 'worktree remove' in cmd`);
+      assert.ok(!cmd.includes('branch -d'), `[${label}] found 'branch -d' in cmd`);
+      assert.ok(!cmd.includes('branch -D'), `[${label}] found 'branch -D' in cmd`);
+      assert.ok(!cmd.includes('rm -rf'), `[${label}] found 'rm -rf' in cmd`);
+    }
+  });
+}
+
+test('rescueReport never includes remove or prune-metadata entries', () => {
+  const worktrees = [
+    { ...entry({ mergedToMain: true }), cleanupState: 'remove' },
+    { ...entry({ dirtyCount: 1 }),      cleanupState: 'quarantine' },
+    { ...entry({ branch: 'sandbox/x' }), cleanupState: 'preserve' },
+    { ...entry({ prunable: true }),     cleanupState: 'prune-metadata' },
+  ];
+  const report = rescue.rescueReport(worktrees);
+  for (const e of report.entries) {
+    assert.notEqual(e.cleanupState, 'remove');
+    assert.notEqual(e.cleanupState, 'prune-metadata');
+  }
+});
+
+// ── all 8 rescue states are reachable ────────────────────────────────────────
+test('all 8 rescue sub-states are reachable', () => {
+  const states = new Set(allRescueInputs.map(([, e]) => rescue.rescueState(e)));
+  const expected = new Set(['dirty', 'untracked', 'unpushed', 'detached', 'locked', 'permanent', 'missing-ticket', 'unknown']);
+  assert.deepEqual(states, expected);
+});


### PR DESCRIPTION
Refs #2253
merge-evidence-deferred-final: #2253

## Summary
Add stale worktree rescue/quarantine workflow for Epic #2248. Implements `scripts/global/worktree-rescue.js` with 8 rescue sub-states, a rescue report emitter, preserve-only commands, and a quarantine path — all covered by 28 tests.

lane: lane:code-change
test_strategy: tdd-pyramid
