### PR TITLE
feat(hooks): Python env-hydration parity shim #2770

### DIFF
--- a/.changes/unreleased/2770.md
+++ b/.changes/unreleased/2770.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Python env-hydration parity shim** (#2770, Epic #2291 Phase-1): `hooks/scripts/load_local_env.py`
+  mirrors the JS shim's 5-clause contract (fill-don't-override, names-only redaction, graceful,
+  `MEGINGJORD_NO_DOTENV` opt-out, `MEGINGJORD_DOTENV_PATH` relocate) plus a fail-closed `require_keys()`
+  that raises `CredentialAbsent` (never prompts the client). Closes the G9 cross-runtime gap — the
+  shim was JS-only. The two Python credential consumers (`merge_claim_client.py` GITHUB_TOKEN,
+  `fleet-claim-client.py` HAMR_DPOP_TOKEN) now hydrate before reading; the other Python hooks read
+  config flags (not secrets) and are unaffected.

--- a/hooks/scripts/load_local_env.py
+++ b/hooks/scripts/load_local_env.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Python parity of scripts/global/load-local-env.js (#2770, Epic #2291).
+
+Closes the G9 cross-runtime gap: the JS hydration shim was JS-only. This is the SAME
+5-clause contract for any Python credential consumer:
+  fill-don't-override (a real/CI env value always wins),
+  secret-safe (names-only audit, never values),
+  graceful (missing/malformed .env is a no-op, never raises),
+  opt-out via MEGINGJORD_NO_DOTENV=1,
+  relocate via MEGINGJORD_DOTENV_PATH.
+require_keys() adds the fail-closed assertion: a declared-required key absent after hydration
+raises CredentialAbsent (never prompt the client - G1/G4).
+"""
+import os
+import re
+
+# Repo root is two levels up from hooks/scripts/.
+DEFAULT_ENV_PATH = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", ".env"))
+_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_hydrated_once = False
+
+
+class CredentialAbsent(RuntimeError):
+    """A declared-required credential is absent after hydration (fail-closed). Carries .absent."""
+
+    def __init__(self, absent):
+        """Build the fail-closed error; `absent` is the list of missing required key names."""
+        super().__init__(
+            "required credential(s) absent after hydration: [%s] -- resolve via terminal "
+            "entry or approved auth; never prompt the client (G1/G4)" % ",".join(absent))
+        self.absent = absent
+        self.code = "CREDENTIAL_ABSENT"
+
+
+def parse_env(text):
+    """Parse .env text -> list[(name, value)]; skips blanks/comments/malformed; strips export + quotes."""
+    pairs = []
+    for raw in str(text).splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        body = line[7:].strip() if line.startswith("export ") else line
+        if "=" not in body:
+            continue
+        name, _, value = body.partition("=")
+        name, value = name.strip(), value.strip()
+        if not _IDENT.match(name):
+            continue
+        if len(value) >= 2 and ((value[0] == '"' and value[-1] == '"') or (value[0] == "'" and value[-1] == "'")):
+            value = value[1:-1]
+        pairs.append((name, value))
+    return pairs
+
+
+def load_local_env(env=None, path=None, quiet=False):
+    """Hydrate env from the repo-root .env. Fill-don't-override; never raises. Returns dict report."""
+    target = os.environ if env is None else env
+    if target.get("MEGINGJORD_NO_DOTENV") == "1":
+        return {"filled": [], "skipped": "disabled"}
+    env_path = path or target.get("MEGINGJORD_DOTENV_PATH") or DEFAULT_ENV_PATH
+    try:
+        with open(env_path, "r", encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError:
+        return {"filled": [], "skipped": "missing"}  # G5/G6: no file -> pass-through
+    try:
+        pairs = parse_env(text)
+    except Exception:
+        return {"filled": [], "skipped": "parse-error"}  # never raise into the consumer
+    filled = []
+    for name, value in pairs:
+        if name not in target:
+            target[name] = value
+            filled.append(name)
+    if filled and not quiet:
+        # NAMES only, never values (G4/G8).
+        import sys
+        sys.stderr.write("env-hydrate(py): filled=[%s] count=%d source=.env\n" % (",".join(filled), len(filled)))
+    return {"filled": filled, "skipped": None}
+
+
+def load_local_env_once():
+    """Idempotent once-per-process hydration of os.environ (hot paths)."""
+    global _hydrated_once
+    if _hydrated_once:
+        return {"filled": [], "skipped": "cached"}
+    _hydrated_once = True
+    return load_local_env()
+
+
+def require_keys(required, env=None, throw_on_absent=True):
+    """Hydrate once, then assert every declared-required key is present -- fail-closed (#2770).
+
+    Optional keys are not checked (degrade silently). Never prompts. Raises CredentialAbsent on a
+    missing required key unless throw_on_absent is False, in which case it returns the report.
+    """
+    load_local_env_once()
+    target = os.environ if env is None else env
+    names = [required] if isinstance(required, str) else list(required)
+    absent = [n for n in names if not target.get(n)]
+    if absent and throw_on_absent:
+        raise CredentialAbsent(absent)
+    return {"ok": not absent, "absent": absent}
+
+
+if __name__ == "__main__":
+    load_local_env()

--- a/hooks/scripts/merge_claim_client.py
+++ b/hooks/scripts/merge_claim_client.py
@@ -8,10 +8,18 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import urllib.error
 import urllib.parse
 import urllib.request
 from typing import Optional
+
+sys.path.insert(0, os.path.dirname(__file__))  # #2770 hydrate .env before any credential read
+try:
+    from load_local_env import load_local_env_once
+    load_local_env_once()
+except Exception:
+    pass  # graceful: hydration must never break the hook (G6)
 
 HAMR_BASE = os.environ.get("HAMR_BASE_URL", "https://hamr.chf3198.workers.dev")
 DEFAULT_TEAM = os.environ.get("HAMR_TEAM", "claude-code")

--- a/scripts/global/fleet-claim-client.py
+++ b/scripts/global/fleet-claim-client.py
@@ -1,7 +1,14 @@
 """HAMR fleet-claim client (#2525). Tier-1 GitHub-label fallback when HAMR disabled."""
 from __future__ import annotations
-import json, os, subprocess, urllib.error, urllib.request
+import json, os, subprocess, sys, urllib.error, urllib.request
 from typing import Optional
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "hooks", "scripts"))
+try:  # #2770 hydrate .env before any credential read (parity shim lives in hooks/scripts)
+    from load_local_env import load_local_env_once
+    load_local_env_once()
+except Exception:
+    pass  # graceful: hydration must never break the client (G6)
 
 HAMR_BASE = os.environ.get("HAMR_BASE_URL", "https://hamr.chf3198.workers.dev")
 DEFAULT_TEAM = os.environ.get("HAMR_TEAM", "claude-code")

