### PR TITLE
fix(scripts): harden fleet context modules (injection, traversal, budget)

### DIFF
--- a/.changes/unreleased/2819.md
+++ b/.changes/unreleased/2819.md
@@ -1,0 +1,8 @@
+### fix(scripts): harden fleet context-access modules (security) #2819
+
+- `fleet-context-bundle.js`: validate ticket id is a positive integer (blocks
+  command injection in `ticketContext`); resolve + assert paths stay within root
+  (blocks path traversal in `repoMap`).
+- `fleet-context-render.js`: fix char-budget separator over-count + a `clip`
+  edge case (never exceed maxChars). Found by rigorous gemini-2.5-pro Consultant
+  re-review (95/ACCEPT post-fix) of merged #2802 code.

--- a/scripts/global/fleet-context-bundle.js
+++ b/scripts/global/fleet-context-bundle.js
@@ -17,7 +17,9 @@ function runQuiet(command) {
 
 // Live work-log for a ticket: title + body + comment bodies (the design lives in #2792's comments).
 function ticketContext(number) {
-  if (!number) return null;
+  if (number == null) return null;
+  // #2819 security: only a positive integer reaches the shell — blocks command injection.
+  if (!Number.isInteger(number) || number <= 0) return { number, available: false };
   const raw = runQuiet(`gh issue view ${number} --json title,body,comments`);
   if (!raw) return { number, available: false };
   try {
@@ -31,8 +33,13 @@ function ticketContext(number) {
 
 // Lightweight repo-map: top-level fn/class/export signatures of named files (no heavy parser).
 function repoMap(relPaths = [], root = process.cwd()) {
+  const resolvedRoot = path.resolve(root);
   return (relPaths || []).map((relPath) => {
-    const full = path.join(root, relPath);
+    const full = path.resolve(resolvedRoot, relPath);
+    // #2819 security: refuse paths that escape root (e.g. '../') — blocks path traversal.
+    if (full !== resolvedRoot && !full.startsWith(resolvedRoot + path.sep)) {
+      return { path: relPath, available: false };
+    }
     if (!fs.existsSync(full)) return { path: relPath, available: false };
     const source = fs.readFileSync(full, 'utf8');
     const signatures = (source.match(/^\s*(async\s+)?(function|class|module\.exports|exports\.)[^\n{=]*/gm)

--- a/scripts/global/fleet-context-render.js
+++ b/scripts/global/fleet-context-render.js
@@ -21,10 +21,13 @@ function renderWiki(wiki) {
 }
 
 const CLIP_MARKER = '\n…[clipped]';
+const SEP = '\n\n'; // separator joining rendered sections
 
 function clip(text, max) {
-  return text.length <= max ? text
-    : text.slice(0, Math.max(0, max - CLIP_MARKER.length)) + CLIP_MARKER;
+  if (text.length <= max) return text;
+  // #2819: when the budget can't fit the marker, hard-truncate (never exceed max).
+  if (max <= CLIP_MARKER.length) return text.slice(0, Math.max(0, max));
+  return text.slice(0, max - CLIP_MARKER.length) + CLIP_MARKER;
 }
 
 // renderContextPreamble(bundle, {maxChars}) -> { preamble, included, truncated }.
@@ -40,14 +43,15 @@ function renderContextPreamble(bundle = {}, opts = {}) {
   let used = 0;
   let truncated = false;
   for (const [, text] of sections) {
-    const remaining = maxChars - used;
+    const sep = parts.length ? SEP.length : 0; // join '\n\n' to a PRECEDING part only (no over-count)
+    const remaining = maxChars - used - sep;
     if (remaining <= 0) { truncated = true; break; }
     const piece = clip(text, remaining);
     if (piece.length < text.length) truncated = true;
     parts.push(piece);
-    used += piece.length + 2;
+    used += sep + piece.length;
   }
-  return { preamble: parts.join('\n\n'), included: sections.slice(0, parts.length).map(([name]) => name), truncated };
+  return { preamble: parts.join(SEP), included: sections.slice(0, parts.length).map(([name]) => name), truncated };
 }
 
 module.exports = { renderContextPreamble, renderTicket, renderRepoMap, renderWiki, DEFAULT_MAX_CHARS };

--- a/tests/fleet-context-bundle.spec.js
+++ b/tests/fleet-context-bundle.spec.js
@@ -47,3 +47,16 @@ test('#2802 D15: alreadyBundled parts are dropped from the bundle', () => {
   expect(bundle.repoMap).toBeDefined();
   expect(bundle.manifest.included).toEqual(['repoMap']);
 });
+
+// #2819 security hardening
+test('#2819 ticketContext rejects non-integer id (no shell injection)', () => {
+  expect(ticketContext('2802; rm -rf /')).toEqual({ number: '2802; rm -rf /', available: false });
+  expect(ticketContext(-5)).toEqual({ number: -5, available: false });
+  expect(ticketContext(1.5)).toEqual({ number: 1.5, available: false });
+  expect(ticketContext(null)).toBeNull();
+});
+
+test('#2819 repoMap refuses paths escaping root (path traversal)', () => {
+  expect(repoMap(['../../etc/passwd'], ROOT)[0]).toEqual({ path: '../../etc/passwd', available: false });
+  expect(repoMap([SELF], ROOT)[0].available).toBe(true); // legit path still works
+});

--- a/tests/fleet-context-render.spec.js
+++ b/tests/fleet-context-render.spec.js
@@ -52,3 +52,16 @@ test('#2802 renderContextPreamble drops lowest-priority sections first under tig
 test('#2802 renderContextPreamble on empty bundle is safe', () => {
   expect(renderContextPreamble({})).toEqual({ preamble: '', included: [], truncated: false });
 });
+
+// #2819 char-budget off-by-one
+test('#2819 preamble length never exceeds maxChars (no separator over/under-count)', () => {
+  const bundle = {
+    ticket: { number: 1, title: 't', body: 'b'.repeat(50), available: true },
+    repoMap: [{ path: 'p', symbols: ['s'.repeat(50)], available: true }],
+    wiki: ['w'.repeat(50)],
+  };
+  for (const maxChars of [10, 55, 80, 120, 200]) {
+    const { preamble } = renderContextPreamble(bundle, { maxChars });
+    expect(preamble.length).toBeLessThanOrEqual(maxChars);
+  }
+});


### PR DESCRIPTION
Refs #2819
merge-evidence-deferred-final: #2819

## Security remediation (found by rigorous Consultant re-review of merged #2802)
- 🔴 **Command injection** in `ticketContext` → integer-only allow-list (non-int id never reaches the shell).
- 🔴 **Path traversal** in `repoMap` → `path.resolve` + assert within root; `../` refused.
- 🟡 char-budget over-count + `clip` edge case → `preamble.length ≤ maxChars` always.

17 tests incl. adversarial cases (malicious id, traversal attempt, budget boundaries). **gemini-2.5-pro Consultant: 95/ACCEPT** ('correct, complete, no material issues remain').

## Why this exists
The original slices passed consultant-gate but were reviewed by *lightweight* models (qwen-7b/groq) that missed these. This PR remediates both the bugs AND the review-rigor gap (now gemini-2.5-pro tier for substantive code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)