### PR TITLE
feat(scripts): add GitHub-native bundle distribution client (#2751)

### DIFF
--- a/.changes/unreleased/2751.md
+++ b/.changes/unreleased/2751.md
@@ -1,0 +1,4 @@
+### Added
+
+- `github-bundle-client.js`: GitHub-native bundle distribution via Releases API,
+  replacing HAMR `/bundle` routes. `publishBundle` + `fetchBundle` with no new npm deps (#2751).

--- a/scripts/global/github-bundle-client.js
+++ b/scripts/global/github-bundle-client.js
@@ -1,0 +1,85 @@
+// tier: 2
+// github-bundle-client.js — GitHub-native bundle distribution via Releases API. Refs #2751.
+'use strict';
+const https = require('node:https');
+const { execSync } = require('node:child_process');
+
+function getToken() {
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+  return execSync('gh auth token', { encoding: 'utf8' }).trim();
+}
+
+function ghRequest(opts, postData) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(opts, (res) => {
+      let body = '';
+      res.on('data', (d) => { body += d; });
+      res.on('end', () => resolve({ status: res.statusCode, body }));
+    });
+    req.on('error', reject);
+    if (postData) req.write(postData);
+    req.end();
+  });
+}
+
+async function publishBundle(owner, repo, name, payload) {
+  const token = getToken();
+  // Find or create a 'bundles' release tag
+  const tagName = 'bundles';
+  let releaseId;
+  const relRes = await ghRequest({
+    hostname: 'api.github.com', method: 'GET',
+    path: `/repos/${owner}/${repo}/releases/tags/${tagName}`,
+    headers: { authorization: `token ${token}`, 'user-agent': 'megingjord-harness' },
+  });
+  if (relRes.status === 200) {
+    releaseId = JSON.parse(relRes.body).id;
+  } else {
+    const createBody = JSON.stringify({ tag_name: tagName, name: 'Governance Bundles', draft: false, prerelease: true });
+    const createRes = await ghRequest({
+      hostname: 'api.github.com', method: 'POST',
+      path: `/repos/${owner}/${repo}/releases`,
+      headers: {
+        authorization: `token ${token}`, 'user-agent': 'megingjord-harness',
+        'content-type': 'application/json', 'content-length': Buffer.byteLength(createBody),
+      },
+    }, createBody);
+    if (createRes.status >= 400) throw new Error(`release create failed: ${createRes.status}`);
+    releaseId = JSON.parse(createRes.body).id;
+  }
+  const data = Buffer.from(typeof payload === 'string' ? payload : JSON.stringify(payload));
+  const uploadRes = await ghRequest({
+    hostname: 'uploads.github.com', method: 'POST',
+    path: `/repos/${owner}/${repo}/releases/${releaseId}/assets?name=${encodeURIComponent(name)}`,
+    headers: {
+      authorization: `token ${token}`, 'user-agent': 'megingjord-harness',
+      'content-type': 'application/octet-stream', 'content-length': data.length,
+    },
+  }, data);
+  if (uploadRes.status >= 400) throw new Error(`bundle upload failed: ${uploadRes.status}`);
+  return JSON.parse(uploadRes.body);
+}
+
+async function fetchBundle(owner, repo, name) {
+  const token = getToken();
+  const relRes = await ghRequest({
+    hostname: 'api.github.com', method: 'GET',
+    path: `/repos/${owner}/${repo}/releases/tags/bundles`,
+    headers: { authorization: `token ${token}`, 'user-agent': 'megingjord-harness' },
+  });
+  if (relRes.status !== 200) return null;
+  const release = JSON.parse(relRes.body);
+  const asset = release.assets.find((a) => a.name === name);
+  if (!asset) return null;
+  const dlRes = await ghRequest({
+    hostname: 'api.github.com', method: 'GET',
+    path: `/repos/${owner}/${repo}/releases/assets/${asset.id}`,
+    headers: {
+      authorization: `token ${token}`, 'user-agent': 'megingjord-harness',
+      accept: 'application/octet-stream',
+    },
+  });
+  return dlRes.body;
+}
+
+module.exports = { publishBundle, fetchBundle };

--- a/scripts/global/github-bundle-client.js
+++ b/scripts/global/github-bundle-client.js
@@ -4,6 +4,11 @@
 const https = require('node:https');
 const { execSync } = require('node:child_process');
 
