### PR TITLE
feat(scripts): enforce canonical env-hydration across JS consumers #2769

### DIFF
--- a/.changes/unreleased/2769.md
+++ b/.changes/unreleased/2769.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Canonical env-hydration enforcement** (#2769 + #2771, Epic #2291 Phase-1): every JS credential
+  consumer now hydrates the repo-root `.env` through `loadLocalEnvOnce()` before reading
+  `process.env` — 16 previously-unhydrated consumers routed + 14 ad-hoc `dotenv` loaders migrated to
+  the shim. New `requireKeys()` is **fail-closed**: a declared-required key that is absent after
+  hydration throws a typed `CredentialAbsentError` and never prompts the client (G1/G4). A new
+  `hydration-lint` prevention gate (pre-push + CI) blocks any future unhydrated consumer,
+  `dotenv`-outside-shim, or credential-value-leak, with project-configurable credential-name patterns.

--- a/config/credential-name-patterns.json
+++ b/config/credential-name-patterns.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Credential-name match for hydration-lint (#2771). default = suffix set every consumer must hydrate before reading; extra = project-configurable additional regex fragments (no anchors).",
+  "default": ["_API_KEY", "_TOKEN", "_SECRET", "_KEY", "PASSWORD"],
+  "extra": []
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -23,6 +23,8 @@ pre-push:
       run: npm run lint:sh || true
     megalint:
       run: node scripts/global/megalint/index.js
+    hydration-lint:
+      run: node scripts/global/hydration-lint.js
     closeout-preflight:
       run: node scripts/global/closeout-preflight.js
     # #1613: removed `test-evidence-diff` step. The validator at

--- a/scripts/ai-matrix-providers-fleet.js
+++ b/scripts/ai-matrix-providers-fleet.js
@@ -1,6 +1,6 @@
 // ai-matrix-providers-fleet.js — OpenClaw local fleet provider configs
 'use strict';
-require('dotenv').config({ path: require('path').resolve(process.cwd(), '.env') });
+require('./global/load-local-env').loadLocalEnvOnce();
 
 const chat = (url, apiKey, model) => ({
   url,

--- a/scripts/ai-matrix-providers.js
+++ b/scripts/ai-matrix-providers.js
@@ -1,6 +1,6 @@
 // ai-matrix-providers.js — cloud providers; fleet providers: ai-matrix-providers-fleet.js
 'use strict';
-require('dotenv').config({ path: require('path').resolve(process.cwd(), '.env') });
+require('./global/load-local-env').loadLocalEnvOnce();
 
 const chat = (url, apiKey, model) => ({
   url,

--- a/scripts/ai-matrix-updater.js
+++ b/scripts/ai-matrix-updater.js
@@ -4,7 +4,7 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
-require('dotenv').config({ path: path.resolve(process.cwd(), '.env') });
+require('./global/load-local-env').loadLocalEnvOnce();
 const fetch = require('node-fetch');
 const { scoreResponse } = require('./ai-matrix-scorer');
 const { providers } = require('./ai-matrix-providers');

--- a/scripts/dashboard-server.js
+++ b/scripts/dashboard-server.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-require('dotenv').config(); const http = require('http'); const fs = require('fs'); const path = require('path');
+require('./global/load-local-env').loadLocalEnvOnce(); const http = require('http'); const fs = require('fs'); const path = require('path');
 const PORT = process.env.DASH_PORT || 8090; const ROOT = path.resolve(__dirname, '..');
 const MIME = {'.html':'text/html','.css':'text/css','.js':'text/javascript','.json':'application/json'};
 const { resolveFleet, getDeviceURL, getOpenClawURL } = require('./global/fleet-config');

--- a/scripts/global/agent-signature.js
+++ b/scripts/global/agent-signature.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 'use strict';
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 const fs = require('fs');
 const path = require('path');
 const sig = require('./governance-artifact-signature');

--- a/scripts/global/agent-signature.js
+++ b/scripts/global/agent-signature.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 'use strict';
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 const fs = require('fs');
 const path = require('path');
 const sig = require('./governance-artifact-signature');

--- a/scripts/global/anthropic-batch-router.js
+++ b/scripts/global/anthropic-batch-router.js
@@ -4,7 +4,7 @@
 // Routes non-time-critical work (research, wiki anneal) to Anthropic Batch API
 // (50% off + bypasses online quotas) per v3.2 §R5 + v3.2.1.
 'use strict';
-require('dotenv').config({ quiet: true });
+require('./load-local-env').loadLocalEnvOnce();
 
 const ANTHROPIC_BATCH_URL = 'https://api.anthropic.com/v1/messages/batches';
 const ANTHROPIC_VERSION = '2023-06-01';

--- a/scripts/global/anthropic-gateway-smoke.js
+++ b/scripts/global/anthropic-gateway-smoke.js
@@ -2,7 +2,7 @@
 'use strict';
 // tier: 4
 
-require('dotenv').config();
+require('./load-local-env').loadLocalEnvOnce();
 
 const key = process.env.ANTHROPIC_API_KEY;
 const base = process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com';

--- a/scripts/global/batch-validator.js
+++ b/scripts/global/batch-validator.js
@@ -4,7 +4,7 @@
 // Dry-run + opt-in live mode for Anthropic Batch API submission.
 // Default: dry-run = $0 operator cost. Live mode requires --live --operator-approved.
 'use strict';
-require('dotenv').config({ quiet: true });
+require('./load-local-env').loadLocalEnvOnce();
 
 const { submitBatch, pollBatch, isBatchEligible } = require('./anthropic-batch-router');
 

--- a/scripts/global/baton-signing.js
+++ b/scripts/global/baton-signing.js
@@ -1,6 +1,6 @@
 // baton-signing.js — HAMR Wave 1 Ed25519 sign/verify for baton handoff artifacts (#894)
 // node:crypto only. Wave 1: T4 ephemeral keying; T1/T2/T3 probed (presence-only) for hamr:doctor #896.
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 'use strict';
 const { createHash, generateKeyPairSync, sign: cSign, verify: cVerify } = require('node:crypto');
 const { execSync } = require('node:child_process');

--- a/scripts/global/baton-signing.js
+++ b/scripts/global/baton-signing.js
@@ -1,5 +1,6 @@
 // baton-signing.js — HAMR Wave 1 Ed25519 sign/verify for baton handoff artifacts (#894)
 // node:crypto only. Wave 1: T4 ephemeral keying; T1/T2/T3 probed (presence-only) for hamr:doctor #896.
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 'use strict';
 const { createHash, generateKeyPairSync, sign: cSign, verify: cVerify } = require('node:crypto');
 const { execSync } = require('node:child_process');

--- a/scripts/global/cache-stats-push.js
+++ b/scripts/global/cache-stats-push.js
@@ -3,7 +3,7 @@
 // cache-stats-push.js — HAMR Wave 5 child 2 (#933).
 // Computes rolling 7d hit-rate locally and POSTs Ed25519-signed payload to HAMR /cache-stats.
 'use strict';
-require('dotenv').config({ quiet: true });
+require('./load-local-env').loadLocalEnvOnce();
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');

--- a/scripts/global/capability-probe.js
+++ b/scripts/global/capability-probe.js
@@ -66,7 +66,7 @@ function probeTailscale() {
 }
 
 async function probe() {
-  require('dotenv').config({ quiet: true });
+  require('./load-local-env').loadLocalEnvOnce();
   const env = process.env;
   const inv = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'inventory', 'devices.json'), 'utf8'));
   const providerResults = await Promise.all(PROVIDER_PROBES.map(async p => [p.id, await probeProvider(p, env)]));

--- a/scripts/global/dashboard-api.js
+++ b/scripts/global/dashboard-api.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // tier: 3
 // Dashboard API handler — resolves all paths from COPILOT_HOME
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 const http = require('http');
 const fs = require('fs');
 const path = require('path');

--- a/scripts/global/dashboard-api.js
+++ b/scripts/global/dashboard-api.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // tier: 3
 // Dashboard API handler — resolves all paths from COPILOT_HOME
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 const http = require('http');
 const fs = require('fs');
 const path = require('path');

--- a/scripts/global/epic-close-validator.js
+++ b/scripts/global/epic-close-validator.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 'use strict';
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 
 const GH_API_VERSION = '2022-11-28';
 

--- a/scripts/global/epic-close-validator.js
+++ b/scripts/global/epic-close-validator.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 'use strict';
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 
 const GH_API_VERSION = '2022-11-28';
 

--- a/scripts/global/free-router.js
+++ b/scripts/global/free-router.js
@@ -2,6 +2,7 @@
 // Phase 4 / #786 — free-model orchestrator MVP
 // Classifier+signal stack picks dispatch tier. Calls free LLM (Groq) when
 // available; falls back to deterministic cascade-dispatch logic otherwise.
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 const fs = require('fs');
 const path = require('path');
 

--- a/scripts/global/free-router.js
+++ b/scripts/global/free-router.js
@@ -2,7 +2,7 @@
 // Phase 4 / #786 — free-model orchestrator MVP
 // Classifier+signal stack picks dispatch tier. Calls free LLM (Groq) when
 // available; falls back to deterministic cascade-dispatch logic otherwise.
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 const fs = require('fs');
 const path = require('path');
 

--- a/scripts/global/github-bundle-client.js
+++ b/scripts/global/github-bundle-client.js
@@ -1,5 +1,6 @@
 // tier: 2
 // github-bundle-client.js — GitHub-native bundle distribution via Releases API. Refs #2751.
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 'use strict';
 const https = require('node:https');
 const { execSync } = require('node:child_process');

--- a/scripts/global/github-bundle-client.js
+++ b/scripts/global/github-bundle-client.js
@@ -1,6 +1,6 @@
 // tier: 2
 // github-bundle-client.js — GitHub-native bundle distribution via Releases API. Refs #2751.
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 'use strict';
 const https = require('node:https');
 const { execSync } = require('node:child_process');

--- a/scripts/global/github-mailbox.js
+++ b/scripts/global/github-mailbox.js
@@ -1,5 +1,6 @@
 // tier: 2
 // github-mailbox.js — GitHub-native append-log mailbox replacing HAMR /mailbox. Refs #2750.
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 'use strict';
 const https = require('node:https');
 const fs = require('node:fs');

--- a/scripts/global/github-mailbox.js
+++ b/scripts/global/github-mailbox.js
@@ -1,6 +1,6 @@
 // tier: 2
 // github-mailbox.js — GitHub-native append-log mailbox replacing HAMR /mailbox. Refs #2750.
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 'use strict';
 const https = require('node:https');
 const fs = require('node:fs');

--- a/scripts/global/github-mcp-dispatch.js
+++ b/scripts/global/github-mcp-dispatch.js
@@ -1,7 +1,7 @@
 // tier: 2
 // github-mcp-dispatch.js — GitHub-native async MCP dispatch via repository_dispatch. Refs #2752.
 // HAMR stays default for interactive RPC; this is the async fallback for fire-and-forget.
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 'use strict';
 const https = require('node:https');
 const { execSync } = require('node:child_process');

--- a/scripts/global/github-mcp-dispatch.js
+++ b/scripts/global/github-mcp-dispatch.js
@@ -1,6 +1,7 @@
 // tier: 2
 // github-mcp-dispatch.js — GitHub-native async MCP dispatch via repository_dispatch. Refs #2752.
 // HAMR stays default for interactive RPC; this is the async fallback for fire-and-forget.
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 'use strict';
 const https = require('node:https');
 const { execSync } = require('node:child_process');

--- a/scripts/global/governance-bundle-push.js
+++ b/scripts/global/governance-bundle-push.js
@@ -9,7 +9,7 @@
 // Mirrors the substrate-health-push.js producer pattern; graceful no-op (G6)
 // when the fields snapshot or operator key is unavailable.
 'use strict';
-require('dotenv').config({ quiet: true });
+require('./load-local-env').loadLocalEnvOnce();
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');

--- a/scripts/global/governance-drift-classifier.js
+++ b/scripts/global/governance-drift-classifier.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 'use strict';
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');

--- a/scripts/global/governance-drift-classifier.js
+++ b/scripts/global/governance-drift-classifier.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 'use strict';
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');

--- a/scripts/global/hamr-probes.js
+++ b/scripts/global/hamr-probes.js
@@ -1,6 +1,6 @@
 // tier: 2
 // HAMR substrate probes — S2 spike (#877). Non-destructive, fail-soft, 5s timeout.
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 const { execSync } = require('child_process')
 const fs = require('fs')
 const os = require('os')

--- a/scripts/global/hamr-probes.js
+++ b/scripts/global/hamr-probes.js
@@ -1,5 +1,6 @@
 // tier: 2
 // HAMR substrate probes — S2 spike (#877). Non-destructive, fail-soft, 5s timeout.
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 const { execSync } = require('child_process')
 const fs = require('fs')
 const os = require('os')

--- a/scripts/global/hydration-lint.js
+++ b/scripts/global/hydration-lint.js
@@ -61,9 +61,9 @@ function scanText(relPath, text, credAlt) {
 function jsFiles(dir, out = []) {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     if (e.name === 'node_modules' || e.name.startsWith('.')) continue;
-    const p = path.join(dir, e.name);
-    if (e.isDirectory()) jsFiles(p, out);
-    else if (e.name.endsWith('.js') && !e.name.endsWith('.spec.js')) out.push(p);
+    const entryPath = path.join(dir, e.name);
+    if (e.isDirectory()) jsFiles(entryPath, out);
+    else if (e.name.endsWith('.js') && !e.name.endsWith('.spec.js')) out.push(entryPath);
   }
   return out;
 }

--- a/scripts/global/hydration-lint.js
+++ b/scripts/global/hydration-lint.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+'use strict';
+// tier: 1
+// hydration-lint (#2771, Epic #2291): prevention-over-reaction gate for the env-hydration contract.
+// Fails on (R1) `require('dotenv')`/`import dotenv` outside the canonical shim; (R2) a JS file that
+// reads a credential `process.env.<CRED>` without referencing the hydration shim; (R3) a value-leak —
+// a console/logger/print call whose argument is a credential env read. Credential names = the default
+// suffix set plus a project-configurable list (config/credential-name-patterns.json). Pure logic +
+// CLI; the CLI scans `scripts/` so it runs in pre-push + CI (npm run hooks:pre-push) — capability-
+// independent enforcement (cf. #2356). Documented non-standalone fragments are exempt (G2, no FP).
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const SHIM_REL = 'scripts/global/load-local-env.js';
+// Non-standalone / definitional exemptions (the shim defines hydration; the availability + lint
+// modules reference credential names structurally; dashboard-api-handlers is a concatenated fragment
+// hydrated transitively by dashboard-server.js).
+const EXEMPT = new Set([
+  SHIM_REL,
+  'scripts/global/credential-availability.js',
+  'scripts/global/hydration-lint.js',
+  'scripts/dashboard-api-handlers.js',
+]);
+
+/**
+ * Build the credential-name regex source from the patterns config (default + project extra).
+ * @param {{default?:string[],extra?:string[]}} cfg @returns {string} a regex alternation fragment
+ */
+function credentialAlternation(cfg) {
+  const parts = [...(cfg.default || []), ...(cfg.extra || [])].map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  return parts.length ? `(?:${parts.join('|')})` : '(?:_API_KEY|_TOKEN|_SECRET|_KEY|PASSWORD)';
+}
+
+/**
+ * Scan one file's text for hydration-contract violations. Pure — no IO.
+ * @param {string} relPath @param {string} text @param {string} credAlt credential-name alternation
+ * @returns {Array<{rule:string,file:string,detail:string}>}
+ */
+function scanText(relPath, text, credAlt) {
+  const violations = [];
+  if (EXEMPT.has(relPath)) return violations;
+  const credRead = new RegExp(`process\\.env(?:\\.[A-Za-z_]*${credAlt}[A-Za-z_]*|\\[['"][A-Za-z_]*${credAlt}[A-Za-z_]*['"]\\])`);
+  // R1 — dotenv outside the shim
+  if (/require\(['"]dotenv['"]\)|^\s*import\s+.*\bdotenv\b/m.test(text)) {
+    violations.push({ rule: 'dotenv-outside-shim', file: relPath, detail: 'use loadLocalEnvOnce() from load-local-env.js, not dotenv directly' });
+  }
+  // R2 — credential read without hydration reference
+  if (credRead.test(text) && !/load-local-env|loadLocalEnv/.test(text)) {
+    violations.push({ rule: 'unhydrated-consumer', file: relPath, detail: 'reads a credential process.env.* but never calls loadLocalEnvOnce() — hydrate before reading' });
+  }
+  // R3 — value-leak: a log/print sink whose argument embeds a credential env read
+  const leak = new RegExp(`(?:console\\.[a-z]+|logger\\.[a-z]+|print)\\s*\\([^)]*${credRead.source}`);
+  if (leak.test(text)) {
+    violations.push({ rule: 'credential-value-leak', file: relPath, detail: 'a log/print sink embeds a credential env value — log names only (G4)' });
+  }
+  return violations;
+}
+
+/** Recursively collect `.js` files under a dir, skipping node_modules. @returns {string[]} abs paths */
+function jsFiles(dir, out = []) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.name === 'node_modules' || e.name.startsWith('.')) continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) jsFiles(p, out);
+    else if (e.name.endsWith('.js') && !e.name.endsWith('.spec.js')) out.push(p);
+  }
+  return out;
+}
+
+/** Lint the repo's `scripts/` tree. @returns {Array<{rule,file,detail}>} */
+function lintRepo(root = ROOT) {
+  let cfg = {};
+  try { cfg = JSON.parse(fs.readFileSync(path.join(root, 'config/credential-name-patterns.json'), 'utf8')); }
+  catch { cfg = {}; }
+  const credAlt = credentialAlternation(cfg);
+  const out = [];
+  for (const abs of jsFiles(path.join(root, 'scripts'))) {
+    const rel = path.relative(root, abs).split(path.sep).join('/');
+    out.push(...scanText(rel, fs.readFileSync(abs, 'utf8'), credAlt));
+  }
+  return out;
+}
+
+/**
+ * One-time collision-risk audit (#2771 AC8): list non-credential `process.env.X` reads whose name
+ * would become a credential match if a `*_KEY`/`*_TOKEN`/... sibling were later added. Advisory only —
+ * never gates. @returns {Array<{file:string,name:string}>}
+ */
+function auditCollisionRisk(root = ROOT) {
+  const out = [];
+  const readRe = /process\.env\.([A-Za-z_][A-Za-z0-9_]*)/g;
+  const credSuffix = /(_API_KEY|_TOKEN|_SECRET|_KEY|PASSWORD)$/;
+  for (const abs of jsFiles(path.join(root, 'scripts'))) {
+    const rel = path.relative(root, abs).split(path.sep).join('/');
+    const text = fs.readFileSync(abs, 'utf8');
+    let m;
+    while ((m = readRe.exec(text))) {
+      const name = m[1];
+      if (!credSuffix.test(name) && /(API|TOKEN|SECRET|AUTH|PASS|CRED)/i.test(name)) out.push({ file: rel, name });
+    }
+  }
+  return out;
+}
+
+module.exports = { scanText, credentialAlternation, lintRepo, auditCollisionRisk, EXEMPT };
+
+if (require.main === module) {
+  if (process.argv.includes('--audit')) {
+    const risks = auditCollisionRisk();
+    console.log(`hydration-lint audit: ${risks.length} collision-risk env name(s) (advisory, non-gating)`);
+    risks.forEach((r) => console.log(`  - ${r.file}: process.env.${r.name}`));
+    process.exit(0);
+  }
+  const findings = lintRepo();
+  if (process.argv.includes('--json')) { process.stdout.write(JSON.stringify(findings) + '\n'); }
+  if (findings.length) {
+    console.error(`hydration-lint: ${findings.length} violation(s):`);
+    findings.forEach((f) => console.error(`  - [${f.rule}] ${f.file}: ${f.detail}`));
+    process.exit(1);
+  }
+  console.log('hydration-lint: OK — all credential consumers hydrate; no dotenv-outside-shim; no value leaks');
+}

--- a/scripts/global/ide-proxy-quality-parity.js
+++ b/scripts/global/ide-proxy-quality-parity.js
@@ -2,7 +2,7 @@
 // ide-proxy-quality-parity.js — Epic #1020 AC: completion satisfaction parity.
 // Measures routed-lane vs baseline-lane response similarity for each corpus turn.
 // Default mode is DRY-RUN (canned responses) for $0 cost. Live mode opt-in.
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 'use strict';
 const path = require('node:path');
 const fs = require('node:fs');

--- a/scripts/global/ide-proxy-quality-parity.js
+++ b/scripts/global/ide-proxy-quality-parity.js
@@ -2,6 +2,7 @@
 // ide-proxy-quality-parity.js — Epic #1020 AC: completion satisfaction parity.
 // Measures routed-lane vs baseline-lane response similarity for each corpus turn.
 // Default mode is DRY-RUN (canned responses) for $0 cost. Live mode opt-in.
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 'use strict';
 const path = require('node:path');
 const fs = require('node:fs');

--- a/scripts/global/load-local-env.js
+++ b/scripts/global/load-local-env.js
@@ -84,6 +84,41 @@ function loadLocalEnvOnce() {
   return loadLocalEnv();
 }
 
-module.exports = { loadLocalEnv, loadLocalEnvOnce, parseEnv, hydrate, DEFAULT_ENV_PATH };
+/**
+ * Typed error for a declared-required credential that is absent after hydration (#2769 AC5).
+ * Carries the absent key names. Its presence signals fail-closed: callers MUST surface the
+ * absence (terminal entry / approved auth) and MUST NOT prompt the client for the raw secret (G1/G4).
+ */
+class CredentialAbsentError extends Error {
+  constructor(absent) {
+    super(`required credential(s) absent after hydration: [${absent.join(',')}] — `
+      + 'resolve via terminal entry or approved auth; never prompt the client (G1/G4)');
+    this.name = 'CredentialAbsentError';
+    this.absent = absent;
+    this.code = 'CREDENTIAL_ABSENT';
+  }
+}
+
+/**
+ * Hydrate (once) then assert that every declared-required key is present — fail-closed (#2769 AC5).
+ * Optional keys are NOT checked here; they degrade silently. Never prompts the client; on a missing
+ * required key it throws CredentialAbsentError (or returns the report when opts.throwOnAbsent===false).
+ * Shares the availability semantics of credential-availability.js#preCredentialPromptCheck without a
+ * circular dependency (this is the lower layer).
+ * @param {string|string[]} requiredKeys @param {{env?:object,throwOnAbsent?:boolean}} opts
+ * @returns {{ok:boolean, absent:string[]}}
+ */
+function requireKeys(requiredKeys, opts = {}) {
+  loadLocalEnvOnce();
+  const env = opts.env || process.env;
+  const names = Array.isArray(requiredKeys) ? requiredKeys : [requiredKeys];
+  const absent = names.filter((name) => env[name] === undefined || env[name] === '');
+  if (absent.length && opts.throwOnAbsent !== false) throw new CredentialAbsentError(absent);
+  return { ok: absent.length === 0, absent };
+}
+
+module.exports = {
+  loadLocalEnv, loadLocalEnvOnce, requireKeys, CredentialAbsentError, parseEnv, hydrate, DEFAULT_ENV_PATH,
+};
 
 if (require.main === module) loadLocalEnv();

--- a/scripts/global/mailbox-client.js
+++ b/scripts/global/mailbox-client.js
@@ -3,7 +3,7 @@
 // mailbox-client.js — operator-side R2 mailbox client (#918).
 // Per HAMR v3.2 §R2: signed Google A2A envelopes; reuses baton-signing.js (#894).
 'use strict';
-require('dotenv').config({ quiet: true });
+require('./load-local-env').loadLocalEnvOnce();
 const crypto = require('node:crypto');
 const baton = require('./baton-signing');
 

--- a/scripts/global/pre-push-gates.js
+++ b/scripts/global/pre-push-gates.js
@@ -13,6 +13,7 @@ const BYPASSED_GATES = [
   'npm run lint:py',
   'npm run lint:sh',
   'node scripts/global/megalint/index.js',
+  'node scripts/global/hydration-lint.js',
 ];
 
 function warnBypass(source) {

--- a/scripts/global/routing-refresh.js
+++ b/scripts/global/routing-refresh.js
@@ -7,7 +7,7 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
-require('dotenv').config({ path: path.join(__dirname, '..', '..', '.env'), quiet: true });
+require('./load-local-env').loadLocalEnvOnce();
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const SNAP = path.join(ROOT, '.dashboard', 'routing-snapshot.json');

--- a/scripts/global/substrate-health-push.js
+++ b/scripts/global/substrate-health-push.js
@@ -3,7 +3,7 @@
 // substrate-health-push.js — HAMR Wave 6 child 3 (#943).
 // Runs substrate-health.js (#911) locally; signs canonical JSON; POSTs to HAMR /substrate-health.
 'use strict';
-require('dotenv').config({ quiet: true });
+require('./load-local-env').loadLocalEnvOnce();
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');

--- a/scripts/global/substrate-health.js
+++ b/scripts/global/substrate-health.js
@@ -1,6 +1,7 @@
 // tier: 2
 // HAMR Wave 2 child 2: substrate-health probe (#911) — runtime tier sensor.
 // Per HAMR v3.2 §R7 + v3.2.1 §R9.3. Writes ~/.megingjord/substrate-health.json.
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 'use strict';
 const fs = require('node:fs');
 const path = require('node:path');

--- a/scripts/global/substrate-health.js
+++ b/scripts/global/substrate-health.js
@@ -1,7 +1,7 @@
 // tier: 2
 // HAMR Wave 2 child 2: substrate-health probe (#911) — runtime tier sensor.
 // Per HAMR v3.2 §R7 + v3.2.1 §R9.3. Writes ~/.megingjord/substrate-health.json.
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 'use strict';
 const fs = require('node:fs');
 const path = require('node:path');

--- a/scripts/global/ticket-reconcile.js
+++ b/scripts/global/ticket-reconcile.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 'use strict';
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 const fs = require('fs');
 const path = require('path');
 

--- a/scripts/global/ticket-reconcile.js
+++ b/scripts/global/ticket-reconcile.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 'use strict';
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 const fs = require('fs');
 const path = require('path');
 

--- a/scripts/global/token-telemetry-reconcile.js
+++ b/scripts/global/token-telemetry-reconcile.js
@@ -13,7 +13,7 @@ async function viaHamr(p, fn) {
   if (!HAMR?.wrapProviderCall || process.env.MEGINGJORD_HAMR_DISABLED === '1') return fn();
   const r = await HAMR.wrapProviderCall(p, fn, { tier: 'observability' }); return r.value ?? r; // #1160 canonical (alias: r.response)
 }
-function loadEnv() { try { require('dotenv').config({ path: path.join(__dirname, '..', '..', '.env') }); } catch {} }
+function loadEnv() { try { require('./load-local-env').loadLocalEnvOnce(); } catch {} }
 const EXACT = new Set(['exact_request', 'exact_aggregate']);
 function providerMeta(days) {
   const map = {};

--- a/scripts/global/wrangler-auth.js
+++ b/scripts/global/wrangler-auth.js
@@ -3,6 +3,7 @@
 // wrangler-auth.js — Isolated wrangler executor for D1 (#1564).
 // Sources CLOUDFLARE_API_TOKEN from .env into a child process only.
 // Token never appears in shell history or command-line arguments.
+require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 'use strict';
 const { spawnSync } = require('node:child_process');
 const path = require('node:path');

--- a/scripts/global/wrangler-auth.js
+++ b/scripts/global/wrangler-auth.js
@@ -3,7 +3,7 @@
 // wrangler-auth.js — Isolated wrangler executor for D1 (#1564).
 // Sources CLOUDFLARE_API_TOKEN from .env into a child process only.
 // Token never appears in shell history or command-line arguments.
-require('./load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 'use strict';
 const { spawnSync } = require('node:child_process');
 const path = require('node:path');

--- a/scripts/quota-probes.js
+++ b/scripts/quota-probes.js
@@ -1,6 +1,6 @@
 // Quota Probes — live API checks for Groq, Google AI Studio
 // Returns normalized quota data for dashboard consumption
-require('./global/load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('./global/load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 
 const https = require('https');
 

--- a/scripts/quota-probes.js
+++ b/scripts/quota-probes.js
@@ -1,5 +1,6 @@
 // Quota Probes — live API checks for Groq, Google AI Studio
 // Returns normalized quota data for dashboard consumption
+require('./global/load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 
 const https = require('https');
 

--- a/scripts/wiki/wiki-llm.js
+++ b/scripts/wiki/wiki-llm.js
@@ -1,6 +1,7 @@
 // scripts/wiki/wiki-llm.js — LLM integration for wiki operations
 // Fleet routing: OpenClaw (primary) → Groq → Cerebras (failover)
 // HAMR-wrap (#1082): callLLM wraps via hamr-provider-wrapper when available.
+require('../global/load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
 
 const HAMR = (() => { try { return require('../global/hamr-provider-wrapper'); } catch { return null; } })();
 const PROVIDER_TIER = { OpenClaw: 'fleet-fast', 'OpenClaw-Quality': 'fleet-quality',

--- a/scripts/wiki/wiki-llm.js
+++ b/scripts/wiki/wiki-llm.js
@@ -1,7 +1,7 @@
 // scripts/wiki/wiki-llm.js — LLM integration for wiki operations
 // Fleet routing: OpenClaw (primary) → Groq → Cerebras (failover)
 // HAMR-wrap (#1082): callLLM wraps via hamr-provider-wrapper when available.
-require('../global/load-local-env').loadLocalEnvOnce(); // #2769 hydrate .env before any credential read
+require('../global/load-local-env').loadLocalEnvOnce(); // hydrate .env before any credential read (canonical shim)
 
 const HAMR = (() => { try { return require('../global/hamr-provider-wrapper'); } catch { return null; } })();
 const PROVIDER_TIER = { OpenClaw: 'fleet-fast', 'OpenClaw-Quality': 'fleet-quality',

--- a/tests/hydration-lint.spec.js
+++ b/tests/hydration-lint.spec.js
@@ -1,0 +1,49 @@
+// #2771 — hydration-lint prevention gate: dotenv-outside-shim, unhydrated-consumer, value-leak,
+// plus the repo-wide assertion that the #2769 sweep left zero violations.
+const { test, expect } = require('@playwright/test');
+const { scanText, credentialAlternation, lintRepo } = require('../scripts/global/hydration-lint');
+
+const CRED = credentialAlternation({ default: ['_API_KEY', '_TOKEN', '_SECRET', '_KEY', 'PASSWORD'] });
+
+test('R1: flags require(dotenv) outside the shim', () => {
+  const v = scanText('scripts/x.js', "const x = require('dotenv').config();", CRED);
+  expect(v.some((f) => f.rule === 'dotenv-outside-shim')).toBe(true);
+});
+
+test('R2: flags a credential process.env read with no hydration reference', () => {
+  const v = scanText('scripts/x.js', 'const k = process.env.OPENAI_API_KEY;', CRED);
+  expect(v.some((f) => f.rule === 'unhydrated-consumer')).toBe(true);
+});
+
+test('R2: a credential read WITH loadLocalEnvOnce present is clean', () => {
+  const v = scanText('scripts/x.js',
+    "require('./load-local-env').loadLocalEnvOnce();\nconst k = process.env.OPENAI_API_KEY;", CRED);
+  expect(v.length).toBe(0);
+});
+
+test('R2: bracket-style credential access is also caught', () => {
+  const v = scanText('scripts/x.js', "const k = process.env['GITHUB_TOKEN'];", CRED);
+  expect(v.some((f) => f.rule === 'unhydrated-consumer')).toBe(true);
+});
+
+test('R3: flags a console call that embeds a credential value (value-leak)', () => {
+  const v = scanText('scripts/x.js',
+    "require('./load-local-env').loadLocalEnvOnce();\nconsole.log(process.env.ANTHROPIC_API_KEY);", CRED);
+  expect(v.some((f) => f.rule === 'credential-value-leak')).toBe(true);
+});
+
+test('no false positive: a non-credential env read is ignored', () => {
+  const v = scanText('scripts/x.js', 'const port = process.env.PORT;', CRED);
+  expect(v.length).toBe(0);
+});
+
+test('exemption: the shim itself and the dashboard fragment are not flagged', () => {
+  expect(scanText('scripts/global/load-local-env.js', "require('dotenv')", CRED).length).toBe(0);
+  expect(scanText('scripts/dashboard-api-handlers.js', 'const k = process.env.OPENROUTER_API_KEY;', CRED).length)
+    .toBe(0);
+});
+
+test('repo-wide: the #2769 sweep leaves zero hydration violations', () => {
+  const findings = lintRepo();
+  expect(findings, `expected clean repo, got: ${JSON.stringify(findings)}`).toEqual([]);
+});

--- a/tests/load-local-env-requirekeys.spec.js
+++ b/tests/load-local-env-requirekeys.spec.js
@@ -1,0 +1,67 @@
+// #2769 — requireKeys fail-closed + visibility + perf, on the canonical hydration shim.
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { requireKeys, CredentialAbsentError } = require('../scripts/global/load-local-env');
+
+function freshEnvProbe(envContents, readVar, extraEnv = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-'));
+  const envFile = path.join(dir, '.env');
+  fs.writeFileSync(envFile, envContents);
+  const shim = path.resolve(__dirname, '..', 'scripts/global/load-local-env.js');
+  return execFileSync(process.execPath, ['-e',
+    `require(${JSON.stringify(shim)}).loadLocalEnvOnce(); process.stdout.write(String(process.env.${readVar}))`],
+  { env: { MEGINGJORD_DOTENV_PATH: envFile, PATH: process.env.PATH, ...extraEnv }, encoding: 'utf8' });
+}
+
+test('requireKeys: a present key passes (ok, no absent)', () => {
+  process.env.__RK_PRESENT = 'v';
+  expect(requireKeys('__RK_PRESENT')).toEqual({ ok: true, absent: [] });
+});
+
+test('requireKeys: absent + throwOnAbsent:false reports without throwing (optional degrade)', () => {
+  const r = requireKeys('__RK_OPTIONAL_ABSENT', { throwOnAbsent: false });
+  expect(r.ok).toBe(false);
+  expect(r.absent).toEqual(['__RK_OPTIONAL_ABSENT']);
+});
+
+test('requireKeys: an absent REQUIRED key throws a typed fail-closed error, never prompts', () => {
+  let err;
+  try { requireKeys('__RK_REQUIRED_ABSENT'); } catch (e) { err = e; }
+  expect(err instanceof CredentialAbsentError).toBe(true);
+  expect(err.code).toBe('CREDENTIAL_ABSENT');
+  expect(err.absent).toEqual(['__RK_REQUIRED_ABSENT']);
+  expect(err.message).toMatch(/never prompt the client/);
+});
+
+test('requireKeys: an empty-string value counts as absent (fail-closed)', () => {
+  process.env.__RK_EMPTY = '';
+  expect(requireKeys('__RK_EMPTY', { throwOnAbsent: false }).ok).toBe(false);
+});
+
+test('integration: a fresh child process with EMPTY env resolves keys from .env (visible-where-intended)', () => {
+  expect(freshEnvProbe('RK_FROM_DOTENV=hello123\n', 'RK_FROM_DOTENV')).toBe('hello123');
+});
+
+test('integration: absent-where-not — a key NOT in .env stays undefined after hydration', () => {
+  expect(freshEnvProbe('RK_ONLY=1\n', 'RK_NEVER_DECLARED')).toBe('undefined');
+});
+
+test('integration: fill-don\'t-override — a real env value wins over .env', () => {
+  expect(freshEnvProbe('RK_OVERRIDE=from_dotenv\n', 'RK_OVERRIDE', { RK_OVERRIDE: 'from_real_env' }))
+    .toBe('from_real_env');
+});
+
+test('perf: one-shot hydration is well under the 10ms startup budget (#2769 AC6)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-'));
+  const envFile = path.join(dir, '.env');
+  fs.writeFileSync(envFile, Array.from({ length: 50 }, (_, i) => `RK_PERF_${i}=v${i}`).join('\n') + '\n');
+  delete require.cache[require.resolve('../scripts/global/load-local-env')];
+  const mod = require('../scripts/global/load-local-env');
+  const start = process.hrtime.bigint();
+  mod.loadLocalEnv({ path: envFile, env: {}, quiet: true });
+  const ms = Number(process.hrtime.bigint() - start) / 1e6;
+  expect(ms, `hydration took ${ms.toFixed(2)}ms, budget is <10ms`).toBeLessThan(10);
+});


### PR DESCRIPTION
## Summary

Epic #2291 Phase-1 — JS half of the canonical env-hydration contract. **Multi-close batch**: #2769 (sweep + shim) lead, #2771 (prevention lint + visibility regression) sibling. Shared JS-hydration surface + single test surface.

- **Sweep**: 16 credential consumers that read `process.env` without hydrating now call `loadLocalEnvOnce()`; 14 ad-hoc `require('dotenv')` loaders migrated to the shim. (`dashboard-api-handlers.js` — a concatenated fragment — exempt; hydrated transitively by `dashboard-server.js`.)
- **Fail-closed** `requireKeys()`: a declared-required key absent after hydration throws a typed `CredentialAbsentError` that never prompts the client (G1/G4) — closes the #2569 recurrence.
- **`hydration-lint`** (pre-push + CI): blocks future unhydrated consumers, `dotenv`-outside-shim, and credential value-leaks; project-configurable credential-name patterns; one-time collision audit.

## Tests (tdd-pyramid)
- `npx playwright test tests/load-local-env-requirekeys.spec.js tests/hydration-lint.spec.js` → **16 passed** (incl fresh-empty-env visibility boundary + <10ms perf).
- `node scripts/global/hydration-lint.js` → OK (0 violations, proves sweep complete); `npm run lint` → 416 files ≤100; megalint exit 0.

## Cross-family review
gemini-2.5-flash@google-ai-studio (free-cloud **G3** lane): **ACCEPT 9/10**, no real bug.

Refs #2769 #2771 #2291 #2292
merge-evidence-deferred-final: #2769
Closes #2771

Baton artifacts on #2769 (full set) + #2771 (batch brief evidence): MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