--- a/tests/hooks/test_load_local_env.py
+++ b/tests/hooks/test_load_local_env.py
@@ -1,0 +1,78 @@
+"""#2770 - Python parity of the env-hydration shim: 5-clause contract + fail-closed require_keys."""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HOOKS = os.path.join(os.path.dirname(__file__), "..", "..", "hooks", "scripts")
+sys.path.insert(0, os.path.abspath(HOOKS))
+
+import load_local_env as lle  # noqa: E402
+
+
+class ParseEnv(unittest.TestCase):
+    def test_parses_skips_comments_blanks_and_strips_export_quotes(self):
+        pairs = dict(lle.parse_env('# c\n\nexport A=1\nB="two"\nC=\'three\'\n=bad\nD\n'))
+        self.assertEqual(pairs, {"A": "1", "B": "two", "C": "three"})
+
+
+class Hydrate(unittest.TestCase):
+    def test_fill_dont_override(self):
+        env = {"KEEP": "real"}
+        with tempfile.NamedTemporaryFile("w", suffix=".env", delete=False) as fh:
+            fh.write("KEEP=from_dotenv\nNEW=v\n")
+            path = fh.name
+        lle.load_local_env(env=env, path=path, quiet=True)
+        self.assertEqual(env["KEEP"], "real")   # real value wins
+        self.assertEqual(env["NEW"], "v")        # absent key filled
+
+    def test_graceful_on_missing_file(self):
+        self.assertEqual(lle.load_local_env(env={}, path="/no/such/.env", quiet=True)["skipped"], "missing")
+
+    def test_opt_out_env_flag(self):
+        self.assertEqual(lle.load_local_env(env={"MEGINGJORD_NO_DOTENV": "1"}, quiet=True)["skipped"], "disabled")
+
+    def test_relocate_via_env_var(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".env", delete=False) as fh:
+            fh.write("RELOC=yes\n")
+            path = fh.name
+        env = {"MEGINGJORD_DOTENV_PATH": path}
+        lle.load_local_env(env=env, quiet=True)
+        self.assertEqual(env["RELOC"], "yes")
+
+
+class RequireKeys(unittest.TestCase):
+    def test_present_key_ok(self):
+        self.assertEqual(lle.require_keys("X", env={"X": "1"}), {"ok": True, "absent": []})
+
+    def test_absent_optional_reports_without_raising(self):
+        self.assertEqual(lle.require_keys("Y", env={}, throw_on_absent=False), {"ok": False, "absent": ["Y"]})
+
+    def test_absent_required_raises_failclosed_never_prompts(self):
+        with self.assertRaises(lle.CredentialAbsent) as ctx:
+            lle.require_keys("Z", env={})
+        self.assertEqual(ctx.exception.code, "CREDENTIAL_ABSENT")
+        self.assertEqual(ctx.exception.absent, ["Z"])
+        self.assertIn("never prompt the client", str(ctx.exception))
+
+    def test_empty_string_counts_as_absent(self):
+        self.assertFalse(lle.require_keys("E", env={"E": ""}, throw_on_absent=False)["ok"])
+
+
+class FreshProcessVisibility(unittest.TestCase):
+    def test_fresh_empty_env_resolves_from_dotenv_and_absent_stays_absent(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".env", delete=False) as fh:
+            fh.write("PY_FROM_DOTENV=hi\n")
+            path = fh.name
+        code = ("import os,sys; sys.path.insert(0, os.path.abspath(%r)); import load_local_env as l; "
+                "l.load_local_env_once(); "
+                "print(os.environ.get('PY_FROM_DOTENV'), os.environ.get('PY_NEVER'))" % os.path.abspath(HOOKS))
+        out = subprocess.check_output([sys.executable, "-c", code],
+                                      env={"MEGINGJORD_DOTENV_PATH": path, "PATH": os.environ.get("PATH", "")},
+                                      text=True).strip()
+        self.assertEqual(out, "hi None")  # visible-where-intended, absent-where-not
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/load-local-env-py-2770.spec.js
+++ b/tests/load-local-env-py-2770.spec.js
@@ -1,0 +1,18 @@
+// #2770 - JS harness running the Python parity-shim unittest suite under the CI runner.
+// The implementation under test is hooks/scripts/load_local_env.py; assertions live in unittest.
+'use strict';
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+test('load_local_env.py parity-shim Python suite passes (#2770)', () => {
+  const root = path.resolve(__dirname, '..');
+  let out = '';
+  try {
+    out = execFileSync('python3', ['-m', 'unittest', 'tests.hooks.test_load_local_env'],
+      { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (err) {
+    throw new Error(`Python unittest suite failed:\n${err.stdout || ''}\n${err.stderr || ''}`);
+  }
+  expect(typeof out).toBe('string');
+});


### PR DESCRIPTION
## Summary

Epic #2291 Phase-1 — Python parity of the env-hydration contract (#2770). Closes the **G9** cross-runtime gap (the shim was JS-only).

- `hooks/scripts/load_local_env.py`: the same 5-clause contract (fill-don't-override, names-only redaction, graceful-never-raise, `MEGINGJORD_NO_DOTENV` opt-out, `MEGINGJORD_DOTENV_PATH` relocate) + fail-closed `require_keys()` raising `CredentialAbsent` (never prompts the client — G1/G4).
- Wired the **2** real Python credential consumers (`merge_claim_client.py` GITHUB_TOKEN, `fleet-claim-client.py` HAMR_DPOP_TOKEN) to hydrate before reading. The other 16 hooks read config flags (not secrets) — correctly out of scope.

## Tests (tdd-pyramid)
- `python3 -m unittest tests.hooks.test_load_local_env` → **10 passed** (incl fresh-empty-env subprocess visibility boundary).
- `npx playwright test tests/load-local-env-py-2770.spec.js` → 1 passed (CI-harness wrapper).
- ruff clean on new files.

## Cross-family review
gemini-2.5-flash@google-ai-studio (free-cloud **G3** lane): **ACCEPT 10/10**, no real bug.

## Note
This surfaced a pre-existing latent #2739 defect (pretool_guard fleet-bypass incident silently never written — missing module-level `import os`); filed as **#2782**, not bundled here.

Refs #2770 #2291 #2292
merge-evidence-deferred-final: #2770

Baton artifacts on #2770: MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
