### PR TITLE
feat(fleet): fleet-call-guard: bounded timeout + lint rule

### DIFF
--- a/.changes/unreleased/2626.md
+++ b/.changes/unreleased/2626.md
@@ -1,5 +1,3 @@
-## #2626 — fleet-call-guard: bounded timeout + lint guard for ad-hoc fleet calls
-
 ### Added
 
 - `scripts/global/fleet-call-guard.js` — reusable guarded fleet call helper

--- a/.changes/unreleased/2626.md
+++ b/.changes/unreleased/2626.md
@@ -1,0 +1,16 @@
+## #2626 — fleet-call-guard: bounded timeout + lint guard for ad-hoc fleet calls
+
+### Added
+
+- `scripts/global/fleet-call-guard.js` — reusable guarded fleet call helper
+  (45s default timeout, 2 retries, `fallback_tier:'free-cloud'` fallback signal,
+  `FLEET_GUARD_DISABLED=1` escape hatch, G8 incident emission on timeout).
+  Prevents G3 violations caused by fleet session stalls forcing paid provider fallback.
+- `scripts/global/megalint/fleet-call-lint.js` — megalint validator detecting
+  unbounded `curl /api/generate` (missing `--max-time`) and
+  `fetch(api/generate)` (missing `AbortController`/`AbortSignal`) calls in PR files.
+  Registered in `megalint/index.js` as `fleet-call-lint`.
+- `tests/fleet-call-guard.spec.js` — 5 node:test specs covering success, timeout,
+  retry-success, retry_exhaustion, and FLEET_GUARD_DISABLED bypass.
+- `docs/howto/fleet-call-guard.md` — CLI + programmatic usage guide with G6
+  caller contract, escape hatch, and guard vs. cascade-dispatch comparison.

--- a/docs/howto/fleet-call-guard.md
+++ b/docs/howto/fleet-call-guard.md
@@ -1,0 +1,78 @@
+# fleet-call-guard.js — Usage Guide
+
+> **When to use**: for ad-hoc fleet model calls that do NOT go through
+> `cascade-dispatch.js`. If routing through the harness, cascade-dispatch is
+> preferred. Use this guard when calling a fleet model directly (scripts, test
+> harness, one-off analysis).
+
+## CLI Usage
+
+```sh
+node scripts/global/fleet-call-guard.js \
+  --model qwen2.5-coder:7b \
+  --host http://100.91.113.16:11434 \
+  --prompt "rate this code 1-10" \
+  --timeout 30000 \
+  --max-retries 2
+```
+
+Exit codes:
+
+| Code | Meaning | stdout |
+|------|---------|--------|
+| `0` | Success | `{"success":true,"response":"...","model":"...","elapsed_ms":N}` |
+| `1` | Timeout | `{"success":false,"reason":"timeout","elapsed_ms":N,"host":"...","fallback_tier":"free-cloud"}` |
+| `1` | Retry exhaustion | `{"success":false,"reason":"retry_exhaustion","attempts":N,"fallback_tier":"free-cloud"}` |
+| `2` | Unexpected error | stderr message |
+
+## Programmatic API
+
+```js
+const { callWithGuard } = require('./scripts/global/fleet-call-guard.js');
+
+const result = await callWithGuard({
+  model: 'qwen2.5-coder:7b',       // Ollama model name
+  host: 'http://100.91.113.16:11434', // fleet host URL
+  prompt: 'Review this function...',
+  timeout: 45000,   // ms before a single attempt times out (default: 45000)
+  maxRetries: 2,    // retries after failure (default: 2; 0 = no retries)
+});
+
+if (!result.success) {
+  // G6 contract: guard signals; caller routes.
+  routeTo(result.fallback_tier); // 'free-cloud'
+}
+```
+
+## G6 Caller Contract
+
+`fleet-call-guard.js` is a **signal emitter** — it does NOT auto-route to the
+fallback tier. On failure it returns `fallback_tier: 'free-cloud'`. The caller
+must act on that signal (e.g. call free-cloud-dispatch.js, openrouter-free, etc).
+
+On timeout, the guard also appends to `~/.megingjord/incidents.jsonl` with
+`pattern_id: 'fleet-call-timeout'` for Tier-1 observability.
+
+## Escape Hatch (G5 portability)
+
+```sh
+FLEET_GUARD_DISABLED=1 node scripts/global/fleet-call-guard.js ...
+```
+
+Bypasses timeout enforcement. Use for air-gapped operators where fleet is absent
+at baseline (G5), or during integration testing that does not need the guard.
+
+## guard vs. cascade-dispatch.js
+
+| | fleet-call-guard.js | cascade-dispatch.js |
+|---|---|---|
+| Use for | Ad-hoc, direct calls | All routine routing |
+| Timeout | 45s default, configurable | Built-in via AbortController |
+| Fallback | Caller-routed (signal) | Automatic (built into cascade) |
+| Retries | Yes, configurable | Via cascade retry logic |
+
+## Security Note (G4)
+
+Fleet hosts are on Tailscale VPN (private network, 100.x.x.x). stdout contains
+only model response and metadata — no credentials. Never log prompt contents
+containing secrets.

