### PR TITLE
feat(scripts): canonical chain-derivations library (#2722)

### DIFF
--- a/.changes/unreleased/2722.md
+++ b/.changes/unreleased/2722.md
@@ -1,0 +1,2 @@
+### Added
+- **Canonical chain-derivations library** (#2722, Epic #2709): `scripts/global/chain-derivations.js` derives formerly operator-discretionary governance state from observable facts - `active_ticket` from the branch name, `admin_ops` from git/PR facts (not local cache), and stale-advisory auto-clear targets (e.g. `governance:close-without-merge` on a closed+merged issue). Single source of truth so these auto-emitted links cannot drift per-runtime or depend on operator memory.

--- a/scripts/global/chain-derivations.js
+++ b/scripts/global/chain-derivations.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+'use strict';
+// tier: 1
+// chain-derivations (Epic #2709 / #2722): the canonical, single-source derivations
+// that convert formerly operator-discretionary governance links into auto-emitted
+// ones. The harness repeatedly hand-set `active_ticket` and `admin_ops` state and
+// hand-cleared stale advisories; these pure functions derive them from observable
+// facts (branch name, git/PR state, issue labels) so no operator memory is required.
+// Pure logic (unit-testable); callers inject the live git/gh facts.
+
+const BRANCH_RE = /^(?:feat|fix|hotfix|chore|skill)\/(\d+)(?:-|$)/;
+const STALE_CLOSE_WITHOUT_MERGE = 'governance:close-without-merge';
+
+// active_ticket from a ticket branch name; null when the branch is not ticket-shaped.
+function activeTicketFromBranch(branch) {
+  const match = BRANCH_RE.exec(String(branch || '').trim());
+  return match ? Number(match[1]) : null;
+}
+
+// admin_ops flags derived from observable git/PR facts (not local cache).
+function adminOpsFromFacts(facts = {}) {
+  const merged = Boolean(facts.prMerged);
+  return {
+    commit: Boolean(facts.hasCommit),
+    push: Boolean(facts.branchPushed),
+    pr_create: Boolean(facts.prNumber),
+    ci_green: facts.requiredChecksAllGreen === true,
+    merge: merged,
+  };
+}
+
+// Stale advisory labels that should be auto-cleared given the issue's true state.
+// e.g. a closed+merged issue must not carry `governance:close-without-merge`.
+function staleAdvisoriesToClear(issue = {}) {
+  const labels = issue.labels || [];
+  const clear = [];
+  if (issue.state === 'closed' && issue.merged && labels.includes(STALE_CLOSE_WITHOUT_MERGE)) {
+    clear.push(STALE_CLOSE_WITHOUT_MERGE);
+  }
+  return clear;
+}
+
+module.exports = { activeTicketFromBranch, adminOpsFromFacts, staleAdvisoriesToClear,
+  BRANCH_RE, STALE_CLOSE_WITHOUT_MERGE };
+
+if (require.main === module) {
+  const branch = process.argv[2] || '';
+  console.log(JSON.stringify({ active_ticket: activeTicketFromBranch(branch) }));
+}

--- a/tests/chain-derivations.spec.js
+++ b/tests/chain-derivations.spec.js
@@ -1,0 +1,41 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const cd = require(path.resolve(__dirname, '..', 'scripts', 'global', 'chain-derivations.js'));
+
+test('active_ticket is derived from a ticket branch name', () => {
+  assert.strictEqual(cd.activeTicketFromBranch('feat/2722-chain-derivations'), 2722);
+  assert.strictEqual(cd.activeTicketFromBranch('fix/5-nav'), 5);
+  assert.strictEqual(cd.activeTicketFromBranch('hotfix/99'), 99);
+});
+
+test('a non-ticket branch derives null (no false active_ticket)', () => {
+  assert.strictEqual(cd.activeTicketFromBranch('main'), null);
+  assert.strictEqual(cd.activeTicketFromBranch('feature/no-number'), null);
+  assert.strictEqual(cd.activeTicketFromBranch(''), null);
+});
+
+test('admin_ops is derived from observable facts, not cache', () => {
+  const ops = cd.adminOpsFromFacts({ hasCommit: true, branchPushed: true, prNumber: 2728,
+    requiredChecksAllGreen: true, prMerged: true });
+  assert.deepStrictEqual(ops, { commit: true, push: true, pr_create: true, ci_green: true, merge: true });
+});
+
+test('admin_ops merge is false until the PR is actually merged', () => {
+  const ops = cd.adminOpsFromFacts({ hasCommit: true, prNumber: 1, requiredChecksAllGreen: false });
+  assert.strictEqual(ops.merge, false);
+  assert.strictEqual(ops.ci_green, false);
+});
+
+test('a closed+merged issue carrying close-without-merge is flagged for auto-clear', () => {
+  const clear = cd.staleAdvisoriesToClear({ state: 'closed', merged: true,
+    labels: ['type:task', cd.STALE_CLOSE_WITHOUT_MERGE] });
+  assert.deepStrictEqual(clear, [cd.STALE_CLOSE_WITHOUT_MERGE]);
+});
+
+test('an open issue with the advisory is NOT cleared (only false positives)', () => {
+  const clear = cd.staleAdvisoriesToClear({ state: 'open', merged: false,
+    labels: [cd.STALE_CLOSE_WITHOUT_MERGE] });
+  assert.deepStrictEqual(clear, []);
+});


### PR DESCRIPTION
Refs #2722
Refs #2710

Epic #2709 auto-emitted links: canonical derivations for active_ticket (from branch), admin_ops (from git/PR facts, not cache), and stale-advisory auto-clear. Single source so these links cannot drift per-runtime or depend on operator memory - eliminating the manual state-patching seen repeatedly this session.

## Evidence
- node --test -> 6/6
- npm run lint clean
- Cross-family: gemini-2.5-flash@google-ai-studio ACCEPT 95/100

## Baton (on #2722)
MANAGER/COLLABORATOR/ADMIN/CONSULTANT posted.

merge-evidence-deferred-final: #2722