### PR TITLE
feat(scripts): fleet context-preamble renderer (P1-0 slice 2)

### DIFF
--- a/.changes/unreleased/2802-render.md
+++ b/.changes/unreleased/2802-render.md
@@ -1,6 +1,0 @@
-### feat(scripts): context-preamble renderer — P1-0 slice 2 #2802
-
-- Adds `scripts/global/fleet-context-render.js` (Epic #2791 P1-0, D12/D15):
-  renders an assembled context bundle into a token-bounded prompt preamble
-  (priority ticket > repo-map > wiki; flags truncation). Pairs with slice 1.
-  7 tests. Dogfood-reviewed (groq-llama-70b 92/ACCEPT; applied its finding).

--- a/.changes/unreleased/2802-render.md
+++ b/.changes/unreleased/2802-render.md
@@ -1,0 +1,6 @@
+### feat(scripts): context-preamble renderer — P1-0 slice 2 #2802
+
+- Adds `scripts/global/fleet-context-render.js` (Epic #2791 P1-0, D12/D15):
+  renders an assembled context bundle into a token-bounded prompt preamble
+  (priority ticket > repo-map > wiki; flags truncation). Pairs with slice 1.
+  7 tests. Dogfood-reviewed (groq-llama-70b 92/ACCEPT; applied its finding).

--- a/.changes/unreleased/2802.md
+++ b/.changes/unreleased/2802.md
@@ -4,3 +4,9 @@
   assembles a fleet model's context from the live ticket (work-log), a
   lightweight repo-map, and wiki hits, plus a delta-fetch manifest. The substrate
   that gives fleet models rich context for development + review. 7 tests.
+
+### feat(scripts): context-preamble renderer — P1-0 slice 2 #2802
+
+- Adds `scripts/global/fleet-context-render.js` (D12/D15): renders an assembled
+  bundle into a token-bounded prompt preamble (priority ticket>repo-map>wiki).
+  Dogfood-reviewed (groq 92/ACCEPT; applied its CLIP_MARKER finding). 7 tests.

--- a/scripts/global/fleet-context-render.js
+++ b/scripts/global/fleet-context-render.js
@@ -1,0 +1,53 @@
+// Renders an assembled fleet context bundle (#2802 slice 2; design D12/D15) into a token-bounded
+// text preamble — "the most information possible" within a budget. Pairs with assembleContextBundle
+// (slice 1). Truncation priority: ticket > repo-map > wiki (drop lowest-priority first). Pure (no IO).
+const DEFAULT_MAX_CHARS = 4000;
+
+function renderTicket(ticket) {
+  if (!ticket || ticket.available === false) return '';
+  const recent = (ticket.comments || []).slice(-3).join('\n---\n');
+  return `=== TICKET #${ticket.number}: ${ticket.title || ''} ===\n${(ticket.body || '').trim()}`
+    + (recent ? `\n--- recent comments ---\n${recent}` : '');
+}
+
+function renderRepoMap(repoMap) {
+  return (repoMap || [])
+    .filter((entry) => entry.available !== false && (entry.symbols || []).length)
+    .map((entry) => `# ${entry.path}\n${entry.symbols.join('\n')}`).join('\n\n');
+}
+
+function renderWiki(wiki) {
+  return (wiki || []).length ? `=== WIKI ===\n${wiki.join('\n')}` : '';
+}
+
+const CLIP_MARKER = '\n…[clipped]';
+
+function clip(text, max) {
+  return text.length <= max ? text
+    : text.slice(0, Math.max(0, max - CLIP_MARKER.length)) + CLIP_MARKER;
+}
+
+// renderContextPreamble(bundle, {maxChars}) -> { preamble, included, truncated }.
+// Fills sections in priority order up to maxChars; flags truncation; never throws on a sparse bundle.
+function renderContextPreamble(bundle = {}, opts = {}) {
+  const maxChars = opts.maxChars || DEFAULT_MAX_CHARS;
+  const sections = [
+    ['ticket', renderTicket(bundle.ticket)],
+    ['repoMap', renderRepoMap(bundle.repoMap)],
+    ['wiki', renderWiki(bundle.wiki)],
+  ].filter(([, text]) => text);
+  const parts = [];
+  let used = 0;
+  let truncated = false;
+  for (const [, text] of sections) {
+    const remaining = maxChars - used;
+    if (remaining <= 0) { truncated = true; break; }
+    const piece = clip(text, remaining);
+    if (piece.length < text.length) truncated = true;
+    parts.push(piece);
+    used += piece.length + 2;
+  }
+  return { preamble: parts.join('\n\n'), included: sections.slice(0, parts.length).map(([name]) => name), truncated };
+}
+
+module.exports = { renderContextPreamble, renderTicket, renderRepoMap, renderWiki, DEFAULT_MAX_CHARS };

--- a/tests/fleet-context-render.spec.js
+++ b/tests/fleet-context-render.spec.js
@@ -1,0 +1,54 @@
+// Refs #2802 P1-0 slice 2 — context-preamble renderer (D12/D15). Pure-function tests.
+const { test, expect } = require('@playwright/test');
+const {
+  renderContextPreamble, renderTicket, renderRepoMap, renderWiki,
+} = require('../scripts/global/fleet-context-render.js');
+
+const BUNDLE = {
+  ticket: { number: 2802, title: 'access layer', body: 'build it', comments: ['c1', 'c2'], available: true },
+  repoMap: [{ path: 'a.js', symbols: ['function foo', 'class Bar'], available: true }],
+  wiki: ['wiki-hit-1'],
+};
+
+test('#2802 renderTicket includes number, title, body, recent comments', () => {
+  const out = renderTicket(BUNDLE.ticket);
+  expect(out).toContain('TICKET #2802: access layer');
+  expect(out).toContain('build it');
+  expect(out).toContain('c2');
+});
+
+test('#2802 renderTicket on unavailable ticket returns empty', () => {
+  expect(renderTicket({ available: false })).toBe('');
+  expect(renderTicket(null)).toBe('');
+});
+
+test('#2802 renderRepoMap lists path + symbols, skips unavailable/empty', () => {
+  expect(renderRepoMap(BUNDLE.repoMap)).toContain('# a.js');
+  expect(renderRepoMap(BUNDLE.repoMap)).toContain('class Bar');
+  expect(renderRepoMap([{ path: 'x', available: false }])).toBe('');
+});
+
+test('#2802 renderContextPreamble assembles all sections in priority order', () => {
+  const { preamble, included, truncated } = renderContextPreamble(BUNDLE);
+  expect(included).toEqual(['ticket', 'repoMap', 'wiki']);
+  expect(truncated).toBe(false);
+  expect(preamble.indexOf('TICKET')).toBeLessThan(preamble.indexOf('a.js')); // ticket before repo-map
+  expect(preamble.indexOf('a.js')).toBeLessThan(preamble.indexOf('WIKI')); // repo-map before wiki
+});
+
+test('#2802 renderContextPreamble respects maxChars budget + flags truncation', () => {
+  const { preamble, truncated } = renderContextPreamble(BUNDLE, { maxChars: 40 });
+  expect(preamble.length).toBeLessThanOrEqual(60); // budget + clip marker
+  expect(truncated).toBe(true);
+});
+
+test('#2802 renderContextPreamble drops lowest-priority sections first under tight budget', () => {
+  // budget fits ticket only → wiki/repoMap dropped
+  const { included } = renderContextPreamble(BUNDLE, { maxChars: 50 });
+  expect(included).toContain('ticket');
+  expect(included).not.toContain('wiki');
+});
+
+test('#2802 renderContextPreamble on empty bundle is safe', () => {
+  expect(renderContextPreamble({})).toEqual({ preamble: '', included: [], truncated: false });
+});


### PR DESCRIPTION
Refs #2802
merge-evidence-deferred-final: #2802

## P1-0 slice 2 of Epic #2791
`fleet-context-render.js` (design D12/D15): renders an assembled context bundle (slice 1) into a token-bounded prompt preamble — priority ticket > repo-map > wiki, truncation-flagged. The piece that delivers 'the most information possible' to a fleet model within a budget.

## Full dogfood loop now working
slice1 (assemble) → slice2 (render) → fed to a fleet reviewer that reviewed slice 2 → **92/ACCEPT**, and I applied its finding (extracted CLIP_MARKER constant). 7/7 tests.

#2802 stays OPEN (deferred-final) for further slices (dispatch integration, sandbox exec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)