--- a/scripts/global/fleet-call-guard.js
+++ b/scripts/global/fleet-call-guard.js
@@ -1,0 +1,100 @@
+'use strict';
+// fleet-call-guard.js — bounded-timeout guard for ad-hoc fleet model calls.
+// G3: fleet stalls -> paid fallback = G3 violation. This guard prevents it.
+// Exports callWithGuard() for programmatic use; CLI via node fleet-call-guard.js.
+// Refs #2626.
+const http = require('node:http');
+const https = require('node:https');
+const fs = require('node:fs');
+const nodePath = require('node:path');
+const { homedir } = require('node:os');
+
+const DEFAULT_TIMEOUT_MS = 45000;
+const HTTPS_DEFAULT_PORT = 443;
+const DEFAULT_OLLAMA_PORT = 11434;
+
+function appendIncident(host, elapsed_ms) {
+  const dir = nodePath.join(homedir(), '.megingjord');
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.appendFileSync(nodePath.join(dir, 'incidents.jsonl'),
+      JSON.stringify({ pattern_id: 'fleet-call-timeout', host, elapsed_ms,
+        timestamp: new Date().toISOString() }) + '\n');
+  } catch (_) {}
+}
+
+function rawPost(hostUrl, prompt, model) {
+  return new Promise((resolve, reject) => {
+    const endpoint = new URL('/api/generate', hostUrl);
+    const driver = endpoint.protocol === 'https:' ? https : http;
+    const body = JSON.stringify({ model, stream: false, prompt });
+    const req = driver.request({
+      hostname: endpoint.hostname,
+      port: endpoint.port || (endpoint.protocol === 'https:' ? HTTPS_DEFAULT_PORT : 80),
+      path: endpoint.pathname, method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
+    }, (res) => {
+      let responseBody = '';
+      res.on('data', chunk => { responseBody += chunk; });
+      res.on('end', () => {
+        try { resolve(JSON.parse(responseBody)); } catch (parseErr) { reject(parseErr); }
+      });
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function makeTimeoutRace(timeout) {
+  return new Promise((_, rej) => setTimeout(() => {
+    const timeoutErr = new Error('timeout');
+    timeoutErr.isTimeout = true;
+    rej(timeoutErr);
+  }, timeout));
+}
+
+async function callWithGuard({
+  model = 'qwen2.5-coder:7b', host, prompt = '',
+  timeout = DEFAULT_TIMEOUT_MS, maxRetries = 2,
+} = {}) {
+  if (process.env.FLEET_GUARD_DISABLED === '1') {
+    const t0 = Date.now();
+    try {
+      const res = await rawPost(host, prompt, model);
+      return { success: true, response: res.response || '', model, elapsed_ms: Date.now() - t0 };
+    } catch (ex) {
+      return { success: false, reason: 'error', message: ex.message, fallback_tier: 'free-cloud' };
+    }
+  }
+  const t0 = Date.now();
+  let lastErr = null;
+  for (let i = 0; i <= maxRetries; i++) {
+    try {
+      const res = await Promise.race([rawPost(host, prompt, model), makeTimeoutRace(timeout)]);
+      return { success: true, response: res.response || '', model, elapsed_ms: Date.now() - t0 };
+    } catch (err) { lastErr = err; }
+  }
+  const elapsed_ms = Date.now() - t0;
+  if (lastErr && lastErr.isTimeout) {
+    appendIncident(host, elapsed_ms);
+    return { success: false, reason: 'timeout', elapsed_ms, host, fallback_tier: 'free-cloud' };
+  }
+  return { success: false, reason: 'retry_exhaustion', attempts: maxRetries, fallback_tier: 'free-cloud' };
+}
+
+module.exports = { callWithGuard };
+
+/* istanbul ignore next */
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const getArg = key => { const idx = args.indexOf(key); return idx >= 0 ? args[idx + 1] : undefined; };
+  callWithGuard({
+    model: getArg('--model'), host: getArg('--host') || `http://localhost:${DEFAULT_OLLAMA_PORT}`,
+    prompt: getArg('--prompt') || '', timeout: Number(getArg('--timeout') || DEFAULT_TIMEOUT_MS),
+    maxRetries: Number(getArg('--max-retries') || 2),
+  }).then(result => {
+    process.stdout.write(JSON.stringify(result) + '\n');
+    process.exit(result.success ? 0 : 1);
+  }).catch(ex => { process.stderr.write(ex.message + '\n'); process.exit(2); });
+}

--- a/scripts/global/megalint/fleet-call-lint.js
+++ b/scripts/global/megalint/fleet-call-lint.js
@@ -1,0 +1,53 @@
+'use strict';
+// fleet-call-lint.js — detect unbounded direct fleet /api/generate calls.
+// G1/G3: ad-hoc curl/fetch calls that bypass cascade-dispatch.js timeout
+// controls can stall sessions and force paid provider fallback (G3 violation).
+// validate() takes { files: [{path, content}] }. Refs #2626.
+const nodePath = require('node:path');
+
+// Files that are already guarded — do not lint these.
+const EXEMPT_BASENAMES = new Set([
+  'cascade-dispatch.js', 'fleet-call-guard.js', 'fleet-call-lint.js',
+  'worker.ts', 'durable-object.ts', 'litellm-client.js',
+]);
+
+const CURL_RE = /\bcurl\b[^\n]*?\/api\/generate/;
+const FETCH_RE = /\bfetch\s*\([^)]*api\/generate/;
+const EXEMPT_LINE = /\/\/\s*fleet-guard:\s*exempt/;
+
+function checkLine(line) {
+  if (EXEMPT_LINE.test(line)) return null;
+  if (CURL_RE.test(line) && !line.includes('--max-time')) {
+    return { reason: 'curl-without-max-time', snippet: line.trim().slice(0, 100) };
+  }
+  if (FETCH_RE.test(line) &&
+      !line.includes('AbortController') && !line.includes('AbortSignal')) {
+    return { reason: 'fetch-without-abort', snippet: line.trim().slice(0, 100) };
+  }
+  return null;
+}
+
+function scanFile({ path: filePath, content }) {
+  if (EXEMPT_BASENAMES.has(nodePath.basename(filePath))) return [];
+  const violations = [];
+  (content || '').split('\n').forEach((line, idx) => {
+    const hit = checkLine(line);
+    if (hit) {
+      violations.push({
+        rule: 'fleet-unbounded-call',
+        path: filePath,
+        line: idx + 1,
+        detail: `${hit.reason}: ${hit.snippet}`,
+      });
+    }
+  });
+  return violations;
+}
+
+function validate({ files = [] } = {}) {
+  if (process.env.FLEET_GUARD_DISABLED === '1') return { ok: true, violations: [] };
+  const violations = files.flatMap(f => scanFile(f));
+  return { ok: violations.length === 0, violations };
+}
+
+module.exports = { validate, scanFile, checkLine, EXEMPT_BASENAMES };

--- a/scripts/global/megalint/index.js
+++ b/scripts/global/megalint/index.js
@@ -25,6 +25,7 @@ const crossTeamResponseFidelity = require('./cross-team-response-fidelity.js');
 const changelogFragmentPresence = require('./changelog-fragment-presence.js');
 const adminMergeException = require('./admin-merge-exception.js');
 const batchCancelEvidence = require('./batch-cancel-evidence.js');
+const fleetCallLint = require('./fleet-call-lint.js');
 
 // parity-validator exposes run() not validate(); wrap to standard interface.
 const parityValidatorAdapter = {
@@ -61,6 +62,7 @@ const VALIDATORS = {
   'changelog-fragment-presence': changelogFragmentPresence,
   'admin-merge-exception': adminMergeException,
   'batch-cancel-evidence': batchCancelEvidence,
+  'fleet-call-lint': fleetCallLint,
 };
 
 function runAll(input) {

--- a/tests/fleet-call-guard.spec.js
+++ b/tests/fleet-call-guard.spec.js
@@ -1,0 +1,91 @@
+'use strict';
+// fleet-call-guard.spec.js — Refs #2626.
+// Tests: success, timeout, retry-success, retry_exhaustion, FLEET_GUARD_DISABLED.
+// Uses inline http.createServer() to avoid external dependencies (G10/G3).
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { callWithGuard } = require('../scripts/global/fleet-call-guard.js');
+
+let BASE_PORT = 29800;
+function nextPort() { return BASE_PORT++; }
+
+function startServer(handler) {
+  const port = nextPort();
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(port, () => resolve({ server, port }));
+  });
+}
+
+test('success: result.success true, elapsed_ms present', async () => {
+  const { server, port } = await startServer((req, res) => {
+    let b = '';
+    req.on('data', c => { b += c; });
+    req.on('end', () => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ response: 'hello' }));
+    });
+  });
+  const result = await callWithGuard({ host: `http://localhost:${port}`, prompt: 'hi', timeout: 2000, maxRetries: 0 });
+  server.close();
+  assert.strictEqual(result.success, true);
+  assert.ok(typeof result.elapsed_ms === 'number' && result.elapsed_ms >= 0);
+});
+
+test('timeout: reason=timeout, fallback_tier=free-cloud', async () => {
+  // Server never responds — triggers timeout
+  const { server, port } = await startServer((_req, _res) => {});
+  const result = await callWithGuard({ host: `http://localhost:${port}`, prompt: 'hi', timeout: 150, maxRetries: 0 });
+  server.close();
+  assert.strictEqual(result.success, false);
+  assert.strictEqual(result.reason, 'timeout');
+  assert.strictEqual(result.fallback_tier, 'free-cloud');
+});
+
+test('retry success: succeeds on second attempt', async () => {
+  let calls = 0;
+  const port = nextPort();
+  await new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      calls++;
+      if (calls === 1) { req.socket.destroy(); return; }
+      let b = '';
+      req.on('data', c => { b += c; });
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ response: 'ok' }));
+      });
+    });
+    server.listen(port, () => resolve(server));
+  }).then(server => {
+    return callWithGuard({ host: `http://localhost:${port}`, prompt: 'hi', timeout: 2000, maxRetries: 1 })
+      .then(result => { server.close(); assert.strictEqual(result.success, true); });
+  });
+});
+
+test('retry_exhaustion: reason=retry_exhaustion, attempts=maxRetries', async () => {
+  const { server, port } = await startServer((req, _res) => { req.socket.destroy(); });
+  const result = await callWithGuard({ host: `http://localhost:${port}`, prompt: 'hi', timeout: 2000, maxRetries: 1 });
+  server.close();
+  assert.strictEqual(result.success, false);
+  assert.strictEqual(result.reason, 'retry_exhaustion');
+  assert.strictEqual(result.attempts, 1);
+  assert.strictEqual(result.fallback_tier, 'free-cloud');
+});
+
+test('FLEET_GUARD_DISABLED=1: guard bypassed, call passes through', async () => {
+  const { server, port } = await startServer((req, res) => {
+    let b = '';
+    req.on('data', c => { b += c; });
+    req.on('end', () => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ response: 'bypass' }));
+    });
+  });
+  process.env.FLEET_GUARD_DISABLED = '1';
+  const result = await callWithGuard({ host: `http://localhost:${port}`, prompt: 'hi', timeout: 50 });
+  delete process.env.FLEET_GUARD_DISABLED;
+  server.close();
+  assert.strictEqual(result.success, true);
+});


