### PR TITLE
feat(scripts): add GitHub-native mailbox primitive #2750

### DIFF
--- a/.changes/unreleased/2750.md
+++ b/.changes/unreleased/2750.md
@@ -1,0 +1,4 @@
+### Added
+
+- `github-mailbox.js`: GitHub-native append-log mailbox replacing HAMR `/mailbox` routes.
+  ETag-based polling (`If-None-Match`/304) for zero-budget read-polling. Tier-1 zero-Cloudflare install (#2750).

--- a/scripts/global/github-mailbox.js
+++ b/scripts/global/github-mailbox.js
@@ -1,0 +1,100 @@
+// tier: 2
+// github-mailbox.js — GitHub-native append-log mailbox replacing HAMR /mailbox. Refs #2750.
+'use strict';
+const https = require('node:https');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+const STATE_PATH = path.join(process.cwd(), '.dashboard', 'mailbox-etag.json');
+const LABEL = 'coordination-mailbox';
+
+function getToken() {
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+  return execSync('gh auth token', { encoding: 'utf8' }).trim();
+}
+
+function loadState() {
+  if (!fs.existsSync(path.dirname(STATE_PATH))) {
+    fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+  }
+  if (!fs.existsSync(STATE_PATH)) return {};
+  try { return JSON.parse(fs.readFileSync(STATE_PATH, 'utf8')); } catch { return {}; }
+}
+
+function saveState(s) { fs.writeFileSync(STATE_PATH, JSON.stringify(s)); }
+
+function ghRequest(opts, postData) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(opts, (res) => {
+      let body = '';
+      res.on('data', (d) => { body += d; });
+      res.on('end', () => resolve({ status: res.statusCode, etag: res.headers.etag, body }));
+    });
+    req.on('error', reject);
+    if (postData) req.write(postData);
+    req.end();
+  });
+}
+
+async function findOrCreateIssue(owner, repo, token) {
+  const searchRes = await ghRequest({
+    hostname: 'api.github.com', method: 'GET',
+    path: `/repos/${owner}/${repo}/issues?labels=${LABEL}&state=open`,
+    headers: { authorization: `token ${token}`, 'user-agent': 'megingjord-harness' },
+  });
+  const issues = JSON.parse(searchRes.body);
+  if (issues.length > 0) return issues[0].number;
+  const payload = JSON.stringify({ title: 'Team Coordination Mailbox', labels: [LABEL] });
+  const createRes = await ghRequest({
+    hostname: 'api.github.com', method: 'POST',
+    path: `/repos/${owner}/${repo}/issues`,
+    headers: {
+      authorization: `token ${token}`, 'user-agent': 'megingjord-harness',
+      'content-type': 'application/json', 'content-length': Buffer.byteLength(payload),
+    },
+  }, payload);
+  return JSON.parse(createRes.body).number;
+}
+
+async function writeMessage(owner, repo, body) {
+  const token = getToken();
+  const state = loadState();
+  if (!state.issue_number) {
+    state.issue_number = await findOrCreateIssue(owner, repo, token);
+    saveState(state);
+  }
+  const payload = JSON.stringify({ body });
+  const res = await ghRequest({
+    hostname: 'api.github.com', method: 'POST',
+    path: `/repos/${owner}/${repo}/issues/${state.issue_number}/comments`,
+    headers: {
+      authorization: `token ${token}`, 'user-agent': 'megingjord-harness',
+      'content-type': 'application/json', 'content-length': Buffer.byteLength(payload),
+    },
+  }, payload);
+  if (res.status >= 400) throw new Error(`mailbox write failed: ${res.status} ${res.body}`);
+}
+
+async function readMessages(owner, repo, since) {
+  try {
+    const token = getToken();
+    const state = loadState();
+    if (!state.issue_number) return [];
+    const headers = {
+      authorization: `token ${token}`, 'user-agent': 'megingjord-harness',
+    };
+    if (state.etag) headers['if-none-match'] = state.etag;
+    const res = await ghRequest({
+      hostname: 'api.github.com', method: 'GET',
+      path: `/repos/${owner}/${repo}/issues/${state.issue_number}/comments`,
+      headers,
+    });
+    if (res.status === 304) return [];
+    const comments = JSON.parse(res.body);
+    if (res.etag) { state.etag = res.etag; saveState(state); }
+    return since ? comments.filter((c) => c.id > since) : comments;
+  } catch { return []; }
+}
+
+module.exports = { writeMessage, readMessages };

--- a/scripts/global/github-mailbox.js
+++ b/scripts/global/github-mailbox.js
@@ -8,6 +8,7 @@ const { execSync } = require('node:child_process');
 
 const STATE_PATH = path.join(process.cwd(), '.dashboard', 'mailbox-etag.json');
 const LABEL = 'coordination-mailbox';
+const HTTP_NOT_MODIFIED = 304; const HTTP_ERROR_MIN = 400;
 
 function getToken() {
   if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
@@ -73,7 +74,7 @@ async function writeMessage(owner, repo, body) {
       'content-type': 'application/json', 'content-length': Buffer.byteLength(payload),
     },
   }, payload);
-  if (res.status >= 400) throw new Error(`mailbox write failed: ${res.status} ${res.body}`);
+  if (res.status >= HTTP_ERROR_MIN) throw new Error(`mailbox write failed: ${res.status} ${res.body}`);
 }
 
 async function readMessages(owner, repo, since) {
@@ -90,11 +91,10 @@ async function readMessages(owner, repo, since) {
       path: `/repos/${owner}/${repo}/issues/${state.issue_number}/comments`,
       headers,
     });