+const HTTP_OK = 200;
+const HTTP_ERROR_MIN = 400;
+const TAG_NAME = 'bundles';
+const UA = { 'user-agent': 'megingjord-harness' };
+
 function getToken() {
   if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
   return execSync('gh auth token', { encoding: 'utf8' }).trim();
@@ -22,63 +27,43 @@ function ghRequest(opts, postData) {
   });
 }
 
+async function ensureRelease(owner, repo, token) {
+  const headers = { authorization: `token ${token}`, ...UA };
+  const relRes = await ghRequest({ hostname: 'api.github.com', method: 'GET',
+    path: `/repos/${owner}/${repo}/releases/tags/${TAG_NAME}`, headers });
+  if (relRes.status === HTTP_OK) return JSON.parse(relRes.body).id;
+  const createBody = JSON.stringify({ tag_name: TAG_NAME, name: 'Governance Bundles', draft: false, prerelease: true });
+  const cr = await ghRequest({ hostname: 'api.github.com', method: 'POST',
+    path: `/repos/${owner}/${repo}/releases`,
+    headers: { ...headers, 'content-type': 'application/json', 'content-length': Buffer.byteLength(createBody) },
+  }, createBody);
+  if (cr.status >= HTTP_ERROR_MIN) throw new Error(`release create failed: ${cr.status}`);
+  return JSON.parse(cr.body).id;
+}
+
 async function publishBundle(owner, repo, name, payload) {
   const token = getToken();
-  // Find or create a 'bundles' release tag
-  const tagName = 'bundles';
-  let releaseId;
-  const relRes = await ghRequest({
-    hostname: 'api.github.com', method: 'GET',
-    path: `/repos/${owner}/${repo}/releases/tags/${tagName}`,
-    headers: { authorization: `token ${token}`, 'user-agent': 'megingjord-harness' },
-  });
-  if (relRes.status === 200) {
-    releaseId = JSON.parse(relRes.body).id;
-  } else {
-    const createBody = JSON.stringify({ tag_name: tagName, name: 'Governance Bundles', draft: false, prerelease: true });
-    const createRes = await ghRequest({
-      hostname: 'api.github.com', method: 'POST',
-      path: `/repos/${owner}/${repo}/releases`,
-      headers: {
-        authorization: `token ${token}`, 'user-agent': 'megingjord-harness',
-        'content-type': 'application/json', 'content-length': Buffer.byteLength(createBody),
-      },
-    }, createBody);
-    if (createRes.status >= 400) throw new Error(`release create failed: ${createRes.status}`);
-    releaseId = JSON.parse(createRes.body).id;
-  }
+  const releaseId = await ensureRelease(owner, repo, token);
   const data = Buffer.from(typeof payload === 'string' ? payload : JSON.stringify(payload));
-  const uploadRes = await ghRequest({
-    hostname: 'uploads.github.com', method: 'POST',
+  const uploadRes = await ghRequest({ hostname: 'uploads.github.com', method: 'POST',
     path: `/repos/${owner}/${repo}/releases/${releaseId}/assets?name=${encodeURIComponent(name)}`,
-    headers: {
-      authorization: `token ${token}`, 'user-agent': 'megingjord-harness',
-      'content-type': 'application/octet-stream', 'content-length': data.length,
-    },
+    headers: { authorization: `token ${token}`, ...UA, 'content-type': 'application/octet-stream', 'content-length': data.length },
   }, data);
-  if (uploadRes.status >= 400) throw new Error(`bundle upload failed: ${uploadRes.status}`);
+  if (uploadRes.status >= HTTP_ERROR_MIN) throw new Error(`bundle upload failed: ${uploadRes.status}`);
   return JSON.parse(uploadRes.body);
 }
 
 async function fetchBundle(owner, repo, name) {
   const token = getToken();
-  const relRes = await ghRequest({
-    hostname: 'api.github.com', method: 'GET',
-    path: `/repos/${owner}/${repo}/releases/tags/bundles`,
-    headers: { authorization: `token ${token}`, 'user-agent': 'megingjord-harness' },
-  });
-  if (relRes.status !== 200) return null;
-  const release = JSON.parse(relRes.body);
-  const asset = release.assets.find((a) => a.name === name);
+  const headers = { authorization: `token ${token}`, ...UA };
+  const relRes = await ghRequest({ hostname: 'api.github.com', method: 'GET',
+    path: `/repos/${owner}/${repo}/releases/tags/${TAG_NAME}`, headers });
+  if (relRes.status !== HTTP_OK) return null;
+  const asset = JSON.parse(relRes.body).assets.find((a) => a.name === name);
   if (!asset) return null;
-  const dlRes = await ghRequest({
-    hostname: 'api.github.com', method: 'GET',
+  const dlRes = await ghRequest({ hostname: 'api.github.com', method: 'GET',
     path: `/repos/${owner}/${repo}/releases/assets/${asset.id}`,
-    headers: {
-      authorization: `token ${token}`, 'user-agent': 'megingjord-harness',
-      accept: 'application/octet-stream',
-    },
-  });
+    headers: { ...headers, accept: 'application/octet-stream' } });
   return dlRes.body;
 }
 

--- a/tests/github-bundle-client.spec.js
+++ b/tests/github-bundle-client.spec.js
@@ -1,0 +1,75 @@
+// tests/github-bundle-client.spec.js — unit tests for GitHub-native bundle client. Refs #2751.
+'use strict';
+const assert = require('node:assert/strict');
+const { describe, it, before } = require('node:test');
+const path = require('node:path');
+
+let publishBundle, fetchBundle;
+let mockResponses = [];
+
+function makeRes(status, body) {
+  return {
+    statusCode: status,
+    headers: {},
+    on(ev, cb) { if (ev === 'data') cb(body); if (ev === 'end') cb(); return this; },
+  };
+}
+
+before(() => {
+  const Module = require('node:module');
+  const origLoad = Module._load;
+  Module._load = function(req, parent, isMain) {
+    if (req === 'node:https') {
+      return {
+        request(opts, cb) {
+          const resp = mockResponses.shift() || makeRes(200, '{}');
+          cb(resp);
+          return { write() {}, end() {}, on() {} };
+        },
+      };
+    }
+    if (req === 'node:child_process') return { execSync: () => 'tok' };
+    return origLoad.apply(this, arguments);
+  };
+  const modulePath = path.resolve(__dirname, '../scripts/global/github-bundle-client');
+  delete require.cache[require.resolve(modulePath)];
+  ({ publishBundle, fetchBundle } = require(modulePath));
+});
+
+describe('fetchBundle', () => {
+  it('returns null when release not found', async () => {
+    mockResponses.push(makeRes(404, '{}'));
+    const result = await fetchBundle('owner', 'repo', 'test.json');
+    assert.equal(result, null);
+  });
+
+  it('returns null when asset not in release', async () => {
+    mockResponses.push(makeRes(200, JSON.stringify({ assets: [] })));
+    const result = await fetchBundle('owner', 'repo', 'missing.json');
+    assert.equal(result, null);
+  });
+
+  it('returns asset content when found', async () => {
+    const release = { assets: [{ id: 1, name: 'bundle.json' }] };
+    mockResponses.push(makeRes(200, JSON.stringify(release)));
+    mockResponses.push(makeRes(200, '{"data":"test"}'));
+    const result = await fetchBundle('owner', 'repo', 'bundle.json');
+    assert.equal(result, '{"data":"test"}');
+  });
+});
+
+describe('publishBundle', () => {
+  it('creates release and uploads asset', async () => {
+    mockResponses.push(makeRes(404, '{}')); // release not found
+    mockResponses.push(makeRes(201, JSON.stringify({ id: 42 }))); // create release
+    mockResponses.push(makeRes(201, JSON.stringify({ name: 'test.json', id: 99 }))); // upload
+    const result = await publishBundle('owner', 'repo', 'test.json', '{}');
+    assert.equal(result.name, 'test.json');
+  });
+
+  it('throws when upload fails', async () => {
+    mockResponses.push(makeRes(200, JSON.stringify({ id: 1 }))); // existing release
+    mockResponses.push(makeRes(422, '{"message":"Unprocessable"}'));
+    await assert.rejects(() => publishBundle('owner', 'repo', 'fail.json', '{}'), /bundle upload failed/);
+  });
+});


### PR DESCRIPTION
Add github-bundle-client.js: zero-dep GitHub Releases-based bundle distribution replacing HAMR /bundle.

- publishBundle uploads JSON asset to bundles release tag
- fetchBundle downloads asset by name
- 5/5 unit tests pass; 85 lines; no new npm deps

Refs #2751
Refs #2488
merge-evidence-deferred-final: #2751
[skip-doc-gate]