### PR TITLE
docs: remediate Epic #2488 doc debt #2768

### DIFF
--- a/.changes/unreleased/2768.md
+++ b/.changes/unreleased/2768.md
@@ -1,0 +1,5 @@
+### Fixed
+- Updated `ARCHITECTURE.md`, `README.md`, `docs/provider-neutral-routing.md`,
+  wiki `mailbox.md`, `hamr-failover-map.md`, and new `github-native-layer2.md`
+  concept page to document the zero-Cloudflare GitHub-native Layer-2 path
+  introduced by Epic #2488 (#2768).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,6 +46,24 @@ The Workspace Layer resides inside the individual target project's repository. T
 
 ---
 
+## 1b. Layer-2 Coordination (HAMR vs GitHub-Native)
+
+Cross-agent coordination routes through one of two Layer-2 backends, selected
+by environment variable:
+
+| `MEGINGJORD_HAMR_ENABLED` | Backend | Requires |
+|---|---|---|
+| unset / `0` (**default**) | GitHub-native (`github-native-client.js`) | GitHub repo only |
+| `1` | HAMR Cloudflare Worker | Cloudflare account |
+
+GitHub-native routes (default): `github-mailbox.js` (Issues), `github-bundle-client.js`
+(Releases), `github-mcp-dispatch.js` (repository_dispatch), telemetry/health via
+scheduled Actions artifacts. The unified client auto-selects based on the env var.
+
+See `docs/howto/github-native-layer2.md` and [[github-native-layer2]] wiki page.
+
+---
+
 ## 2. Multi-Runtime Parity
 
 A core architectural goal of Megingjord is **runtime parity**. Standardizing developer-agent behavior across multiple execution environments prevents configuration drift and cognitive overhead.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ history, workspace wiki, and local overrides.
 to all three runtimes — Copilot, Claude Code, and Codex are equal first-class
 citizens.
 
+**Zero-Cloudflare by default**: Cross-agent coordination (mailbox, bundles,
+telemetry, async dispatch) uses GitHub-native primitives out of the box — no
+Cloudflare account or `wrangler deploy` required. Set `MEGINGJORD_HAMR_ENABLED=1`
+to opt into the accelerated HAMR Cloudflare Worker for higher-throughput paths.
+See [`docs/howto/github-native-layer2.md`](docs/howto/github-native-layer2.md).
+
 See [`docs/howto/installation.md`](docs/howto/installation.md) for the full
 install walkthrough, including adding a second project.
 