### PR DESCRIPTION
merge-evidence-deferred-final: #2626
Refs #2626

## Summary

Implements guardrail for ad-hoc fleet model calls to prevent G3 violations from session stalls forcing paid provider escalation.

## Changes

- `scripts/global/fleet-call-guard.js` — `callWithGuard()`: 45s default timeout, 2 retries, `fallback_tier:'free-cloud'` signal, `FLEET_GUARD_DISABLED=1` escape hatch, G8 incident emission on timeout
- `scripts/global/megalint/fleet-call-lint.js` — validator detecting unbounded `curl /api/generate` (no `--max-time`) and `fetch(api/generate)` (no `AbortController`) calls; registered in `megalint/index.js`
- `tests/fleet-call-guard.spec.js` — 5 node:test specs (success, timeout, retry-success, retry_exhaustion, FLEET_GUARD_DISABLED)
- `docs/howto/fleet-call-guard.md` — usage guide with CLI, API, G6 caller contract, escape hatch
- `.changes/unreleased/2626.md` — changelog fragment

## Validation

- All 5 tests pass: `node --test tests/fleet-call-guard.spec.js`
- Lint clean: `npm run lint` — 373 files, ✅ all within limit
- Cross-family review: 85/100 by qwen2.5-coder:7b-instruct-q3_K_S (Qwen ≠ Anthropic)