### PR TITLE
docs: split 5 lint-capped docs into linked suites #2776

### DIFF
--- a/.changes/unreleased/2776.md
+++ b/.changes/unreleased/2776.md
@@ -1,0 +1,8 @@
+### Fixed
+- Split five lint-capped documentation files into linked document suites
+  so content is no longer artificially truncated:
+  - CONTRIBUTING.md plus docs/contributing-skills.md, docs/contributing-workflow.md, docs/contributing-dev-setup.md
+  - docs/ARCHITECTURE.md plus docs/architecture-routing.md, docs/architecture-governance.md, docs/architecture-deployment.md
+  - ARCHITECTURE.md plus docs/architecture-layer-model.md, docs/architecture-baton-model.md, docs/architecture-runtime-parity.md
+  - wiki/WIKI.md plus wiki/WIKI-operations.md, wiki/WIKI-typology.md
+  - AGENTS.md plus docs/agents-governance.md, docs/agents-workflow.md (#2776)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 ## Repo purpose
 
 Development workbench for the DevEnv Ops Harness:
+
 - `skills/` → deploy to `~/.copilot/skills/` and `~/.agents/skills/`
 - `instructions/` → deploy to `~/.copilot/instructions/`
 - `hooks/` → deploy to `~/.copilot/hooks/` and `~/.codex/devenv-ops/hooks/`
@@ -47,9 +48,9 @@ Development workbench for the DevEnv Ops Harness:
 
 ## Quick reference
 
-| Topic | File |
-|---|---|
-| Team&Model signing, role taxonomy, key contracts | [`docs/agents-governance.md`](docs/agents-governance.md) |
-| Dev to deploy workflow, Layer-2, skill index, dashboard | [`docs/agents-workflow.md`](docs/agents-workflow.md) |
-| Baton model (roles, artifacts, CI gates) | [`docs/architecture-baton-model.md`](docs/architecture-baton-model.md) |
-| Contributing guide | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Topic                                                   | File                                                                   |
+| ------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Team&Model signing, role taxonomy, key contracts        | [`docs/agents-governance.md`](docs/agents-governance.md)               |
+| Dev to deploy workflow, Layer-2, skill index, dashboard | [`docs/agents-workflow.md`](docs/agents-workflow.md)                   |
+| Baton model (roles, artifacts, CI gates)                | [`docs/architecture-baton-model.md`](docs/architecture-baton-model.md) |
+| Contributing guide                                      | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                   |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,100 +1,55 @@
 # AGENTS.md — Megingjord baseline
 
-> **Cross-team contract**: see `governance/README.md` for the canonical entry point covering Team&Model signing, baton order, ticket-first workflow, and dedicated worktree (the 4 invariants). This file is the generic-AGENTS.md adapter.
+> **Cross-team contract**: see `governance/README.md` for the canonical entry
+> point (4 invariants: Team&Model signing, baton order, ticket-first, dedicated
+> worktree). This file is the generic-AGENTS.md adapter.
+>
+> Governance detail: [`docs/agents-governance.md`](docs/agents-governance.md)
+> Workflow and deploy detail: [`docs/agents-workflow.md`](docs/agents-workflow.md)
 
 ## Agent startup protocol (required)
 
-1. Load `.github/copilot-instructions.md` before planning edits.
-2. Global skills, instructions, hooks, and Codex assets in this repo are the **development source**.
-3. Never edit deployed runtimes directly: `~/.copilot/`, `~/.codex/`, or `~/.agents/skills/`.
-4. Validate changes with lint and tests before claiming completion.
+1. Read `governance/README.md` — the 4 invariants are non-negotiable.
+2. Load `.github/copilot-instructions.md` (Copilot) or `CLAUDE.md` (Claude Code)
+   before planning any edits.
+3. Global skills, instructions, hooks, and Codex assets in this repo are the
+   **development source**. Never edit deployed runtimes directly.
+4. Never edit `~/.copilot/`, `~/.codex/`, or `~/.agents/skills/` directly.
+5. Run `npm run lint && npm test` before claiming completion on any change.
+6. Check `/memories/repo/` and `/memories/session/` for prior context first.
 
 ## Repo purpose
 
-This repo is the **development workbench** for the DevEnv Ops Harness runtimes:
-- `skills/` → develop here, deploy to `~/.copilot/skills/` and `~/.agents/skills/`
-- `instructions/` → develop global instructions here, deploy to `~/.copilot/instructions/`
-- `hooks/` → develop hook logic here, deploy to `~/.copilot/hooks/` and `~/.codex/devenv-ops/hooks/`
-- `scripts/global/` → develop runtime scripts here, deploy to `~/.copilot/scripts/` and `~/.codex/devenv-ops/scripts/`
-- `.codex/` → develop Codex `AGENTS.md`, config, hooks, and rules install assets here
-- `agents/` → develop custom Copilot agents here, deploy to `~/.copilot/agents/`
-- `dashboard/` is a standalone web app — treat with full web-app rigor.
-- `research/` docs are living — update them when runtime behavior changes.
+Development workbench for the DevEnv Ops Harness:
+- `skills/` → deploy to `~/.copilot/skills/` and `~/.agents/skills/`
+- `instructions/` → deploy to `~/.copilot/instructions/`
+- `hooks/` → deploy to `~/.copilot/hooks/` and `~/.codex/devenv-ops/hooks/`
+- `scripts/global/` → deploy to `~/.copilot/scripts/` and `~/.codex/devenv-ops/scripts/`
+- `.codex/` → develop Codex AGENTS.md, config, hooks, and rules here
+- `agents/` → deploy to `~/.copilot/agents/`
+- `dashboard/` → standalone web app; treat with full web-app engineering rigor
+- `research/` → living docs; update when runtime behaviour changes
 
 ## Edit discipline
 
-- Keep changes minimal and localized.
-- ≤100 lines per file (lint-enforced).
-- JSON for structured data (inventory/, config).
-- Markdown for prose (research/, ADRs).
-- **Branch before editing global resources**: `git checkout -b skill/<name>` or `feat/<topic>`
-- **Test before deploying**: verify behavior in the target runtime.
+- Less than or equal to 100 lines per file (lint-enforced); split into linked files
+- **Branch before editing**: create a feat/N-slug or fix/N-slug branch (one ticket per branch)
+- **Ticket first**: open an issue before any file edits — governance rule number 1
+- JSON for structured data; Markdown for prose
+- Test before deploying: verify behaviour in the target runtime
 
 ## Concurrent session safety
 
-- Never share one live checkout between Copilot, Claude Code, and Codex.
-- Give each agent its own worktree + branch, then merge through PRs.
-- Quarantine collisions in a rescue worktree instead of cleaning in place.
-- See `research/concurrent-agent-worktrees-2026-04-24.md`.
+- Never share one live checkout between Copilot, Claude Code, and Codex
+- Give each agent its own worktree and branch; merge changes through PRs
+- Quarantine conflicts in a rescue worktree; never clean collisions in place
+- See `research/concurrent-agent-worktrees-2026-04-24.md`
 
-## Team&Model signing
+## Quick reference
 
-- AI-authored governed artifacts must include human alias + structured `Team&Model` provenance.
-- Repo-local overrides may tighten the format, but must not remove provenance.
-- See `instructions/team-model-signing.instructions.md`.
-
-## Review guidelines
-
-- In Codex PR reviews, treat ticket lifecycle, baton order, signer
-  fidelity, isolated worktrees, and runtime-home edits as release-blocking
-  governance risks.
-- Verify governed changes include matching docs, research, wiki, or drift
-  notes when behavior or operator workflow changes.
-- When Codex behavior is uncertain, use official OpenAI Codex docs instead of
-  inferring from Claude or Copilot compatibility.
-
-## HAMR cross-team routing
-
-- All 3 teams route governed provider calls through HAMR (`https://hamr.chf3198.workers.dev`).
-- Activate per-checkout: `npm run hamr:activate`. Verify: `npm run hamr:sync-verify`.
-- Canonical + provider-neutral contracts: `instructions/hamr-routing.instructions.md`, `instructions/provider-neutral-governance.instructions.md`.
-
-## Skill index
-
-Auto-derived from `skills/<name>/SKILL.md` — see [`docs/skills-agents.md`](docs/skills-agents.md). Regenerate via `node scripts/global/skill-views-derive.js`.
-
-## Development → Deploy workflow
-
-```
-1. Branch:  git checkout -b skill/<name>-change
-2. Edit:    skills/<name>/SKILL.md (or instructions/, hooks/, `.codex/`)
-3. Test:    Verify behavior in the target runtime
-4. Merge:   git checkout main && git merge --no-ff
-5. Deploy:  run the affected runtime deploy command
-```
-
-## Dashboard conventions
-
-- Alpine.js for state, vanilla JS for logic
-- No build step; Cloudflare Pages for production deployment
-
-## Merge-evidence
-
-Use `merge-evidence-deferred-final: #N` in PR body (or `Closes #N`). See `governance-carve-outs/index.md`.
-
-## Role Taxonomy
-
-The harness uses a 7-role canonical taxonomy: Manager / Collaborator / Admin /
-Consultant / IT / Red-Team / Client. Guest-Collaborator is reserved but not active.
-Operator is a meta-term for the AI agent — not a distinct role.
-Canonical definition: `instructions/role-baton-routing.instructions.md` §"Role Taxonomy".
-
-## Key contracts (2026-H1)
-
-- **Doc-coverage gate**: `COLLABORATOR_HANDOFF` must include `doc-coverage:` block for `lane:code-change`. See `docs/howto/merge-time-doc-governance.md`.
-- **Baton builders**: Use `baton-comment-build.js`, `pr-comment-build.js`, `changelog-fragment-build.js` for governed artifacts.
-- **Governance chains**: Run `npm run governance:chains:check` on governance path changes. See `docs/howto/governance-chains.md`.
-- **OTel GenAI**: `isValidGenAI()` from `scripts/global/otel-genai-conformance.js`; validate telemetry fields before emit.
-- **Fleet-call-guard**: All fleet calls must use bounded timeout (see `docs/howto/fleet-call-guard.md`; PR #2697).
-- **Credential guard**: Check `credential-availability.js` before prompting user for secrets; `.env` may already have them.
-- **Admin-merge-exception**: Override merges require `merge-bypass:admin-exception` label per Epic #2517.
+| Topic | File |
+|---|---|
+| Team&Model signing, role taxonomy, key contracts | [`docs/agents-governance.md`](docs/agents-governance.md) |
+| Dev to deploy workflow, Layer-2, skill index, dashboard | [`docs/agents-workflow.md`](docs/agents-workflow.md) |
+| Baton model (roles, artifacts, CI gates) | [`docs/architecture-baton-model.md`](docs/architecture-baton-model.md) |
+| Contributing guide | [`CONTRIBUTING.md`](CONTRIBUTING.md) |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,98 +1,63 @@
 # Megingjord Harness Architecture
 
-Megingjord is a governance-first AI agent harness designed to provide robust, cross-runtime compliance, skills propagation, and local operational safety. This document details the core architectural layers, deployment topology, and governance flow.
+Megingjord is a **governance-first AI agent harness** providing cross-runtime
+compliance, skills propagation, and local operational safety for developer AI
+workflows across GitHub Copilot, Claude Code, and Codex.
 
----
+## Document map
 
-## 1. Multi-Layer Deployment Model (Two-Tier)
+| Topic | Detail |
+|---|---|
+| Two-tier layer model (global / workspace) | [`docs/architecture-layer-model.md`](docs/architecture-layer-model.md) |
+| Baton governance (Manager→Collaborator→Admin→Consultant) | [`docs/architecture-baton-model.md`](docs/architecture-baton-model.md) |
+| Multi-runtime parity (Copilot / Claude Code / Codex) | [`docs/architecture-runtime-parity.md`](docs/architecture-runtime-parity.md) |
+| Routing, fleet, cascade dispatch | [`docs/architecture-routing.md`](docs/architecture-routing.md) |
+| Deployment, Layer-2 coordination, sync commands | [`docs/architecture-deployment.md`](docs/architecture-deployment.md) |
+| Governance CI, wiki system, dashboard | [`docs/architecture-governance.md`](docs/architecture-governance.md) |
+| Contributor-facing subsystem index | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
 
-Megingjord operates on a strict **two-tier architecture**: a machine-level **Global Layer** and a repo-level **Workspace Layer**. This separation ensures that all projects share a common compliance baseline while retaining the flexibility to specify project-specific overrides.
+## Core architectural principles
+
+1. **Governance over convenience** — CI gates enforce baton order, signing, and
+   ticket-first workflow for every change; violations block merge
+2. **Source-of-truth discipline** — never edit deployed runtimes directly;
+   all changes flow from this repo outward via deploy commands
+3. **Runtime parity** — Copilot, Claude Code, and Codex are equal first-class
+   citizens; no runtime gets preferential treatment
+4. **Zero-cost default** — free-cloud (Gemini) and fleet (Ollama/Tailscale)
+   before any paid provider; override only when justified
+5. **No external infra required** — GitHub-native Layer-2 coordination works
+   without Cloudflare when `MEGINGJORD_HAMR_ENABLED` is unset
+
+## Two-tier model (overview)
 
 ```mermaid
 graph TD
-    subgraph Global ["Global Machine Layer (Home Directory (~/))"]
-        G_Copilot["~/.copilot/<br>(Global skills, instructions, hooks, scripts, wiki)"]
-        G_Claude["~/.claude/<br>(Global agents, hooks, settings)"]
-        G_Codex["~/.codex/<br>(Global AGENTS.md, config, hooks, rules)"]
-    end
-
-    subgraph Local ["Workspace Layer (Project Repository Root (./))"]
-        W_Copilot[".github/copilot-instructions.md<br>(Workspace overrides & adapters)"]
-        W_Claude["CLAUDE.md + .claude/settings.json<br>(Workspace overrides & adapters)"]
-        W_Codex["AGENTS.md + .codex/<br>(Workspace overrides & adapters)"]
-    end
-
-    %% Deployment flow
-    Deploy["Harness Repo Source<br>(skills/ instructions/ hooks/ scripts/)"] -->|npm run deploy:apply| G_Copilot
-    Deploy -->|npm run deploy:apply| G_Claude
-    Deploy -->|npm run deploy:apply| G_Codex
-
-    %% Override flow
-    W_Copilot -->|Local Context & Overrides| G_Copilot
-    W_Claude -->|Local Context & Overrides| G_Claude
-    W_Codex -->|Local Context & Overrides| G_Codex
+  subgraph Repo ["Source of Truth (this repo)"]
+    skills["skills/"] --- instr["instructions/"] --- hooks["hooks/"]
+  end
+  subgraph Global ["Global Layer (~/)"]
+    cop["~/.copilot/"] --- claude["~/.claude/"] --- codex["~/.codex/"]
+  end
+  subgraph Workspace ["Workspace Layer (each project repo)"]
+    w_cop[".github/copilot-instructions.md"]
+    w_claude["CLAUDE.md"]
+    w_codex["AGENTS.md"]
+  end
+  Repo -->|npm run deploy:apply| Global
+  Workspace -->|extends / overrides| Global
 ```
 
-### The Global Layer
-The Global Layer is installed once per machine (using `npm run deploy:apply`) and is shared across all local developer repositories.
-* **GitHub Copilot Chat (`~/.copilot/`)**: Houses core skills, global instructions, hook scripts, and compiled wiki databases.
-* **Claude Code (`~/.claude/`)**: Standardizes custom agents, global hooks, and command settings.
-* **Codex (`~/.codex/`)**: Centralizes the `AGENTS.md` and default rule schemas.
+## Harness Goal Constitution
 
-### The Workspace Layer
-The Workspace Layer resides inside the individual target project's repository. These files are checked into Git, establishing a transparent history of project-level context.
-* Local files extend or override global rules (e.g. project name, tech stack, workspace-specific commands).
-* On conflicts, global security and compliance rules take precedence unless explicitly delegated by a registered governance baton.
+**G1 Governance > G2 Quality > G3 Zero Cost > G4 Privacy > G5 Portability >
+G6 Resilience > G7 Throughput > G8 Observability > G9 Interoperability > G10 Maintainability**
 
----
+Record rationale in ticket/PR evidence whenever a lower-priority goal wins.
 
-## 1b. Layer-2 Coordination (HAMR vs GitHub-Native)
+## Scope and constraints
 
-Cross-agent coordination routes through one of two Layer-2 backends, selected
-by environment variable:
-
-| `MEGINGJORD_HAMR_ENABLED` | Backend | Requires |
-|---|---|---|
-| unset / `0` (**default**) | GitHub-native (`github-native-client.js`) | GitHub repo only |
-| `1` | HAMR Cloudflare Worker | Cloudflare account |
-
-GitHub-native routes (default): `github-mailbox.js` (Issues), `github-bundle-client.js`
-(Releases), `github-mcp-dispatch.js` (repository_dispatch), telemetry/health via
-scheduled Actions artifacts. The unified client auto-selects based on the env var.
-
-See `docs/howto/github-native-layer2.md` and [[github-native-layer2]] wiki page.
-
----
-
-## 2. Multi-Runtime Parity
-
-A core architectural goal of Megingjord is **runtime parity**. Standardizing developer-agent behavior across multiple execution environments prevents configuration drift and cognitive overhead.
-
-```
-                  ┌─────────────────────────────────────┐
-                  │      Unified Harness Manifest       │
-                  │ (inventory/governance-manifest.json) │
-                  └──────────────────┬──────────────────┘
-                                     │
-                 ┌───────────────────┼───────────────────┐
-                 ▼                   ▼                   ▼
-        ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐
-        │  GitHub Copilot │ │   Claude Code   │ │      Codex      │
-        │   Instructions  │ │    CLAUDE.md    │ │    AGENTS.md    │
-        └─────────────────┘ └─────────────────┘ └─────────────────┘
-```
-
-The harness compiler (`npm run governance:adapters:emit`) ingests a single central manifest and automatically generates target-specific shims for every supported engine. Copilot, Claude Code, and Codex are supported as equal first-class citizens, sharing a unified compliance footprint.
-
----
-
-## 3. Governance Baton Model
-
-Megingjord enforces a strict Agile-linked role validation cycle, coordinating operations through four distinct batons:
-
-1. **Manager (Role: Manager)**: Conducts initial research, defines goals, captures tickets (Epic, story, task), and determines architectural scope.
-2. **Collaborator (Role: Collaborator)**: Executes the development work, modifies files in isolated sandboxes, and implements the required acceptance criteria.
-3. **Admin (Role: Admin)**: Automates quality verification, runs test suites, manages credentials securely, and handles PR staging.
-4. **Consultant (Role: Consultant)**: Conducts adversarial red-team analyses, identifies operational risks, and finalizes post-mortem evaluations.
-
-This ensures comprehensive operational governance and end-to-end traceability across every phase of the development lifecycle.
+- ≤100 lines per file (lint-enforced for checked paths); split into linked files for more
+- No build step; all JS uses CommonJS modules loaded at runtime
+- JSON for structured data; Markdown for prose
+- One live worktree per agent session (concurrent session safety)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,15 +6,15 @@ workflows across GitHub Copilot, Claude Code, and Codex.
 
 ## Document map
 
-| Topic | Detail |
-|---|---|
-| Two-tier layer model (global / workspace) | [`docs/architecture-layer-model.md`](docs/architecture-layer-model.md) |
-| Baton governance (Manager→Collaborator→Admin→Consultant) | [`docs/architecture-baton-model.md`](docs/architecture-baton-model.md) |
-| Multi-runtime parity (Copilot / Claude Code / Codex) | [`docs/architecture-runtime-parity.md`](docs/architecture-runtime-parity.md) |
-| Routing, fleet, cascade dispatch | [`docs/architecture-routing.md`](docs/architecture-routing.md) |
-| Deployment, Layer-2 coordination, sync commands | [`docs/architecture-deployment.md`](docs/architecture-deployment.md) |
-| Governance CI, wiki system, dashboard | [`docs/architecture-governance.md`](docs/architecture-governance.md) |
-| Contributor-facing subsystem index | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
+| Topic                                                    | Detail                                                                       |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Two-tier layer model (global / workspace)                | [`docs/architecture-layer-model.md`](docs/architecture-layer-model.md)       |
+| Baton governance (Manager→Collaborator→Admin→Consultant) | [`docs/architecture-baton-model.md`](docs/architecture-baton-model.md)       |
+| Multi-runtime parity (Copilot / Claude Code / Codex)     | [`docs/architecture-runtime-parity.md`](docs/architecture-runtime-parity.md) |
+| Routing, fleet, cascade dispatch                         | [`docs/architecture-routing.md`](docs/architecture-routing.md)               |
+| Deployment, Layer-2 coordination, sync commands          | [`docs/architecture-deployment.md`](docs/architecture-deployment.md)         |
+| Governance CI, wiki system, dashboard                    | [`docs/architecture-governance.md`](docs/architecture-governance.md)         |
+| Contributor-facing subsystem index                       | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)                               |
 
 ## Core architectural principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,100 +1,54 @@
 # Contributing to Megingjord
 
-## Universal vs Personal Skills
+Welcome! Detailed guides are linked below.
 
-Skills are categorized in `skills/.plugin-triage.json`:
+## Guide index
 
-- **Universal** (24): Ship in `plugin.json` for all consumers
-- **Personal** (11): Deploy only via `deploy.sh` to `~/.copilot/`
+| Topic | Guide |
+|---|---|
+| Skill development — add, modify, test skills | [`docs/contributing-skills.md`](docs/contributing-skills.md) |
+| PR process — baton gates, doc coverage, signing | [`docs/contributing-workflow.md`](docs/contributing-workflow.md) |
+| Dev environment — setup, commands, code style | [`docs/contributing-dev-setup.md`](docs/contributing-dev-setup.md) |
 
-## Adding a Universal Skill
+## Types of contribution
 
-1. Create `skills/<name>/SKILL.md` with YAML frontmatter
-2. Add to `plugin.json` `skills` array
-3. Add to `skills/.plugin-triage.json` `universal` list
-4. Run `npm run validate:triage` to verify sync
-5. Branch → PR → squash merge → `npm run deploy:apply`
+- **Skills** — New capabilities delivered to Copilot / Claude Code / Codex runtimes
+- **Instructions** — Governance policy markdown for `instructions/`
+- **Scripts** — Node.js utilities in `scripts/global/` that deploy to `~/.copilot/scripts/`
+- **Wiki** — Knowledge pages in `wiki/wisdom/`, `wiki/work-log/`, `wiki/code/`
+- **Dashboard** — Fleet monitoring UI in `dashboard/`
+- **Governance** — Hook policies, CI workflows in `.github/workflows/`
 
-## Adding a Personal Skill
-
-1. Create `skills/<name>/SKILL.md`
-2. Add to `skills/.plugin-triage.json` `personal` list
-3. Do NOT add to `plugin.json`
-4. Run `npm run validate:triage`
-
-## Skill Format
-
-```markdown
----
-name: skill-name
-description: One-line description
----
-
-# skill-name — Title
-
-## Purpose
-
-## Scope
-
-## Constraints
-
-## Instructions
-
-## Verification
-```
-
-## Testing Plugin Installation
-
-1. Push changes to a branch
-2. In VS Code: `Chat: Install Plugin From Source`
-3. Paste the branch Git URL
-4. Verify skills appear in chat suggestions
-
-## Cross-Tool Compatibility
-
-| Tool            | Detection Path                         |
-| --------------- | -------------------------------------- |
-| VS Code Copilot | `plugin.json` (root)                   |
-| Claude Code     | `.claude-plugin/plugin.json` (symlink) |
-| GitHub Copilot  | `.github/plugin/plugin.json` (symlink) |
-
-Symlinks auto-resolve to root `plugin.json`.
-
-## Claude Code Runtime Install
-
-Deploy hooks, agents, and slash commands to the Claude Code runtime:
+## First-time contributor quickstart
 
 ```bash
-npm run deploy:claude:apply   # .claude/ → ~/.claude/
-npm run sync:claude            # ~/.claude/ → .claude/ (pull back)
+# 1. Clone and install
+git clone https://github.com/chf3198/megingjord-harness.git
+cd megingjord-harness && npm install
+
+# 2. Validate baseline before making any changes
+npm run lint && npm test && npm run validate:triage
+
+# 3. Create a ticket (governance rule — required before branching)
+gh issue create --title "feat: your change" --label "type:feat,priority:P2"
+
+# 4. Branch from main using the required naming pattern
+git checkout -b feat/123-short-slug   # or fix/123-short-slug
+
+# 5. Implement, verify, open PR
+npm run format:check && npm run lint && npm test
+gh pr create --title "feat(scope): description #123"
 ```
 
-## Constraints
+## Reporting a bug
 
-- **≤100 lines** per file (lint-enforced)
-- **Branch before editing**: `feat/<issue>-<slug>`
-- **Conventional commits**: `feat(scope):`, `fix(scope):`
-- **settings.json drift**: Permission approvals auto-append to `.claude/settings.json`. Commit these via `chore:` commit with ticket ref before branching (#506).
-- Run `npm run format:check && npm run lint && npm run lint:readability:ci` before pushing
+Open an issue with label `type:bug`. Include:
+1. Runtime (`copilot` | `claude-code` | `codex`)
+2. Reproduction steps
+3. Observed vs expected behaviour
+4. `npm run lint && npm test` output
 
-## PR Checklist
+## Code of conduct
 
-Before submitting a pull request, verify:
-
-- [ ] `npm run format:check && npm run lint` passes
-- [ ] `npm run lint:readability:ci` passes (no readability regressions)
-- [ ] `npm run validate:triage` passes (if skills changed)
-- [ ] `npm run validate:compat` passes (if plugin.json changed)
-- [ ] All new files ≤100 lines
-- [ ] Conventional commit message format used
-
-## Baton Gate Chain
-
-Every PR runs `baton-gates.yml`: collaborator-gate → admin-gate → consultant-gate.
-PR body must include `COLLABORATOR_HANDOFF`, `ADMIN_HANDOFF`, and `CONSULTANT_CLOSEOUT`.
-All sections require `Signed-by:`, `Team&Model:`, and `Role:`; Admin must differ from Collaborator.
-PRs >10 files or >500 LOC require `BLOCKER_NOTE` plus evidence closeout.
-
-Admin merge checklist: `pr-title-required` ≤60 chars, all gates green, artifacts present.
-Lane model: `code-change` (full baton), `docs/research` (Manager+Consultant), `config-only` (Admin+Consultant).
-`COLLABORATOR_HANDOFF` on `lane:code-change` must include a `doc-coverage:` block per `config/doc-coverage-matrix.yml`.
+All contributors follow [Contributor Covenant v2.1](CODE_OF_CONDUCT.md).
+Violations: `conduct@megingjord.dev`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ Welcome! Detailed guides are linked below.
 
 ## Guide index
 
-| Topic | Guide |
-|---|---|
-| Skill development — add, modify, test skills | [`docs/contributing-skills.md`](docs/contributing-skills.md) |
-| PR process — baton gates, doc coverage, signing | [`docs/contributing-workflow.md`](docs/contributing-workflow.md) |
-| Dev environment — setup, commands, code style | [`docs/contributing-dev-setup.md`](docs/contributing-dev-setup.md) |
+| Topic                                           | Guide                                                              |
+| ----------------------------------------------- | ------------------------------------------------------------------ |
+| Skill development — add, modify, test skills    | [`docs/contributing-skills.md`](docs/contributing-skills.md)       |
+| PR process — baton gates, doc coverage, signing | [`docs/contributing-workflow.md`](docs/contributing-workflow.md)   |
+| Dev environment — setup, commands, code style   | [`docs/contributing-dev-setup.md`](docs/contributing-dev-setup.md) |
 
 ## Types of contribution
 
@@ -43,6 +43,7 @@ gh pr create --title "feat(scope): description #123"
 ## Reporting a bug
 
 Open an issue with label `type:bug`. Include:
+
 1. Runtime (`copilot` | `claude-code` | `codex`)
 2. Reproduction steps
 3. Observed vs expected behaviour

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,15 +4,15 @@ Navigation hub for architecture documentation, structured after arc42 sections.
 
 ## Document map
 
-| Section | File | arc42 ref |
-|---|---|---|
-| Executive overview, goal constitution | [`ARCHITECTURE.md`](../ARCHITECTURE.md) | §1 Intro & Goals |
-| Two-tier layer model detail | [`docs/architecture-layer-model.md`](architecture-layer-model.md) | §7 Deployment |
-| Baton governance model | [`docs/architecture-baton-model.md`](architecture-baton-model.md) | §8 Crosscutting |
-| Multi-runtime parity | [`docs/architecture-runtime-parity.md`](architecture-runtime-parity.md) | §5 Building Blocks |
-| Routing, fleet, cascade dispatch | [`docs/architecture-routing.md`](architecture-routing.md) | §6 Runtime View |
-| Deployment model, Layer-2, sync | [`docs/architecture-deployment.md`](architecture-deployment.md) | §7 Deployment |
-| Governance CI, wiki, dashboard | [`docs/architecture-governance.md`](architecture-governance.md) | §8 Crosscutting |
+| Section                               | File                                                                    | arc42 ref          |
+| ------------------------------------- | ----------------------------------------------------------------------- | ------------------ |
+| Executive overview, goal constitution | [`ARCHITECTURE.md`](../ARCHITECTURE.md)                                 | §1 Intro & Goals   |
+| Two-tier layer model detail           | [`docs/architecture-layer-model.md`](architecture-layer-model.md)       | §7 Deployment      |
+| Baton governance model                | [`docs/architecture-baton-model.md`](architecture-baton-model.md)       | §8 Crosscutting    |
+| Multi-runtime parity                  | [`docs/architecture-runtime-parity.md`](architecture-runtime-parity.md) | §5 Building Blocks |
+| Routing, fleet, cascade dispatch      | [`docs/architecture-routing.md`](architecture-routing.md)               | §6 Runtime View    |
+| Deployment model, Layer-2, sync       | [`docs/architecture-deployment.md`](architecture-deployment.md)         | §7 Deployment      |
+| Governance CI, wiki, dashboard        | [`docs/architecture-governance.md`](architecture-governance.md)         | §8 Crosscutting    |
 
 ## High-level data flow (C4 — Context)
 
@@ -34,15 +34,15 @@ Codex                          policy.json          OR Cloud (Claude /       + s
 
 ## Subsystem index
 
-| Subsystem | Entry point | Detail |
-|---|---|---|
-| **Routing** | `scripts/global/cascade-dispatch.js` | [architecture-routing.md](architecture-routing.md) |
-| **Capability detection** | `scripts/global/capability-probe.js` | [architecture-routing.md](architecture-routing.md) |
-| **Governance CI** | `.github/workflows/baton-gates.yml` | [architecture-governance.md](architecture-governance.md) |
-| **Wiki system** | `wiki/` + `scripts/wiki/ingest.js` | [architecture-governance.md](architecture-governance.md) |
-| **Dashboard** | `dashboard/index.html` | [architecture-governance.md](architecture-governance.md) |
-| **Fleet** | `inventory/devices.json` | [architecture-routing.md](architecture-routing.md) |
-| **Deployment** | `scripts/deploy.sh` | [architecture-deployment.md](architecture-deployment.md) |
+| Subsystem                | Entry point                          | Detail                                                   |
+| ------------------------ | ------------------------------------ | -------------------------------------------------------- |
+| **Routing**              | `scripts/global/cascade-dispatch.js` | [architecture-routing.md](architecture-routing.md)       |
+| **Capability detection** | `scripts/global/capability-probe.js` | [architecture-routing.md](architecture-routing.md)       |
+| **Governance CI**        | `.github/workflows/baton-gates.yml`  | [architecture-governance.md](architecture-governance.md) |
+| **Wiki system**          | `wiki/` + `scripts/wiki/ingest.js`   | [architecture-governance.md](architecture-governance.md) |
+| **Dashboard**            | `dashboard/index.html`               | [architecture-governance.md](architecture-governance.md) |
+| **Fleet**                | `inventory/devices.json`             | [architecture-routing.md](architecture-routing.md)       |
+| **Deployment**           | `scripts/deploy.sh`                  | [architecture-deployment.md](architecture-deployment.md) |
 
 ## Key quality attributes
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,100 +1,54 @@
 # Megingjord — Architecture
 
-Navigation map for the governance-first multi-runtime AI agent harness.
+Navigation hub for architecture documentation, structured after arc42 sections.
 
-## High-level data flow
+## Document map
+
+| Section | File | arc42 ref |
+|---|---|---|
+| Executive overview, goal constitution | [`ARCHITECTURE.md`](../ARCHITECTURE.md) | §1 Intro & Goals |
+| Two-tier layer model detail | [`docs/architecture-layer-model.md`](architecture-layer-model.md) | §7 Deployment |
+| Baton governance model | [`docs/architecture-baton-model.md`](architecture-baton-model.md) | §8 Crosscutting |
+| Multi-runtime parity | [`docs/architecture-runtime-parity.md`](architecture-runtime-parity.md) | §5 Building Blocks |
+| Routing, fleet, cascade dispatch | [`docs/architecture-routing.md`](architecture-routing.md) | §6 Runtime View |
+| Deployment model, Layer-2, sync | [`docs/architecture-deployment.md`](architecture-deployment.md) | §7 Deployment |
+| Governance CI, wiki, dashboard | [`docs/architecture-governance.md`](architecture-governance.md) | §8 Crosscutting |
+
+## High-level data flow (C4 — Context)
 
 ```
-Editor / Agent runtime         Routing               Execution                Governance
-───────────────────────        ───────────           ─────────────            ──────────────
-VS Code Copilot          ─→    cascade-dispatch ─→  Fleet (Ollama via         GitHub issues +
-Claude Code                    + model-routing-     Tailscale)                workflows + skills
-Codex                          policy.json          OR Cloud (Claude /        + scripts/global/
+Editor / Agent runtime         Routing               Execution               Governance
+───────────────────────        ───────────           ─────────────           ──────────────
+VS Code Copilot          ─→    cascade-dispatch ─→  Fleet (Ollama via        GitHub issues +
+Claude Code                    + model-routing-     Tailscale)               workflows + skills
+Codex                          policy.json          OR Cloud (Claude /       + scripts/global/
                                                     OpenAI / Groq /
-                                                    Cerebras / Google AI)
-                                                       │
-                                                       ▼
-                                          .dashboard/events.jsonl
-                                                       │
-                                                       ▼
-                                                Dashboard (SSE)
+                                                    Gemini / Cerebras)
+                                                          │
+                                                          ▼
+                                               .dashboard/events.jsonl
+                                                          │
+                                                          ▼
+                                                 Dashboard (SSE :8090)
 ```
 
-## Subsystems
+## Subsystem index
 
-### Routing
+| Subsystem | Entry point | Detail |
+|---|---|---|
+| **Routing** | `scripts/global/cascade-dispatch.js` | [architecture-routing.md](architecture-routing.md) |
+| **Capability detection** | `scripts/global/capability-probe.js` | [architecture-routing.md](architecture-routing.md) |
+| **Governance CI** | `.github/workflows/baton-gates.yml` | [architecture-governance.md](architecture-governance.md) |
+| **Wiki system** | `wiki/` + `scripts/wiki/ingest.js` | [architecture-governance.md](architecture-governance.md) |
+| **Dashboard** | `dashboard/index.html` | [architecture-governance.md](architecture-governance.md) |
+| **Fleet** | `inventory/devices.json` | [architecture-routing.md](architecture-routing.md) |
+| **Deployment** | `scripts/deploy.sh` | [architecture-deployment.md](architecture-deployment.md) |
 
-- `scripts/global/cascade-dispatch.js` — fleet-first cascade (Free → Fleet → Haiku → Premium)
-- `scripts/global/model-routing-policy.json` — capability matrix, lane order
-- `scripts/global/task-router-dispatch.js` — direct dispatch to a tier
-- `scripts/global/free-router.js` — free-model orchestrator; classifier + signal stack, falls back to cascade-dispatch
-- `agents/router.agent.md` — Routing role definition
+## Key quality attributes
 
-### Capability detection (ADR-013)
+- **G1 Governance**: policy, role, provenance enforced at CI layer
+- **G2 Quality**: lint + readability + test-evidence gates on every PR
+- **G3 Zero Cost**: free-cloud (Gemini) and fleet (Ollama) before paid providers
+- **G4 Privacy**: sensitive context stays local unless explicitly overridden
 
-- `scripts/global/capability-probe.js` + `capability-show.js` — probe providers, fleet hosts, toolchain
-- `scripts/global/rag-search.js` — repo-context search; MCP-first with ripgrep fallback
-- `scripts/global/state-offload-client.js` — per-turn state offload to a Worker
-
-### Governance
-
-- `.github/workflows/` — baton-gates, evidence-completeness, doc-update-gate, label-lint, etc.
-- `scripts/global/governance-drift-classifier.js` — drift detection
-- `scripts/global/ticket-reconcile.js` — local↔GitHub ticket consistency
-- `scripts/global/epic-close-validator.js` — epic close-readiness
-
-### Wiki (LLM Knowledge System)
-
-- `~/.copilot/wiki/` — compiled wiki (read-only from non-Megingjord repos)
-- `wiki/` (this repo) — source markdown that compiles into the above
-- `~/.copilot/scripts/wiki-search.js` — search CLI used by `npm run help:topic`
-- `scripts/wiki/ingest.js`, `lint.js`, `anneal.js` — pipeline
-
-### Dashboard
-
-- `dashboard/index.html` — Alpine.js shell, all panels declared as `<template>`
-- `dashboard/js/app.js` — `dashboardApp()` Alpine root component, refresh cycle
-- `dashboard/js/render-panels.js` — pure functions returning HTML for each panel
-- `dashboard/js/event-source.js` + `event-bus.js` — SSE client + JSONL polling
-- `scripts/dashboard-server.js` — Node HTTP server :8090, SSE handler
-
-### Fleet
-
-- `inventory/devices.json` — Tailscale IPs, Ollama models, GPU/CPU class
-- `scripts/health-check.js` — fleet connectivity probe
-- `wiki/wisdom/global/entities/{36gbwinresource,openclaw,penguin-1}.md` — per-device authoritative state
-
-## Data flows
-
-- **Events** — agents/tools append JSONL to `.dashboard/events.jsonl`; dashboard SSE broadcasts to clients.
-- **Baton** — every issue is a baton; roles transition Manager → Collaborator → Admin → Consultant; CI gates verify the trail.
-- **State** — short-term state in `.dashboard/state/` (gitignored); long-term truth in GitHub issues/PRs.
-
-## Deployment model — two layers
-
-The harness operates in two independent layers per machine:
-
-**Global layer** (deployed once, shared by all projects):
-- `~/.copilot/` — Copilot skills, instructions, hooks, scripts, wiki
-- `~/.claude/` — Claude Code commands, agents, hooks
-- `~/.codex/` — Codex AGENTS.md, config, rules
-
-**Workspace layer** (per-project, committed to each project repo):
-- `.github/copilot-instructions.md`, `CLAUDE.md`, `AGENTS.md`
-- `.claude/settings.json`, `.codex/`
-
-All three runtimes (Copilot, Claude Code, Codex) are first-class: the same
-source deploys to all three. See [`docs/howto/installation.md`](howto/installation.md).
-
-## Cross-runtime sync
-
-- `scripts/sync.sh` — pull from runtime root into repo
-- `scripts/deploy.sh` — deploy repo to global runtime roots; `--target copilot|claude|codex|both|all`
-
-## Related documents
-
-- `docs/howto/installation.md` — install walkthrough, two-layer model
-- `docs/howto/sandbox-worktree-governance.md` — worktree lifecycle taxonomy, evidence checkpoints, and safe cleanup rules
-- `docs/HELP-GUIDELINES.md` — HELP panel UX patterns
-- `docs/DECISIONS.md` — architecture decision records; `docs/STYLE-GUIDE.md` — terminology
-- `research/adr/` — full ADR set
+Full goal constitution: [`ARCHITECTURE.md § Harness Goal Constitution`](../ARCHITECTURE.md)

--- a/docs/agents-governance.md
+++ b/docs/agents-governance.md
@@ -9,19 +9,19 @@ All AI-authored governed artifacts (baton handoffs, PR evidence, governance
 docs) must carry structured provenance:
 
 ```yaml
-Signed-by: Soren Mason           # human alias from agents/roster.json
+Signed-by: Soren Mason # human alias from agents/roster.json
 Team&Model: copilot:claude-sonnet-4-6@github
-Role: manager                    # must match the artifact type
+Role: manager # must match the artifact type
 ```
 
 Signing aliases for this repo (copilot:claude-sonnet-4-6@github):
 
-| Role | Alias |
-|---|---|
-| Manager | Soren Mason |
+| Role         | Alias        |
+| ------------ | ------------ |
+| Manager      | Soren Mason  |
 | Collaborator | Soren Harper |
-| Admin | Soren Reyes |
-| Consultant | Soren Vale |
+| Admin        | Soren Reyes  |
+| Consultant   | Soren Vale   |
 
 Repo-local overrides may tighten the format but must **not** remove provenance.
 See `instructions/team-model-signing.instructions.md`.
@@ -29,6 +29,7 @@ See `instructions/team-model-signing.instructions.md`.
 ## Review guidelines
 
 When reviewing a Codex PR, treat these as **release-blocking governance risks**:
+
 - Ticket lifecycle violations (MH posted after file edits; wrong baton order)
 - Signer fidelity failures (wrong alias or wrong `Role:` field in an artifact)
 - Isolated worktree violations (shared checkout between concurrent agents)
@@ -40,15 +41,15 @@ never infer from Claude or Copilot compatibility. APIs differ.
 
 ## Role taxonomy (7-role canonical set)
 
-| Role | Responsibilities |
-|---|---|
-| **Manager** | Research, scope, ticket, acceptance criteria; no file edits |
-| **Collaborator** | Implementation, branch, tests, doc-coverage handoff |
-| **Admin** | CI, credentials, PR staging, deployment; signer ≠ Collaborator |
-| **Consultant** | Adversarial review, risk assessment, rubric rating, terminal approval |
-| **IT** | Infrastructure, secrets, Tailscale fleet management |
-| **Red-Team** | Security assessment, prompt injection testing |
-| **Client** | External stakeholder; informs UX and requirements |
+| Role             | Responsibilities                                                      |
+| ---------------- | --------------------------------------------------------------------- |
+| **Manager**      | Research, scope, ticket, acceptance criteria; no file edits           |
+| **Collaborator** | Implementation, branch, tests, doc-coverage handoff                   |
+| **Admin**        | CI, credentials, PR staging, deployment; signer ≠ Collaborator        |
+| **Consultant**   | Adversarial review, risk assessment, rubric rating, terminal approval |
+| **IT**           | Infrastructure, secrets, Tailscale fleet management                   |
+| **Red-Team**     | Security assessment, prompt injection testing                         |
+| **Client**       | External stakeholder; informs UX and requirements                     |
 
 `Guest-Collaborator` is reserved but not active. `Operator` is a meta-term for
 the AI agent — not a distinct role in the baton chain.
@@ -68,15 +69,15 @@ See `docs/agents-workflow.md § Layer-2 routing`.
 
 ## 2026-H1 key contracts
 
-| Contract | Detail |
-|---|---|
-| **Doc-coverage gate** | `COLLABORATOR_HANDOFF` must include `doc-coverage:` block on `lane:code-change` |
-| **Baton builders** | Use `baton-comment-build.js`, `pr-comment-build.js`, `changelog-fragment-build.js` |
-| **Governance chains** | Run `npm run governance:chains:check` on governance path changes |
-| **OTel GenAI** | `isValidGenAI()` from `otel-genai-conformance.js` before any telemetry emit |
-| **Fleet-call-guard** | All fleet calls must use bounded timeout; see `docs/howto/fleet-call-guard.md` |
-| **Credential guard** | Check `credential-availability.js` before prompting user for any secret |
-| **Admin-merge-exception** | Override merges require `merge-bypass:admin-exception` label per Epic #2517 |
+| Contract                  | Detail                                                                             |
+| ------------------------- | ---------------------------------------------------------------------------------- |
+| **Doc-coverage gate**     | `COLLABORATOR_HANDOFF` must include `doc-coverage:` block on `lane:code-change`    |
+| **Baton builders**        | Use `baton-comment-build.js`, `pr-comment-build.js`, `changelog-fragment-build.js` |
+| **Governance chains**     | Run `npm run governance:chains:check` on governance path changes                   |
+| **OTel GenAI**            | `isValidGenAI()` from `otel-genai-conformance.js` before any telemetry emit        |
+| **Fleet-call-guard**      | All fleet calls must use bounded timeout; see `docs/howto/fleet-call-guard.md`     |
+| **Credential guard**      | Check `credential-availability.js` before prompting user for any secret            |
+| **Admin-merge-exception** | Override merges require `merge-bypass:admin-exception` label per Epic #2517        |
 
 ## Merge evidence convention
 

--- a/docs/agents-governance.md
+++ b/docs/agents-governance.md
@@ -1,0 +1,91 @@
+# Agent Governance Reference
+
+> Companion to `AGENTS.md`. Covers Team&Model signing, review guidelines,
+> role taxonomy, HAMR routing, and 2026-H1 governance contracts.
+
+## Team & Model signing
+
+All AI-authored governed artifacts (baton handoffs, PR evidence, governance
+docs) must carry structured provenance:
+
+```yaml
+Signed-by: Soren Mason           # human alias from agents/roster.json
+Team&Model: copilot:claude-sonnet-4-6@github
+Role: manager                    # must match the artifact type
+```
+
+Signing aliases for this repo (copilot:claude-sonnet-4-6@github):
+
+| Role | Alias |
+|---|---|
+| Manager | Soren Mason |
+| Collaborator | Soren Harper |
+| Admin | Soren Reyes |
+| Consultant | Soren Vale |
+
+Repo-local overrides may tighten the format but must **not** remove provenance.
+See `instructions/team-model-signing.instructions.md`.
+
+## Review guidelines
+
+When reviewing a Codex PR, treat these as **release-blocking governance risks**:
+- Ticket lifecycle violations (MH posted after file edits; wrong baton order)
+- Signer fidelity failures (wrong alias or wrong `Role:` field in an artifact)
+- Isolated worktree violations (shared checkout between concurrent agents)
+- Runtime-home direct edits (`~/.copilot/` or `~/.codex/` modified in-place)
+- Governed changes without matching docs, research, or wiki updates
+
+When Codex behaviour is uncertain, consult **official OpenAI Codex docs** —
+never infer from Claude or Copilot compatibility. APIs differ.
+
+## Role taxonomy (7-role canonical set)
+
+| Role | Responsibilities |
+|---|---|
+| **Manager** | Research, scope, ticket, acceptance criteria; no file edits |
+| **Collaborator** | Implementation, branch, tests, doc-coverage handoff |
+| **Admin** | CI, credentials, PR staging, deployment; signer ≠ Collaborator |
+| **Consultant** | Adversarial review, risk assessment, rubric rating, terminal approval |
+| **IT** | Infrastructure, secrets, Tailscale fleet management |
+| **Red-Team** | Security assessment, prompt injection testing |
+| **Client** | External stakeholder; informs UX and requirements |
+
+`Guest-Collaborator` is reserved but not active. `Operator` is a meta-term for
+the AI agent — not a distinct role in the baton chain.
+Canonical: `instructions/role-baton-routing.instructions.md` §"Role Taxonomy".
+
+## HAMR cross-team routing
+
+All three teams route governed provider calls through HAMR when `MEGINGJORD_HAMR_ENABLED=1`:
+
+- Endpoint: `https://hamr.chf3198.workers.dev`
+- Activate per-checkout: `npm run hamr:activate`
+- Verify: `npm run hamr:sync-verify`
+- Canonical contracts: `instructions/hamr-routing.instructions.md`
+
+Default (env var unset): GitHub-native Layer-2 routing (no Cloudflare required).
+See `docs/agents-workflow.md § Layer-2 routing`.
+
+## 2026-H1 key contracts
+
+| Contract | Detail |
+|---|---|
+| **Doc-coverage gate** | `COLLABORATOR_HANDOFF` must include `doc-coverage:` block on `lane:code-change` |
+| **Baton builders** | Use `baton-comment-build.js`, `pr-comment-build.js`, `changelog-fragment-build.js` |
+| **Governance chains** | Run `npm run governance:chains:check` on governance path changes |
+| **OTel GenAI** | `isValidGenAI()` from `otel-genai-conformance.js` before any telemetry emit |
+| **Fleet-call-guard** | All fleet calls must use bounded timeout; see `docs/howto/fleet-call-guard.md` |
+| **Credential guard** | Check `credential-availability.js` before prompting user for any secret |
+| **Admin-merge-exception** | Override merges require `merge-bypass:admin-exception` label per Epic #2517 |
+
+## Merge evidence convention
+
+PR bodies must include:
+
+```
+merge-evidence-deferred-final: #N   # preferred (no auto-close)
+Closes #N                           # backward-compat
+```
+
+Same marker required across Claude Code / Codex / Copilot.
+See `governance-carve-outs/index.md` for rationale.

--- a/docs/agents-workflow.md
+++ b/docs/agents-workflow.md
@@ -20,28 +20,29 @@
 
 ## Deploy commands
 
-| Command | Effect |
-|---|---|
-| `npm run deploy:apply` | Repo → `~/.copilot/` |
-| `npm run deploy:codex:apply` | Repo → `~/.codex/` |
-| `npm run deploy:claude:apply` | Repo → `~/.claude/` |
-| `npm run deploy:both:apply` | Repo → Copilot + Codex |
-| `npm run sync` | `~/.copilot/` → repo (pull back) |
-| `npm run sync:codex` | `~/.codex/` → repo (pull back) |
-| `npm run sync:claude` | `~/.claude/` → repo (pull back) |
+| Command                       | Effect                           |
+| ----------------------------- | -------------------------------- |
+| `npm run deploy:apply`        | Repo → `~/.copilot/`             |
+| `npm run deploy:codex:apply`  | Repo → `~/.codex/`               |
+| `npm run deploy:claude:apply` | Repo → `~/.claude/`              |
+| `npm run deploy:both:apply`   | Repo → Copilot + Codex           |
+| `npm run sync`                | `~/.copilot/` → repo (pull back) |
+| `npm run sync:codex`          | `~/.codex/` → repo (pull back)   |
+| `npm run sync:claude`         | `~/.claude/` → repo (pull back)  |
 
 ## Layer-2 routing
 
 Two coordination backends; selected by `MEGINGJORD_HAMR_ENABLED`:
 
-| Value | Backend | Auth needed |
-|---|---|---|
-| unset / `0` | GitHub-native (zero infra required) | GitHub token only |
-| `1` | HAMR Cloudflare Worker | Cloudflare + `OPERATOR_KEY_SEED_B64` |
+| Value       | Backend                             | Auth needed                          |
+| ----------- | ----------------------------------- | ------------------------------------ |
+| unset / `0` | GitHub-native (zero infra required) | GitHub token only                    |
+| `1`         | HAMR Cloudflare Worker              | Cloudflare + `OPERATOR_KEY_SEED_B64` |
 
 GitHub-native unified client: `scripts/global/github-native-client.js`
 
 HAMR activation:
+
 ```bash
 npm run hamr:activate        # writes HAMR config to local runtime
 npm run hamr:sync-verify     # confirms routing through Worker
@@ -61,6 +62,7 @@ node scripts/global/skill-views-derive.js
 ## Dashboard conventions
 
 The monitoring dashboard at `:8090` is a zero-build-step static web app:
+
 - **Alpine.js** for reactive state; **vanilla JS** for all logic
 - No build step; no bundler; all assets served as static files from `dashboard/`
 - Panels declared as `<template>` elements in `dashboard/index.html`
@@ -68,6 +70,7 @@ The monitoring dashboard at `:8090` is a zero-build-step static web app:
 - **Cloudflare Pages** for production deployment
 
 When modifying the dashboard:
+
 1. Test locally with `npm start` → `http://localhost:8090`
 2. Verify SSE events appear in the event panel
 3. Run `npm test` to validate E2E panel rendering
@@ -75,6 +78,7 @@ When modifying the dashboard:
 ## Fleet auto-detection
 
 Fleet topology auto-detected at runtime:
+
 - `scripts/global/fleet-config.js` reads `inventory/devices.json`
 - IPs resolve from `.env` overrides first, then Tailscale DNS discovery
 - `scripts/health-check.js` pings all hosts; writes `.dashboard/state/fleet-health.json`

--- a/docs/agents-workflow.md
+++ b/docs/agents-workflow.md
@@ -1,0 +1,93 @@
+# Agent Development and Deploy Workflow
+
+> Companion to `AGENTS.md`. Covers the full branch→deploy cycle, Layer-2
+> routing, skill index regeneration, and dashboard development conventions.
+
+## Development → deploy cycle
+
+```
+1. Ticket    gh issue create --title "..." --label "type:feat,priority:P2"
+2. Branch    git checkout -b feat/<N>-slug
+3. Worktree  git worktree add ../<repo>-<N> -b feat/<N>-slug  (if parallel work)
+4. Edit      Make changes in the feature branch / worktree
+5. Verify    npm run lint && npm test && npm run validate:triage
+6. Baton     Post MANAGER_HANDOFF on issue; implement; post remaining artifacts
+7. PR        gh pr create --title "feat(scope): description #<N>"
+8. Merge     CI gates pass → GraphQL mergePullRequest (squash method)
+9. Deploy    npm run deploy:apply  (and/or :codex / :both)
+10. Verify   Confirm skill/script in runtime; run behaviour test
+```
+
+## Deploy commands
+
+| Command | Effect |
+|---|---|
+| `npm run deploy:apply` | Repo → `~/.copilot/` |
+| `npm run deploy:codex:apply` | Repo → `~/.codex/` |
+| `npm run deploy:claude:apply` | Repo → `~/.claude/` |
+| `npm run deploy:both:apply` | Repo → Copilot + Codex |
+| `npm run sync` | `~/.copilot/` → repo (pull back) |
+| `npm run sync:codex` | `~/.codex/` → repo (pull back) |
+| `npm run sync:claude` | `~/.claude/` → repo (pull back) |
+
+## Layer-2 routing
+
+Two coordination backends; selected by `MEGINGJORD_HAMR_ENABLED`:
+
+| Value | Backend | Auth needed |
+|---|---|---|
+| unset / `0` | GitHub-native (zero infra required) | GitHub token only |
+| `1` | HAMR Cloudflare Worker | Cloudflare + `OPERATOR_KEY_SEED_B64` |
+
+GitHub-native unified client: `scripts/global/github-native-client.js`
+
+HAMR activation:
+```bash
+npm run hamr:activate        # writes HAMR config to local runtime
+npm run hamr:sync-verify     # confirms routing through Worker
+```
+
+## Skill index
+
+Auto-derived from `skills/<name>/SKILL.md` descriptors.
+View: [`docs/skills-agents.md`](../docs/skills-agents.md)
+
+Regenerate after adding or modifying any skill:
+
+```bash
+node scripts/global/skill-views-derive.js
+```
+
+## Dashboard conventions
+
+The monitoring dashboard at `:8090` is a zero-build-step static web app:
+- **Alpine.js** for reactive state; **vanilla JS** for all logic
+- No build step; no bundler; all assets served as static files from `dashboard/`
+- Panels declared as `<template>` elements in `dashboard/index.html`
+- Pure render functions in `dashboard/js/render-panels.js`
+- **Cloudflare Pages** for production deployment
+
+When modifying the dashboard:
+1. Test locally with `npm start` → `http://localhost:8090`
+2. Verify SSE events appear in the event panel
+3. Run `npm test` to validate E2E panel rendering
+
+## Fleet auto-detection
+
+Fleet topology auto-detected at runtime:
+- `scripts/global/fleet-config.js` reads `inventory/devices.json`
+- IPs resolve from `.env` overrides first, then Tailscale DNS discovery
+- `scripts/health-check.js` pings all hosts; writes `.dashboard/state/fleet-health.json`
+
+## Worktree cleanup
+
+After a PR merges, clean up the worktree:
+
+```bash
+git worktree remove ../<repo>-<N>       # remove worktree directory
+git branch -d feat/<N>-slug              # delete local branch
+git push origin --delete feat/<N>-slug  # delete remote branch
+```
+
+See `research/concurrent-agent-worktrees-2026-04-24.md` for the full safety
+contract including conflict quarantine and rescue procedures.

--- a/docs/architecture-baton-model.md
+++ b/docs/architecture-baton-model.md
@@ -1,0 +1,80 @@
+# Architecture — Governance Baton Model
+
+The baton model is Megingjord's core change-management mechanism. Every
+governed change must transit all four roles in sequence before it can merge.
+
+## Role sequence
+
+```
+Manager → Collaborator → Admin → Consultant
+   ↓           ↓           ↓          ↓
+ Ticket      Branch      Verify    Red-team
+ + scope     + code      + CI      + approve
+```
+
+## Role responsibilities
+
+### Manager
+- Files the GitHub issue with `scope:`, `lane:`, `test_strategy:`, and ACs
+- Posts `MANAGER_HANDOFF` comment on the issue **before** any file edits
+- Sets direction and constraints only; never modifies source files
+
+### Collaborator
+- Creates the feature branch (`feat/<N>-slug`) and implements all ACs
+- Posts `COLLABORATOR_HANDOFF` after pushing; includes `doc-coverage:` block
+- Runs `npm run lint && npm test` before handing off
+- Must carry a different `Signed-by` alias than Admin (CI enforces this)
+
+### Admin
+- Runs CI checks; verifies test results; opens the PR
+- Posts `ADMIN_HANDOFF` confirming signer independence and deploy impact
+- Handles environment: credentials, deploy targeting, runtime state
+- Does not merge; merge is the Consultant's terminal gate
+
+### Consultant
+- Adversarial review: edge cases, risks, doc gaps, goal-constitution alignment
+- Posts `CONSULTANT_CLOSEOUT` with `rubric_rating: N/10` (≥7 required to pass)
+- Identifies post-merge follow-up tickets for non-trivial residual risk
+- Terminal role: merge is blocked until `CONSULTANT_CLOSEOUT` is posted
+
+## Artifact format
+
+| Artifact | Required fields |
+|---|---|
+| `MANAGER_HANDOFF` | `scope:` `lane:` `test_strategy:` `acceptance:` `Signed-by:` `Team&Model:` `Role: manager` |
+| `COLLABORATOR_HANDOFF` | `branch:` `commit:` per-AC checklist `doc-coverage:` `Signed-by:` `Team&Model:` `Role: collaborator` |
+| `ADMIN_HANDOFF` | `branch:` `commit:` `signer-independence-check:` `Signed-by:` `Team&Model:` `Role: admin` |
+| `CONSULTANT_CLOSEOUT` | `ticket:` `verdict:` `rubric_rating:` `Signed-by:` `Team&Model:` `Role: consultant` |
+
+## Team & Model signing
+
+Every baton artifact carries structured AI-authorship provenance:
+
+```yaml
+Signed-by: Soren Mason           # human alias from agents/roster.json
+Team&Model: copilot:claude-sonnet-4-6@github
+Role: manager                    # must match the artifact type
+```
+
+`scripts/global/baton-artifact-governance.js` validates:
+1. All required fields are present and non-empty
+2. The `Role:` field matches the artifact name (`MANAGER_HANDOFF` → `manager`)
+3. Admin and Collaborator carry different `Signed-by` values
+
+## CI gate chain
+
+`baton-gates.yml` runs gates in dependency order:
+
+1. `collaborator-gate` — validates `COLLABORATOR_HANDOFF` structure
+2. `admin-gate` — validates `ADMIN_HANDOFF` + signer independence
+3. `consultant-gate` — validates `CONSULTANT_CLOSEOUT` + rubric ≥7
+4. `test-evidence` — validates `test_strategy:` matches actual test artifacts
+5. `evidence-completeness` — issue must be OPEN; all four artifacts present
+
+## Lane model
+
+| Lane label | Baton required | Typical use |
+|---|---|---|
+| `lane:code-change` | Full baton (all 4 roles) | Feature branches, bug fixes |
+| `lane:docs-research` | Manager + Consultant | Wiki pages, research notes |
+| `lane:config-only` | Admin + Consultant | Configuration-only changes |

--- a/docs/architecture-baton-model.md
+++ b/docs/architecture-baton-model.md
@@ -15,23 +15,27 @@ Manager → Collaborator → Admin → Consultant
 ## Role responsibilities
 
 ### Manager
+
 - Files the GitHub issue with `scope:`, `lane:`, `test_strategy:`, and ACs
 - Posts `MANAGER_HANDOFF` comment on the issue **before** any file edits
 - Sets direction and constraints only; never modifies source files
 
 ### Collaborator
+
 - Creates the feature branch (`feat/<N>-slug`) and implements all ACs
 - Posts `COLLABORATOR_HANDOFF` after pushing; includes `doc-coverage:` block
 - Runs `npm run lint && npm test` before handing off
 - Must carry a different `Signed-by` alias than Admin (CI enforces this)
 
 ### Admin
+
 - Runs CI checks; verifies test results; opens the PR
 - Posts `ADMIN_HANDOFF` confirming signer independence and deploy impact
 - Handles environment: credentials, deploy targeting, runtime state
 - Does not merge; merge is the Consultant's terminal gate
 
 ### Consultant
+
 - Adversarial review: edge cases, risks, doc gaps, goal-constitution alignment
 - Posts `CONSULTANT_CLOSEOUT` with `rubric_rating: N/10` (≥7 required to pass)
 - Identifies post-merge follow-up tickets for non-trivial residual risk
@@ -39,24 +43,25 @@ Manager → Collaborator → Admin → Consultant
 
 ## Artifact format
 
-| Artifact | Required fields |
-|---|---|
-| `MANAGER_HANDOFF` | `scope:` `lane:` `test_strategy:` `acceptance:` `Signed-by:` `Team&Model:` `Role: manager` |
+| Artifact               | Required fields                                                                                      |
+| ---------------------- | ---------------------------------------------------------------------------------------------------- |
+| `MANAGER_HANDOFF`      | `scope:` `lane:` `test_strategy:` `acceptance:` `Signed-by:` `Team&Model:` `Role: manager`           |
 | `COLLABORATOR_HANDOFF` | `branch:` `commit:` per-AC checklist `doc-coverage:` `Signed-by:` `Team&Model:` `Role: collaborator` |
-| `ADMIN_HANDOFF` | `branch:` `commit:` `signer-independence-check:` `Signed-by:` `Team&Model:` `Role: admin` |
-| `CONSULTANT_CLOSEOUT` | `ticket:` `verdict:` `rubric_rating:` `Signed-by:` `Team&Model:` `Role: consultant` |
+| `ADMIN_HANDOFF`        | `branch:` `commit:` `signer-independence-check:` `Signed-by:` `Team&Model:` `Role: admin`            |
+| `CONSULTANT_CLOSEOUT`  | `ticket:` `verdict:` `rubric_rating:` `Signed-by:` `Team&Model:` `Role: consultant`                  |
 
 ## Team & Model signing
 
 Every baton artifact carries structured AI-authorship provenance:
 
 ```yaml
-Signed-by: Soren Mason           # human alias from agents/roster.json
+Signed-by: Soren Mason # human alias from agents/roster.json
 Team&Model: copilot:claude-sonnet-4-6@github
-Role: manager                    # must match the artifact type
+Role: manager # must match the artifact type
 ```
 
 `scripts/global/baton-artifact-governance.js` validates:
+
 1. All required fields are present and non-empty
 2. The `Role:` field matches the artifact name (`MANAGER_HANDOFF` → `manager`)
 3. Admin and Collaborator carry different `Signed-by` values
@@ -73,8 +78,8 @@ Role: manager                    # must match the artifact type
 
 ## Lane model
 
-| Lane label | Baton required | Typical use |
-|---|---|---|
-| `lane:code-change` | Full baton (all 4 roles) | Feature branches, bug fixes |
-| `lane:docs-research` | Manager + Consultant | Wiki pages, research notes |
-| `lane:config-only` | Admin + Consultant | Configuration-only changes |
+| Lane label           | Baton required           | Typical use                 |
+| -------------------- | ------------------------ | --------------------------- |
+| `lane:code-change`   | Full baton (all 4 roles) | Feature branches, bug fixes |
+| `lane:docs-research` | Manager + Consultant     | Wiki pages, research notes  |
+| `lane:config-only`   | Admin + Consultant       | Configuration-only changes  |

--- a/docs/architecture-deployment.md
+++ b/docs/architecture-deployment.md
@@ -1,0 +1,86 @@
+# Architecture — Deployment Model
+
+## Two-layer deployment
+
+Megingjord operates two independent layers per machine. All changes flow from
+this repo (source of truth) outward to runtime targets — never the reverse.
+
+```
+This Repo (main)                   Runtime targets
+────────────────────               ──────────────────────────────────────
+skills/          ──deploy──▶  ~/.copilot/skills/  +  ~/.agents/skills/
+instructions/    ──deploy──▶  ~/.copilot/instructions/
+hooks/           ──deploy──▶  ~/.copilot/hooks/   +  ~/.codex/devenv-ops/hooks/
+scripts/global/  ──deploy──▶  ~/.copilot/scripts/ +  ~/.codex/devenv-ops/scripts/
+.codex/          ──deploy──▶  ~/.codex/ (AGENTS.md, config.toml, hooks.json, rules/)
+agents/          ──deploy──▶  ~/.copilot/agents/
+wiki/            ──deploy──▶  ~/.copilot/wiki/
+dashboard/       ──deploy──▶  ~/.copilot/dashboard/ (static)
+```
+
+**Global layer** (`~/.copilot/`, `~/.claude/`, `~/.codex/`): installed once per
+machine; shared by all developer repositories on that machine.
+
+**Workspace layer** (each project repo root): `.github/copilot-instructions.md`,
+`CLAUDE.md`, `AGENTS.md`, `.claude/settings.json` — committed into each project
+and override/extend the global layer for that project only.
+
+## Deploy commands
+
+| Command | Effect |
+|---|---|
+| `npm run deploy:apply` | Repo → `~/.copilot/` |
+| `npm run deploy:codex:apply` | Repo → `~/.codex/` |
+| `npm run deploy:claude:apply` | Repo → `~/.claude/` |
+| `npm run deploy:both:apply` | Repo → Copilot + Codex |
+| `npm run sync` | `~/.copilot/` → repo (pull back) |
+| `npm run sync:codex` | `~/.codex/` → repo (pull back) |
+| `npm run sync:claude` | `~/.claude/` → repo (pull back) |
+
+**Invariant**: never edit `~/.copilot/`, `~/.codex/`, or `~/.claude/` directly.
+All changes flow through this repo. Direct edits are silently overwritten on the
+next `deploy:apply` run.
+
+## Layer-2 coordination — HAMR vs GitHub-native
+
+Two backends for cross-agent coordination; selected by `MEGINGJORD_HAMR_ENABLED`:
+
+| `MEGINGJORD_HAMR_ENABLED` | Backend | External infra required |
+|---|---|---|
+| unset / `0` (default) | GitHub-native client | GitHub repo access only |
+| `1` | HAMR Cloudflare Worker | Cloudflare account + secrets |
+
+GitHub-native primitives (default — zero external infrastructure):
+
+| Primitive | Script | Mechanism |
+|---|---|---|
+| Mailbox | `github-mailbox.js` | GitHub Issues comment thread + ETag polling |
+| Bundle distribution | `github-bundle-client.js` | GitHub Releases assets |
+| MCP dispatch | `github-mcp-dispatch.js` | `repository_dispatch` event |
+| Telemetry | `github-telemetry-read.js` | Actions artifact (6h scheduled upload) |
+| Substrate health | `github-substrate-health-read.js` | Actions artifact upload |
+
+The unified client `scripts/global/github-native-client.js` auto-selects backend
+based on the env var. See [`docs/howto/github-native-layer2.md`](howto/github-native-layer2.md).
+
+## Multi-runtime parity
+
+A single governance manifest drives all three runtimes:
+
+```
+inventory/governance-manifest.json
+    │
+    ├─▶ .github/copilot-instructions.md  (GitHub Copilot)
+    ├─▶ CLAUDE.md                        (Claude Code)
+    └─▶ AGENTS.md                        (Codex)
+```
+
+`npm run governance:adapters:emit` regenerates runtime-specific shims from the
+central manifest. See [`docs/architecture-runtime-parity.md`](architecture-runtime-parity.md).
+
+## Related documents
+
+- [`ARCHITECTURE.md`](../ARCHITECTURE.md) — executive overview and document map
+- [`docs/architecture-layer-model.md`](architecture-layer-model.md) — layer topology detail
+- [`docs/howto/installation.md`](howto/installation.md) — install walkthrough
+- [`docs/howto/sandbox-worktree-governance.md`](howto/sandbox-worktree-governance.md) — worktree lifecycle

--- a/docs/architecture-deployment.md
+++ b/docs/architecture-deployment.md
@@ -27,15 +27,15 @@ and override/extend the global layer for that project only.
 
 ## Deploy commands
 
-| Command | Effect |
-|---|---|
-| `npm run deploy:apply` | Repo → `~/.copilot/` |
-| `npm run deploy:codex:apply` | Repo → `~/.codex/` |
-| `npm run deploy:claude:apply` | Repo → `~/.claude/` |
-| `npm run deploy:both:apply` | Repo → Copilot + Codex |
-| `npm run sync` | `~/.copilot/` → repo (pull back) |
-| `npm run sync:codex` | `~/.codex/` → repo (pull back) |
-| `npm run sync:claude` | `~/.claude/` → repo (pull back) |
+| Command                       | Effect                           |
+| ----------------------------- | -------------------------------- |
+| `npm run deploy:apply`        | Repo → `~/.copilot/`             |
+| `npm run deploy:codex:apply`  | Repo → `~/.codex/`               |
+| `npm run deploy:claude:apply` | Repo → `~/.claude/`              |
+| `npm run deploy:both:apply`   | Repo → Copilot + Codex           |
+| `npm run sync`                | `~/.copilot/` → repo (pull back) |
+| `npm run sync:codex`          | `~/.codex/` → repo (pull back)   |
+| `npm run sync:claude`         | `~/.claude/` → repo (pull back)  |
 
 **Invariant**: never edit `~/.copilot/`, `~/.codex/`, or `~/.claude/` directly.
 All changes flow through this repo. Direct edits are silently overwritten on the
@@ -45,20 +45,20 @@ next `deploy:apply` run.
 
 Two backends for cross-agent coordination; selected by `MEGINGJORD_HAMR_ENABLED`:
 
-| `MEGINGJORD_HAMR_ENABLED` | Backend | External infra required |
-|---|---|---|
-| unset / `0` (default) | GitHub-native client | GitHub repo access only |
-| `1` | HAMR Cloudflare Worker | Cloudflare account + secrets |
+| `MEGINGJORD_HAMR_ENABLED` | Backend                | External infra required      |
+| ------------------------- | ---------------------- | ---------------------------- |
+| unset / `0` (default)     | GitHub-native client   | GitHub repo access only      |
+| `1`                       | HAMR Cloudflare Worker | Cloudflare account + secrets |
 
 GitHub-native primitives (default — zero external infrastructure):
 
-| Primitive | Script | Mechanism |
-|---|---|---|
-| Mailbox | `github-mailbox.js` | GitHub Issues comment thread + ETag polling |
-| Bundle distribution | `github-bundle-client.js` | GitHub Releases assets |
-| MCP dispatch | `github-mcp-dispatch.js` | `repository_dispatch` event |
-| Telemetry | `github-telemetry-read.js` | Actions artifact (6h scheduled upload) |
-| Substrate health | `github-substrate-health-read.js` | Actions artifact upload |
+| Primitive           | Script                            | Mechanism                                   |
+| ------------------- | --------------------------------- | ------------------------------------------- |
+| Mailbox             | `github-mailbox.js`               | GitHub Issues comment thread + ETag polling |
+| Bundle distribution | `github-bundle-client.js`         | GitHub Releases assets                      |
+| MCP dispatch        | `github-mcp-dispatch.js`          | `repository_dispatch` event                 |
+| Telemetry           | `github-telemetry-read.js`        | Actions artifact (6h scheduled upload)      |
+| Substrate health    | `github-substrate-health-read.js` | Actions artifact upload                     |
 
 The unified client `scripts/global/github-native-client.js` auto-selects backend
 based on the env var. See [`docs/howto/github-native-layer2.md`](howto/github-native-layer2.md).

--- a/docs/architecture-governance.md
+++ b/docs/architecture-governance.md
@@ -1,0 +1,76 @@
+# Architecture — Governance, Wiki, and Dashboard
+
+## Governance CI system
+
+Every PR runs a chain of required GitHub Actions workflows:
+
+| Workflow | Purpose | Gate |
+|---|---|---|
+| `baton-gates.yml` | Manager→Collaborator→Admin→Consultant artifact chain | ✅ required |
+| `evidence-completeness.yml` | Issue must be OPEN + all baton artifacts present | ✅ required |
+| `lint-required.yml` | All files ≤100 lines | ✅ required |
+| `doc-update-gate.yml` | Docs updated or `[skip-doc-gate]` with justification | ✅ required |
+| `branch-name-required.yml` | `feat/<N>-` or `fix/<N>-` or `chore/` pattern | ✅ required |
+| `pr-title-required.yml` | Conventional Commits, subject ≤60 chars | ✅ required |
+| `quality-required.yml` | `lint:readability:ci` passes | ✅ required |
+| `changelog-fragment.yml` | `.changes/unreleased/<N>.md` exists | ✅ required |
+| `danger-required.yml` | Danger JS policy (large PR blocker-note, etc.) | ✅ required |
+
+Supporting scripts:
+- `scripts/global/governance-drift-classifier.js` — detects policy/config drift
+- `scripts/global/ticket-reconcile.js` — local↔GitHub ticket consistency check
+- `scripts/global/epic-close-validator.js` — validates epic close-readiness
+- `scripts/global/baton-artifact-governance.js` — validates baton artifact structure
+
+## Wiki system (LLM knowledge base)
+
+The wiki is a three-layer knowledge system deployed to `~/.copilot/wiki/`:
+
+| Layer | Path | Owner | Purpose |
+|---|---|---|---|
+| Raw sources | `raw/` | Human | Immutable after placement |
+| Wiki pages | `wiki/` | LLM | Derived knowledge; freely updated |
+| Schema | `wiki/WIKI.md` | Co-owned | Conventions and page contracts |
+
+Wiki pipeline (`scripts/wiki/`):
+1. `ingest.js` — reads `raw/` sources; writes/updates wiki pages
+2. `lint.js` — checks frontmatter completeness, broken links, stale timestamps
+3. `anneal.js` — cross-reference pass; ensures bidirectional wikilinks
+
+Page types: `entity` (person/device/service), `concept` (idea/pattern),
+`source` (raw-source digest), `synthesis` (cross-cutting analysis).
+
+Consumed by `scripts/global/wiki-search.js` via `npm run help:topic`.
+
+## Dashboard architecture
+
+The fleet monitoring dashboard is a zero-build-step static web app on `:8090`:
+
+```
+dashboard/
+├── index.html            # Alpine.js shell; panels declared as <template>
+├── js/
+│   ├── app.js            # dashboardApp() Alpine root; refresh cycle
+│   ├── render-panels.js  # Pure render functions → HTML string per panel
+│   ├── event-source.js   # SSE client (connects to :8090/events)
+│   └── event-bus.js      # Internal pub/sub; decouples panels
+└── css/app.css
+```
+
+`scripts/dashboard-server.js` — Node HTTP server:
+- `GET /events` — SSE stream; broadcasts `.dashboard/events.jsonl` tail
+- `GET /state` — fleet health, capability cache, ticket summary snapshot
+- Static file serving for all `dashboard/` assets
+
+Data inputs:
+- `.dashboard/events.jsonl` — append-only log of all agent and tool events
+- `.dashboard/state/*.json` — fleet health, capability cache, skill manifest
+
+## Governance chains
+
+`config/governance-chains.yml` defines dependency chains between governance
+documents and scripts. Run `npm run governance:chains:check` after changing
+any file in `instructions/`, `hooks/`, `.github/workflows/`, or `config/`.
+
+Broken chains (a file changed without updating its downstream dependents)
+fail the `quality-required` CI check.

--- a/docs/architecture-governance.md
+++ b/docs/architecture-governance.md
@@ -4,19 +4,20 @@
 
 Every PR runs a chain of required GitHub Actions workflows:
 
-| Workflow | Purpose | Gate |
-|---|---|---|
-| `baton-gates.yml` | Manager→Collaborator→Admin→Consultant artifact chain | ✅ required |
-| `evidence-completeness.yml` | Issue must be OPEN + all baton artifacts present | ✅ required |
-| `lint-required.yml` | All files ≤100 lines | ✅ required |
-| `doc-update-gate.yml` | Docs updated or `[skip-doc-gate]` with justification | ✅ required |
-| `branch-name-required.yml` | `feat/<N>-` or `fix/<N>-` or `chore/` pattern | ✅ required |
-| `pr-title-required.yml` | Conventional Commits, subject ≤60 chars | ✅ required |
-| `quality-required.yml` | `lint:readability:ci` passes | ✅ required |
-| `changelog-fragment.yml` | `.changes/unreleased/<N>.md` exists | ✅ required |
-| `danger-required.yml` | Danger JS policy (large PR blocker-note, etc.) | ✅ required |
+| Workflow                    | Purpose                                              | Gate        |
+| --------------------------- | ---------------------------------------------------- | ----------- |
+| `baton-gates.yml`           | Manager→Collaborator→Admin→Consultant artifact chain | ✅ required |
+| `evidence-completeness.yml` | Issue must be OPEN + all baton artifacts present     | ✅ required |
+| `lint-required.yml`         | All files ≤100 lines                                 | ✅ required |
+| `doc-update-gate.yml`       | Docs updated or `[skip-doc-gate]` with justification | ✅ required |
+| `branch-name-required.yml`  | `feat/<N>-` or `fix/<N>-` or `chore/` pattern        | ✅ required |
+| `pr-title-required.yml`     | Conventional Commits, subject ≤60 chars              | ✅ required |
+| `quality-required.yml`      | `lint:readability:ci` passes                         | ✅ required |
+| `changelog-fragment.yml`    | `.changes/unreleased/<N>.md` exists                  | ✅ required |
+| `danger-required.yml`       | Danger JS policy (large PR blocker-note, etc.)       | ✅ required |
 
 Supporting scripts:
+
 - `scripts/global/governance-drift-classifier.js` — detects policy/config drift
 - `scripts/global/ticket-reconcile.js` — local↔GitHub ticket consistency check
 - `scripts/global/epic-close-validator.js` — validates epic close-readiness
@@ -26,13 +27,14 @@ Supporting scripts:
 
 The wiki is a three-layer knowledge system deployed to `~/.copilot/wiki/`:
 
-| Layer | Path | Owner | Purpose |
-|---|---|---|---|
-| Raw sources | `raw/` | Human | Immutable after placement |
-| Wiki pages | `wiki/` | LLM | Derived knowledge; freely updated |
-| Schema | `wiki/WIKI.md` | Co-owned | Conventions and page contracts |
+| Layer       | Path           | Owner    | Purpose                           |
+| ----------- | -------------- | -------- | --------------------------------- |
+| Raw sources | `raw/`         | Human    | Immutable after placement         |
+| Wiki pages  | `wiki/`        | LLM      | Derived knowledge; freely updated |
+| Schema      | `wiki/WIKI.md` | Co-owned | Conventions and page contracts    |
 
 Wiki pipeline (`scripts/wiki/`):
+
 1. `ingest.js` — reads `raw/` sources; writes/updates wiki pages
 2. `lint.js` — checks frontmatter completeness, broken links, stale timestamps
 3. `anneal.js` — cross-reference pass; ensures bidirectional wikilinks
@@ -58,11 +60,13 @@ dashboard/
 ```
 
 `scripts/dashboard-server.js` — Node HTTP server:
+
 - `GET /events` — SSE stream; broadcasts `.dashboard/events.jsonl` tail
 - `GET /state` — fleet health, capability cache, ticket summary snapshot
 - Static file serving for all `dashboard/` assets
 
 Data inputs:
+
 - `.dashboard/events.jsonl` — append-only log of all agent and tool events
 - `.dashboard/state/*.json` — fleet health, capability cache, skill manifest
 

--- a/docs/architecture-layer-model.md
+++ b/docs/architecture-layer-model.md
@@ -1,0 +1,97 @@
+# Architecture — Two-Tier Layer Model
+
+The harness separates concerns into two independent deployment layers. This
+separation ensures every project shares a common governance baseline while
+retaining full flexibility for workspace-level overrides.
+
+## Global layer (`~/.*`)
+
+Installed once per machine via `npm run deploy:apply`. Shared across all repos.
+
+```
+~/.copilot/
+├── skills/         ← from skills/ (universals compiled; personal deployed locally)
+├── instructions/   ← from instructions/
+├── hooks/          ← from hooks/
+├── scripts/        ← from scripts/global/
+├── agents/         ← from agents/
+└── wiki/           ← compiled from wiki/
+
+~/.claude/
+├── agents/         ← Claude Code custom agent definitions
+├── hooks/          ← Claude Code pre/post-tool hooks
+└── settings.json   ← Merged with workspace .claude/settings.json
+
+~/.codex/
+├── AGENTS.md       ← from .codex/AGENTS.md
+├── config.toml     ← from .codex/config.toml
+├── hooks.json      ← from .codex/hooks.json
+└── rules/          ← from .codex/rules/
+```
+
+## Workspace layer (project repo root)
+
+Committed into each target project. Provides project-specific context and
+optional overrides of the global layer.
+
+| File | Runtime | Role |
+|---|---|---|
+| `.github/copilot-instructions.md` | GitHub Copilot | Project adapter; extends global |
+| `CLAUDE.md` | Claude Code | Project adapter; extends global |
+| `AGENTS.md` | Codex | Project adapter; extends global |
+| `.claude/settings.json` | Claude Code | Tool permissions; merged with `~/.claude/settings.json` |
+
+**Conflict resolution**: global security and governance rules always take
+precedence over workspace overrides, unless a governance baton explicitly
+delegates an exception for that project.
+
+## Mermaid — full layer topology
+
+```mermaid
+graph TD
+  subgraph Repo ["This Repo (develop)"]
+    S_skills["skills/"]
+    S_instr["instructions/"]
+    S_hooks["hooks/"]
+    S_scripts["scripts/global/"]
+    S_codex[".codex/"]
+    S_agents["agents/"]
+  end
+
+  subgraph Global ["Global Layer (~/)"]
+    G_cop["~/.copilot/"]
+    G_claude["~/.claude/"]
+    G_codex["~/.codex/"]
+  end
+
+  subgraph Project ["Workspace Layer (project repo)"]
+    P_cop[".github/copilot-instructions.md"]
+    P_claude["CLAUDE.md + .claude/settings.json"]
+    P_codex["AGENTS.md + .codex/"]
+  end
+
+  S_skills --> G_cop; S_instr --> G_cop; S_hooks --> G_cop; S_scripts --> G_cop
+  S_scripts --> G_codex; S_hooks --> G_codex; S_codex --> G_codex
+  S_agents --> G_cop
+  P_cop -->|extends| G_cop
+  P_claude -->|extends| G_claude
+  P_codex -->|extends| G_codex
+```
+
+## Deploy flow and conflict rules
+
+```
+1. Edit source on a feature branch → PR → baton gates → merge to main
+2. npm run deploy:apply          (Copilot + wiki)
+   npm run deploy:codex:apply    (Codex)
+   npm run deploy:both:apply     (both at once)
+3. Verify skill/script in target runtime
+4. NEVER edit ~/.copilot/ or ~/.codex/ or ~/.claude/ directly
+```
+
+| Scenario | Result |
+|---|---|
+| Workspace adds skill not in global | Active for that project only |
+| Workspace overrides global instruction | Workspace value wins |
+| Global security rule conflicts with workspace | Global wins always |
+| Both workspace and global define the same hook | Both run; global first |

--- a/docs/architecture-layer-model.md
+++ b/docs/architecture-layer-model.md
@@ -34,12 +34,12 @@ Installed once per machine via `npm run deploy:apply`. Shared across all repos.
 Committed into each target project. Provides project-specific context and
 optional overrides of the global layer.
 
-| File | Runtime | Role |
-|---|---|---|
-| `.github/copilot-instructions.md` | GitHub Copilot | Project adapter; extends global |
-| `CLAUDE.md` | Claude Code | Project adapter; extends global |
-| `AGENTS.md` | Codex | Project adapter; extends global |
-| `.claude/settings.json` | Claude Code | Tool permissions; merged with `~/.claude/settings.json` |
+| File                              | Runtime        | Role                                                    |
+| --------------------------------- | -------------- | ------------------------------------------------------- |
+| `.github/copilot-instructions.md` | GitHub Copilot | Project adapter; extends global                         |
+| `CLAUDE.md`                       | Claude Code    | Project adapter; extends global                         |
+| `AGENTS.md`                       | Codex          | Project adapter; extends global                         |
+| `.claude/settings.json`           | Claude Code    | Tool permissions; merged with `~/.claude/settings.json` |
 
 **Conflict resolution**: global security and governance rules always take
 precedence over workspace overrides, unless a governance baton explicitly
@@ -89,9 +89,9 @@ graph TD
 4. NEVER edit ~/.copilot/ or ~/.codex/ or ~/.claude/ directly
 ```
 
-| Scenario | Result |
-|---|---|
-| Workspace adds skill not in global | Active for that project only |
-| Workspace overrides global instruction | Workspace value wins |
-| Global security rule conflicts with workspace | Global wins always |
-| Both workspace and global define the same hook | Both run; global first |
+| Scenario                                       | Result                       |
+| ---------------------------------------------- | ---------------------------- |
+| Workspace adds skill not in global             | Active for that project only |
+| Workspace overrides global instruction         | Workspace value wins         |
+| Global security rule conflicts with workspace  | Global wins always           |
+| Both workspace and global define the same hook | Both run; global first       |

--- a/docs/architecture-routing.md
+++ b/docs/architecture-routing.md
@@ -1,0 +1,84 @@
+# Architecture — Routing and Capability Detection
+
+Routing is the core of Megingjord's cost-optimisation strategy (G3 Zero Cost).
+The cascade-dispatch always tries free/local tiers before paid cloud providers.
+
+## Cascade dispatch (ADR-012)
+
+`scripts/global/cascade-dispatch.js` implements a four-tier priority cascade:
+
+| Priority | Tier | Providers |
+|---|---|---|
+| 1 (cheapest) | Free | Gemini via Google AI Studio free quota |
+| 2 | Fleet | Ollama models on Tailscale hosts (local GPU) |
+| 3 | Budget | Claude Haiku, GPT-3.5-class, Groq |
+| 4 (costliest) | Premium | Claude Sonnet/Opus, GPT-4-class |
+
+The cascade evaluates tiers in order and uses the first available, healthy tier
+that can handle the task's context length and required capabilities.
+
+## Free router
+
+`scripts/global/free-router.js` sits in front of cascade-dispatch:
+1. Runs a lightweight topic classifier to estimate task difficulty
+2. Builds a signal stack (context length, tool requirements, sensitivity)
+3. Dispatches directly to the appropriate tier — skips cascade overhead
+4. Falls back to cascade-dispatch if the signal stack is ambiguous
+
+## Model routing policy
+
+`scripts/global/model-routing-policy.json` — capability matrix keyed by
+task type × provider. Defines lane order, timeout caps, and fallback rules.
+
+Key task types: `code-edit`, `code-review`, `doc-write`, `governance-check`,
+`wiki-ingest`, `fleet-health`, `telemetry-read`.
+
+## Task router
+
+`scripts/global/task-router-dispatch.js` — direct dispatch to a named tier,
+bypassing the cascade. Used by governance workflows that need deterministic
+model selection (e.g. `governance-check` lane always uses a specific model).
+
+## Capability detection (ADR-013)
+
+`scripts/global/capability-probe.js` probes each provider at startup:
+1. Checks API key availability via `credential-availability.js`
+2. Pings model endpoint with a minimal test prompt
+3. Caches result in `.dashboard/state/capability-cache.json`
+
+`capability-show.js` displays the cached probe result in CLI format.
+
+## Fleet architecture
+
+Fleet hosts are defined in `inventory/devices.json`:
+
+```json
+{
+  "hosts": [
+    { "id": "36gbwinresource", "tailscale_ip": "...", "gpu": "RTX 4090",
+      "models": ["llama3.3", "qwen2.5-coder"] },
+    { "id": "openclaw",        "tailscale_ip": "...", "gpu": "M3 Max",
+      "models": ["llama3.3:7b"] },
+    { "id": "penguin-1",       "tailscale_ip": "...", "cpu_only": true,
+      "models": ["phi3-mini"] }
+  ]
+}
+```
+
+Fleet routing rules (from `model-routing-policy.json`):
+- Tasks within available model context window → fleet first
+- Tasks requiring tool use → cloud (fleet Ollama models lack tool support)
+- Fleet unavailable (health check fails) → cascade to cloud with G3 cost note
+
+`scripts/health-check.js` pings all hosts and writes `.dashboard/state/fleet-health.json`.
+
+## RAG search
+
+`scripts/global/rag-search.js` — repo-context search for wiki ingest and
+governance queries. Priority: MCP server → ripgrep → Node `fs` glob.
+
+## State offload
+
+`scripts/global/state-offload-client.js` — offloads per-turn state to a
+Cloudflare Worker. Keeps hot-path context under model context limits without
+losing long-horizon state across turns.

--- a/docs/architecture-routing.md
+++ b/docs/architecture-routing.md
@@ -7,12 +7,12 @@ The cascade-dispatch always tries free/local tiers before paid cloud providers.
 
 `scripts/global/cascade-dispatch.js` implements a four-tier priority cascade:
 
-| Priority | Tier | Providers |
-|---|---|---|
-| 1 (cheapest) | Free | Gemini via Google AI Studio free quota |
-| 2 | Fleet | Ollama models on Tailscale hosts (local GPU) |
-| 3 | Budget | Claude Haiku, GPT-3.5-class, Groq |
-| 4 (costliest) | Premium | Claude Sonnet/Opus, GPT-4-class |
+| Priority      | Tier    | Providers                                    |
+| ------------- | ------- | -------------------------------------------- |
+| 1 (cheapest)  | Free    | Gemini via Google AI Studio free quota       |
+| 2             | Fleet   | Ollama models on Tailscale hosts (local GPU) |
+| 3             | Budget  | Claude Haiku, GPT-3.5-class, Groq            |
+| 4 (costliest) | Premium | Claude Sonnet/Opus, GPT-4-class              |
 
 The cascade evaluates tiers in order and uses the first available, healthy tier
 that can handle the task's context length and required capabilities.
@@ -20,6 +20,7 @@ that can handle the task's context length and required capabilities.
 ## Free router
 
 `scripts/global/free-router.js` sits in front of cascade-dispatch:
+
 1. Runs a lightweight topic classifier to estimate task difficulty
 2. Builds a signal stack (context length, tool requirements, sensitivity)
 3. Dispatches directly to the appropriate tier — skips cascade overhead
@@ -42,6 +43,7 @@ model selection (e.g. `governance-check` lane always uses a specific model).
 ## Capability detection (ADR-013)
 
 `scripts/global/capability-probe.js` probes each provider at startup:
+
 1. Checks API key availability via `credential-availability.js`
 2. Pings model endpoint with a minimal test prompt
 3. Caches result in `.dashboard/state/capability-cache.json`
@@ -55,17 +57,20 @@ Fleet hosts are defined in `inventory/devices.json`:
 ```json
 {
   "hosts": [
-    { "id": "36gbwinresource", "tailscale_ip": "...", "gpu": "RTX 4090",
-      "models": ["llama3.3", "qwen2.5-coder"] },
-    { "id": "openclaw",        "tailscale_ip": "...", "gpu": "M3 Max",
-      "models": ["llama3.3:7b"] },
-    { "id": "penguin-1",       "tailscale_ip": "...", "cpu_only": true,
-      "models": ["phi3-mini"] }
+    {
+      "id": "36gbwinresource",
+      "tailscale_ip": "...",
+      "gpu": "RTX 4090",
+      "models": ["llama3.3", "qwen2.5-coder"]
+    },
+    { "id": "openclaw", "tailscale_ip": "...", "gpu": "M3 Max", "models": ["llama3.3:7b"] },
+    { "id": "penguin-1", "tailscale_ip": "...", "cpu_only": true, "models": ["phi3-mini"] }
   ]
 }
 ```
 
 Fleet routing rules (from `model-routing-policy.json`):
+
 - Tasks within available model context window → fleet first
 - Tasks requiring tool use → cloud (fleet Ollama models lack tool support)
 - Fleet unavailable (health check fails) → cascade to cloud with G3 cost note

--- a/docs/architecture-runtime-parity.md
+++ b/docs/architecture-runtime-parity.md
@@ -1,0 +1,83 @@
+# Architecture — Multi-Runtime Parity
+
+A core architectural goal is that Copilot, Claude Code, and Codex behave
+identically for all governed operations. No runtime is second-class.
+
+## Parity model
+
+```
+                ┌─────────────────────────────────────────────┐
+                │           Governance Manifest               │
+                │    inventory/governance-manifest.json       │
+                └──────────────────┬──────────────────────────┘
+                                   │
+               ┌───────────────────┼───────────────────┐
+               ▼                   ▼                   ▼
+    ┌───────────────────┐ ┌────────────────┐ ┌──────────────────┐
+    │  GitHub Copilot   │ │  Claude Code   │ │      Codex       │
+    │ copilot-instr.md  │ │  CLAUDE.md     │ │  AGENTS.md       │
+    │ ~/.copilot/       │ │  ~/.claude/    │ │  ~/.codex/       │
+    └───────────────────┘ └────────────────┘ └──────────────────┘
+```
+
+## Adapter generation
+
+`npm run governance:adapters:emit` reads `inventory/governance-manifest.json`
+and emits runtime-specific shims for each engine:
+
+| Output | Target runtime | Mechanism |
+|---|---|---|
+| `.github/copilot-instructions.md` | GitHub Copilot Chat | Workspace instructions |
+| `CLAUDE.md` | Claude Code | Startup context file |
+| `AGENTS.md` | OpenAI Codex | AGENTS.md protocol |
+| `generated/governance-adapters/` | All (audit trail) | Timestamped snapshots |
+
+Adapters are rebuilt on every governance manifest change. The
+`orchestrator-governance-parity.json` registry tracks which features are active
+per runtime and is checked by `quality-required` CI.
+
+## Parity coverage matrix
+
+| Feature | Copilot | Claude Code | Codex |
+|---|---|---|---|
+| Skills / capabilities | ✅ `plugin.json` | ✅ `.claude-plugin/` | ⚠️ `AGENTS.md` tools |
+| Instructions | ✅ | ✅ | ✅ |
+| Hooks | ✅ | ✅ | ✅ |
+| Baton governance | ✅ | ✅ | ✅ |
+| Wiki access | ✅ | ✅ | ✅ |
+| Layer-2 routing | ✅ | ✅ | ✅ |
+
+⚠️ = partial; Codex tool support depends on the OpenAI Codex API version in use.
+
+## Cross-runtime review discipline
+
+When Copilot and Claude Code or Codex disagree on behaviour:
+1. Consult the **official docs** for the uncertain runtime — never infer from another
+2. File a parity issue with labels `type:bug,area:parity`
+3. The adapter generator is the correct fix path; never patch one runtime's file manually
+
+See `instructions/cross-family-review.instructions.md` for the full protocol.
+
+## Runtime-specific notes
+
+**GitHub Copilot Chat**: Skills route through `plugin.json`. New skills require
+a plugin reload (`Chat: Refresh Skills`) after deploy. Universal skills affect
+all consumers; personal skills deploy only to `~/.copilot/` on this machine.
+
+**Claude Code**: Hooks in `~/.claude/hooks/` run as shell commands. Ensure
+execute permissions on `.sh` files after deploy — `deploy:claude:apply` sets
+these automatically. Agent definitions live in `~/.claude/agents/`.
+
+**Codex**: Use official OpenAI Codex documentation for behaviour questions.
+Do not infer from Copilot or Claude Code compatibility. Tool calls are declared
+in `AGENTS.md § tools` using JSON Schema format. The `pre-task` and `post-task`
+hook lifecycle differs from Claude Code's hook model.
+
+## Adapter parity check
+
+```bash
+npm run governance:adapters:emit  # regenerate all adapters
+git diff generated/               # inspect drift
+```
+
+Unexpected diff → file a parity ticket before merging the change.

--- a/docs/architecture-runtime-parity.md
+++ b/docs/architecture-runtime-parity.md
@@ -25,12 +25,12 @@ identically for all governed operations. No runtime is second-class.
 `npm run governance:adapters:emit` reads `inventory/governance-manifest.json`
 and emits runtime-specific shims for each engine:
 
-| Output | Target runtime | Mechanism |
-|---|---|---|
+| Output                            | Target runtime      | Mechanism              |
+| --------------------------------- | ------------------- | ---------------------- |
 | `.github/copilot-instructions.md` | GitHub Copilot Chat | Workspace instructions |
-| `CLAUDE.md` | Claude Code | Startup context file |
-| `AGENTS.md` | OpenAI Codex | AGENTS.md protocol |
-| `generated/governance-adapters/` | All (audit trail) | Timestamped snapshots |
+| `CLAUDE.md`                       | Claude Code         | Startup context file   |
+| `AGENTS.md`                       | OpenAI Codex        | AGENTS.md protocol     |
+| `generated/governance-adapters/`  | All (audit trail)   | Timestamped snapshots  |
 
 Adapters are rebuilt on every governance manifest change. The
 `orchestrator-governance-parity.json` registry tracks which features are active
@@ -38,20 +38,21 @@ per runtime and is checked by `quality-required` CI.
 
 ## Parity coverage matrix
 
-| Feature | Copilot | Claude Code | Codex |
-|---|---|---|---|
+| Feature               | Copilot          | Claude Code          | Codex                |
+| --------------------- | ---------------- | -------------------- | -------------------- |
 | Skills / capabilities | ✅ `plugin.json` | ✅ `.claude-plugin/` | ⚠️ `AGENTS.md` tools |
-| Instructions | ✅ | ✅ | ✅ |
-| Hooks | ✅ | ✅ | ✅ |
-| Baton governance | ✅ | ✅ | ✅ |
-| Wiki access | ✅ | ✅ | ✅ |
-| Layer-2 routing | ✅ | ✅ | ✅ |
+| Instructions          | ✅               | ✅                   | ✅                   |
+| Hooks                 | ✅               | ✅                   | ✅                   |
+| Baton governance      | ✅               | ✅                   | ✅                   |
+| Wiki access           | ✅               | ✅                   | ✅                   |
+| Layer-2 routing       | ✅               | ✅                   | ✅                   |
 
 ⚠️ = partial; Codex tool support depends on the OpenAI Codex API version in use.
 
 ## Cross-runtime review discipline
 
 When Copilot and Claude Code or Codex disagree on behaviour:
+
 1. Consult the **official docs** for the uncertain runtime — never infer from another
 2. File a parity issue with labels `type:bug,area:parity`
 3. The adapter generator is the correct fix path; never patch one runtime's file manually

--- a/docs/contributing-dev-setup.md
+++ b/docs/contributing-dev-setup.md
@@ -1,0 +1,88 @@
+# Development Environment Setup
+
+## Prerequisites
+
+| Tool | Minimum version | Purpose |
+|---|---|---|
+| Node.js | 18 | All scripts; `nvm` recommended for version management |
+| Git | 2.35 | Worktree support required for concurrent agents |
+| GitHub CLI (`gh`) | 2.x | Issue, PR, and CI management |
+| Tailscale | any | Fleet routing to Ollama hosts (optional) |
+
+## Install and verify
+
+```bash
+git clone https://github.com/chf3198/megingjord-harness.git
+cd megingjord-harness
+npm install
+
+# Verify all baseline checks pass before making any changes
+npm run lint            # ≤100-line file limit
+npm test                # Playwright E2E + unit tests
+npm run validate:triage # Skill triage JSON sync
+npm run validate:compat # Plugin.json compatibility
+```
+
+## Key commands
+
+| Command | Purpose |
+|---|---|
+| `npm start` | Dashboard on `:8090` |
+| `npm run lint` | 100-line file limit check |
+| `npm run format:check` | Prettier check (read-only, no writes) |
+| `npm run format` | Prettier write (auto-fix) |
+| `npm test` | Full E2E + unit test suite |
+| `npm run validate:triage` | Skill triage JSON sync check |
+| `npm run validate:compat` | `plugin.json` compatibility check |
+| `npm run sync` | Pull Copilot runtime → repo |
+| `npm run sync:codex` | Pull Codex runtime → repo |
+| `npm run deploy:apply` | Deploy repo → Copilot runtime |
+| `npm run deploy:codex:apply` | Deploy repo → Codex runtime |
+| `npm run deploy:both:apply` | Deploy repo → Copilot + Codex |
+
+## Code style
+
+- **Formatter**: Prettier (config in `.prettierrc`) — run before every commit
+- **Module system**: CommonJS (`require` / `module.exports`); no ESM; no build step
+- **File cap**: ≤100 lines per file; split with a linked companion file if needed
+- **Naming**: `camelCase` for JS identifiers; `kebab-case` for filenames; `UPPER_SNAKE` for env vars
+- **Constants**: name magic numbers at the top of the file; no inline literals
+
+## Environment variables
+
+Copy `.env.example` → `.env` and populate as needed:
+
+| Variable | Purpose |
+|---|---|
+| `GOOGLE_AI_STUDIO_API_KEY` | Free-cloud dispatch via Gemini |
+| `MEGINGJORD_HAMR_ENABLED` | Set to `1` to use HAMR Cloudflare Worker for Layer-2 |
+| `OPERATOR_KEY_SEED_B64` | 32-byte base64 seed for stable HAMR mailbox auth |
+
+Check `scripts/global/credential-availability.js` before prompting for any secret —
+the value may already exist in `.env` or another approved hydration source.
+
+## Worktree discipline (concurrent session safety)
+
+Each agent or parallel task requires its own Git worktree and branch:
+
+```bash
+git worktree add ../<repo>-<issue> -b feat/<issue>-slug
+# work in the worktree
+git worktree remove ../<repo>-<issue>   # clean up after merge
+```
+
+See [`research/concurrent-agent-worktrees-2026-04-24.md`](../research/concurrent-agent-worktrees-2026-04-24.md)
+for the full safety contract, conflict quarantine procedure, and rescue steps.
+
+## Testing changes in a target runtime
+
+1. Deploy to the target runtime: `npm run deploy:apply`
+2. Open VS Code and exercise the changed skill or instruction
+3. Verify behaviour matches `SKILL.md § Verification`
+4. Pull changes back if needed: `npm run sync`
+
+## settings.json drift
+
+Copilot permission approvals append to `.claude/settings.json` automatically.
+Commit these via a `chore:` commit with ticket reference before branching on
+them. See note in `CONTRIBUTING.md § Constraints` and issue #506.

--- a/docs/contributing-dev-setup.md
+++ b/docs/contributing-dev-setup.md
@@ -2,12 +2,12 @@
 
 ## Prerequisites
 
-| Tool | Minimum version | Purpose |
-|---|---|---|
-| Node.js | 18 | All scripts; `nvm` recommended for version management |
-| Git | 2.35 | Worktree support required for concurrent agents |
-| GitHub CLI (`gh`) | 2.x | Issue, PR, and CI management |
-| Tailscale | any | Fleet routing to Ollama hosts (optional) |
+| Tool              | Minimum version | Purpose                                               |
+| ----------------- | --------------- | ----------------------------------------------------- |
+| Node.js           | 18              | All scripts; `nvm` recommended for version management |
+| Git               | 2.35            | Worktree support required for concurrent agents       |
+| GitHub CLI (`gh`) | 2.x             | Issue, PR, and CI management                          |
+| Tailscale         | any             | Fleet routing to Ollama hosts (optional)              |
 
 ## Install and verify
 
@@ -25,20 +25,20 @@ npm run validate:compat # Plugin.json compatibility
 
 ## Key commands
 
-| Command | Purpose |
-|---|---|
-| `npm start` | Dashboard on `:8090` |
-| `npm run lint` | 100-line file limit check |
-| `npm run format:check` | Prettier check (read-only, no writes) |
-| `npm run format` | Prettier write (auto-fix) |
-| `npm test` | Full E2E + unit test suite |
-| `npm run validate:triage` | Skill triage JSON sync check |
-| `npm run validate:compat` | `plugin.json` compatibility check |
-| `npm run sync` | Pull Copilot runtime → repo |
-| `npm run sync:codex` | Pull Codex runtime → repo |
-| `npm run deploy:apply` | Deploy repo → Copilot runtime |
-| `npm run deploy:codex:apply` | Deploy repo → Codex runtime |
-| `npm run deploy:both:apply` | Deploy repo → Copilot + Codex |
+| Command                      | Purpose                               |
+| ---------------------------- | ------------------------------------- |
+| `npm start`                  | Dashboard on `:8090`                  |
+| `npm run lint`               | 100-line file limit check             |
+| `npm run format:check`       | Prettier check (read-only, no writes) |
+| `npm run format`             | Prettier write (auto-fix)             |
+| `npm test`                   | Full E2E + unit test suite            |
+| `npm run validate:triage`    | Skill triage JSON sync check          |
+| `npm run validate:compat`    | `plugin.json` compatibility check     |
+| `npm run sync`               | Pull Copilot runtime → repo           |
+| `npm run sync:codex`         | Pull Codex runtime → repo             |
+| `npm run deploy:apply`       | Deploy repo → Copilot runtime         |
+| `npm run deploy:codex:apply` | Deploy repo → Codex runtime           |
+| `npm run deploy:both:apply`  | Deploy repo → Copilot + Codex         |
 
 ## Code style
 
@@ -52,11 +52,11 @@ npm run validate:compat # Plugin.json compatibility
 
 Copy `.env.example` → `.env` and populate as needed:
 
-| Variable | Purpose |
-|---|---|
-| `GOOGLE_AI_STUDIO_API_KEY` | Free-cloud dispatch via Gemini |
-| `MEGINGJORD_HAMR_ENABLED` | Set to `1` to use HAMR Cloudflare Worker for Layer-2 |
-| `OPERATOR_KEY_SEED_B64` | 32-byte base64 seed for stable HAMR mailbox auth |
+| Variable                   | Purpose                                              |
+| -------------------------- | ---------------------------------------------------- |
+| `GOOGLE_AI_STUDIO_API_KEY` | Free-cloud dispatch via Gemini                       |
+| `MEGINGJORD_HAMR_ENABLED`  | Set to `1` to use HAMR Cloudflare Worker for Layer-2 |
+| `OPERATOR_KEY_SEED_B64`    | 32-byte base64 seed for stable HAMR mailbox auth     |
 
 Check `scripts/global/credential-availability.js` before prompting for any secret —
 the value may already exist in `.env` or another approved hydration source.

--- a/docs/contributing-skills.md
+++ b/docs/contributing-skills.md
@@ -1,0 +1,97 @@
+# Skill Development Guide
+
+Skills are self-contained capability modules. Each has a `SKILL.md` descriptor
+and, where needed, a supporting script in `scripts/global/`.
+
+## Universal vs personal skills
+
+Skills are categorised in `skills/.plugin-triage.json`:
+
+| Category | Ships via | Runtime target |
+|---|---|---|
+| **Universal** | `plugin.json` | All consumers (deployed globally) |
+| **Personal** | `deploy.sh` | `~/.copilot/` on this machine only |
+
+## Skill directory layout
+
+```
+skills/<name>/
+├── SKILL.md          # Required — descriptor with YAML frontmatter
+└── (supporting files as needed, each ≤100 lines)
+```
+
+## SKILL.md format
+
+```markdown
+---
+name: skill-name
+description: One-line description ≤80 characters
+version: 1.0.0
+runtime: copilot | claude | codex | all
+category: governance | routing | wiki | fleet | utility
+---
+
+# skill-name — Title
+
+## Purpose
+What problem this skill solves and for whom.
+
+## Scope
+Which files, subsystems, or operations it touches.
+
+## Constraints
+Edge cases, limitations, incompatibilities.
+
+## Instructions
+Step-by-step guidance the LLM follows when invoking this skill.
+
+## Verification
+How to confirm the skill works after deployment.
+```
+
+## Adding a universal skill
+
+1. Create `skills/<name>/SKILL.md` with valid YAML frontmatter
+2. Add entry to `plugin.json` → `skills` array
+3. Add to `skills/.plugin-triage.json` → `universal` list
+4. Run `npm run validate:triage` → must pass with no errors
+5. Run `npm run validate:compat` if `plugin.json` changed
+6. Branch → PR → squash-merge → `npm run deploy:apply`
+
+## Adding a personal skill
+
+1. Create `skills/<name>/SKILL.md`
+2. Add to `skills/.plugin-triage.json` → `personal` list
+3. **Do NOT** add to `plugin.json` (personal skills are machine-local only)
+4. Run `npm run validate:triage` → must pass
+
+## Testing plugin installation
+
+1. Push your branch to `origin`
+2. In VS Code: **Chat: Install Plugin From Source**
+3. Paste the branch Git URL (e.g. `https://github.com/chf3198/megingjord-harness#your-branch`)
+4. Confirm skills appear in the Copilot chat suggestion list
+5. Exercise the skill; verify output matches `SKILL.md § Verification`
+
+## Cross-tool compatibility
+
+| Runtime | Detection path | Install mechanism |
+|---|---|---|
+| VS Code Copilot | `plugin.json` (root) | Plugin reload (`Chat: Refresh Skills`) |
+| Claude Code | `.claude-plugin/plugin.json` (symlink) | `npm run deploy:claude:apply` |
+| GitHub Copilot | `.github/plugin/plugin.json` (symlink) | Plugin install |
+
+All three symlinks resolve to the root `plugin.json` automatically.
+
+## Claude Code runtime install
+
+```bash
+npm run deploy:claude:apply   # repo .claude/ → ~/.claude/
+npm run sync:claude            # ~/.claude/ → repo .claude/ (pull back)
+```
+
+## File size constraint
+
+All skill files must be **≤100 lines** (lint-enforced). If `SKILL.md §
+Instructions` exceeds this, split into `SKILL.md` (nav/overview) +
+`SKILL-detail.md` (full instruction body) and link from `§ Instructions`.

--- a/docs/contributing-skills.md
+++ b/docs/contributing-skills.md
@@ -95,7 +95,5 @@ npm run deploy:claude:apply   # repo .claude/ → ~/.claude/
 npm run sync:claude            # ~/.claude/ → repo .claude/ (pull back)
 ```
 
-## File size constraint
-
-All skill files must be **≤100 lines** (lint-enforced). If instructions exceed
-this, split into `SKILL.md` (nav) + `SKILL-detail.md` and link.
+All skill files must be **≤100 lines** (lint-enforced). Split oversized skills
+into `SKILL.md` (nav) + `SKILL-detail.md` (body) and link between them.

--- a/docs/contributing-skills.md
+++ b/docs/contributing-skills.md
@@ -7,10 +7,10 @@ and, where needed, a supporting script in `scripts/global/`.
 
 Skills are categorised in `skills/.plugin-triage.json`:
 
-| Category | Ships via | Runtime target |
-|---|---|---|
-| **Universal** | `plugin.json` | All consumers (deployed globally) |
-| **Personal** | `deploy.sh` | `~/.copilot/` on this machine only |
+| Category      | Ships via     | Runtime target                     |
+| ------------- | ------------- | ---------------------------------- |
+| **Universal** | `plugin.json` | All consumers (deployed globally)  |
+| **Personal**  | `deploy.sh`   | `~/.copilot/` on this machine only |
 
 ## Skill directory layout
 
@@ -34,18 +34,23 @@ category: governance | routing | wiki | fleet | utility
 # skill-name — Title
 
 ## Purpose
+
 What problem this skill solves and for whom.
 
 ## Scope
+
 Which files, subsystems, or operations it touches.
 
 ## Constraints
+
 Edge cases, limitations, incompatibilities.
 
 ## Instructions
+
 Step-by-step guidance the LLM follows when invoking this skill.
 
 ## Verification
+
 How to confirm the skill works after deployment.
 ```
 
@@ -75,11 +80,11 @@ How to confirm the skill works after deployment.
 
 ## Cross-tool compatibility
 
-| Runtime | Detection path | Install mechanism |
-|---|---|---|
-| VS Code Copilot | `plugin.json` (root) | Plugin reload (`Chat: Refresh Skills`) |
-| Claude Code | `.claude-plugin/plugin.json` (symlink) | `npm run deploy:claude:apply` |
-| GitHub Copilot | `.github/plugin/plugin.json` (symlink) | Plugin install |
+| Runtime         | Detection path                         | Install mechanism                      |
+| --------------- | -------------------------------------- | -------------------------------------- |
+| VS Code Copilot | `plugin.json` (root)                   | Plugin reload (`Chat: Refresh Skills`) |
+| Claude Code     | `.claude-plugin/plugin.json` (symlink) | `npm run deploy:claude:apply`          |
+| GitHub Copilot  | `.github/plugin/plugin.json` (symlink) | Plugin install                         |
 
 All three symlinks resolve to the root `plugin.json` automatically.
 

--- a/docs/contributing-skills.md
+++ b/docs/contributing-skills.md
@@ -97,6 +97,5 @@ npm run sync:claude            # ~/.claude/ → repo .claude/ (pull back)
 
 ## File size constraint
 
-All skill files must be **≤100 lines** (lint-enforced). If `SKILL.md §
-Instructions` exceeds this, split into `SKILL.md` (nav/overview) +
-`SKILL-detail.md` (full instruction body) and link from `§ Instructions`.
+All skill files must be **≤100 lines** (lint-enforced). If instructions exceed
+this, split into `SKILL.md` (nav) + `SKILL-detail.md` and link from `§ Instructions`.

--- a/docs/contributing-skills.md
+++ b/docs/contributing-skills.md
@@ -98,4 +98,4 @@ npm run sync:claude            # ~/.claude/ → repo .claude/ (pull back)
 ## File size constraint
 
 All skill files must be **≤100 lines** (lint-enforced). If instructions exceed
-this, split into `SKILL.md` (nav) + `SKILL-detail.md` and link from `§ Instructions`.
+this, split into `SKILL.md` (nav) + `SKILL-detail.md` and link.

--- a/docs/contributing-workflow.md
+++ b/docs/contributing-workflow.md
@@ -15,22 +15,22 @@ Manager → Collaborator → Admin → Consultant
 
 PR body **must** include all four artifacts:
 
-| Artifact | Required fields |
-|---|---|
-| `MANAGER_HANDOFF` | `scope:` `lane:` `test_strategy:` `acceptance:` `Signed-by:` `Team&Model:` `Role: manager` |
+| Artifact               | Required fields                                                                                      |
+| ---------------------- | ---------------------------------------------------------------------------------------------------- |
+| `MANAGER_HANDOFF`      | `scope:` `lane:` `test_strategy:` `acceptance:` `Signed-by:` `Team&Model:` `Role: manager`           |
 | `COLLABORATOR_HANDOFF` | `branch:` `commit:` per-AC checklist `doc-coverage:` `Signed-by:` `Team&Model:` `Role: collaborator` |
-| `ADMIN_HANDOFF` | `branch:` `commit:` `signer-independence-check:` `Signed-by:` `Team&Model:` `Role: admin` |
-| `CONSULTANT_CLOSEOUT` | `ticket:` `verdict:` `rubric_rating: N/10` (≥7) `Signed-by:` `Team&Model:` `Role: consultant` |
+| `ADMIN_HANDOFF`        | `branch:` `commit:` `signer-independence-check:` `Signed-by:` `Team&Model:` `Role: admin`            |
+| `CONSULTANT_CLOSEOUT`  | `ticket:` `verdict:` `rubric_rating: N/10` (≥7) `Signed-by:` `Team&Model:` `Role: consultant`        |
 
 > Admin and Collaborator must carry **different** `Signed-by` values — CI enforces this.
 
 ## Lane model
 
-| Lane label | Baton required | Typical use |
-|---|---|---|
-| `lane:code-change` | Full baton (all 4 roles) | Feature branches, bug fixes |
-| `lane:docs-research` | Manager + Consultant | Wiki pages, research notes |
-| `lane:config-only` | Admin + Consultant | Config-only changes |
+| Lane label           | Baton required           | Typical use                 |
+| -------------------- | ------------------------ | --------------------------- |
+| `lane:code-change`   | Full baton (all 4 roles) | Feature branches, bug fixes |
+| `lane:docs-research` | Manager + Consultant     | Wiki pages, research notes  |
+| `lane:config-only`   | Admin + Consultant       | Config-only changes         |
 
 Label your issue before creating the branch; `baton-gates.yml` reads the label.
 
@@ -71,11 +71,11 @@ Allowed types: `feat` `fix` `chore` `docs` `content` `perf` `refactor` `style`
 
 `test_strategy:` in `MANAGER_HANDOFF` drives the `test-evidence` CI check:
 
-| Strategy | CI requirement |
-|---|---|
+| Strategy      | CI requirement                                                    |
+| ------------- | ----------------------------------------------------------------- |
 | `tdd-pyramid` | Unit + integration + E2E tests present, or N/A with justification |
-| `peer-review` | `CONSULTANT_CLOSEOUT` with `rubric_rating: ≥7/10` |
-| `drift-lint` | `docs-drift-maintenance` text appears in issue comment trail |
+| `peer-review` | `CONSULTANT_CLOSEOUT` with `rubric_rating: ≥7/10`                 |
+| `drift-lint`  | `docs-drift-maintenance` text appears in issue comment trail      |
 
 ## Large PRs (>10 files or >500 LOC)
 

--- a/docs/contributing-workflow.md
+++ b/docs/contributing-workflow.md
@@ -1,0 +1,93 @@
+# PR Process and Governance Workflow
+
+Every change to this repo transits the full baton gate chain before merge.
+
+## Baton gate chain
+
+All PRs run `baton-gates.yml` in sequence:
+
+```
+Manager → Collaborator → Admin → Consultant
+   ↓           ↓           ↓          ↓
+ Ticket      Branch      Verify    Red-team
+ + scope     + code      + CI      + approve
+```
+
+PR body **must** include all four artifacts:
+
+| Artifact | Required fields |
+|---|---|
+| `MANAGER_HANDOFF` | `scope:` `lane:` `test_strategy:` `acceptance:` `Signed-by:` `Team&Model:` `Role: manager` |
+| `COLLABORATOR_HANDOFF` | `branch:` `commit:` per-AC checklist `doc-coverage:` `Signed-by:` `Team&Model:` `Role: collaborator` |
+| `ADMIN_HANDOFF` | `branch:` `commit:` `signer-independence-check:` `Signed-by:` `Team&Model:` `Role: admin` |
+| `CONSULTANT_CLOSEOUT` | `ticket:` `verdict:` `rubric_rating: N/10` (≥7) `Signed-by:` `Team&Model:` `Role: consultant` |
+
+> Admin and Collaborator must carry **different** `Signed-by` values — CI enforces this.
+
+## Lane model
+
+| Lane label | Baton required | Typical use |
+|---|---|---|
+| `lane:code-change` | Full baton (all 4 roles) | Feature branches, bug fixes |
+| `lane:docs-research` | Manager + Consultant | Wiki pages, research notes |
+| `lane:config-only` | Admin + Consultant | Config-only changes |
+
+Label your issue before creating the branch; `baton-gates.yml` reads the label.
+
+## doc-coverage block
+
+Every `COLLABORATOR_HANDOFF` on a `lane:code-change` PR must include:
+
+```yaml
+doc-coverage:
+  UPDATED: <path> — <what changed>
+  N/A: <path> — <reason why not applicable>
+```
+
+See [`config/doc-coverage-matrix.yml`](../config/doc-coverage-matrix.yml) for
+all surfaces that must be assessed per change type.
+
+## PR checklist
+
+- [ ] `npm run format:check` passes (no formatting drift)
+- [ ] `npm run lint` passes (all files ≤100 lines)
+- [ ] `npm run lint:readability:ci` passes (no readability regressions)
+- [ ] `npm run validate:triage` passes (if skills changed)
+- [ ] `npm run validate:compat` passes (if `plugin.json` changed)
+- [ ] `.changes/unreleased/<issue>.md` changelog fragment created
+- [ ] PR title: `type(scope): subject ≤60 chars #<N>` — conventional commits format
+- [ ] Branch name: `feat/<N>-slug` or `fix/<N>-slug`
+
+## PR title format
+
+```
+type(scope): subject ≤60 chars #<issue>
+```
+
+Allowed types: `feat` `fix` `chore` `docs` `content` `perf` `refactor` `style`
+`test` `skill` `hotfix`
+
+## Test strategy values
+
+`test_strategy:` in `MANAGER_HANDOFF` drives the `test-evidence` CI check:
+
+| Strategy | CI requirement |
+|---|---|
+| `tdd-pyramid` | Unit + integration + E2E tests present, or N/A with justification |
+| `peer-review` | `CONSULTANT_CLOSEOUT` with `rubric_rating: ≥7/10` |
+| `drift-lint` | `docs-drift-maintenance` text appears in issue comment trail |
+
+## Large PRs (>10 files or >500 LOC)
+
+Include a `BLOCKER_NOTE` section in the PR body explaining why the change is
+large and confirming evidence closeout. CI's `danger-required` check enforces this.
+
+## Baton artifact builders
+
+Use the provided helpers to generate correctly formatted artifacts:
+
+```bash
+node scripts/global/baton-comment-build.js     # issue comment template
+node scripts/global/pr-comment-build.js        # PR body template
+node scripts/global/changelog-fragment-build.js # .changes/unreleased/<N>.md
+```

--- a/wiki/WIKI-operations.md
+++ b/wiki/WIKI-operations.md
@@ -11,6 +11,7 @@ raw/<source>.md  →  wiki/sources/<slug>.md  →  entity/concept pages  →  in
 ```
 
 Procedure:
+
 1. Human places source in `raw/` with frontmatter (`status: pending`)
 2. LLM reads the source and discusses key takeaways with the operator
 3. LLM writes `wiki/sources/<slug>.md` — a ≤100-line digest
@@ -54,11 +55,11 @@ Run: `node scripts/wiki/lint.js`
 
 ## Content trust scoring
 
-| Score | Meaning | Trigger to change |
-|---|---|---|
-| `confidence: high` | ≥3 independent sources agree | Contradicting source → drop to `medium` |
+| Score                | Meaning                        | Trigger to change                       |
+| -------------------- | ------------------------------ | --------------------------------------- |
+| `confidence: high`   | ≥3 independent sources agree   | Contradicting source → drop to `medium` |
 | `confidence: medium` | 1–2 sources; no contradictions | Confirming 3rd source → raise to `high` |
-| `confidence: low` | Single source or inferred | Never raise without additional source |
+| `confidence: low`    | Single source or inferred      | Never raise without additional source   |
 
 Contradicting a `high` confidence claim requires filing a research ticket, not
 just editing the page in place. Log the conflict first.

--- a/wiki/WIKI-operations.md
+++ b/wiki/WIKI-operations.md
@@ -1,0 +1,82 @@
+# WIKI Operations
+
+> Operations reference for the LLM wiki system. See `wiki/WIKI.md` for schema.
+
+## Ingest
+
+Transforms a raw source into structured wiki knowledge.
+
+```
+raw/<source>.md  →  wiki/sources/<slug>.md  →  entity/concept pages  →  index
+```
+
+Procedure:
+1. Human places source in `raw/` with frontmatter (`status: pending`)
+2. LLM reads the source and discusses key takeaways with the operator
+3. LLM writes `wiki/sources/<slug>.md` — a ≤100-line digest
+4. LLM creates or revises entity/concept pages; wikilinks in both directions
+5. LLM updates `wiki/index.md` with new/changed pages (grouped by type)
+6. LLM appends entry to `wiki/log.md` → `## [YYYY-MM-DD] ingest | <source-slug>`
+7. Mark raw source frontmatter `status: ingested`
+
+Run: `node scripts/wiki/ingest.js --source raw/<file>.md`
+
+## Query
+
+Synthesises an answer from existing wiki pages.
+
+1. LLM reads `wiki/index.md` to find all relevant pages
+2. LLM reads those pages in full; synthesises answer with `[[citations]]`
+3. Novel insights (≥2 sources, non-obvious conclusions) → file as `wiki/syntheses/<slug>.md`
+4. Log the query: `## [YYYY-MM-DD] query | <topic>`
+
+## Lint
+
+Structural health check; run before committing any wiki changes.
+
+1. Check for broken `[[wikilinks]]` (target must exist in `wiki/index.md`)
+2. Check for orphan pages (no inbound wikilinks from any other page)
+3. Check frontmatter completeness (all required fields present and non-empty)
+4. Check `wiki/index.md` is in sync with actual `wiki/` file tree
+5. Flag stale claims: `last_verified` >90 days → warn
+6. Flag contradictions between pages on the same topic
+7. Output a health report with actionable items (appended to `wiki/log.md`)
+
+Run: `node scripts/wiki/lint.js`
+
+## Cross-reference rules
+
+- Every entity/concept page must link to ≥1 related page (via `related:` field)
+- Source summaries must link to the entities/concepts they mention
+- Syntheses must cite ≥2 source or concept pages
+- **Bidirectional**: if A links to B, B should link back to A
+- Orphan check runs automatically during `wiki/lint.js`
+
+## Content trust scoring
+
+| Score | Meaning | Trigger to change |
+|---|---|---|
+| `confidence: high` | ≥3 independent sources agree | Contradicting source → drop to `medium` |
+| `confidence: medium` | 1–2 sources; no contradictions | Confirming 3rd source → raise to `high` |
+| `confidence: low` | Single source or inferred | Never raise without additional source |
+
+Contradicting a `high` confidence claim requires filing a research ticket, not
+just editing the page in place. Log the conflict first.
+
+## Anneal (cross-reference pass)
+
+`scripts/wiki/anneal.js` ensures bidirectional links are symmetric.
+
+Run after ingest if new pages were created:
+
+```bash
+node scripts/wiki/anneal.js           # preview missing back-links
+node scripts/wiki/anneal.js --fix     # write missing back-links in place
+```
+
+## Versioning policy
+
+- Track changes via `updated:` frontmatter (not Git blame)
+- Breaking changes to a page's core claim → bump `updated:`, add `sources_count:` delta
+- Superseded content → set `status: deprecated` + `superseded_by: [[new-page]]`
+- Never delete a deprecated page; keep it for audit trail

--- a/wiki/WIKI-typology.md
+++ b/wiki/WIKI-typology.md
@@ -31,23 +31,23 @@
 Pages in one sub-wiki **must not** wikilink to pages in another sub-wiki
 unless the link is an explicit cross-wiki reference:
 
-| Prefix | Meaning | Example |
-|---|---|---|
-| *(none)* | Same sub-wiki reference | `[[github-native-layer2]]` |
-| `code::` | Reference to code wiki | `code::[[cascade-dispatch-js]]` |
-| `work-log::` | Reference to work-log | `work-log::[[session-2026-06-08]]` |
-| `wisdom::` | Reference to wisdom wiki | `wisdom::[[hamr-failover-map]]` |
+| Prefix       | Meaning                  | Example                            |
+| ------------ | ------------------------ | ---------------------------------- |
+| _(none)_     | Same sub-wiki reference  | `[[github-native-layer2]]`         |
+| `code::`     | Reference to code wiki   | `code::[[cascade-dispatch-js]]`    |
+| `work-log::` | Reference to work-log    | `work-log::[[session-2026-06-08]]` |
+| `wisdom::`   | Reference to wisdom wiki | `wisdom::[[hamr-failover-map]]`    |
 
 Cross-wiki links must be justified in the page frontmatter `related:` annotation.
 
 ## Fleet routing (inference operations)
 
-| Operation | Primary host | Failover |
-|---|---|---|
-| Ingest (summarise + cross-ref) | OpenClaw (7B, M3 Max) | Groq, Cerebras |
-| Query (synthesis) | OpenClaw (7B) | Copilot Pro |
-| Lint (structural checks) | Local Node.js scripts | — (never pay for lint) |
-| Anneal (link pass) | Local Node.js scripts | — |
+| Operation                      | Primary host          | Failover               |
+| ------------------------------ | --------------------- | ---------------------- |
+| Ingest (summarise + cross-ref) | OpenClaw (7B, M3 Max) | Groq, Cerebras         |
+| Query (synthesis)              | OpenClaw (7B)         | Copilot Pro            |
+| Lint (structural checks)       | Local Node.js scripts | — (never pay for lint) |
+| Anneal (link pass)             | Local Node.js scripts | —                      |
 
 Fleet availability is checked via `scripts/health-check.js` before dispatching.
 If the primary host is unreachable, routing falls back to the next available
@@ -64,10 +64,10 @@ for structural operations.
 
 ## Special pages
 
-| File | Purpose | Mutability |
-|---|---|---|
-| `wiki/index.md` | Catalog of every page, grouped by type; updated on ingest | LLM rewrites freely |
-| `wiki/log.md` | Append-only chronological ops record | Append only |
-| `wiki/WIKI.md` | Schema and conventions | Co-owned; change by agreement |
-| `wiki/WIKI-operations.md` | Ingest/query/lint procedures | LLM updates |
-| `wiki/WIKI-typology.md` | This file — typology and routing | LLM updates |
+| File                      | Purpose                                                   | Mutability                    |
+| ------------------------- | --------------------------------------------------------- | ----------------------------- |
+| `wiki/index.md`           | Catalog of every page, grouped by type; updated on ingest | LLM rewrites freely           |
+| `wiki/log.md`             | Append-only chronological ops record                      | Append only                   |
+| `wiki/WIKI.md`            | Schema and conventions                                    | Co-owned; change by agreement |
+| `wiki/WIKI-operations.md` | Ingest/query/lint procedures                              | LLM updates                   |
+| `wiki/WIKI-typology.md`   | This file — typology and routing                          | LLM updates                   |

--- a/wiki/WIKI-typology.md
+++ b/wiki/WIKI-typology.md
@@ -1,0 +1,73 @@
+# WIKI Typology, Fleet Routing, and Constraints
+
+> Companion to `wiki/WIKI.md`. Covers three-wiki typology, fleet routing for
+> inference operations, namespace isolation, and operational constraints.
+
+## Three-wiki typology (detail)
+
+### Code wiki (`wiki/code/`)
+
+**Purpose**: annotated understanding of this repo's own source code.
+**Content**: module-level summaries, interface contracts, known edge cases.
+**Update trigger**: significant code change merged to `main`.
+**Consumer**: `wiki-search.js` when answering "how does X work?" queries.
+
+### Work-log wiki (`wiki/work-log/`)
+
+**Purpose**: session audit trail and governed ticket history.
+**Content**: per-session summaries, ticket decisions, baton outcomes.
+**Update trigger**: every governed PR merge (Admin posts entry).
+**Mutation rule**: append-only — never edit past entries; corrections go in new entries.
+
+### Wisdom wiki (`wiki/wisdom/`)
+
+**Purpose**: distilled external knowledge and cross-system insights.
+**Content**: source summaries, concept pages, R&D syntheses, fleet entity pages.
+**Update trigger**: after raw source ingest or research synthesis.
+**Sub-paths**: `global/` (harness-wide); `project/` (per-project knowledge).
+
+## Namespace isolation
+
+Pages in one sub-wiki **must not** wikilink to pages in another sub-wiki
+unless the link is an explicit cross-wiki reference:
+
+| Prefix | Meaning | Example |
+|---|---|---|
+| *(none)* | Same sub-wiki reference | `[[github-native-layer2]]` |
+| `code::` | Reference to code wiki | `code::[[cascade-dispatch-js]]` |
+| `work-log::` | Reference to work-log | `work-log::[[session-2026-06-08]]` |
+| `wisdom::` | Reference to wisdom wiki | `wisdom::[[hamr-failover-map]]` |
+
+Cross-wiki links must be justified in the page frontmatter `related:` annotation.
+
+## Fleet routing (inference operations)
+
+| Operation | Primary host | Failover |
+|---|---|---|
+| Ingest (summarise + cross-ref) | OpenClaw (7B, M3 Max) | Groq, Cerebras |
+| Query (synthesis) | OpenClaw (7B) | Copilot Pro |
+| Lint (structural checks) | Local Node.js scripts | — (never pay for lint) |
+| Anneal (link pass) | Local Node.js scripts | — |
+
+Fleet availability is checked via `scripts/health-check.js` before dispatching.
+If the primary host is unreachable, routing falls back to the next available
+tier (G6 Resilience). Lint and anneal are local-only; G3 Zero Cost is non-negotiable
+for structural operations.
+
+## Constraints
+
+- Wiki files ≤100 lines (lint-enforced for `wiki/*.md`; `wiki/wisdom/` is exempt)
+- Split with a companion file if content naturally exceeds 100 lines — do not truncate
+- Markdown only; no binary files in `wiki/`
+- `wiki/index.md` and `wiki/log.md` are exempt from the 100-line limit by design
+- Git tracks `wiki/`; `raw/` sources are the source of truth; wiki is derived and rebuild-safe
+
+## Special pages
+
+| File | Purpose | Mutability |
+|---|---|---|
+| `wiki/index.md` | Catalog of every page, grouped by type; updated on ingest | LLM rewrites freely |
+| `wiki/log.md` | Append-only chronological ops record | Append only |
+| `wiki/WIKI.md` | Schema and conventions | Co-owned; change by agreement |
+| `wiki/WIKI-operations.md` | Ingest/query/lint procedures | LLM updates |
+| `wiki/WIKI-typology.md` | This file — typology and routing | LLM updates |

--- a/wiki/WIKI.md
+++ b/wiki/WIKI.md
@@ -2,23 +2,33 @@
 
 > The LLM reads this file to understand how the wiki works.
 > Co-evolved by human and LLM as conventions mature.
+> Operations detail: [`wiki/WIKI-operations.md`](WIKI-operations.md)
+> Typology and fleet routing: [`wiki/WIKI-typology.md`](WIKI-typology.md)
 
-## Architecture (3 layers)
+## Three-wiki typology
+
+| Sub-wiki | Path | Purpose |
+|---|---|---|
+| **Code wiki** | `wiki/code/` | Annotated code understanding |
+| **Work-log wiki** | `wiki/work-log/` | Session and ticket audit trail (append-only) |
+| **Wisdom wiki** | `wiki/wisdom/` | Distilled knowledge, research, and fleet entity pages |
+
+## Three-layer architecture
 
 | Layer | Path | Owner | Mutability |
 |---|---|---|---|
 | Raw sources | `raw/` | Human curates | Immutable after placement |
-| Wiki | `wiki/` | LLM writes | LLM updates freely |
+| Wiki pages | `wiki/` | LLM writes | LLM updates freely |
 | Schema | `WIKI.md` | Co-owned | Changed by agreement |
 
-## Page Types
+## Page types
 
 | Type | Directory | Purpose |
 |---|---|---|
-| Entity | `wiki/entities/` | Person, device, service, tool |
-| Concept | `wiki/concepts/` | Idea, pattern, technique, decision |
-| Source summary | `wiki/sources/` | Digest of one raw source |
-| Synthesis | `wiki/syntheses/` | Cross-cutting analysis, comparisons |
+| Entity | `wiki/*/entities/` | Person, device, service, tool |
+| Concept | `wiki/*/concepts/` | Idea, pattern, technique, decision |
+| Source summary | `wiki/*/sources/` | Digest of one raw source |
+| Synthesis | `wiki/*/syntheses/` | Cross-cutting analysis, comparisons |
 
 ## Frontmatter (required on every wiki page)
 
@@ -35,66 +45,22 @@ status: stub | draft | active | deprecated
 confidence: high | medium | low
 last_verified: 2026-04-30
 sources_count: N
-superseded_by: "[[newer-page]]"   # optional — when content is replaced
+superseded_by: "[[newer-page]]"   # optional
 ---
 ```
 
-**Lint**: `last_verified` >90d → stale. **Confidence**: `high`=3+ sources; `medium`=1-2; `low`=1 or inferred.
+**Confidence**: `high` = 3+ sources; `medium` = 1–2; `low` = 1 or inferred.
+**Staleness**: `last_verified` >90 days → stale warning during lint.
 
-## Naming Conventions
+## Naming conventions
 
-- Filenames: `kebab-case.md` (e.g., `penguin-1.md`, `llm-wiki-pattern.md`)
+- Filenames: `kebab-case.md` (e.g. `penguin-1.md`, `llm-wiki-pattern.md`)
 - Wikilinks: `[[page-name]]` — no path prefix, no extension
-- One concept per page — split if a page exceeds 80 lines of content
+- One concept per page — if content exceeds 80 lines, split into linked pages
 
-## Special Files
+## Special files
 
-- `wiki/index.md` — catalog of every page, grouped by type. Updated on
-  every ingest. LLM reads this first when answering queries.
-- `wiki/log.md` — append-only chronological record of operations.
-  Format: `## [YYYY-MM-DD] operation | Subject`
-
-## Operations
-
-### Ingest
-1. Human places source in `raw/` with frontmatter
-2. LLM reads source, discusses key takeaways
-3. LLM writes `wiki/sources/<slug>.md` summary
-4. LLM updates entity/concept pages (create or revise)
-5. LLM updates `wiki/index.md` with new/changed pages
-6. LLM appends entry to `wiki/log.md`
-7. Mark raw source frontmatter `status: ingested`
-
-### Query
-1. LLM reads `wiki/index.md` to find relevant pages
-2. LLM reads those pages, synthesizes answer with `[[citations]]`
-3. Valuable answers get filed as `wiki/syntheses/<slug>.md`
-
-### Lint
-1. Check for broken `[[wikilinks]]` (target page must exist)
-2. Check for orphan pages (no inbound links)
-3. Check frontmatter completeness (all required fields present)
-4. Check `wiki/index.md` is in sync with actual wiki/ contents
-5. Flag contradictions between pages
-6. Flag stale claims superseded by newer sources
-7. Output: health report with actionable items
-
-## Cross-Reference Rules
-
-- Every entity/concept page must link to ≥1 related page
-- Source summaries must link to entities/concepts they mention
-- Syntheses must cite ≥2 source/concept pages
-- Bidirectional: if A links to B, B should link back to A
-
-## Fleet Routing (for inference operations)
-
-| Operation | Primary | Failover |
-|---|---|---|
-| Ingest (summarize + cross-ref) | OpenClaw (7B) | Groq, Cerebras |
-| Query (synthesis) | OpenClaw (7B) | Copilot Pro |
-| Lint (structural checks) | Local scripts | Groq (fast) |
-
-## Constraints
-
-- Wiki files ≤100 lines (split if needed); Markdown only; no binary files
-- Git tracks wiki/; raw sources are the source of truth; wiki is derived
+- `wiki/index.md` — catalog of every page, grouped by type; updated on ingest
+- `wiki/log.md` — append-only chronological ops record
+- `wiki/WIKI-operations.md` — ingest, query, lint, and anneal procedures
+- `wiki/WIKI-typology.md` — three-wiki typology, fleet routing, namespace rules

--- a/wiki/WIKI.md
+++ b/wiki/WIKI.md
@@ -7,45 +7,45 @@
 
 ## Three-wiki typology
 
-| Sub-wiki | Path | Purpose |
-|---|---|---|
-| **Code wiki** | `wiki/code/` | Annotated code understanding |
-| **Work-log wiki** | `wiki/work-log/` | Session and ticket audit trail (append-only) |
-| **Wisdom wiki** | `wiki/wisdom/` | Distilled knowledge, research, and fleet entity pages |
+| Sub-wiki          | Path             | Purpose                                               |
+| ----------------- | ---------------- | ----------------------------------------------------- |
+| **Code wiki**     | `wiki/code/`     | Annotated code understanding                          |
+| **Work-log wiki** | `wiki/work-log/` | Session and ticket audit trail (append-only)          |
+| **Wisdom wiki**   | `wiki/wisdom/`   | Distilled knowledge, research, and fleet entity pages |
 
 ## Three-layer architecture
 
-| Layer | Path | Owner | Mutability |
-|---|---|---|---|
-| Raw sources | `raw/` | Human curates | Immutable after placement |
-| Wiki pages | `wiki/` | LLM writes | LLM updates freely |
-| Schema | `WIKI.md` | Co-owned | Changed by agreement |
+| Layer       | Path      | Owner         | Mutability                |
+| ----------- | --------- | ------------- | ------------------------- |
+| Raw sources | `raw/`    | Human curates | Immutable after placement |
+| Wiki pages  | `wiki/`   | LLM writes    | LLM updates freely        |
+| Schema      | `WIKI.md` | Co-owned      | Changed by agreement      |
 
 ## Page types
 
-| Type | Directory | Purpose |
-|---|---|---|
-| Entity | `wiki/*/entities/` | Person, device, service, tool |
-| Concept | `wiki/*/concepts/` | Idea, pattern, technique, decision |
-| Source summary | `wiki/*/sources/` | Digest of one raw source |
-| Synthesis | `wiki/*/syntheses/` | Cross-cutting analysis, comparisons |
+| Type           | Directory           | Purpose                             |
+| -------------- | ------------------- | ----------------------------------- |
+| Entity         | `wiki/*/entities/`  | Person, device, service, tool       |
+| Concept        | `wiki/*/concepts/`  | Idea, pattern, technique, decision  |
+| Source summary | `wiki/*/sources/`   | Digest of one raw source            |
+| Synthesis      | `wiki/*/syntheses/` | Cross-cutting analysis, comparisons |
 
 ## Frontmatter (required on every wiki page)
 
 ```yaml
 ---
-title: "Page Title"
+title: 'Page Title'
 type: entity | concept | source | synthesis
 created: 2026-04-13
 updated: 2026-04-13
 tags: [tag1, tag2]
 sources: [raw/articles/filename.md]
-related: ["[[Other Page]]"]
+related: ['[[Other Page]]']
 status: stub | draft | active | deprecated
 confidence: high | medium | low
 last_verified: 2026-04-30
 sources_count: N
-superseded_by: "[[newer-page]]"   # optional
+superseded_by: '[[newer-page]]' # optional
 ---
 ```
 


### PR DESCRIPTION
docs: split five lint-capped docs into linked suites #2776

Refs #2776

Five documentation files were artificially capped at exactly 100 lines,
causing critical sections to be silently omitted. This PR splits each into a
suite of linked pages (each still within the 100-line lint limit) so content
is thorough rather than truncated.

## Changes (18 files: 5 updated + 13 created)

**CONTRIBUTING.md** (100 → 54 lines) — navigation overview; full content in:
- docs/contributing-skills.md (97 lines) — skill format, testing, cross-tool compat
- docs/contributing-workflow.md (93 lines) — baton gates, lane model, doc-coverage
- docs/contributing-dev-setup.md (88 lines) — env setup, commands, code style, worktrees

**docs/ARCHITECTURE.md** (100 → 54 lines) — arc42 nav hub with 7-section map:
- docs/architecture-routing.md (84 lines) — cascade dispatch, fleet, capability detection
- docs/architecture-governance.md (76 lines) — governance CI, wiki, dashboard
- docs/architecture-deployment.md (86 lines) — two-layer model, Layer-2, sync commands

**ARCHITECTURE.md** (98 → 63 lines) — executive overview with document map:
- docs/architecture-layer-model.md (98 lines) — full layer topology with Mermaid
- docs/architecture-baton-model.md (80 lines) — complete 4-role baton model
- docs/architecture-runtime-parity.md (83 lines) — parity matrix, adapter generation

**wiki/WIKI.md** (100 → 66 lines) — schema and page-type overview:
- wiki/WIKI-operations.md (82 lines) — ingest, query, lint, anneal procedures
- wiki/WIKI-typology.md (73 lines) — three-wiki typology, fleet routing, constraints

**AGENTS.md** (100 → 55 lines) — startup protocol and nav:
- docs/agents-governance.md (91 lines) — signing, role taxonomy, key contracts
- docs/agents-workflow.md (93 lines) — deploy cycle, Layer-2, skill index, dashboard

## Research basis
- arc42 template sections 1–12 (introduction, constraints, context, building
  blocks, runtime view, deployment, crosscutting, decisions, quality, risks)
- C4 Model hierarchy (context, containers, components, code)
- GitHub community-health documentation standards

[skip-doc-gate]
