### PR TITLE
feat(scripts): fleet-bypass intercept + tier-vocabulary validator

### DIFF
--- a/.changes/unreleased/2739.md
+++ b/.changes/unreleased/2739.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Fleet-bypass intercept + tier-vocabulary validator** (#2739, Epic #2192 P1-B): closed two
+  fleet-red-team-evasion vectors. `pretool_guard.py` now intercepts a raw `curl` to a fleet/ollama
+  host that bypasses the HAMR dispatch wrappers (vector V2) — it emits an `ask` plus a Tier-1
+  `incidents.jsonl` event and honors the `# hamr-bypass-ok:` carve-out, fail-open on any error.
+  New `scripts/global/tier-vocabulary-validator.js` rejects a `wrapProviderCall('ollama'|'fleet', …)`
+  whose `tier` is not in the canonical `model-routing-policy.json` vocabulary (vector V3). Both are
+  registered as `enforced` links in `config/governance-chains.yml`. Refs #2193 (Phase-0 design).

--- a/config/governance-chains.yml
+++ b/config/governance-chains.yml
@@ -39,3 +39,9 @@ chains:
     - link: cross-family-review-required-at-consultant-phase
       guarantee: enforced
       enforcement_point: scripts/global/megalint/fleet-review-required.js
+    - link: fleet-tier-in-canonical-vocabulary
+      guarantee: enforced
+      enforcement_point: scripts/global/tier-vocabulary-validator.js
+    - link: raw-fleet-curl-routed-through-dispatch
+      guarantee: enforced
+      enforcement_point: hooks/scripts/pretool_guard.py

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -101,12 +101,45 @@ def require_bypass_exception(joined: str, state: dict, cwd: str) -> bool:
     except Exception:
         return True
 
+# Bounded {0,512} quantifier caps the backtracking window (#2739 cross-family review
+# hardening): a curl command line longer than this never legitimately targets a fleet host.
+RE_FLEET_CURL = re.compile(r"curl\b[^\n|]{0,512}(?::11434\b|/api/(?:generate|tags|chat)\b)")
+
+def is_raw_fleet_curl(joined: str) -> bool:
+    """True when a raw curl targets a fleet/ollama endpoint outside the dispatch
+    wrappers without the documented carve-out (#2192 vector #2 - raw curl bypasses
+    HAMR cost+observability). Fail-open: any error returns False (never brick)."""
+    try:
+        if "hamr-bypass-ok" in joined:
+            return False
+        return bool(RE_FLEET_CURL.search(joined))
+    except Exception:
+        return False
+
+def _emit_fleet_bypass_incident(cwd: str) -> None:
+    """Append a Tier-1 incident for a raw-fleet-curl bypass (#2192 AC1). Never raises."""
+    try:
+        path = os.path.join(os.path.expanduser("~"), ".megingjord", "incidents.jsonl")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        event = {"version": 3, "service": "pretool-guard-fleet-bypass",
+                 "env": "local", "event": "governance.raw-fleet-curl-bypass",
+                 "pattern_id": "raw-fleet-curl-bypasses-hamr", "severity": "low", "cwd": cwd}
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event) + "\n")
+    except Exception:
+        pass  # telemetry failure must not affect the hook decision
+
 def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
     flags, ops = state.get("flags", {}), state.get("admin_ops", {})
     repo_type = state.get("repo_type", "generic")
     no_code_lane = active_ticket_is_no_code_lane(state, cwd)
     if no_code_lane and NO_CODE_ADMIN_RE.search(joined):
         return emit("deny", "No-code remediation lane is issue-only. Admin/implementation commands are blocked; re-route to lane:code-change.")
+    if is_raw_fleet_curl(joined):
+        _emit_fleet_bypass_incident(cwd)
+        return emit("ask", "Raw fleet/ollama curl detected (#2192 vector 2): prefer dispatchRedTeam / "
+                    "cascade-dispatch so HAMR records cost+observability. Add '# hamr-bypass-ok: <reason>' "
+                    "for an audited diagnostic bypass.", "Bypasses HAMR cost/observability layer.")
     if DANGEROUS_CMD_RE.search(joined): return emit("deny","Blocked dangerous terminal command.")
     if is_main_checkout(cwd):
         sw = RE_BRANCH_SWITCH.search(joined)

