### PR TITLE
feat(scripts): fleet context CLI — closes the dogfood loop (P1-0)

### DIFF
--- a/.changes/unreleased/2831.md
+++ b/.changes/unreleased/2831.md
@@ -1,0 +1,10 @@
+### feat(scripts): fleet context CLI — closes the dogfood loop #2831
+
+- Adds `scripts/global/fleet-context-cli.js` (P1-0 child of #2802, design D12/D15):
+  wires the context assembler+renderer+dispatcher (slices 1–3) to the existing
+  zero-cost free-cloud cascade and exposes a CLI
+  (`--ticket --paths --wiki --task --max-context-chars`), so a fleet model
+  actually receives auto-assembled ticket+repo-map+wiki context before a task.
+  No new provider surface (G3). Validated end-to-end: dispatched to gemini and
+  returned a context-grounded answer. Dogfood-reviewed by gemini-2.5-pro
+  (REJECT/40 → fixes → ACCEPT/100; it caught a real arg-parsing bug). 9 tests.

--- a/scripts/global/fleet-context-cli.js
+++ b/scripts/global/fleet-context-cli.js
@@ -1,0 +1,77 @@
+// Fleet context CLI (#2831 P1-0 child of #2802; design D12/D15). Closes the dogfood loop: assemble
+// ticket+repo-map+wiki context (slice 1), render the preamble (slice 2), prepend to a task and
+// dispatch (slice 3) via the existing zero-cost cascade (free-cloud-dispatch). No new provider
+// surface — reuses the cost-ascending lanes (G3). Pure helpers are exported + unit-tested network-free.
+const { dispatchWithContext } = require('./fleet-context-dispatch');
+const { dispatchFreeCloud } = require('./free-cloud-dispatch');
+
+// Parse `--flag value` / `--flag=value` argv into an options object. Non-flag tokens are ignored.
+// A flag immediately followed by another `--flag` (or end of argv) is valueless → '' (does NOT
+// swallow the next flag as its value).
+function parseArgs(argv = []) {
+  const opts = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (typeof token !== 'string' || !token.startsWith('--')) continue;
+    const eq = token.indexOf('=');
+    if (eq !== -1) { opts[token.slice(2, eq)] = token.slice(eq + 1); continue; }
+    const next = argv[index + 1];
+    const valueless = next === undefined || (typeof next === 'string' && next.startsWith('--'));
+    opts[token.slice(2)] = valueless ? '' : (index += 1, next);
+  }
+  return opts;
+}
+
+// Parse a required-numeric CLI value; fail fast (G8) on empty/whitespace/non-numeric input rather
+// than passing NaN — or a misleading Number('')===0 — downstream.
+function numericOpt(name, raw) {
+  const parsed = Number(raw);
+  if (String(raw).trim() === '' || !Number.isFinite(parsed)) {
+    throw new Error(`--${name} must be a number, got '${raw}'`);
+  }
+  return parsed;
+}
+
+// Map raw CLI options to dispatchWithContext input (numbers validated, paths split on comma).
+function toContextOpts(cli = {}) {
+  const out = { task: cli.task || '' };
+  if (cli.ticket) out.ticket = numericOpt('ticket', cli.ticket);
+  if (cli.paths) out.paths = cli.paths.split(',').map((entry) => entry.trim()).filter(Boolean);
+  if (cli.wiki) out.wikiQuery = cli.wiki;
+  if (cli['max-context-chars']) out.maxContextChars = numericOpt('max-context-chars', cli['max-context-chars']);
+  return out;
+}
+
+// Real zero-cost dispatch (G3): free-cloud cascade. Returns {content, provider}; throws with the
+// cascade's reason on failure (G6 surfaces why, never a silent empty). `impl` injectable for tests.
+async function freeCloudDispatch(prompt, impl = dispatchFreeCloud) {
+  const result = await impl(prompt);
+  if (!result.ok) {
+    const tried = result.tried ? ` (${result.tried.join(', ')})` : '';
+    throw new Error(`free-cloud dispatch failed: ${result.reason}${tried}`);
+  }
+  return { content: result.content, provider: result.provider };
+}
+
+// runCli(argv, deps) -> { result, manifest, included, truncated }. deps.dispatch injectable (tests
+// supply a fake to stay network-free); defaults to the real free-cloud cascade.
+async function runCli(argv = [], deps = {}) {
+  const cli = parseArgs(argv);
+  const dispatch = deps.dispatch || ((prompt) => freeCloudDispatch(prompt));
+  return dispatchWithContext({ ...toContextOpts(cli), dispatch });
+}
+
+async function main() {
+  const out = await runCli(process.argv.slice(2));
+  const summary = `included: ${out.included.join(', ') || 'none'}${out.truncated ? ' (truncated)' : ''}`;
+  process.stdout.write(`=== fleet-context dispatch (${summary}) ===\n`);
+  const payload = out.result;
+  process.stdout.write(`${typeof payload === 'string' ? payload : (payload.content || JSON.stringify(payload))}\n`);
+  if (payload && payload.provider) process.stderr.write(`[fleet-context-cli] provider: ${payload.provider}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => { process.stderr.write(`${error.message}\n`); process.exit(1); });
+}
+
+module.exports = { parseArgs, numericOpt, toContextOpts, freeCloudDispatch, runCli };

--- a/tests/fleet-context-cli.spec.js
+++ b/tests/fleet-context-cli.spec.js
@@ -1,0 +1,62 @@
+// Refs #2831 (P1-0 child of #2802) — fleet context CLI. Network-free: dispatch is injected.
+const { test, expect } = require('@playwright/test');
+const {
+  parseArgs, numericOpt, toContextOpts, freeCloudDispatch, runCli,
+} = require('../scripts/global/fleet-context-cli.js');
+
+const SELF = 'scripts/global/fleet-context-cli.js'; // a real text file → repo-map only, no network
+
+test('#2831 parseArgs handles --flag value, --flag=value, and ignores non-flags', () => {
+  expect(parseArgs(['--ticket', '2802', '--task=hi', 'stray', '--wiki', 'q']))
+    .toEqual({ ticket: '2802', task: 'hi', wiki: 'q' });
+  expect(parseArgs(['--flag'])).toEqual({ flag: '' }); // trailing valueless flag → empty string
+});
+
+test('#2831 parseArgs does NOT swallow a following flag as a value (gemini REJECT finding)', () => {
+  expect(parseArgs(['--flag1', '--flag2'])).toEqual({ flag1: '', flag2: '' });
+  expect(parseArgs(['--a', '--b', 'v'])).toEqual({ a: '', b: 'v' });
+});
+
+test('#2831 numericOpt rejects non-numeric input (fail fast, no silent NaN)', () => {
+  expect(numericOpt('ticket', '2802')).toBe(2802);
+  expect(numericOpt('n', '0')).toBe(0); // legit zero still accepted
+  expect(() => numericOpt('ticket', 'invalid')).toThrow(/--ticket must be a number, got 'invalid'/);
+  expect(() => numericOpt('ticket', '')).toThrow(/--ticket must be a number/); // valueless flag → not silently 0
+  expect(() => numericOpt('ticket', '   ')).toThrow(/--ticket must be a number/);
+  expect(() => toContextOpts({ 'max-context-chars': 'NaNnope' })).toThrow(/--max-context-chars must be a number/);
+});
+
+test('#2831 toContextOpts parses numbers + splits paths', () => {
+  const out = toContextOpts({ ticket: '2802', paths: 'a.js, b.js ,', wiki: 'q', 'max-context-chars': '500', task: 't' });
+  expect(out).toEqual({ task: 't', ticket: 2802, paths: ['a.js', 'b.js'], wikiQuery: 'q', maxContextChars: 500 });
+});
+
+test('#2831 toContextOpts defaults task to empty and omits unset fields', () => {
+  expect(toContextOpts({})).toEqual({ task: '' });
+});
+
+test('#2831 freeCloudDispatch returns content+provider on ok', async () => {
+  const out = await freeCloudDispatch('p', async () => ({ ok: true, content: 'ANSWER', provider: 'gemini' }));
+  expect(out).toEqual({ content: 'ANSWER', provider: 'gemini' });
+});
+
+test('#2831 freeCloudDispatch throws the cascade reason on failure (G6 surfaces why)', async () => {
+  await expect(freeCloudDispatch('p', async () => ({ ok: false, reason: 'no_free_cloud_available', tried: ['gemini:no_key'] })))
+    .rejects.toThrow(/free-cloud dispatch failed: no_free_cloud_available \(gemini:no_key\)/);
+});
+
+test('#2831 runCli assembles context + dispatches the rendered prompt (injected dispatch, no network)', async () => {
+  let seen = null;
+  const out = await runCli(['--paths', SELF, '--task', 'Review this.'], { dispatch: async (prompt) => { seen = prompt; return 'OK'; } });
+  expect(seen).toContain('=== AUTO-ASSEMBLED CONTEXT');
+  expect(seen).toContain('=== TASK ===\nReview this.');
+  expect(out.result).toBe('OK');
+  expect(out.included).toContain('repoMap');
+  expect(out.manifest.schema).toBe('fleet-context-bundle/v1');
+});
+
+test('#2831 runCli with only a task dispatches the bare task', async () => {
+  let seen = null;
+  await runCli(['--task', 'just do it'], { dispatch: async (prompt) => { seen = prompt; return 'OK'; } });
+  expect(seen).toBe('just do it');
+});


### PR DESCRIPTION
Refs #2831

Closes #2831

P1-0 child of #2802 — closes the fleet context-access **dogfood loop**. Built as a
Sub-issue child (not a deferred-final increment on #2802) to avoid the #2825
auto-close defect: `Closes #2831` finalizes only this child; parent **#2802 stays OPEN**
for remaining children.

## What this adds
- `scripts/global/fleet-context-cli.js` — wires the context assembler+renderer+dispatcher
  (slices 1–3) to the existing **zero-cost free-cloud cascade** and exposes a CLI
  (`--ticket --paths --wiki --task --max-context-chars`), so a fleet model receives
  auto-assembled ticket+repo-map+wiki context before a task. No new provider surface (G3).

## Verification
- 9/9 `tests/fleet-context-cli.spec.js` (network-free; dispatch injected); lint clean; readability 474.
- **End-to-end manual-verify**: dispatched to gemini (free-cloud, $0) and got a context-grounded answer.
- Dogfood cross-family review (**gemini-2.5-pro**, rigorous tier): REJECT/40 → fixed a real
  parseArgs flag-swallow bug + unvalidated `Number()` → CONCERNS/75 (caught the fix's own
  regression) → **ACCEPT/100**, all G=10.

## Baton artifacts (on #2831)
MANAGER_HANDOFF · COLLABORATOR_HANDOFF · ADMIN_HANDOFF · CONSULTANT_CLOSEOUT — all with canonical
signing blocks; signer-independence Harper ≠ Reyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
