### PR TITLE
feat(scripts): add GitHub-native MCP dispatch async fallback (#2752)

### DIFF
--- a/.changes/unreleased/2752.md
+++ b/.changes/unreleased/2752.md
@@ -1,0 +1,4 @@
+### Added
+
+- `github-mcp-dispatch.js`: GitHub-native async MCP dispatch via `repository_dispatch`,
+  replacing HAMR `/mcp` for fire-and-forget use cases. HAMR stays default for interactive RPC (#2752).

--- a/scripts/global/github-mcp-dispatch.js
+++ b/scripts/global/github-mcp-dispatch.js
@@ -5,6 +5,8 @@
 const https = require('node:https');
 const { execSync } = require('node:child_process');
 
+const HTTP_ERROR_MIN = 400;
+
 function getToken() {
   if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
   return execSync('gh auth token', { encoding: 'utf8' }).trim();
@@ -35,7 +37,7 @@ async function dispatch(owner, repo, eventType, payload = {}) {
       accept: 'application/vnd.github.v3+json',
     },
   }, data);
-  if (res.status >= 400) throw new Error(`dispatch failed: ${res.status} ${res.body}`);
+  if (res.status >= HTTP_ERROR_MIN) throw new Error(`dispatch failed: ${res.status} ${res.body}`);
   return { dispatched: true, event_type: eventType, timestamp: new Date().toISOString() };
 }
 

--- a/scripts/global/github-mcp-dispatch.js
+++ b/scripts/global/github-mcp-dispatch.js
@@ -1,0 +1,42 @@
+// tier: 2
+// github-mcp-dispatch.js — GitHub-native async MCP dispatch via repository_dispatch. Refs #2752.
+// HAMR stays default for interactive RPC; this is the async fallback for fire-and-forget.
+'use strict';
+const https = require('node:https');
+const { execSync } = require('node:child_process');
+
+function getToken() {
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+  return execSync('gh auth token', { encoding: 'utf8' }).trim();
+}
+
+function ghRequest(opts, postData) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(opts, (res) => {
+      let body = '';
+      res.on('data', (d) => { body += d; });
+      res.on('end', () => resolve({ status: res.statusCode, body }));
+    });
+    req.on('error', reject);
+    if (postData) req.write(postData);
+    req.end();
+  });
+}
+
+async function dispatch(owner, repo, eventType, payload = {}) {
+  const token = getToken();
+  const data = JSON.stringify({ event_type: eventType, client_payload: payload });
+  const res = await ghRequest({
+    hostname: 'api.github.com', method: 'POST',
+    path: `/repos/${owner}/${repo}/dispatches`,
+    headers: {
+      authorization: `token ${token}`, 'user-agent': 'megingjord-harness',
+      'content-type': 'application/json', 'content-length': Buffer.byteLength(data),
+      accept: 'application/vnd.github.v3+json',
+    },
+  }, data);
+  if (res.status >= 400) throw new Error(`dispatch failed: ${res.status} ${res.body}`);
+  return { dispatched: true, event_type: eventType, timestamp: new Date().toISOString() };
+}
+
+module.exports = { dispatch };

--- a/tests/github-mcp-dispatch.spec.js
+++ b/tests/github-mcp-dispatch.spec.js
@@ -1,0 +1,59 @@
+// tests/github-mcp-dispatch.spec.js — unit tests for GitHub-native MCP dispatch. Refs #2752.
+'use strict';
+const assert = require('node:assert/strict');
+const { describe, it, before } = require('node:test');
+const path = require('node:path');
+
+let dispatch;
+let mockResponses = [];
+
+function makeRes(status, body) {
+  return {
+    statusCode: status,
+    headers: {},
+    on(ev, cb) { if (ev === 'data') cb(body); if (ev === 'end') cb(); return this; },
+  };
+}
+
+before(() => {
+  const Module = require('node:module');
+  const origLoad = Module._load;
+  Module._load = function(req, parent, isMain) {
+    if (req === 'node:https') {
+      return {
+        request(opts, cb) {
+          const resp = mockResponses.shift() || makeRes(204, '');
+          cb(resp);
+          return { write() {}, end() {}, on() {} };
+        },
+      };
+    }
+    if (req === 'node:child_process') return { execSync: () => 'tok' };
+    return origLoad.apply(this, arguments);
+  };
+  const modulePath = path.resolve(__dirname, '../scripts/global/github-mcp-dispatch');
+  delete require.cache[require.resolve(modulePath)];
+  ({ dispatch } = require(modulePath));
+});
+
+describe('dispatch', () => {
+  it('returns dispatch object on success', async () => {
+    mockResponses.push(makeRes(204, ''));
+    const result = await dispatch('owner', 'repo', 'mcp-review');
+    assert.equal(result.dispatched, true);
+    assert.equal(result.event_type, 'mcp-review');
+    assert.ok(result.timestamp);
+  });
+
+  it('dispatches with custom event type', async () => {
+    mockResponses.push(makeRes(204, ''));
+    const result = await dispatch('owner', 'repo', 'custom-event', { key: 'val' });
+    assert.equal(result.event_type, 'custom-event');
+    assert.equal(result.dispatched, true);
+  });
+
+  it('throws on HTTP error', async () => {
+    mockResponses.push(makeRes(422, '{"message":"bad"}'));
+    await assert.rejects(() => dispatch('owner', 'repo', 'bad'), /dispatch failed/);
+  });
+});


### PR DESCRIPTION
Add github-mcp-dispatch.js: fire-and-forget async MCP dispatch via repository_dispatch.

- Replaces HAMR /mcp for async use-cases
- HAMR stays default for interactive RPC (Phase-0 carve-out)
- 3/3 unit tests pass; 45 lines

Refs #2752
Refs #2488
merge-evidence-deferred-final: #2752
[skip-doc-gate]