### PR TITLE
fix(scripts): fail-loud unknown flags + MANAGER_HANDOFF field guard

### DIFF
--- a/.changes/unreleased/2693.md
+++ b/.changes/unreleased/2693.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- `baton-comment-build.js` now exits 1 on unrecognized flags (fail-loud) instead
+  of silently falling through to an empty legacy render. Prevents empty
+  MANAGER_HANDOFFs that drop `lane:`, `test_strategy:`, and routing fields.
+- `MANAGER_HANDOFF` legacy path validates required fields in output; exits 1 if
+  any of `scope`, `lane`, `test_strategy`, `acceptance`, `gates` are absent.
+- Adds 6-test regression suite (`tests/baton-comment-build.test.js`).
+
+Refs #2693

--- a/scripts/global/baton-comment-build.js
+++ b/scripts/global/baton-comment-build.js
@@ -3,6 +3,34 @@
 const { canonicalSignerAlias } = require('./signer-alias');
 const { buildArtifact } = require('./baton-artifact-builder');
 
+// AC1 (#2693): fail loud on unrecognized flags so stale callers surface errors.
+const KNOWN_FLAGS = new Set([
+  'artifact', 'role', 'team-model', 'ticket', 'fields-json',
+  'summary', 'related-tickets', 'overlap-decision',
+]);
+function checkUnknownFlags() {
+  for (const token of process.argv.slice(2)) {
+    const m = token.match(/^--(.+)/);
+    if (m && !KNOWN_FLAGS.has(m[1])) {
+      const known = [...KNOWN_FLAGS].map((f) => `--${f}`).join(', ');
+      process.stderr.write(`error: unknown flag '--${m[1]}'. Recognized: ${known}\n`);
+      process.exit(1);
+    }
+  }
+}
+
+// AC2 (#2693): MANAGER_HANDOFF legacy output must contain all routing fields.
+const MH_REQUIRED = ['scope', 'lane', 'test_strategy', 'acceptance', 'gates'];
+function checkLegacyOutput(artifact, output) {
+  if (artifact !== 'MANAGER_HANDOFF') return;
+  for (const field of MH_REQUIRED) {
+    if (!new RegExp(`(?:^|\\n)${field}\\s*:`).test(output)) {
+      process.stderr.write(`error: MANAGER_HANDOFF missing required field '${field}' in legacy output\n`);
+      process.exit(1);
+    }
+  }
+}
+
 function arg(name, fallback = '') {
   const i = process.argv.indexOf(`--${name}`);
   return i >= 0 ? (process.argv[i + 1] || '') : fallback;
@@ -23,6 +51,7 @@ function buildBatonComment({ artifact, ticket, role, teamModel, summary = '', re
 }
 
 function main() {
+  checkUnknownFlags();
   const artifact = arg('artifact', 'MANAGER_HANDOFF').toUpperCase();
   const role = arg('role', 'manager').toLowerCase();
   const teamModel = arg('team-model', process.env.TEAM_MODEL || '');
@@ -43,7 +72,9 @@ function main() {
   const summary = arg('summary', '');
   const relatedTickets = arg('related-tickets', '');
   const overlapDecision = arg('overlap-decision', '');
-  console.log(buildBatonComment({ artifact, ticket, role, teamModel, summary, relatedTickets, overlapDecision }));
+  const out = buildBatonComment({ artifact, ticket, role, teamModel, summary, relatedTickets, overlapDecision });
+  checkLegacyOutput(artifact, out);
+  console.log(out);
 }
 
 if (require.main === module) main();

--- a/tests/baton-comment-build.test.js
+++ b/tests/baton-comment-build.test.js
@@ -1,0 +1,78 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const { writeFileSync, unlinkSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+
+const SCRIPT = join(__dirname, '../scripts/global/baton-comment-build.js');
+const TM = 'copilot:claude-sonnet-4-6@anthropic';
+
+function run(args) {
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+      env: { ...process.env, TEAM_MODEL: TM },
+      encoding: 'utf8',
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (e) {
+    return { code: e.status || 1, stdout: e.stdout || '', stderr: e.stderr || '' };
+  }
+}
+
+// T1: single unknown flag exits 1 with "unknown flag" in stderr
+test('T1: unknown flag exits 1', () => {
+  const r = run(['--artifact', 'COLLABORATOR_HANDOFF', '--unknown-flag', 'val',
+    '--ticket', '1']);
+  assert.equal(r.code, 1);
+  assert.ok(r.stderr.includes('unknown flag'), `stderr: ${r.stderr}`);
+});
+
+// T2: multiple unknown flags — exits 1 for first unknown
+test('T2: multiple unknown flags exits 1', () => {
+  const r = run(['--artifact', 'MANAGER_HANDOFF', '--foo', 'bar', '--baz', 'qux',
+    '--ticket', '1']);
+  assert.equal(r.code, 1);
+  assert.ok(r.stderr.includes('unknown flag'), `stderr: ${r.stderr}`);
+});
+
+// T3: MANAGER_HANDOFF legacy path without --summary exits 1 (missing required fields)
+test('T3: MANAGER_HANDOFF legacy missing fields exits 1', () => {
+  const r = run(['--artifact', 'MANAGER_HANDOFF', '--ticket', '1']);
+  assert.equal(r.code, 1);
+  assert.ok(r.stderr.includes('missing required field'), `stderr: ${r.stderr}`);
+});
+
+// T4: COLLABORATOR_HANDOFF legacy path without fields exits 0 (backward-compat)
+test('T4: COLLABORATOR_HANDOFF legacy no fields exits 0', () => {
+  const r = run(['--artifact', 'COLLABORATOR_HANDOFF', '--ticket', '1']);
+  assert.equal(r.code, 0);
+});
+
+// T5: --fields-json with valid file exits 0 and output contains required fields
+test('T5: --fields-json valid exits 0 with scope/lane in output', () => {
+  const tmp = join(tmpdir(), `bcb-test-${Date.now()}.json`);
+  const fields = {
+    scope: 'test scope', lane: 'lane:code-change',
+    test_strategy: 'tdd-pyramid', acceptance: 'ac', gates: 'lint',
+    related_tickets: '#1', overlap_decision: 'none',
+  };
+  writeFileSync(tmp, JSON.stringify(fields));
+  try {
+    const r = run(['--artifact', 'MANAGER_HANDOFF', '--ticket', '99',
+      '--fields-json', tmp]);
+    assert.equal(r.code, 0);
+    assert.ok(r.stdout.includes('scope:'), `stdout: ${r.stdout}`);
+    assert.ok(r.stdout.includes('lane:'), `stdout: ${r.stdout}`);
+  } finally {
+    try { unlinkSync(tmp); } catch { /* best-effort cleanup */ }
+  }
+});
+
+// T6: all recognized flags accepted, exits 0 (no false positives)
+test('T6: all recognized flags exit 0', () => {
+  const r = run(['--artifact', 'COLLABORATOR_HANDOFF', '--role', 'collaborator',
+    '--ticket', '1', '--summary', 'test']);
+  assert.equal(r.code, 0);
+});


### PR DESCRIPTION
## Summary

Fix `baton-comment-build.js` to prevent silent empty-handoff production caused by unrecognized flags on stale canonical-main callers.

## Changes

- **AC1**: `checkUnknownFlags()` — exits 1 with descriptive error on any `--<flag>` not in `KNOWN_FLAGS` set. Stale callers immediately surface the error instead of silently rendering an incomplete artifact.
- **AC2**: `checkLegacyOutput()` — after `buildBatonComment()`, MANAGER_HANDOFF output validated for required fields (`scope`, `lane`, `test_strategy`, `acceptance`, `gates`); exits 1 if any absent. Non-MANAGER_HANDOFF artifacts unaffected (backward-compat).
- **AC3**: 6-test regression suite (`tests/baton-comment-build.test.js`): T1-T6 all pass.
- **AC4**: 81 lines (limit 100).

## G3

Missing `lane:` field from empty handoffs caused routing fallback to paid providers. Fail-loud also eliminates CI rerun cycles from empty handoffs (each rerun = wasted compute).

## Test evidence

```
6/6 pass: node tests/baton-comment-build.test.js
npm run lint: ✅ All files within 100-line limit
readability gate: 475/475 warnings (EXIT 0)
```

merge-evidence-deferred-final: #2693
Refs #2693