### PR TITLE
fix(dashboard): anonymize infrastructure details in demo fixtures

### DIFF
--- a/dashboard/fixtures/scenario-1-healthy.jsonl
+++ b/dashboard/fixtures/scenario-1-healthy.jsonl
@@ -1,4 +1,4 @@
-{"type":"system","message":"Fleet online","detail":"3 nodes: 36gbwinresource · openclaw · penguin-1","ts":0}
+{"type":"system","message":"Fleet online","detail":"3 nodes: fleet-win-01 · openclaw · dev-1","ts":0}
 {"type":"system","message":"MCP connected","detail":"filesystem · github · search (3 servers, 23 tools)","ts":800}
 {"type":"agent","message":"Session started","detail":"copilot · claude-sonnet-4.6 · ticket #2809","ts":1500}
 {"type":"baton","role":"manager","issue":2809,"message":"Manager scoping","detail":"AC authoring + gates","ts":2200}

--- a/dashboard/fixtures/scenario-2-governance.jsonl
+++ b/dashboard/fixtures/scenario-2-governance.jsonl
@@ -1,4 +1,4 @@
-{"type":"system","message":"Fleet online","detail":"2 nodes available: 36gbwinresource · openclaw","ts":0}
+{"type":"system","message":"Fleet online","detail":"2 nodes available: fleet-win-01 · openclaw","ts":0}
 {"type":"agent","message":"Session started","detail":"codex · gpt-5.4 · no ticket linked","ts":1000}
 {"type":"warn","message":"Governance alert","detail":"G1 ticket-first-gate FAIL — no open issue for branch feat/unlabeled","ts":1800}
 {"type":"warn","message":"Baton blocked","detail":"codex cannot push without a linked GitHub issue","ts":1900}

