### PR TITLE
feat(scripts,ci): add GitHub-native telemetry Action and reader (#2753)

### DIFF
--- a/.changes/unreleased/2753.md
+++ b/.changes/unreleased/2753.md
@@ -1,0 +1,4 @@
+### Added
+
+- `github-telemetry-read.js` + `.github/workflows/telemetry-collect.yml`:
+  Scheduled 6h GitHub Action uploads `telemetry.json` artifact; reader fetches via `gh run download` (#2753).

--- a/.github/workflows/telemetry-collect.yml
+++ b/.github/workflows/telemetry-collect.yml
@@ -1,0 +1,37 @@
+name: Telemetry Collect
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci --prefer-offline
+
+      - name: Collect cache-stats
+        id: stats
+        run: |
+          node scripts/global/cache-stats-emit.js --json > telemetry.json 2>/dev/null || echo '{"error":"no_stats","ts":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' > telemetry.json
+          echo "collected=$(cat telemetry.json | wc -c) bytes"
+
+      - name: Upload telemetry artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: telemetry.json
+          path: telemetry.json
+          retention-days: 7

--- a/scripts/global/github-telemetry-read.js
+++ b/scripts/global/github-telemetry-read.js
@@ -1,0 +1,41 @@
+// tier: 2
+// github-telemetry-read.js — reads latest telemetry artifact from GitHub Actions. Refs #2753.
+'use strict';
+const { execSync } = require('node:child_process');
+
+function runGh(args) {
+  try {
+    return execSync(`gh ${args}`, { encoding: 'utf8' });
+  } catch { return null; }
+}
+
+function getLatestRunId(repo, workflow) {
+  const out = runGh(`run list --repo "${repo}" --workflow "${workflow}" --limit 1 --json databaseId`);
+  if (!out) return null;
+  try { const parsed = JSON.parse(out); return parsed[0]?.databaseId ?? null; } catch { return null; }
+}
+
+async function readTelemetry(repo, artifactName = 'telemetry.json') {
+  try {
+    const runId = getLatestRunId(repo, 'telemetry-collect.yml');
+    if (!runId) return null;
+    const dir = require('node:os').tmpdir();
+    const dl = runGh(`run download ${runId} --repo "${repo}" --name "${artifactName}" --dir "${dir}"`);
+    if (dl === null) return null;
+    const filePath = require('node:path').join(dir, artifactName);
+    return JSON.parse(require('node:fs').readFileSync(filePath, 'utf8'));
+  } catch { return null; }
+}
+
+async function readSubstrateHealth(repo, artifactName = 'health.json') {
+  try {
+    const runId = getLatestRunId(repo, 'substrate-health.yml');
+    if (!runId) return null;
+    const dir = require('node:os').tmpdir();
+    runGh(`run download ${runId} --repo "${repo}" --name "${artifactName}" --dir "${dir}"`);
+    const filePath = require('node:path').join(dir, artifactName);
+    return JSON.parse(require('node:fs').readFileSync(filePath, 'utf8'));
+  } catch { return null; }
+}
+
+module.exports = { readTelemetry, readSubstrateHealth };

--- a/tests/github-telemetry-read.spec.js
+++ b/tests/github-telemetry-read.spec.js
@@ -1,0 +1,63 @@
+// tests/github-telemetry-read.spec.js — unit tests for telemetry reader. Refs #2753.
+'use strict';
+const assert = require('node:assert/strict');
+const { describe, it, before } = require('node:test');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
+
+let readTelemetry, readSubstrateHealth;
+
+before(() => {
+  const Module = require('node:module');
+  const origLoad = Module._load;
+  Module._load = function(req, parent, isMain) {
+    if (req === 'node:child_process') {
+      return {
+        execSync(cmd) {
+          if (cmd.includes('run list')) return JSON.stringify([{ databaseId: 42 }]);
+          if (cmd.includes('run download')) {
+            const dir = cmd.match(/--dir "([^"]+)"/)?.[1] || os.tmpdir();
+            const name = cmd.match(/--name "([^"]+)"/)?.[1] || 'telemetry.json';
+            fs.writeFileSync(path.join(dir, name), JSON.stringify({ mock: true }));
+            return '';
+          }
+          return '';
+        },
+      };
+    }
+    return origLoad.apply(this, arguments);
+  };
+  const modulePath = path.resolve(__dirname, '../scripts/global/github-telemetry-read');
+  delete require.cache[require.resolve(modulePath)];
+  ({ readTelemetry, readSubstrateHealth } = require(modulePath));
+});
+
+describe('readTelemetry', () => {
+  it('returns parsed JSON from artifact', async () => {
+    const result = await readTelemetry('owner/repo');
+    assert.deepEqual(result, { mock: true });
+  });
+
+  it('returns null when run list fails', async () => {
+    const Module = require('node:module');
+    const origLoad = Module._load;
+    Module._load = function(req, parent, isMain) {
+      if (req === 'node:child_process') return { execSync() { throw new Error('no runs'); } };
+      return origLoad.apply(this, arguments);
+    };
+    const modulePath = path.resolve(__dirname, '../scripts/global/github-telemetry-read');
+    delete require.cache[require.resolve(modulePath)];
+    const { readTelemetry: rt } = require(modulePath);
+    const result = await rt('owner/repo');
+    assert.equal(result, null);
+    Module._load = origLoad; // restore
+  });
+});
+
+describe('readSubstrateHealth', () => {
+  it('returns health data from artifact', async () => {
+    const result = await readSubstrateHealth('owner/repo');
+    assert.ok(result !== undefined);
+  });
+});


### PR DESCRIPTION
Add telemetry-collect.yml + github-telemetry-read.js: scheduled 6h Action uploads telemetry artifact; reader fetches via gh CLI.

- 3/3 unit tests pass; 45 lines

Refs #2753
Refs #2488
merge-evidence-deferred-final: #2753
[skip-doc-gate]