--- a/scripts/global/tier-vocabulary-validator.js
+++ b/scripts/global/tier-vocabulary-validator.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+'use strict';
+// tier: 1
+// tier-vocabulary-validator (Epic #2192 / #2739): rejects a wrapProviderCall on a
+// fleet/ollama provider that passes a tier outside the canonical vocabulary - the
+// P1-7 defect class (a mis-labeled tier silently mis-records cost data as a paid
+// sticky-pick). The legal tier set is sourced from the canonical
+// model-routing-policy.json (single source of truth, no local drift), plus the
+// documented 'diagnostic' carve-out. Pure logic (unit-testable).
+
+const fs = require('fs');
+const path = require('path');
+
+const FLEET_PROVIDERS = new Set(['ollama', 'fleet']);
+const DIAGNOSTIC = 'diagnostic';
+const POLICY_PATH = 'scripts/global/model-routing-policy.json';
+const CALL_RE = /wrapProviderCall\(\s*['"](ollama|fleet)['"][\s\S]*?tier:\s*['"]([^'"]+)['"]/g;
+
+function legalTiers(policy) {
+  return new Set([...Object.keys((policy && policy.models) || {}), DIAGNOSTIC]);
+}
+
+function loadPolicy(repoRoot) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot || process.cwd(), POLICY_PATH), 'utf8'));
+}
+
+// validate a single (provider, tier) pair against the policy vocabulary.
+function validateTier(provider, tier, policy) {
+  if (!FLEET_PROVIDERS.has(String(provider || ''))) return { ok: true, violations: [] };
+  if (tier == null || tier === '') return { ok: true, violations: [] };
+  if (legalTiers(policy).has(tier)) return { ok: true, violations: [] };
+  return { ok: false, violations: [{ rule: 'fleet-tier-not-in-vocabulary',
+    detail: `wrapProviderCall('${provider}', ..., {tier:'${tier}'}) - '${tier}' is not in the canonical `
+      + `tier vocabulary (${[...legalTiers(policy)].join('|')}); mis-labeled tier corrupts cost data (P1-7)` }] };
+}
+
+// scan source text for wrapProviderCall(fleet, {tier:'X'}) with an illegal X.
+function scanSource(sourceText, policy) {
+  const violations = [];
+  const legal = legalTiers(policy);
+  let match;
+  CALL_RE.lastIndex = 0;
+  while ((match = CALL_RE.exec(String(sourceText || ''))) !== null) {
+    const [, provider, tier] = match;
+    if (!legal.has(tier)) {
+      violations.push({ rule: 'fleet-tier-not-in-vocabulary',
+        detail: `${provider} call uses tier '${tier}' not in vocabulary (${[...legal].join('|')})` });
+    }
+  }
+  return violations;
+}
+
+function validate(ctx = {}) {
+  const policy = ctx.policy || loadPolicy(ctx.repoRoot);
+  if (ctx.sourceText !== undefined) return { ok: scanSource(ctx.sourceText, policy).length === 0,
+    violations: scanSource(ctx.sourceText, policy) };
+  return validateTier(ctx.provider, ctx.tier, policy);
+}
+
+module.exports = { validate, validateTier, scanSource, legalTiers, loadPolicy, FLEET_PROVIDERS };