--- a/dashboard/js/context-flow.js
+++ b/dashboard/js/context-flow.js
@@ -9,11 +9,11 @@ function renderContextFlow() {
     { x: 370, y: 50, icon: '☁️', label: 'Cloud LLM', sub: 'Copilot API', tip: 'GitHub Copilot cloud models (GPT-4o, Claude). Primary route. Responses stream back to VS Code.' },
     { x: 540, y: 50, icon: '🐙', label: 'GitHub', sub: 'API + Actions', tip: 'GitHub API: issues, PRs, commits. Actions CI/CD. Context flows bidirectionally via gh CLI and webhooks.' },
     { x: 120, y: 150, icon: '🌐', label: 'Tailscale', sub: 'VPN Mesh', tip: 'Encrypted WireGuard mesh connecting all fleet devices. Routes traffic between Chromebooks and Windows laptop.' },
-    { x: 290, y: 150, icon: '⚡', label: 'OpenClaw', sub: 'LiteLLM :4000', tip: 'LiteLLM proxy on Windows laptop. Routes to local Ollama models. Fallback when cloud is rate-limited.' },
-    { x: 460, y: 150, icon: '🤖', label: 'Ollama', sub: 'Local 7B', tip: 'Local inference on Windows laptop (16GB RAM). Runs 7B models. Accessed via OpenClaw proxy over Tailscale.' },
-    { x: 60, y: 210, icon: '💻', label: 'CB-2', sub: 'This machine', tip: 'Chromebook-2 (penguin): primary dev workstation. 2.7GB RAM. Runs VS Code + dashboard.' },
-    { x: 200, y: 210, icon: '💻', label: 'CB-1', sub: 'SLM node', tip: 'Chromebook-1 (penguin-1): runs Ollama with tiny SLM models for lightweight local inference.' },
-    { x: 370, y: 210, icon: '🖥️', label: 'Win Laptop', sub: 'OpenClaw host', tip: 'Windows laptop (16GB). Hosts OpenClaw + Ollama. Primary fleet compute for local LLM inference.' },
+    { x: 290, y: 150, icon: '⚡', label: 'OpenClaw', sub: 'LiteLLM Proxy', tip: 'LiteLLM proxy on fleet host. Routes to local Ollama models. Fallback when cloud is rate-limited.' },
+    { x: 460, y: 150, icon: '🤖', label: 'Ollama', sub: 'Local LLM', tip: 'Local inference on fleet host. Runs quantized open-source models. Accessed via OpenClaw proxy over Tailscale.' },
+    { x: 60, y: 210, icon: '💻', label: 'Dev-1', sub: 'Workstation', tip: 'Primary dev workstation. Runs VS Code + dashboard.' },
+    { x: 200, y: 210, icon: '💻', label: 'Dev-2', sub: 'SLM node', tip: 'Secondary dev node: runs Ollama with small models for lightweight local inference.' },
+    { x: 370, y: 210, icon: '🖥️', label: 'Fleet Host', sub: 'OpenClaw host', tip: 'Fleet compute node. Hosts OpenClaw + Ollama. Primary local LLM inference.' },
   ];
   const arrows = [
     { from: 0, to: 1, label: 'prompt', tip: 'User prompt + file context + conversation history sent to model router' },
@@ -21,9 +21,9 @@ function renderContextFlow() {
     { from: 1, to: 5, label: 'local', dashed: true, tip: 'Fallback route: prompt sent to OpenClaw LiteLLM proxy over Tailscale' },
     { from: 5, to: 6, label: 'inference', tip: 'OpenClaw forwards to local Ollama for model inference' },
     { from: 4, to: 5, label: 'mesh', dashed: true, tip: 'Tailscale VPN tunnels traffic between devices' },
-    { from: 7, to: 4, label: '', dashed: true, tip: 'CB-2 connects to Tailscale mesh' },
-    { from: 8, to: 4, label: '', dashed: true, tip: 'CB-1 connects to Tailscale mesh' },
-    { from: 9, to: 5, label: 'host', tip: 'Windows laptop hosts the OpenClaw proxy locally' },
+    { from: 7, to: 4, label: '', dashed: true, tip: 'Dev-1 connects to Tailscale mesh' },
+    { from: 8, to: 4, label: '', dashed: true, tip: 'Dev-2 connects to Tailscale mesh' },
+    { from: 9, to: 5, label: 'host', tip: 'Fleet host runs OpenClaw proxy locally' },
     { from: 0, to: 3, label: 'gh cli', tip: 'VS Code uses gh CLI for issue/PR operations' },
   ];
   return `<div class="cf-wrap"><svg viewBox="0 0 ${W} ${H}"

--- a/dashboard/js/llm-context.js
+++ b/dashboard/js/llm-context.js
@@ -11,12 +11,12 @@ const LLM_MODELS = [
   { name: 'GPT-5.2', ctx: 128000, tier: 'cloud', mult: 1 },
   { name: 'GPT-5 mini', ctx: 128000, tier: 'cloud', mult: 0 },
   { name: 'Grok Code Fast 1', ctx: 128000, tier: 'cloud', mult: 0.25 },
-  { name: 'qwen2.5:7b', ctx: 128000, tier: 'local', device: 'windows-laptop' },
-  { name: 'mistral:latest', ctx: 32000, tier: 'local', device: 'windows-laptop' },
-  { name: 'qwen3.5:0.8b', ctx: 32000, tier: 'local', device: 'penguin-1' },
-  { name: 'phi3:mini', ctx: 4000, tier: 'local', device: 'windows-laptop' },
-  { name: 'gemma3:270m', ctx: 8000, tier: 'local', device: 'penguin-1' },
-  { name: 'tinyllama', ctx: 2048, tier: 'local', device: 'penguin-1' },
+  { name: 'qwen2.5:7b', ctx: 128000, tier: 'local', device: 'fleet-host' },
+  { name: 'mistral:latest', ctx: 32000, tier: 'local', device: 'fleet-host' },
+  { name: 'qwen3.5:0.8b', ctx: 32000, tier: 'local', device: 'dev-2' },
+  { name: 'phi3:mini', ctx: 4000, tier: 'local', device: 'fleet-host' },
+  { name: 'gemma3:270m', ctx: 8000, tier: 'local', device: 'dev-2' },
+  { name: 'tinyllama', ctx: 2048, tier: 'local', device: 'dev-2' },
 ];
 
 function renderLLMContext() {


### PR DESCRIPTION
Refs #2821

## Summary
G4 privacy fix identified during UAT. The GitHub Pages demo was exposing real infrastructure details publicly.

## Changes
- `context-flow.js`: CB-2→Dev-1, CB-1→Dev-2, Win Laptop→Fleet Host; removed penguin/penguin-1 hostnames from tooltips, removed RAM amounts (2.7GB/16GB), removed port (:4000)
- `llm-context.js`: windows-laptop→fleet-host, penguin-1→dev-2
- `fixtures/scenario-1-healthy.jsonl`: 36gbwinresource→fleet-win-01, penguin-1→dev-1
- `fixtures/scenario-2-governance.jsonl`: 36gbwinresource→fleet-win-01

## Verification
```
grep penguin|36gbwin|CB-2|CB-1|Win Laptop|windows-laptop|2.7GB|16GB|:4000 <edited files>
```
→ No matches (clean)

merge-evidence-deferred-final: #2821