### PR TITLE
feat(dashboard): VS Code Webview transport bridge + HOST_ENV vscode detection

### DIFF
--- a/.changes/unreleased/2816.md
+++ b/.changes/unreleased/2816.md
@@ -1,0 +1,12 @@
+### Added
+
+- `vscode-transport.js` — VS Code Webview postMessage bridge; acquires the VS Code API handle and overrides `connectSSE()` with `window.addEventListener('message')` when `HOST_ENV === 'vscode'`
+- `window.vsCodeRequest(type, payload)` helper for extension-host data requests
+
+### Changed
+
+- `transport.js` — detects `vscode` mode via `typeof acquireVsCodeApi !== 'undefined'`; `HOST_ENV` is now one of `demo | vscode | local`
+- `event-source.js` — routes to `connectSSEVscode()` when `HOST_ENV === 'vscode'`
+- `index.html` — loads `vscode-transport.js` between `transport.js` and all other scripts
+
+Refs #2816 | Epic #2803

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -6,7 +6,7 @@
     <title>Megingjord — Fleet Operations Center</title>
     <link rel="stylesheet" href="css/app.css"><link rel="stylesheet" href="css/stats.css"><link rel="stylesheet" href="css/router.css"><link rel="stylesheet" href="css/config.css"><link rel="stylesheet" href="css/views.css"><link rel="stylesheet" href="css/topology.css"><link rel="stylesheet" href="css/anneal-queue.css"><link rel="stylesheet" href="css/goal-coverage.css"><link rel="stylesheet" href="css/hamr-panel.css"><link rel="stylesheet" href="css/merge-evidence.css"><link rel="stylesheet" href="css/context-flow-anim.css"><link rel="stylesheet" href="css/panel-anim.css">
     <link rel="stylesheet" href="css/baton.css"><link rel="stylesheet" href="css/ticket-log.css"><link rel="stylesheet" href="css/activity.css"><link rel="stylesheet" href="css/wiki.css"><link rel="stylesheet" href="css/wiki-metrics.css"><link rel="stylesheet" href="css/fleet-health.css"><link rel="stylesheet" href="css/governance.css"><link rel="stylesheet" href="css/context.css"><link rel="stylesheet" href="css/github.css"><link rel="stylesheet" href="css/settings.css"><link rel="stylesheet" href="css/agents.css"><link rel="stylesheet" href="css/demo.css">
-    <script src="js/transport.js"></script><script defer src="js/alpine.min.js"></script>
+    <script src="js/transport.js"></script><script src="js/vscode-transport.js"></script><script defer src="js/alpine.min.js"></script>
     <script src="js/health-check.js"></script><script src="js/quota-tracker.js"></script>
     <script src="js/device-monitor.js"></script><script src="js/router-tracker.js"></script>
     <script src="js/live-stats.js"></script><script src="js/quota-live.js"></script>

--- a/dashboard/js/event-source.js
+++ b/dashboard/js/event-source.js
@@ -12,6 +12,10 @@ function connectSSE(app) {
     if (window.fixtureRunner) window.fixtureRunner.start(app, localStorage.getItem('demo-scenario'));
     return;
   }
+  if (window.HOST_ENV === 'vscode') {
+    if (typeof window.connectSSEVscode === 'function') window.connectSSEVscode(app);
+    return;
+  }
   if (typeof EventSource === 'undefined') return startFallback(app);
   try { _eventSource = new EventSource(SSE_URL); } catch { return startFallback(app); }
 

--- a/dashboard/js/transport.js
+++ b/dashboard/js/transport.js
@@ -1,12 +1,15 @@
 // transport.js — environment detection
 // Must load BEFORE all other scripts. Sets window.IS_DEMO and window.HOST_ENV.
-// Function overrides (loadDevices, loadServices, etc.) are applied by
-// transport-mocks.js which loads AFTER all other scripts.
+// HOST_ENV: 'demo' (github.io or ?demo=1) | 'vscode' (acquireVsCodeApi present)
+//           | 'local' (default dev server)
+// Function overrides applied by transport-mocks.js (demo) / vscode-transport.js
 
 (function () {
   'use strict';
-  var params = new URLSearchParams(window.location.search);
-  window.IS_DEMO = window.location.hostname.includes('github.io')
+  const params = new URLSearchParams(window.location.search);
+  const isDemo = window.location.hostname.includes('github.io')
     || params.get('demo') === '1';
-  window.HOST_ENV = window.IS_DEMO ? 'demo' : 'local';
+  const isVscode = !isDemo && typeof acquireVsCodeApi !== 'undefined';
+  window.IS_DEMO = isDemo;
+  window.HOST_ENV = isDemo ? 'demo' : isVscode ? 'vscode' : 'local';
 })();

--- a/dashboard/js/vscode-transport.js
+++ b/dashboard/js/vscode-transport.js
@@ -14,6 +14,7 @@
   // Pending request callbacks: requestId → { resolve, reject, timeout }
   const _pending = Object.create(null);
   let _reqId = 0;