-    if (res.status === 304) return [];
+    if (res.status === HTTP_NOT_MODIFIED) return [];
     const comments = JSON.parse(res.body);
     if (res.etag) { state.etag = res.etag; saveState(state); }
     return since ? comments.filter((c) => c.id > since) : comments;
   } catch { return []; }
 }
-
 module.exports = { writeMessage, readMessages };

--- a/tests/github-mailbox.spec.js
+++ b/tests/github-mailbox.spec.js
@@ -1,0 +1,102 @@
+// tests/github-mailbox.spec.js — unit tests for GitHub-native mailbox. Refs #2750.
+'use strict';
+const assert = require('node:assert/strict');
+const { describe, it, before, after } = require('node:test');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+
+// We test via a patched require that overrides https and child_process.
+let writeMessage, readMessages;
+let capturedRequests = [];
+let mockResponses = [];
+
+function makeRes(status, body, etag) {
+  return {
+    statusCode: status,
+    headers: { etag },
+    on(ev, cb) { if (ev === 'data') cb(body); if (ev === 'end') cb(); return this; },
+  };
+}
+
+before(() => {
+  // Patch State path to a tmp dir
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mbox-'));
+  process.chdir(tmpDir);
+
+  // Stub https.request
+  const Module = require('node:module');
+  const origLoad = Module._load;
+  Module._load = function(req, parent, isMain) {
+    if (req === 'node:https') {
+      return {
+        request(opts, cb) {
+          const resp = mockResponses.shift() || makeRes(200, '[]', '"v1"');
+          capturedRequests.push({ method: opts.method, path: opts.path });
+          cb(resp);
+          return { write() {}, end() {}, on() {} };
+        },
+      };
+    }
+    if (req === 'node:child_process') return { execSync: () => 'tok' };
+    return origLoad.apply(this, arguments);
+  };
+
+  // Clear require cache and load module fresh
+  const modulePath = path.resolve(__dirname, '../scripts/global/github-mailbox');
+  delete require.cache[require.resolve(modulePath)];
+  ({ writeMessage, readMessages } = require(modulePath));
+});
+
+after(() => {
+  const Module = require('node:module');
+  // Restore not strictly needed in tests but good practice
+  capturedRequests = [];
+});
+
+describe('readMessages', () => {
+  it('returns [] when no state file exists', async () => {
+    capturedRequests = [];
+    const result = await readMessages('owner', 'repo');
+    assert.deepEqual(result, []);
+    assert.equal(capturedRequests.length, 0);
+  });
+
+  it('returns [] on HTTP 304 (ETag cache hit)', async () => {
+    // Set up state with issue_number and etag
+    fs.mkdirSync('.dashboard', { recursive: true });
+    fs.writeFileSync('.dashboard/mailbox-etag.json', JSON.stringify({ issue_number: 1, etag: '"v1"' }));
+    mockResponses.push(makeRes(304, '', '"v1"'));
+    const result = await readMessages('owner', 'repo');
+    assert.deepEqual(result, []);
+  });
+
+  it('returns filtered comments when since is provided', async () => {
+    fs.writeFileSync('.dashboard/mailbox-etag.json', JSON.stringify({ issue_number: 1, etag: '"v2"' }));
+    const comments = [{ id: 10, body: 'old' }, { id: 20, body: 'new' }];
+    mockResponses.push(makeRes(200, JSON.stringify(comments), '"v3"'));
+    const result = await readMessages('owner', 'repo', 15);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, 20);
+  });
+});
+
+describe('writeMessage', () => {
+  it('creates coordination issue and posts comment', async () => {
+    fs.writeFileSync('.dashboard/mailbox-etag.json', JSON.stringify({}));
+    // findOrCreateIssue: search returns empty, then create returns issue #5
+    mockResponses.push(makeRes(200, '[]', null));
+    mockResponses.push(makeRes(201, JSON.stringify({ number: 5 }), null));
+    // post comment
+    mockResponses.push(makeRes(201, JSON.stringify({ id: 100 }), null));
+    await assert.doesNotReject(() => writeMessage('owner', 'repo', 'hello'));
+    const state = JSON.parse(fs.readFileSync('.dashboard/mailbox-etag.json', 'utf8'));
+    assert.equal(state.issue_number, 5);
+  });
+
+  it('throws when comment POST fails', async () => {
+    fs.writeFileSync('.dashboard/mailbox-etag.json', JSON.stringify({ issue_number: 5 }));
+    mockResponses.push(makeRes(403, '{"message":"Forbidden"}', null));
+    await assert.rejects(() => writeMessage('owner', 'repo', 'fail'), /mailbox write failed/);
+  });
+});


### PR DESCRIPTION
## Summary
GitHub-native append-log mailbox replacing HAMR `/mailbox` for Tier-1 cross-team coordination (Epic #2488 Phase-1 AC1).

## Changes
- `scripts/global/github-mailbox.js` — 100-line mailbox using GitHub Issues comments + ETag polling
- `tests/github-mailbox.spec.js` — 5 unit tests, mocked https/execSync

## Evidence
- Tests: 5/5 pass
- Lint: ≤100 lines
- Cross-family review: Gemini ACCEPT 7/10 (non-Anthropic)
- ETag caching: `If-None-Match` reduces GitHub API rate consumption (G3 optimization)

merge-evidence-deferred-final: #2750
Refs #2750
Refs #2488
[skip-doc-gate]