@@ -88,6 +94,10 @@ npm run lint
 npm test
 npm run deploy:both:apply
 ```
+
+No Cloudflare account needed. Cross-agent coordination works immediately via
+GitHub-native primitives. To enable the HAMR accelerated path after deploying
+the Worker: add `MEGINGJORD_HAMR_ENABLED=1` to your `.env`.
 
 ## Env-backed credentials
 

--- a/docs/provider-neutral-routing.md
+++ b/docs/provider-neutral-routing.md
@@ -39,6 +39,21 @@ Runtime records describe agent surfaces. Provider records describe serving
 paths. Keep those ownership boundaries separate when comparing Codex, Copilot,
 Claude Code, HAMR, OpenClaw, OpenRouter, Ollama, LiteLLM, or vendor APIs.
 
+## Layer-2 Coordination Routing
+
+Cross-agent coordination (mailbox, bundles, telemetry) is separate from the
+LLM inference lane above. It uses `github-native-client.js` for routing:
+
+| Path | Default (Tier-1) | Opt-in (Tier-2) |
+|---|---|---|
+| Mailbox | `github-mailbox.js` via GitHub Issues | HAMR `/mailbox/*` |
+| Bundles | `github-bundle-client.js` via Releases | HAMR `/bundle/*` |
+| Telemetry | `github-telemetry-read.js` via Actions artifact | HAMR `/quota` |
+| Async dispatch | `github-mcp-dispatch.js` via `repository_dispatch` | HAMR MCP |
+
+Toggle: `MEGINGJORD_HAMR_ENABLED=1` activates Tier-2. Default is Tier-1
+(GitHub-native, zero paid infrastructure). See `docs/howto/github-native-layer2.md`.
+
 ## Validation
 
 Routing changes should include:

--- a/wiki/wisdom/global/concepts/github-native-layer2.md
+++ b/wiki/wisdom/global/concepts/github-native-layer2.md
@@ -1,0 +1,57 @@
+---
+title: "GitHub-Native Layer-2 Coordination"
+type: concept
+created: 2026-06-08
+updated: 2026-06-08
+tags: [layer-2, github-native, hamr, mailbox, bundle, telemetry, g3, zero-cost]
+related: ["[[mailbox]]", "[[hamr-failover-map]]", "[[hamr-core-worker]]"]
+status: active
+wiki_type: wisdom
+scope: global
+content_trust_score: 0.95
+freshness_window: 30d
+last_updated: 2026-06-08
+content_hash: placeholder
+---
+
+# GitHub-Native Layer-2 Coordination
+
+Tier-1 coordination routes implemented as pure GitHub API primitives.
+Zero Cloudflare, zero paid infrastructure. Ships in Epic #2488.
+
+## Why it exists
+
+HAMR (Cloudflare Worker) is the accelerated Tier-2 path for cross-agent
+coordination. GitHub-native is the **default Tier-1 path**: functional for
+all standard use cases, costs nothing beyond the GitHub repo itself.
+
+## Route table
+
+| Coordination need | Script | GitHub primitive |
+|---|---|---|
+| Mailbox write/read | `github-mailbox.js` | Issues comment + ETag poll |
+| Bundle publish/fetch | `github-bundle-client.js` | Releases assets API |
+| Async task dispatch | `github-mcp-dispatch.js` | `repository_dispatch` |
+| Quota / cache telemetry | `github-telemetry-read.js` | Actions artifact |
+| Substrate health | `github-substrate-health-read.js` | Actions artifact |
+| Nightly review | `review-run.yml` | Scheduled Action (02:00 UTC) |
+| Rotation check | `rotation-check.yml` | Weekly Action (Mon 09:00 UTC) |
+
+## Unified client
+
+`scripts/global/github-native-client.js` wraps all routes. Selects backend
+via `MEGINGJORD_HAMR_ENABLED` env var:
+
+- `0` / unset → GitHub-native (default)
+- `1` → HAMR Cloudflare Worker
+
+## G3 impact
+
+Removes the Cloudflare Worker hard dependency for new operators. Tier-1
+install = `git clone` + `npm run deploy:apply`. No HAMR account needed.
+
+## See also
+
+- `docs/howto/github-native-layer2.md` — operator install guide
+- [[mailbox]] — HAMR R2 mailbox (Tier-2 path)
+- [[hamr-failover-map]] — failover routing table

--- a/wiki/wisdom/global/concepts/hamr-failover-map.md
+++ b/wiki/wisdom/global/concepts/hamr-failover-map.md
@@ -2,20 +2,41 @@
 title: "HAMR Failover Map"
 type: concept
 created: 2026-05-11
-updated: 2026-05-11
-tags: [hamr, resilience]
+updated: 2026-06-08
+tags: [hamr, resilience, github-native, layer-2, failover]
 sources: []
-related: ["[[3-tier-degraded-hamr]]", "[[hamr-bundle]]"]
-status: stub
+related: ["[[3-tier-degraded-hamr]]", "[[hamr-bundle]]", "[[github-native-layer2]]"]
+status: active
 ---
 
 # HAMR Failover Map
 
-Routing table mapping HAMR failure modes to fallback substrates and tiers.
+Routing table: HAMR failure mode → GitHub-native fallback → degraded mode.
 
-> **Stub page.** Created to resolve broken wikilinks per #1207 (wiki-orphan-check, tool-002). Expand with implementation details, examples, and cross-references as the concept matures.
+## Tier-1 (default): GitHub-native
+
+All Layer-2 routes have GitHub-native implementations requiring no Cloudflare:
+
+| Route | GitHub-native script | Trigger |
+|---|---|---|
+| `/mailbox/write`, `/mailbox/read` | `github-mailbox.js` | `MEGINGJORD_HAMR_ENABLED` unset |
+| `/bundle/*` | `github-bundle-client.js` | `MEGINGJORD_HAMR_ENABLED` unset |
+| `/mcp dispatch` | `github-mcp-dispatch.js` | `MEGINGJORD_HAMR_ENABLED` unset |
+| `/quota`, `/cache-stats` | `github-telemetry-read.js` | Actions artifact polling |
+| `/substrate-health` | `github-substrate-health-read.js` | Actions artifact polling |
+
+## Tier-2 (opt-in): HAMR Cloudflare Worker
+
+Set `MEGINGJORD_HAMR_ENABLED=1`. Provides DPoP signing, lower latency, KV-backed
+replay protection. See [[hamr-core-worker]] for deployment.
+
+## Failover decision: HAMR unreachable
+
+`github-native-client.js` detects HAMR unavailability via HTTP error / timeout
+and falls back to the corresponding Tier-1 script automatically (G6 resilience).
 
 ## See also
 
-- [[3-tier-degraded-hamr]]
-- [[hamr-bundle]]
+- [[github-native-layer2]] — full route table + dual-mode contract
+- [[3-tier-degraded-hamr]] — deeper HAMR degradation tiers
+- [[hamr-bundle]] — bundle route detail

--- a/wiki/wisdom/global/concepts/mailbox.md
+++ b/wiki/wisdom/global/concepts/mailbox.md
@@ -75,10 +75,24 @@ Existing `agent-coord-remote.js` (megingjord-coord Worker, #740/#785) continues 
 - **R9.4** idempotent: same `(publisher_key_id, nonce)` always returns same write result; replay yields 409 deterministically.
 - **R9** failover: `mailbox-outbox.js` queues writes when Worker unreachable; `flushPending(client)` reconciles on substrate-health recovery.
 
+## GitHub-native alternative (Tier-1, default)
+
+`scripts/global/github-mailbox.js` provides the same write/read contract using
+GitHub Issues comment threads + ETag polling — no Cloudflare required (#2750).
+
+```js
+const { writeMessage, readMessages } = require('./github-mailbox');
+await writeMessage(owner, repo, payload);        // appends comment to issue
+const msgs = await readMessages(owner, repo);    // ETag-gated poll (304 = [])
+```
+
+Select via `github-native-client.js` (auto-routes based on `MEGINGJORD_HAMR_ENABLED`).
+See [[github-native-layer2]] and `docs/howto/github-native-layer2.md`.
+
 ## References
 
 - HAMR v3.2 §R2 + §5 child 5: `research/hamr-v3-2-2026-05-04.md` (#890).
 - v3.2.1 §R9 + DC-1: `research/hamr-v3-2-1-2026-05-05.md` (#907).
 - Baton signing (#894): `scripts/global/baton-signing.js`.
 - HAMR core Worker (#910): `cloudflare/hamr/`.
-- Implementation: this PR (#918).
+- GitHub-native mailbox (#2750): `scripts/global/github-mailbox.js`.


### PR DESCRIPTION
Fix doc debt from Epic #2488: update ARCHITECTURE, README, wiki, and routing docs

Refs #2768

Six documentation surfaces that were skipped (via `[skip-doc-gate]`) during
Epic #2488 are now updated:

- **`ARCHITECTURE.md`**: Added `## 1b. Layer-2 Coordination` section covering HAMR vs GitHub-native env-toggle
- **`README.md`**: Added zero-Cloudflare note in "How it works" and "Quick start"
- **`wiki/.../mailbox.md`**: Added GitHub-native alternative section (`github-mailbox.js`)
- **`wiki/.../hamr-failover-map.md`**: Expanded from stub → active Tier-1/Tier-2 failover table
- **`docs/provider-neutral-routing.md`**: Added Layer-2 coordination routing table
- **`wiki/.../github-native-layer2.md`**: New wisdom-layer concept page for Epic #2488 primitives

[skip-doc-gate]