+  const DEFAULT_TIMEOUT_MS = 8000;
 
   /**
    * Send a typed request to the extension host and return a Promise for the
@@ -24,7 +25,7 @@
    */
   function sendRequest(type, payload, timeoutMs) {
     const requestId = ++_reqId;
-    const timeout = timeoutMs || 8000;
+    const timeout = timeoutMs || DEFAULT_TIMEOUT_MS;
     return new Promise(function (resolve, reject) {
       const timer = setTimeout(function () {
         delete _pending[requestId];
@@ -60,8 +61,8 @@
       if (msg.type === 'activity' || msg.type === 'event') {
         try {
           const payload = msg.data || msg;
-          const a = eventToActivity(payload); // defined in event-source.js
-          addActivity(app.activityLog, a.type, a.message, a.detail);
+          const activity = eventToActivity(payload); // defined in event-source.js
+          addActivity(app.activityLog, activity.type, activity.message, activity.detail);
           if (payload.role && payload.issue) {
             app.batonState = mergeBatonEvents([payload]);
           }

--- a/dashboard/js/vscode-transport.js
+++ b/dashboard/js/vscode-transport.js
@@ -1,0 +1,75 @@
+// vscode-transport.js — VS Code Webview postMessage bridge
+// Loads AFTER transport.js and BEFORE event-source.js.
+// Active only when HOST_ENV === 'vscode'.
+// Provides window.vsCodeBridge for use by event-source.js and other modules.
+
+(function () {
+  'use strict';
+  if (window.HOST_ENV !== 'vscode') return;
+
+  // Acquire the VS Code API handle once (calling it twice throws).
+  const vscode = acquireVsCodeApi(); // eslint-disable-line no-undef
+  window.vsCodeBridge = vscode;
+
+  // Pending request callbacks: requestId → { resolve, reject, timeout }
+  const _pending = Object.create(null);
+  let _reqId = 0;
+
+  /**
+   * Send a typed request to the extension host and return a Promise for the
+   * response. The extension must reply with { requestId, type: 'response', data }.
+   * @param {string} type — message type understood by the extension host
+   * @param {object} [payload] — optional payload
+   * @param {number} [timeoutMs] — default 8 000
+   */
+  function sendRequest(type, payload, timeoutMs) {
+    const requestId = ++_reqId;
+    const timeout = timeoutMs || 8000;
+    return new Promise(function (resolve, reject) {
+      const timer = setTimeout(function () {
+        delete _pending[requestId];
+        reject(new Error('vscode-transport: timeout for ' + type));
+      }, timeout);
+      _pending[requestId] = { resolve, reject, timer };
+      vscode.postMessage({ type, requestId, payload: payload || {} });
+    });
+  }
+
+  /**
+   * Override connectSSE for the vscode mode.
+   * The extension host pushes events via postMessage instead of SSE.
+   * @param {object} app — Alpine component reference
+   */
+  window.connectSSEVscode = function connectSSEVscode(app) {
+    vscode.postMessage({ type: 'subscribe', channel: 'events' });
+
+    window.addEventListener('message', function (event) {
+      const msg = event.data;
+      if (!msg || typeof msg !== 'object') return;
+
+      // Resolve pending request/response pairs.
+      if (msg.type === 'response' && msg.requestId && _pending[msg.requestId]) {
+        const cb = _pending[msg.requestId];
+        clearTimeout(cb.timer);
+        delete _pending[msg.requestId];
+        cb.resolve(msg.data);
+        return;
+      }
+
+      // Route activity events into the Alpine state (same contract as SSE).
+      if (msg.type === 'activity' || msg.type === 'event') {
+        try {
+          const payload = msg.data || msg;
+          const a = eventToActivity(payload); // defined in event-source.js
+          addActivity(app.activityLog, a.type, a.message, a.detail);
+          if (payload.role && payload.issue) {
+            app.batonState = mergeBatonEvents([payload]);
+          }
+        } catch { /* skip malformed */ }
+      }
+    });
+  };
+
+  // Expose sendRequest for other panels that need extension-host data.
+  window.vsCodeRequest = sendRequest;
+})();


### PR DESCRIPTION
Completes the Tri-Mode Architecture (Epic #2803 Phase-2).

## Changes

- **MOD** `transport.js` — adds `acquireVsCodeApi` detection; `HOST_ENV` is now `demo | vscode | local`
- **NEW** `vscode-transport.js` — postMessage bridge; overrides `connectSSE()` when `HOST_ENV === 'vscode'`; handles request/response pairs; routes activity events into Alpine state
- **MOD** `event-source.js` — routes to `connectSSEVscode()` when `HOST_ENV === 'vscode'`
- **MOD** `index.html` — loads `vscode-transport.js` after `transport.js`

All files ≤100 lines. CSP audit clean. npm run lint green.

push-bypass: --no-verify; pre-push-gates fails on pre-existing Epic drift #1948 #2248 #2632 unrelated to this branch.
bypass_reason: pre-push gate Epic drift unrelated to branch
approver: Soren Reyes (admin)

merge-evidence-deferred-final: #2816
Refs #2816
Refs Epic #2803