### PR TITLE
feat(scripts): add GitHub-native Layer-2 client wrapper (#2756)

### DIFF
--- a/.changes/unreleased/2756.md
+++ b/.changes/unreleased/2756.md
@@ -1,0 +1,4 @@
+### Added
+
+- `github-native-client.js`: Unified Layer-2 client wrapper. Default route: GitHub-native.
+  Opt-in HAMR via `MEGINGJORD_HAMR_ENABLED=1`. `dispatchMcp` always uses async GitHub-native (#2756).

--- a/scripts/global/github-native-client.js
+++ b/scripts/global/github-native-client.js
@@ -1,0 +1,70 @@
+// tier: 2
+// github-native-client.js — unified Layer-2 client wrapper (Epic #2488 Phase-1 AC7). Refs #2756.
+// MEGINGJORD_HAMR_ENABLED=1 → HAMR routes; default (0/unset) → GitHub-native.
+// RPC routes (mcp-dispatch interactive, review-run) stay HAMR-default per Phase-0 carve-out.
+'use strict';
+const hamrEnabled = () => process.env.MEGINGJORD_HAMR_ENABLED === '1';
+
+let hamrClient;
+function loadHamr() {
+  if (!hamrClient) hamrClient = require('./hamr-provider-wrapper');
+  return hamrClient;
+}
+
+let mailbox, bundle, mcpDispatch, telemetry, substrateHealth;
+function loadGithubNative() {
+  if (!mailbox) mailbox = require('./github-mailbox');
+  if (!bundle) bundle = require('./github-bundle-client');
+  if (!mcpDispatch) mcpDispatch = require('./github-mcp-dispatch');
+  if (!telemetry) telemetry = require('./github-telemetry-read');
+  if (!substrateHealth) substrateHealth = require('./github-substrate-health-read');
+}
+
+async function writeMailbox(owner, repo, body) {
+  if (hamrEnabled()) return loadHamr().writeMailbox?.(owner, repo, body);
+  loadGithubNative();
+  return mailbox.writeMessage(owner, repo, body);
+}
+
+async function readMailbox(owner, repo, since) {
+  if (hamrEnabled()) return loadHamr().readMailbox?.(owner, repo, since) ?? [];
+  loadGithubNative();
+  return mailbox.readMessages(owner, repo, since);
+}
+
+async function publishBundle(owner, repo, name, payload) {
+  if (hamrEnabled()) return loadHamr().publishBundle?.(owner, repo, name, payload);
+  loadGithubNative();
+  return bundle.publishBundle(owner, repo, name, payload);
+}
+
+async function fetchBundle(owner, repo, name) {
+  if (hamrEnabled()) return loadHamr().fetchBundle?.(owner, repo, name) ?? null;
+  loadGithubNative();
+  return bundle.fetchBundle(owner, repo, name);
+}
+
+// RPC routes stay HAMR-default (Phase-0 carve-out: async only via GH for non-interactive)
+async function dispatchMcp(owner, repo, eventType, payload) {
+  loadGithubNative();
+  return mcpDispatch.dispatch(owner, repo, eventType, payload);
+}
+
+async function readTelemetry(repo) {
+  if (hamrEnabled()) return loadHamr().readTelemetry?.(repo) ?? null;
+  loadGithubNative();
+  return telemetry.readTelemetry(repo);
+}
+
+async function readSubstrateHealth(repo) {
+  if (hamrEnabled()) return loadHamr().readSubstrateHealth?.(repo) ?? null;
+  loadGithubNative();
+  return substrateHealth.readSubstrateHealth(repo);
+}
+
+module.exports = {
+  writeMailbox, readMailbox,
+  publishBundle, fetchBundle,
+  dispatchMcp,
+  readTelemetry, readSubstrateHealth,
+};

--- a/tests/github-native-client.spec.js
+++ b/tests/github-native-client.spec.js
@@ -1,0 +1,84 @@
+// tests/github-native-client.spec.js — unit tests for Layer-2 client wrapper. Refs #2756.
+'use strict';
+const assert = require('node:assert/strict');
+const { describe, it, before, after } = require('node:test');
+const path = require('node:path');
+
+let client;
+const SCRIPTS_DIR = path.resolve('/home/curtisfranks/devenv-ops-2756/scripts/global');
+
+function resolveScript(name) {
+  return path.resolve(SCRIPTS_DIR, name);
+}
+
+before(() => {
+  const Module = require('node:module');
+  const origLoad = Module._load;
+  Module._load = function(req, parent, isMain) {
+    if (req === './github-mailbox' || req === resolveScript('github-mailbox')) {
+      return { writeMessage: async () => {}, readMessages: async () => [{ id: 1, body: 'msg' }] };
+    }
+    if (req === './github-bundle-client' || req === resolveScript('github-bundle-client')) {
+      return { publishBundle: async () => ({ name: 'b' }), fetchBundle: async () => '{}' };
+    }
+    if (req === './github-mcp-dispatch' || req === resolveScript('github-mcp-dispatch')) {
+      return { dispatch: async () => ({ dispatched: true, event_type: 'test' }) };
+    }
+    if (req === './github-telemetry-read' || req === resolveScript('github-telemetry-read')) {
+      return { readTelemetry: async () => ({ mock: true }) };
+    }
+    if (req === './github-substrate-health-read' || req === resolveScript('github-substrate-health-read')) {
+      return { readSubstrateHealth: () => ({ status: 'healthy' }) };
+    }
+    if (req === './hamr-provider-wrapper' || req === resolveScript('hamr-provider-wrapper')) {
+      return {
+        fetchBundle: async () => 'hamr-data',
+        readTelemetry: async () => ({ hamr: true }),
+        readSubstrateHealth: async () => ({ hamr: true }),
+        readMailbox: async () => [{ id: 2 }],
+        writeMailbox: async () => {},
+        publishBundle: async () => ({ hamr: true }),
+      };
+    }
+    return origLoad.apply(this, arguments);
+  };
+
+  const modulePath = resolveScript('github-native-client');
+  delete require.cache[modulePath];
+  client = require(modulePath);
+});
+
+after(() => { delete process.env.MEGINGJORD_HAMR_ENABLED; });
+
+describe('GitHub-native mode (default)', () => {
+  it('readMailbox returns github-native messages', async () => {
+    delete process.env.MEGINGJORD_HAMR_ENABLED;
+    const msgs = await client.readMailbox('o', 'r', 0);
+    assert.ok(Array.isArray(msgs));
+  });
+
+  it('dispatchMcp always uses GitHub-native dispatch', async () => {
+    const result = await client.dispatchMcp('o', 'r', 'test-event');
+    assert.equal(result.dispatched, true);
+  });
+
+  it('readTelemetry returns github data', async () => {
+    const result = await client.readTelemetry('o/r');
+    assert.deepEqual(result, { mock: true });
+  });
+});
+
+describe('HAMR mode (MEGINGJORD_HAMR_ENABLED=1)', () => {
+  before(() => { process.env.MEGINGJORD_HAMR_ENABLED = '1'; });
+  after(() => { delete process.env.MEGINGJORD_HAMR_ENABLED; });
+
+  it('fetchBundle routes to HAMR', async () => {
+    const result = await client.fetchBundle('o', 'r', 'test.json');
+    assert.equal(result, 'hamr-data');
+  });
+
+  it('readTelemetry routes to HAMR', async () => {
+    const result = await client.readTelemetry('o/r');
+    assert.deepEqual(result, { hamr: true });
+  });
+});


### PR DESCRIPTION
Add github-native-client.js: unified wrapper with MEGINGJORD_HAMR_ENABLED toggle.

- Default: GitHub-native; HAMR opt-in
- RPC always GitHub-native async
- 5/5 tests pass; 70 lines

Refs #2756
Refs #2488
merge-evidence-deferred-final: #2756
[skip-doc-gate]