### PR TITLE
feat(scripts): fail-closed judgment-gate logic (#2723)

### DIFF
--- a/.changes/unreleased/2723.md
+++ b/.changes/unreleased/2723.md
@@ -1,0 +1,2 @@
+### Added
+- **Fail-closed judgment-gate logic** (#2723, Epic #2709): `scripts/global/judgment-gate.js` provides the enforcement logic for governance links that need a recorded operator judgment - a recognized flaw must carry an explicit `flaw_decision` token (file-ticket | log-incident-only | memory-note-only | no-action-justified), and a tracked-file mutation with no active baton is blocked. Converts the CLAUDE.md "record a flaw decision" rule and the baton-entry advisory from operator-discretion to machine-checkable, fail-closed gates the baton/hook layer consumes.

--- a/scripts/global/judgment-gate.js
+++ b/scripts/global/judgment-gate.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+'use strict';
+// tier: 1
+// judgment-gate (Epic #2709 / #2723): fail-closed gates for the governance links that
+// need a recorded operator JUDGMENT the system cannot synthesize. Rather than trust the
+// operator to remember, the gate blocks forward progress until the judgment is recorded:
+//   - flaw-recognition decision: a closeout/handoff that recognizes a flaw MUST carry an
+//     explicit flaw_decision token (file-ticket | log-incident-only | memory-note-only |
+//     no-action-justified) - the CLAUDE.md rule, now enforced not just requested.
+//   - baton-entry: a tracked-file mutation with no active baton is a missing link.
+// Pure logic (unit-testable); callers inject the live facts.
+
+const FLAW_MENTION = /\b(flaw|defect|regression|incorrect|bug)\b/i;
+const FLAW_DECISIONS = ['file-ticket', 'log-incident-only', 'memory-note-only', 'no-action-justified'];
+const DECISION_RE = new RegExp(`\\b(?:${FLAW_DECISIONS.join('|')})\\b`, 'i');
+const MUTATING_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit']);
+
+// True (block) when text recognizes a flaw but records no explicit flaw_decision token.
+function flawDecisionMissing(text) {
+  const body = String(text || '');
+  if (!FLAW_MENTION.test(body)) return false;
+  return !DECISION_RE.test(body);
+}
+
+// True (block) when a tracked-file mutation is attempted with no active baton/ticket.
+function batonEntryRequired(toolName, hasActiveTicket) {
+  return MUTATING_TOOLS.has(String(toolName || '')) && !hasActiveTicket;
+}
+
+function judgmentGateDecision(ctx = {}) {
+  const violations = [];
+  if (ctx.artifactText !== undefined && flawDecisionMissing(ctx.artifactText)) {
+    violations.push({ rule: 'flaw-decision-missing',
+      detail: `recognized a flaw but no flaw_decision recorded (one of: ${FLAW_DECISIONS.join(', ')})` });
+  }
+  if (ctx.toolName !== undefined && batonEntryRequired(ctx.toolName, Boolean(ctx.hasActiveTicket))) {
+    violations.push({ rule: 'baton-entry-without-ticket',
+      detail: `${ctx.toolName} mutates tracked state with no active baton - start the baton (link a ticket) first` });
+  }
+  return { ok: violations.length === 0, violations };
+}
+
+module.exports = { flawDecisionMissing, batonEntryRequired, judgmentGateDecision,
+  FLAW_DECISIONS, MUTATING_TOOLS };

--- a/tests/judgment-gate.spec.js
+++ b/tests/judgment-gate.spec.js
@@ -1,0 +1,40 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const jg = require(path.resolve(__dirname, '..', 'scripts', 'global', 'judgment-gate.js'));
+
+test('a recognized flaw with no decision is blocked', () => {
+  assert.strictEqual(jg.flawDecisionMissing('found a flaw in the parser, will look later'), true);
+});
+
+test('a recognized flaw WITH an explicit decision passes', () => {
+  assert.strictEqual(jg.flawDecisionMissing('found a flaw; decision=file-ticket (#99)'), false);
+  assert.strictEqual(jg.flawDecisionMissing('a regression here; no-action-justified: cosmetic'), false);
+});
+
+test('text with no flaw mention is not gated', () => {
+  assert.strictEqual(jg.flawDecisionMissing('shipped the feature, tests green'), false);
+});
+
+test('a mutating tool with no active ticket requires baton entry', () => {
+  assert.strictEqual(jg.batonEntryRequired('Edit', false), true);
+  assert.strictEqual(jg.batonEntryRequired('Write', false), true);
+});
+
+test('a mutating tool WITH an active ticket is allowed', () => {
+  assert.strictEqual(jg.batonEntryRequired('Edit', true), false);
+});
+
+test('a non-mutating tool never requires baton entry', () => {
+  assert.strictEqual(jg.batonEntryRequired('Read', false), false);
+  assert.strictEqual(jg.batonEntryRequired('Bash', false), false);
+});
+
+test('judgmentGateDecision aggregates both gates', () => {
+  const blocked = jg.judgmentGateDecision({ artifactText: 'a bug exists', toolName: 'Write', hasActiveTicket: false });
+  assert.strictEqual(blocked.ok, false);
+  assert.strictEqual(blocked.violations.length, 2);
+  const clean = jg.judgmentGateDecision({ artifactText: 'bug fixed; decision=memory-note-only', toolName: 'Edit', hasActiveTicket: true });
+  assert.deepStrictEqual(clean.violations, []);
+});


### PR DESCRIPTION
Refs #2723
Refs #2710

Epic #2709: pure-logic fail-closed gates for judgment-required governance links - a recognized flaw must carry an explicit flaw_decision token, and a tracked mutation without an active baton is blocked. Converts two CLAUDE.md operator-discretion rules into machine-checkable gates the baton/hook layer consumes.

## Evidence
- node --test 7/7
- npm run lint clean
- Cross-family: gemini-2.5-flash ACCEPT 90/100

merge-evidence-deferred-final: #2723