### PR TITLE
docs(agents): add key contracts section for 2026-H1 features

### DIFF
--- a/.changes/unreleased/2743.md
+++ b/.changes/unreleased/2743.md
@@ -1,0 +1,4 @@
+### Changed
+
+- `AGENTS.md`: added `## Key contracts (2026-H1)` section covering doc-coverage gate, baton builders, governance chains, OTel GenAI validator, fleet-call-guard, credential-prompt-guard, admin-merge-exception; compressed verbose sections to fit 100-line limit. Refs #2743
+- `.codex/AGENTS.md`: mirrored 2026-H1 key contracts summary. Refs #2743

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -17,3 +17,4 @@
 - HAMR routing canonical contract: `instructions/hamr-routing.instructions.md` (cost levers, /quota, /mcp, cache-hit gate). Complementary to the Global Task Router lane policy.
 - OWASP Agentic security mapping: `instructions/owasp-agentic-mapping.instructions.md` (OA1-OA10 risk-to-goal mapping; G1-G10 coverage classification).
 - Cross-team artifact-write contract: `instructions/cross-team-artifact-write.instructions.md` (target-runtime team owns schema/contract test; required before manager-handoff on cross-runtime config writes).
+- **2026-H1 key contracts**: doc-coverage gate (COLLABORATOR_HANDOFF must include `doc-coverage:` block for lane:code-change), baton builders (`baton-comment-build.js`), governance chains (`npm run governance:chains:check`), fleet-call-guard (bounded timeout required, PR #2697), credential-prompt-guard (check `.env` before prompting), admin-merge-exception (Epic #2517 gate). Mirror AGENTS.md §Key contracts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,12 +57,11 @@ This repo is the **development workbench** for the DevEnv Ops Harness runtimes:
 
 - All 3 teams route governed provider calls through HAMR (`https://hamr.chf3198.workers.dev`).
 - Activate per-checkout: `npm run hamr:activate`. Verify: `npm run hamr:sync-verify`.
-- Canonical contract: `instructions/hamr-routing.instructions.md`.
-- Provider-neutral governance contract: `instructions/provider-neutral-governance.instructions.md`.
+- Canonical + provider-neutral contracts: `instructions/hamr-routing.instructions.md`, `instructions/provider-neutral-governance.instructions.md`.
 
 ## Skill index
 
-Auto-derived from `skills/<name>/SKILL.md` frontmatter — see [`docs/skills-agents.md`](docs/skills-agents.md). Regenerate via `node scripts/global/skill-views-derive.js`.
+Auto-derived from `skills/<name>/SKILL.md` — see [`docs/skills-agents.md`](docs/skills-agents.md). Regenerate via `node scripts/global/skill-views-derive.js`.
 
 ## Development → Deploy workflow
 
@@ -77,16 +76,11 @@ Auto-derived from `skills/<name>/SKILL.md` frontmatter — see [`docs/skills-age
 ## Dashboard conventions
 
 - Alpine.js for state, vanilla JS for logic
-- No build step — static files served directly
-- Cloudflare Pages for production deployment
+- No build step; Cloudflare Pages for production deployment
 
-## Merge-evidence convention (cross-runtime, Epic #2295 P1.3)
+## Merge-evidence
 
-PR bodies targeting this harness MUST include merge evidence for their linked issue.
-Preferred form: `merge-evidence-deferred-final: #N` — satisfies `merge-evidence-pr-gate`
-without triggering GitHub auto-close, preserving Consultant terminal-finalize authority.
-Backward-compat: `Closes #N` remains accepted. This convention applies to Claude Code,
-Codex, and Copilot team PRs equally. See `governance-carve-outs/index.md` for rationale.
+Use `merge-evidence-deferred-final: #N` in PR body (or `Closes #N`). See `governance-carve-outs/index.md`.
 
 ## Role Taxonomy
 
@@ -94,3 +88,13 @@ The harness uses a 7-role canonical taxonomy: Manager / Collaborator / Admin /
 Consultant / IT / Red-Team / Client. Guest-Collaborator is reserved but not active.
 Operator is a meta-term for the AI agent — not a distinct role.
 Canonical definition: `instructions/role-baton-routing.instructions.md` §"Role Taxonomy".
+
+## Key contracts (2026-H1)
+
+- **Doc-coverage gate**: `COLLABORATOR_HANDOFF` must include `doc-coverage:` block for `lane:code-change`. See `docs/howto/merge-time-doc-governance.md`.
+- **Baton builders**: Use `baton-comment-build.js`, `pr-comment-build.js`, `changelog-fragment-build.js` for governed artifacts.
+- **Governance chains**: Run `npm run governance:chains:check` on governance path changes. See `docs/howto/governance-chains.md`.
+- **OTel GenAI**: `isValidGenAI()` from `scripts/global/otel-genai-conformance.js`; validate telemetry fields before emit.
+- **Fleet-call-guard**: All fleet calls must use bounded timeout (see `docs/howto/fleet-call-guard.md`; PR #2697).
+- **Credential guard**: Check `credential-availability.js` before prompting user for secrets; `.env` may already have them.
+- **Admin-merge-exception**: Override merges require `merge-bypass:admin-exception` label per Epic #2517.


### PR DESCRIPTION
Refs #2743
merge-evidence-deferred-final: #2743

Adds `## Key contracts (2026-H1)` section to AGENTS.md and .codex/AGENTS.md documenting 7 governance contracts shipped after 2026-05-28. Compresses verbose sections to stay at ≤100 lines (exactly 100).

MANAGER_HANDOFF and COLLABORATOR_HANDOFF (cross_family: 90/100, qwen2.5-coder:7b, Qwen family) posted on issue before PR creation.