### PR TITLE
feat(scripts): fleet context-dispatch + repo-map hardening (P1-0 s3)

### DIFF
--- a/.changes/unreleased/2802.md
+++ b/.changes/unreleased/2802.md
@@ -10,3 +10,13 @@
 - Adds `scripts/global/fleet-context-render.js` (D12/D15): renders an assembled
   bundle into a token-bounded prompt preamble (priority ticket>repo-map>wiki).
   Dogfood-reviewed (groq 92/ACCEPT; applied its CLIP_MARKER finding). 7 tests.
+
+### feat(scripts): context-dispatch helper + repo-map robustness — P1-0 slice 3 #2802
+
+- Adds `scripts/global/fleet-context-dispatch.js` (D12/D15): the operational
+  dogfood — one call assembles the bundle, renders the preamble, prepends it to
+  the task, and dispatches via an injectable fleet/HAMR call (substrate-agnostic).
+- Hardens `repoMap` with an OOM guard (`MAX_FILE_BYTES`, `statSync` size/isFile
+  check) and a NUL-byte binary heuristic; adds opt-in `MEGINGJORD_FLEET_CTX_DEBUG`
+  stderr diagnostics to `runQuiet` (G8). Dogfood-reviewed by gemini-2.5-pro
+  (iter-1 CONCERNS/85 → fixes → iter-2 ACCEPT/95). 11 tests.

--- a/scripts/global/fleet-context-bundle.js
+++ b/scripts/global/fleet-context-bundle.js
@@ -8,11 +8,19 @@ const fs = require('fs');
 const path = require('path');
 
 const RUN_TIMEOUT_MS = 15000; // per-source subprocess cap; missing/slow source degrades gracefully
+const MAX_FILE_BYTES = 262144; // #2802: skip files >256KB (OOM guard) — repo-map is for source files
 
 function runQuiet(command) {
   try {
     return execSync(command, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: RUN_TIMEOUT_MS });
-  } catch (error) { return ''; }
+  } catch (error) {
+    // G8: graceful-silent by default, but surface WHY under an opt-in flag. Logs the command HEAD
+    // + error code only (no captured output) so a missing/unauth `gh` is diagnosable, secret-safe (G4).
+    if (process.env.MEGINGJORD_FLEET_CTX_DEBUG) {
+      process.stderr.write(`[fleet-context] source unavailable: ${command.split(' ')[0]} (${error.code || error.message})\n`);
+    }
+    return '';
+  }
 }
 
 // Live work-log for a ticket: title + body + comment bodies (the design lives in #2792's comments).
