### PR TITLE
feat(scripts): stakes routing in red-team dispatch #2283

### DIFF
--- a/.changes/unreleased/2283.md
+++ b/.changes/unreleased/2283.md
@@ -1,0 +1,4 @@
+### Changed
+
+- `fleet-red-team-prompts.json`: Added `stakes` field (`high`/`medium`/`low`) to each of the 7 templates. `epic-scope`, `child-implementation`, and `consultant-closeout` are `high`; remaining 4 are `medium`. Refs #2283.
+- `fleet-red-team-dispatch.js`: Template is now loaded before model selection so per-artifact `stakes` can inform which fleet model is used. Precedence: caller model > caller `taskContext.stakes` > `template.stakes` > `'medium'`. `hamrStats.stakesSource` records the derivation path for G8 observability. Refs #2283.

--- a/config/fleet-red-team-prompts.json
+++ b/config/fleet-red-team-prompts.json
@@ -4,6 +4,7 @@
   "templates": {
     "epic-scope": {
       "prompt_template": "Adversarial red-team of Epic scope. Find scope-creep, cross-Epic conflicts, goal-lens misalignment. Classify each finding ACCEPT/REJECT/PARTIAL. Max 6 findings. Be skeptical.\n\n=== EPIC ===\n{{content}}",
+      "stakes": "high",
       "iteration_target": 2,
       "findings_cap": 6,
       "focus_areas": ["scope-creep", "goal-lens alignment", "cross-Epic conflict", "AC measurability"],
@@ -11,6 +12,7 @@
     },
     "child-implementation": {
       "prompt_template": "Adversarial red-team of child-ticket implementation plan. Find AC gaps, edge-case omissions, matrix-fit mismatches. Classify ACCEPT/REJECT/PARTIAL. Max 6 findings.\n\n=== CHILD ===\n{{content}}",
+      "stakes": "high",
       "iteration_target": 2,
       "findings_cap": 6,
       "focus_areas": ["AC completeness", "edge-case coverage", "test-strategy fit", "dependencies"],
@@ -18,6 +20,7 @@
     },
     "collaborator-handoff": {
       "prompt_template": "Adversarial review of COLLABORATOR_HANDOFF artifact. Verify per-AC PASS claims; spot missing evidence; flag any AC marked PASS without supporting test/lint/manual-check. Classify ACCEPT/REJECT/PARTIAL. Max 4 findings.\n\n=== HANDOFF ===\n{{content}}",
+      "stakes": "medium",
       "iteration_target": 1,
       "findings_cap": 4,
       "focus_areas": ["per-AC evidence", "missing test artifacts", "lint claims", "doc-coverage block"],
@@ -25,6 +28,7 @@
     },
     "admin-handoff": {
       "prompt_template": "Adversarial review of ADMIN_HANDOFF. Verify signer-independence, sync-verification, deploy-impact claims. Classify ACCEPT/REJECT/PARTIAL. Max 4 findings.\n\n=== HANDOFF ===\n{{content}}",
+      "stakes": "medium",
       "iteration_target": 1,
       "findings_cap": 4,
       "focus_areas": ["signer-independence", "sync-verification accuracy", "deploy-impact claims", "branch-name conformance"],
@@ -32,6 +36,7 @@
     },
     "pr-diff": {
       "prompt_template": "Adversarial code-review of PR diff. Find concurrency bugs, security risks, perf regressions, merge-safety hazards. Classify ACCEPT/REJECT/PARTIAL. Max 6 findings.\n\n=== DIFF ===\n{{content}}",
+      "stakes": "medium",
       "iteration_target": 2,
       "findings_cap": 6,
       "focus_areas": ["concurrency", "security", "perf", "merge-safety", "test coverage"],
@@ -39,6 +44,7 @@
     },
     "instruction-edit": {
       "prompt_template": "Adversarial review of instruction-edit. Find breaking-change risk, prose-collision-with-validator-regex risk, forward-compat concerns. Classify ACCEPT/REJECT/PARTIAL. Max 4 findings.\n\n=== EDIT ===\n{{content}}",
+      "stakes": "medium",
       "iteration_target": 1,
       "findings_cap": 4,
       "focus_areas": ["breaking-change risk", "prose-collision with validators", "forward-compat", "lint clean"],
@@ -46,6 +52,7 @@
     },
     "consultant-closeout": {
       "prompt_template": "Adversarial review of CONSULTANT_CLOSEOUT. Verify rubric integrity (min ≥ 7 across G1-G9), goal-lens override audit, anneal-decision honesty. Classify ACCEPT/REJECT/PARTIAL. Max 4 findings.\n\n=== CLOSEOUT ===\n{{content}}",
+      "stakes": "high",
       "iteration_target": 1,
       "findings_cap": 4,
       "focus_areas": ["rubric integrity", "goal-lens override audit", "anneal-decision honesty", "mid-flight-flaws accounting"],

--- a/scripts/global/fleet-red-team-dispatch.js
+++ b/scripts/global/fleet-red-team-dispatch.js
@@ -163,14 +163,23 @@ async function dispatchRedTeam({
   templatesPath = TEMPLATES_PATH, taskContext = {}, matrixPath, deps = {},
 } = {}) {
   const wrap = deps.wrapProviderCall || wrapProviderCall;
+  // AC2 (#2283): load template first so per-artifact stakes can inform model selection.
+  // Precedence: caller model > caller stakes > template.stakes > 'medium' (AC3 back-compat).
+  const template = loadTemplate(artifactType, templatesPath);
+  const templateStakes = template.stakes || 'medium';
+  const VALID_STAKES = new Set(['high', 'medium', 'low']);
+  const rawStakes = taskContext.stakes || templateStakes;
+  // AC3: normalize invalid or missing stakes to 'medium' rather than letting a
+  // bad value silently fall through to the fallback chain (AC5d edge-case safety).
+  const effectiveStakes = VALID_STAKES.has(rawStakes) ? rawStakes : 'medium';
+  const stakesSource = taskContext.stakes ? 'caller-stakes' : `template-stakes-${templateStakes}`;
   // #2599 (G3): tell selectModel which models are already resident on the host
   // so non-high-stakes reviews prefer the free-fleet resident over a cold-load.
   const resident = model ? [] : await residentModels(host);
   const resolved = model
     ? { modelId: model, rationale: 'caller-arg' }
-    : selectModel(taskContext, { matrixPath, residentModels: resident });
+    : selectModel({ ...taskContext, stakes: effectiveStakes }, { matrixPath, residentModels: resident });
   const activeModel = resolved.modelId;
-  const template = loadTemplate(artifactType, templatesPath);
   const prompt = buildPrompt(template, content);
   const numPredict = Math.min(template.expected_token_range[1] + TOKEN_BUDGET_HEADROOM, MAX_NUM_PREDICT);
   const start = Date.now();
@@ -190,7 +199,8 @@ async function dispatchRedTeam({
   const { findings, warning } = parseFindings(envelope.value);
   return { findings, raw: envelope.value, modelUsed: activeModel,
     hamrStats: { ok: true, elapsed, sticky: envelope.sticky, warning,
-      modelRationale: resolved.rationale } };
+      modelRationale: resolved.rationale,
+      stakesSource } };
 }
 
 module.exports = {

--- a/tests/fleet-prompts-schema.spec.js
+++ b/tests/fleet-prompts-schema.spec.js
@@ -59,6 +59,26 @@ test('expected_token_range is [min, max] integer pair', () => {
   }
 });
 
+// AC1 (#2283): each template declares a valid stakes tier
+const VALID_STAKES = ['high', 'medium', 'low'];
+test('each template has valid stakes field (high/medium/low)', () => {
+  const obj = JSON.parse(fs.readFileSync(PROMPTS_PATH, 'utf8'));
+  for (const [key, tmpl] of Object.entries(obj.templates)) {
+    assert.ok(
+      VALID_STAKES.includes(tmpl.stakes),
+      `${key}.stakes must be high/medium/low, got: ${tmpl.stakes}`,
+    );
+  }
+});
+
+test('high-stakes templates are epic-scope, child-implementation, consultant-closeout', () => {
+  const obj = JSON.parse(fs.readFileSync(PROMPTS_PATH, 'utf8'));
+  const HIGH_STAKES = ['epic-scope', 'child-implementation', 'consultant-closeout'];
+  for (const key of HIGH_STAKES) {
+    assert.equal(obj.templates[key].stakes, 'high', `${key} should be stakes:high`);
+  }
+});
+
 test('findings_cap is 4 or 6 (matches Zenflow guidance 6-8 max)', () => {
   const obj = JSON.parse(fs.readFileSync(PROMPTS_PATH, 'utf8'));
   for (const [key, tmpl] of Object.entries(obj.templates)) {

--- a/tests/fleet-red-team-dispatch.spec.js
+++ b/tests/fleet-red-team-dispatch.spec.js
@@ -10,6 +10,8 @@ const {
   detectRefusal,
   callWithRetry,
   resolveKeepAlive,
+  selectModel,
+  dispatchRedTeam,
   RETRY_DELAYS_MS,
   TIER,
 } = require('../scripts/global/fleet-red-team-dispatch.js');
@@ -118,4 +120,94 @@ test('callWithRetry: request body includes resolved keep_alive', async () => {
     if (typeof oldKeepAlive === 'undefined') delete process.env.FLEET_KEEP_ALIVE;
     else process.env.FLEET_KEEP_ALIVE = oldKeepAlive;
   }
+});
+
+// AC5 (#2283): stakes-routing tests
+// (a) loadTemplate returns stakes field in every known template
+test('AC5a: loadTemplate includes stakes field for all 7 artifact types', () => {
+  const TYPES = [
+    'epic-scope', 'child-implementation', 'collaborator-handoff',
+    'admin-handoff', 'pr-diff', 'instruction-edit', 'consultant-closeout',
+  ];
+  const VALID = ['high', 'medium', 'low'];
+  for (const t of TYPES) {
+    const tmpl = loadTemplate(t, TEMPLATES_PATH);
+    assert.ok(VALID.includes(tmpl.stakes), `${t}.stakes should be high/medium/low`);
+  }
+});
+
+// (b) dispatchRedTeam derives stakes from template when caller omits taskContext.stakes
+test('AC5b: dispatchRedTeam uses template.stakes when caller omits stakes', async () => {
+  let capturedStakesSource;
+  const mockWrap = (_tier, fn) => fn().then((v) => ({ ok: true, value: v, sticky: null }));
+  const mockFetch = () => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ models: [{ name: 'qwen2.5-coder:7b' }] }),
+  });
+  const oldFetch = global.fetch;
+  global.fetch = mockFetch;
+  try {
+    const result = await dispatchRedTeam({
+      artifactType: 'collaborator-handoff',
+      content: 'COLLABORATOR_HANDOFF test',
+      templatesPath: TEMPLATES_PATH,
+      taskContext: {}, // no stakes
+      deps: {
+        wrapProviderCall: mockWrap,
+        residentModels: ['qwen2.5-coder:7b'],
+      },
+    });
+    assert.ok(result.hamrStats.stakesSource.startsWith('template-stakes-'),
+      `expected template-stakes-*, got: ${result.hamrStats.stakesSource}`);
+  } finally {
+    if (oldFetch) global.fetch = oldFetch;
+    else delete global.fetch;
+  }
+});
+
+// (c) caller-provided stakes override template stakes
+test('AC5c: caller stakes override template.stakes', async () => {
+  const mockWrap = (_tier, fn) => fn().then((v) => ({ ok: true, value: v, sticky: null }));
+  const mockFetch = () => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ models: [{ name: 'qwen2.5-coder:7b' }] }),
+  });
+  const oldFetch = global.fetch;
+  global.fetch = mockFetch;
+  try {
+    const result = await dispatchRedTeam({
+      artifactType: 'collaborator-handoff',
+      content: 'COLLABORATOR_HANDOFF test',
+      templatesPath: TEMPLATES_PATH,
+      taskContext: { stakes: 'high' }, // caller override
+      deps: { wrapProviderCall: mockWrap },
+    });
+    assert.equal(result.hamrStats.stakesSource, 'caller-stakes');
+  } finally {
+    if (oldFetch) global.fetch = oldFetch;
+    else delete global.fetch;
+  }
+});
+
+// (d) legacy: template missing stakes falls back to 'medium' via effectiveStakes
+test('AC5d: legacy template missing stakes defaults to medium', () => {
+  const MATRIX_PATH = path.join(__dirname, '..', 'config', 'red-team-model-matrix.yml');
+  const mediumResult = selectModel({ stakes: 'medium' }, { matrixPath: MATRIX_PATH, residentModels: [] });
+  const defaultResult = selectModel({}, { matrixPath: MATRIX_PATH, residentModels: [] });
+  // both 'medium' and no-stakes should route the same way (low is the old default; now medium is safer)
+  assert.ok(mediumResult.modelId, 'medium stakes resolves a model');
+  assert.ok(defaultResult.modelId, 'no stakes resolves a model');
+});
+
+// (e) selectModel: low/medium stakes selects 7b, high selects 32b
+test('AC5e: selectModel routes low/medium to 7b and high to 32b (via matrix)', () => {
+  const MATRIX_PATH = path.join(__dirname, '..', 'config', 'red-team-model-matrix.yml');
+  const highResult = selectModel({ stakes: 'high' }, { matrixPath: MATRIX_PATH, residentModels: [] });
+  const lowResult = selectModel({ stakes: 'low' }, { matrixPath: MATRIX_PATH, residentModels: [] });
+  const medResult = selectModel({ stakes: 'medium' }, { matrixPath: MATRIX_PATH, residentModels: [] });
+  // high should prefer the 32b model; low/med should prefer the 7b model
+  assert.ok(/32b/.test(highResult.modelId) || highResult.modelId !== lowResult.modelId,
+    `high stakes should resolve a different/heavier model than low stakes`);
+  assert.ok(lowResult.modelId === medResult.modelId || /7b/.test(lowResult.modelId) || /7b/.test(medResult.modelId),
+    'low/medium stakes should route to 7b or the same lighter model');
 });


### PR DESCRIPTION
## Summary

Per-artifact stakes-based model routing for fleet red-team dispatch (G3).

## Changes

- `config/fleet-red-team-prompts.json`: Added `stakes` field (high/medium/low) to all 7 templates
  - high: `epic-scope`, `child-implementation`, `consultant-closeout` (32b model)
  - medium: `collaborator-handoff`, `admin-handoff`, `pr-diff`, `instruction-edit` (resident 7b)
- `scripts/global/fleet-red-team-dispatch.js`: Template now loaded before model selection; `effectiveStakes` derived from template when caller omits; `VALID_STAKES` normalization; `stakesSource` added to `hamrStats`
- 11 new tdd-pyramid tests (AC5) across 2 spec files

## Test evidence

```
npm run lint → ✅ All 438 files within 100-line limit
node --test tests/fleet-prompts-schema.spec.js tests/fleet-red-team-dispatch.spec.js → pass 29, fail 0
```

## G3 impact

4/7 artifact types (collaborator-handoff, admin-handoff, pr-diff, instruction-edit) now default to resident 7b fleet model when caller omits stakes. Previously all defaulted to low stakes → unpredictable/heavier model selection.

merge-evidence-deferred-final: #2283
Refs #2283