--- a/tests/hooks/test_pretool_guard_fleet_curl.py
+++ b/tests/hooks/test_pretool_guard_fleet_curl.py
@@ -1,0 +1,41 @@
+"""Unit tests for the #2739 raw-fleet-curl bypass intercept in pretool_guard.
+
+A raw curl to a fleet/ollama endpoint outside the dispatch wrappers is flagged
+(#2192 vector 2) unless it carries the documented `hamr-bypass-ok` carve-out.
+Fail-open: any internal error returns False (never brick a session).
+"""
+import os
+import sys
+import unittest
+
+HOOKS = os.path.join(os.path.dirname(__file__), "..", "..", "hooks", "scripts")
+sys.path.insert(0, os.path.abspath(HOOKS))
+
+import pretool_guard  # noqa: E402
+
+
+class FleetCurlIntercept(unittest.TestCase):
+    def test_raw_ollama_generate_curl_is_flagged(self):
+        self.assertTrue(pretool_guard.is_raw_fleet_curl(
+            "curl -s http://100.91.113.16:11434/api/generate -d @req.json"))
+
+    def test_raw_ollama_tags_curl_is_flagged(self):
+        self.assertTrue(pretool_guard.is_raw_fleet_curl("curl http://host:11434/api/tags"))
+
+    def test_carve_out_marker_suppresses_the_flag(self):
+        self.assertFalse(pretool_guard.is_raw_fleet_curl(
+            "curl http://host:11434/api/generate  # hamr-bypass-ok: diagnostic probe"))
+
+    def test_non_fleet_curl_is_not_flagged(self):
+        self.assertFalse(pretool_guard.is_raw_fleet_curl("curl https://api.github.com/repos/x/y"))
+
+    def test_non_curl_command_is_not_flagged(self):
+        self.assertFalse(pretool_guard.is_raw_fleet_curl("node scripts/global/fleet-red-team-dispatch.js"))
+
+    def test_fail_open_on_bad_input(self):
+        # a non-string must not raise (fail-open)
+        self.assertFalse(pretool_guard.is_raw_fleet_curl(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pretool-guard-fleet-curl-2739.spec.js
+++ b/tests/pretool-guard-fleet-curl-2739.spec.js
@@ -1,0 +1,21 @@
+// #2739 - JS harness that runs the Python unittest suite for the raw-fleet-curl
+// bypass intercept guard. The implementation under test is a Python hook
+// (pretool_guard.is_raw_fleet_curl); the real assertions live in unittest.
+// This spec satisfies the JS-centric test-evidence gate while running Python coverage.
+'use strict';
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+test('pretool_guard raw-fleet-curl intercept Python suite passes (#2739)', () => {
+  const root = path.resolve(__dirname, '..');
+  let out = '';
+  try {
+    out = execFileSync('python3', ['-m', 'unittest',
+      'tests.hooks.test_pretool_guard_fleet_curl'],
+    { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (err) {
+    throw new Error(`Python unittest suite failed:\n${err.stdout || ''}\n${err.stderr || ''}`);
+  }
+  expect(typeof out).toBe('string');
+});

--- a/tests/tier-vocabulary-validator.spec.js
+++ b/tests/tier-vocabulary-validator.spec.js
@@ -1,0 +1,44 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const tv = require(path.resolve(__dirname, '..', 'scripts', 'global', 'tier-vocabulary-validator.js'));
+
+const REPO = path.resolve(__dirname, '..');
+const POLICY = tv.loadPolicy(REPO);
+
+test('the canonical policy yields a non-empty legal tier set incl diagnostic', () => {
+  const legal = tv.legalTiers(POLICY);
+  assert.ok(legal.has('fleet'));
+  assert.ok(legal.has('diagnostic'));
+});
+
+test('a legal fleet tier passes', () => {
+  assert.strictEqual(tv.validateTier('ollama', 'fleet', POLICY).ok, true);
+  assert.strictEqual(tv.validateTier('ollama', 'diagnostic', POLICY).ok, true);
+});
+
+test('an illegal fleet tier is rejected (P1-7 mis-label)', () => {
+  const r = tv.validateTier('ollama', 'fleet-local', POLICY);
+  assert.strictEqual(r.ok, false);
+  assert.ok(r.violations.some((v) => v.rule === 'fleet-tier-not-in-vocabulary'));
+});
+
+test('a non-fleet provider is not gated by this validator', () => {
+  assert.strictEqual(tv.validateTier('anthropic', 'whatever', POLICY).ok, true);
+});
+
+test('null/absent tier is allowed (not all calls specify a tier)', () => {
+  assert.strictEqual(tv.validateTier('ollama', null, POLICY).ok, true);
+});
+
+test('scanSource flags a wrapProviderCall with an illegal fleet tier', () => {
+  const src = "const r = await wrapProviderCall('ollama', cb, { tier: 'fleet-local' });";
+  const v = tv.scanSource(src, POLICY);
+  assert.ok(v.some((x) => x.rule === 'fleet-tier-not-in-vocabulary'));
+});
+
+test('scanSource passes a wrapProviderCall with a legal fleet tier', () => {
+  const src = "await wrapProviderCall('ollama', cb, { tier: 'fleet' });";
+  assert.deepStrictEqual(tv.scanSource(src, POLICY), []);
+});


### PR DESCRIPTION
## Summary

Phase-1 P1-B of Epic #2192 (promote fleet-red-team to a hard-gate guardrail). Closes the two fleet-red-team-evasion vectors from Phase-0 (#2193):

- **V2 — raw-curl HAMR bypass**: `hooks/scripts/pretool_guard.py` now intercepts a raw `curl` to a fleet/ollama host (`:11434` or `/api/{generate,tags,chat}`) that bypasses the dispatch wrappers. It emits an `ask` plus a Tier-1 `incidents.jsonl` event, honors the `# hamr-bypass-ok:` carve-out, and is fail-open on any internal error. Detector regex bounded to `{0,512}` per cross-family review hardening.
- **V3 — fleet-tier mislabel**: new `scripts/global/tier-vocabulary-validator.js` rejects a `wrapProviderCall('ollama'|'fleet', …)` whose `tier` is absent from the canonical `model-routing-policy.json` vocabulary.

Both registered as `enforced` links in `config/governance-chains.yml` (`chain-integrity.js` stays OK).

## Tests
- `python3 -m unittest tests.hooks.test_pretool_guard_fleet_curl` → 6/6 OK
- `node --test tests/tier-vocabulary-validator.spec.js` → 7/7 pass
- JS wrapper spec `tests/pretool-guard-fleet-curl-2739.spec.js` (mirrors 2706)
- `npm run lint` → 404 files, all ≤100 lines

## Cross-family review
ACCEPT 8/10 — gemini-2.5-flash@google-ai-studio (free-cloud G3 lane; fleet qwen host returns empty). One ReDoS-window finding remediated in-PR.

Refs #2739 #2193
merge-evidence-deferred-final: #2739

Baton artifacts (full set on #2739): MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