@@ -37,11 +45,20 @@ function repoMap(relPaths = [], root = process.cwd()) {
   return (relPaths || []).map((relPath) => {
     const full = path.resolve(resolvedRoot, relPath);
     // #2819 security: refuse paths that escape root (e.g. '../') — blocks path traversal.
+    // Note: byte-exact prefix match — correct on the Tier-1 Linux baseline (case-sensitive FS); a
+    // case-insensitive FS (macOS APFS / Windows NTFS) could over-reject a valid casing variant (G5 edge).
     if (full !== resolvedRoot && !full.startsWith(resolvedRoot + path.sep)) {
       return { path: relPath, available: false };
     }
-    if (!fs.existsSync(full)) return { path: relPath, available: false };
-    const source = fs.readFileSync(full, 'utf8');
+    let stat;
+    try { stat = fs.statSync(full); } catch (error) { return { path: relPath, available: false }; }
+    // #2802 robustness: skip non-files + oversize files (OOM guard for huge logs/data dumps).
+    if (!stat.isFile() || stat.size > MAX_FILE_BYTES) return { path: relPath, available: false };
+    const buffer = fs.readFileSync(full);
+    // Binary heuristic: a NUL byte ⇒ skip. Tuned for UTF-8 source (the harness corpus); a UTF-16
+    // text file would false-positive, which is an acceptable skip — repo-map targets UTF-8 code.
+    if (buffer.includes(0)) return { path: relPath, available: false };
+    const source = buffer.toString('utf8');
     const signatures = (source.match(/^\s*(async\s+)?(function|class|module\.exports|exports\.)[^\n{=]*/gm)
       || []).map((line) => line.trim()).slice(0, 40);
     return { path: relPath, symbols: signatures, available: true };

--- a/scripts/global/fleet-context-dispatch.js
+++ b/scripts/global/fleet-context-dispatch.js
@@ -1,0 +1,31 @@
+// Fleet context dispatch helper (#2802 P1-0 slice 3; design D12/D15). The operational dogfood:
+// one call gives a fleet model the MOST context possible — assemble bundle (slice 1) + render
+// preamble (slice 2) + prepend to the task — then dispatch. The pure prompt-build is separable and
+// testable (no network); the dispatch fn is injectable so callers wire the real fleet/HAMR call.
+const { assembleContextBundle } = require('./fleet-context-bundle');
+const { renderContextPreamble } = require('./fleet-context-render');
+
+// buildContextualPrompt(opts) -> { prompt, manifest, included, truncated }. Pure (composes slice1+2).
+// Renders the auto-assembled context, then the task. With no context, returns the bare task.
+function buildContextualPrompt({ ticket, paths = [], wikiQuery, task = '', maxContextChars } = {}) {
+  const bundle = assembleContextBundle({ ticket, paths, wikiQuery });
+  const { preamble, included, truncated } = renderContextPreamble(bundle, { maxChars: maxContextChars });
+  const header = `=== AUTO-ASSEMBLED CONTEXT (included: ${included.join(', ') || 'none'}`
+    + `${truncated ? '; truncated to budget' : ''}) ===`;
+  const prompt = preamble ? `${header}\n${preamble}\n\n=== TASK ===\n${task}` : task;
+  return { prompt, manifest: bundle.manifest, included, truncated };
+}
+
+// dispatchWithContext(opts) -> { result, manifest, included, truncated }. `opts.dispatch` is an
+// injectable `(prompt) => Promise<result>` (the real fleet/HAMR call), keeping this testable and
+// substrate-agnostic (G5). Throws a clear error when no dispatch is wired.
+async function dispatchWithContext(opts = {}) {
+  const built = buildContextualPrompt(opts);
+  if (typeof opts.dispatch !== 'function') {
+    throw new Error('dispatchWithContext: opts.dispatch (prompt) => Promise<result> is required');
+  }
+  const result = await opts.dispatch(built.prompt);
+  return { result, manifest: built.manifest, included: built.included, truncated: built.truncated };
+}
+
+module.exports = { buildContextualPrompt, dispatchWithContext };

--- a/tests/fleet-context-bundle.spec.js
+++ b/tests/fleet-context-bundle.spec.js
@@ -60,3 +60,40 @@ test('#2819 repoMap refuses paths escaping root (path traversal)', () => {
   expect(repoMap(['../../etc/passwd'], ROOT)[0]).toEqual({ path: '../../etc/passwd', available: false });
   expect(repoMap([SELF], ROOT)[0].available).toBe(true); // legit path still works
 });
+
+// #2802 robustness (gemini-2.5-pro OOM/binary finding): skip oversize + binary files, not crash.
+test('#2802 repoMap skips an oversize file (OOM guard) but reads its own text source', () => {
+  const fs = require('fs');
+  const os = require('os');
+  const big = path.join(os.tmpdir(), `fleet-ctx-big-${process.pid}.txt`);
+  fs.writeFileSync(big, 'x'.repeat(300 * 1024)); // 300KB > MAX_FILE_BYTES (256KB)
+  try {
+    // oversize file lives outside ROOT, so pass its own dir as root to isolate the size check
+    expect(repoMap([path.basename(big)], os.tmpdir())[0].available).toBe(false);
+  } finally { fs.unlinkSync(big); }
+  expect(repoMap([SELF], ROOT)[0].available).toBe(true); // text source is NOT misflagged as binary
+});
+
+test('#2802 repoMap flags a NUL-bearing (binary) file as unavailable', () => {
+  const fs = require('fs');
+  const os = require('os');
+  const bin = path.join(os.tmpdir(), `fleet-ctx-bin-${process.pid}.dat`);
+  fs.writeFileSync(bin, Buffer.from([0x41, 0x00, 0x42])); // 'A', NUL, 'B'
+  try {
+    expect(repoMap([path.basename(bin)], os.tmpdir())[0].available).toBe(false);
+  } finally { fs.unlinkSync(bin); }
+});
+
+// #2802 G8 (gemini-2.5-pro observability finding): silent by default, diagnosable under opt-in flag.
+test('#2802 ticketContext failure is silent by default, logs to stderr under debug flag', () => {
+  const { spawnSync } = require('child_process');
+  // issue 999999999 does not exist → `gh issue view` fails → runQuiet catch path exercised.
+  const script = "const{ticketContext}=require('./scripts/global/fleet-context-bundle.js');"
+    + 'console.log(JSON.stringify(ticketContext(999999999)));';
+  const opts = { cwd: path.join(__dirname, '..'), encoding: 'utf8' };
+  const quiet = spawnSync('node', ['-e', script], { ...opts, env: { ...process.env } });
+  const debug = spawnSync('node', ['-e', script], { ...opts, env: { ...process.env, MEGINGJORD_FLEET_CTX_DEBUG: '1' } });
+  expect(quiet.status).toBe(0); // graceful: never throws
+  expect(quiet.stderr).not.toContain('[fleet-context]'); // silent by default
+  expect(debug.stderr).toContain('[fleet-context] source unavailable'); // diagnosable on opt-in
+});

--- a/tests/fleet-context-dispatch.spec.js
+++ b/tests/fleet-context-dispatch.spec.js
@@ -1,0 +1,42 @@
+// Refs #2802 P1-0 slice 3 — fleet context dispatch helper (D12/D15). Network-free tests.
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const {
+  buildContextualPrompt, dispatchWithContext,
+} = require('../scripts/global/fleet-context-dispatch.js');
+
+const SELF = 'scripts/global/fleet-context-dispatch.js';
+const ROOT_OPTS = { paths: [SELF], task: 'Review this.' }; // repo-map only → no network
+
+test('#2802 buildContextualPrompt prepends auto-assembled context to the task', () => {
+  const { prompt, included } = buildContextualPrompt(ROOT_OPTS);
+  expect(prompt).toContain('=== AUTO-ASSEMBLED CONTEXT');
+  expect(prompt).toContain('=== TASK ===\nReview this.');
+  expect(prompt.indexOf('AUTO-ASSEMBLED')).toBeLessThan(prompt.indexOf('TASK')); // context before task
+  expect(included).toContain('repoMap');
+});
+
+test('#2802 buildContextualPrompt with no context returns the bare task', () => {
+  const { prompt, included } = buildContextualPrompt({ task: 'just do it' });
+  expect(prompt).toBe('just do it');
+  expect(included).toEqual([]);
+});
+
+test('#2802 buildContextualPrompt header notes truncation under a tight budget', () => {
+  const { prompt, truncated } = buildContextualPrompt({ ...ROOT_OPTS, maxContextChars: 30 });
+  expect(truncated).toBe(true);
+  expect(prompt).toContain('truncated to budget');
+});
+
+test('#2802 dispatchWithContext calls the injected dispatch with the built prompt', async () => {
+  let seen = null;
+  const out = await dispatchWithContext({ ...ROOT_OPTS, dispatch: async (p) => { seen = p; return 'OK'; } });
+  expect(seen).toContain('=== TASK ===\nReview this.');
+  expect(out.result).toBe('OK');
+  expect(out.included).toContain('repoMap');
+  expect(out.manifest.schema).toBe('fleet-context-bundle/v1');
+});
+
+test('#2802 dispatchWithContext throws a clear error when no dispatch wired', async () => {
+  await expect(dispatchWithContext({ task: 'x' })).rejects.toThrow(/opts.dispatch.*required/);
+});


### PR DESCRIPTION
Refs #2802

merge-evidence-deferred-final: #2802

P1-0 slice 3 of the fleet context-access layer (Epic #2791, design D12/D15). Third
of several slices; **#2802 stays open** for remaining slices (sandbox test-exec, MCP
tool adapters).

## What this adds
- `scripts/global/fleet-context-dispatch.js` — the operational dogfood: `buildContextualPrompt`
  (pure: assemble bundle + render preamble + prepend to task) and `dispatchWithContext`
  (injectable `(prompt)=>Promise<result>` fleet/HAMR call; substrate-agnostic, G5).
- Hardens `repoMap`: OOM guard (`MAX_FILE_BYTES` + `statSync` size/isFile check) and a
  NUL-byte binary heuristic; opt-in `MEGINGJORD_FLEET_CTX_DEBUG` stderr diagnostics on
  `runQuiet` (G8 observability, secret-safe).

## Verification
- 25/25 fleet-context tests pass (`fleet-context-{bundle,render,dispatch}.spec.js`); lint clean
  (451 files ≤100); readability warnings=474 (≤475).
- Dogfood cross-family review: **gemini-2.5-pro** (rigorous tier) iter-1 CONCERNS/85 →
  fixed G8 + documented 2 baseline edges → iter-2 **ACCEPT/95**, min(G1..G9)=7.

## Baton artifacts (on #2802)
COLLABORATOR_HANDOFF · ADMIN_HANDOFF · CONSULTANT_CLOSEOUT — all posted with canonical
Signed-by/Team&Model/Role blocks; signer-independence Harper ≠ Reyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
