### PR TITLE
fix(dashboard): anonymize all device IDs in demo mocks and fixtures

### DIFF
--- a/dashboard/fixtures/scenario-1-healthy.jsonl
+++ b/dashboard/fixtures/scenario-1-healthy.jsonl
@@ -1,4 +1,4 @@
-{"type":"system","message":"Fleet online","detail":"3 nodes: fleet-win-01 · openclaw · dev-1","ts":0}
+{"type":"system","message":"Fleet online","detail":"3 nodes: fleet-win-01 · fleet-openclaw · dev-1","ts":0}
 {"type":"system","message":"MCP connected","detail":"filesystem · github · search (3 servers, 23 tools)","ts":800}
 {"type":"agent","message":"Session started","detail":"copilot · claude-sonnet-4.6 · ticket #2809","ts":1500}
 {"type":"baton","role":"manager","issue":2809,"message":"Manager scoping","detail":"AC authoring + gates","ts":2200}

--- a/dashboard/fixtures/scenario-2-governance.jsonl
+++ b/dashboard/fixtures/scenario-2-governance.jsonl
@@ -1,4 +1,4 @@
-{"type":"system","message":"Fleet online","detail":"2 nodes available: fleet-win-01 · openclaw","ts":0}
+{"type":"system","message":"Fleet online","detail":"2 nodes available: fleet-win-01 · fleet-openclaw","ts":0}
 {"type":"agent","message":"Session started","detail":"codex · gpt-5.4 · no ticket linked","ts":1000}
 {"type":"warn","message":"Governance alert","detail":"G1 ticket-first-gate FAIL — no open issue for branch feat/unlabeled","ts":1800}
 {"type":"warn","message":"Baton blocked","detail":"codex cannot push without a linked GitHub issue","ts":1900}

--- a/dashboard/js/context-flow.js
+++ b/dashboard/js/context-flow.js
@@ -8,7 +8,7 @@ function renderContextFlow() {
     { x: 200, y: 50, icon: '🧠', label: 'AUTO', sub: 'Model Select', tip: 'Routes prompts to Cloud LLM (primary) or OpenClaw (local fallback) based on model availability and rate limits.' },
     { x: 370, y: 50, icon: '☁️', label: 'Cloud LLM', sub: 'Copilot API', tip: 'GitHub Copilot cloud models (GPT-4o, Claude). Primary route. Responses stream back to VS Code.' },
     { x: 540, y: 50, icon: '🐙', label: 'GitHub', sub: 'API + Actions', tip: 'GitHub API: issues, PRs, commits. Actions CI/CD. Context flows bidirectionally via gh CLI and webhooks.' },
-    { x: 120, y: 150, icon: '🌐', label: 'Tailscale', sub: 'VPN Mesh', tip: 'Encrypted WireGuard mesh connecting all fleet devices. Routes traffic between Chromebooks and Windows laptop.' },
+    { x: 120, y: 150, icon: '🌐', label: 'Tailscale', sub: 'VPN Mesh', tip: 'Encrypted WireGuard mesh connecting all fleet devices. Routes traffic between fleet hosts.' },
     { x: 290, y: 150, icon: '⚡', label: 'OpenClaw', sub: 'LiteLLM Proxy', tip: 'LiteLLM proxy on fleet host. Routes to local Ollama models. Fallback when cloud is rate-limited.' },
     { x: 460, y: 150, icon: '🤖', label: 'Ollama', sub: 'Local LLM', tip: 'Local inference on fleet host. Runs quantized open-source models. Accessed via OpenClaw proxy over Tailscale.' },
     { x: 60, y: 210, icon: '💻', label: 'Dev-1', sub: 'Workstation', tip: 'Primary dev workstation. Runs VS Code + dashboard.' },

--- a/dashboard/js/fleet-settings.js
+++ b/dashboard/js/fleet-settings.js
@@ -5,7 +5,7 @@ const OLLAMA_DEFAULT_PORT = 11434;
 
 function loadFleetSettings() {
   const defaults = {
-    fleetIPs: { 'penguin-1': '', 'windows-laptop': '', 'chromebook-2': '' },
+    fleetIPs: { 'dev-1': '', 'fleet-host': '', 'local-dev': '' },
     sshUser: 'admin',
     openclawPort: OPENCLAW_DEFAULT_PORT,
     ollamaPort: OLLAMA_DEFAULT_PORT,

--- a/dashboard/js/transport-mocks.js
+++ b/dashboard/js/transport-mocks.js
@@ -7,10 +7,10 @@ if (window.IS_DEMO) (function () {
   const DEMO_TODAY = new Date().toISOString().slice(0, 10);
   const DEMO_YEST = new Date(Date.now() - DEMO_K.MS_PER_DAY).toISOString().slice(0, 10);
   const DEVICES = [
-    { id: '36gbwinresource', alias: '36GB Windows Resource', role: 'primary-fleet-inference', ram: '32GB', modelCount: 6, tailscaleIP: '100.91.113.16', ollama: true, openclaw: false, local: false, status: 'healthy' },
-    { id: 'windows-laptop', alias: 'OpenClaw Host', role: 'primary-inference', ram: '16GB', modelCount: 7, tailscaleIP: '100.78.22.13', ollama: true, openclaw: true, local: false, status: 'healthy' },
-    { id: 'penguin-1', alias: 'SML Chromebook', role: 'sml-agent', ram: '2.7GB', modelCount: 4, tailscaleIP: '100.86.248.35', ollama: true, openclaw: false, local: false, status: 'degraded' },
-    { id: 'chromebook-2', alias: 'Dev Chromebook', role: 'primary-dev', ram: '6.3GB', modelCount: 0, tailscaleIP: null, ollama: false, openclaw: false, local: true, status: 'healthy' },
+    { id: 'fleet-win-01', alias: 'Fleet Windows Host', role: 'primary-fleet-inference', modelCount: 6, tailscaleIP: '100.x.x.1', ollama: true, openclaw: false, local: false, status: 'healthy' },
+    { id: 'fleet-openclaw', alias: 'OpenClaw Host', role: 'primary-inference', modelCount: 7, tailscaleIP: '100.x.x.2', ollama: true, openclaw: true, local: false, status: 'healthy' },
+    { id: 'dev-1', alias: 'Dev Unit 1', role: 'sml-agent', modelCount: 4, tailscaleIP: '100.x.x.3', ollama: true, openclaw: false, local: false, status: 'degraded' },
+    { id: 'local-dev', alias: 'Local Dev', role: 'primary-dev', modelCount: 0, tailscaleIP: null, ollama: false, openclaw: false, local: true, status: 'healthy' },
   ];
   const SERVICES = [
     { id: 'github-copilot', name: 'GitHub Copilot', type: 'paid', cost: '$19/mo', status: 'active' },
@@ -22,8 +22,8 @@ if (window.IS_DEMO) (function () {
   window.runHealthChecks = async function (devices) {
     return Object.fromEntries((devices || []).map(function (d) {
       if (d.local) return [d.id, { status: 'healthy' }];
-      if (d.id === 'penguin-1') return [d.id, { status: 'degraded', models: ['qwen3.5:0.8b'] }];
-      return [d.id, { status: 'healthy', models: d.id === '36gbwinresource'
+      if (d.id === 'dev-1') return [d.id, { status: 'degraded', models: ['qwen3.5:0.8b'] }];
+      return [d.id, { status: 'healthy', models: d.id === 'fleet-win-01'
         ? ['qwen3:32b', 'qwen2.5-coder:32b', 'starcoder2:3b'] : ['qwen2.5-coder:7b', 'deepseek-coder-v2:lite'] }];
     }));
   };
@@ -31,9 +31,9 @@ if (window.IS_DEMO) (function () {
     return (devices || []).map(function (d) { return Object.assign({}, d, checks[d.id] || {}); });
   };
   window.fetchAllFleetStats = async function () {
-    return { '36gbwinresource': { tokPerSec: 80.5, activeModel: 'starcoder2:3b', utilPct: 42 },
-             'windows-laptop':  { tokPerSec: 8.4,  activeModel: 'qwen2.5-coder:7b', utilPct: 18 },
-             'penguin-1':       { tokPerSec: 12.1, activeModel: 'qwen3.5:0.8b', utilPct: 5 } };
+    return { 'fleet-win-01':    { tokPerSec: 80.5, activeModel: 'starcoder2:3b', utilPct: 42 },
+             'fleet-openclaw': { tokPerSec: 8.4,  activeModel: 'qwen2.5-coder:7b', utilPct: 18 },
+             'dev-1':          { tokPerSec: 12.1, activeModel: 'qwen3.5:0.8b', utilPct: 5 } };
   };
   window.fetchAllLiveQuotas   = async function () { return []; };
   window.pollEventBus         = async function () { return []; };
@@ -46,9 +46,9 @@ if (window.IS_DEMO) (function () {
     return { issues: { open: 12, recent: [{ number: DEMO_K.TICKET, title: 'Phase-1 dashboard', state: 'open' }] }, prs: { open: 1, recent: [] } };
   };
   window.fetchFleetHealthLog = async function () {
-    return [ { ts: Date.now() - DEMO_K.MS_60S, node: '36gbwinresource', status: 'healthy', latencyMs: 12 },
-             { ts: Date.now() - DEMO_K.MS_30S, node: 'windows-laptop',  status: 'healthy', latencyMs: 47 },
-             { ts: Date.now(),                 node: 'penguin-1',        status: 'degraded', latencyMs: DEMO_K.LATENCY_HIGH } ];
+    return [ { ts: Date.now() - DEMO_K.MS_60S, node: 'fleet-win-01',    status: 'healthy',  latencyMs: 12 },
+             { ts: Date.now() - DEMO_K.MS_30S, node: 'fleet-openclaw', status: 'healthy',  latencyMs: 47 },
+             { ts: Date.now(),                 node: 'dev-1',          status: 'degraded', latencyMs: DEMO_K.LATENCY_HIGH } ];
   };
   window.fetchGovernanceState = async function () {
     return { ticketFirst: { status: 'pass', violations: 0 }, signerFidelity: { status: 'pass', violations: 0 },


### PR DESCRIPTION
## Summary
Removes all real device identifiers from the public GitHub Pages demo. Anonymizes device IDs, aliases, and topology descriptions across 6 files.

## Changes
- `transport-mocks.js`: `36gbwinresource`→`fleet-win-01`, `penguin-1`→`dev-1`, `windows-laptop`→`fleet-openclaw`, `chromebook-2`→`local-dev`; removed `ram` field; updated `runHealthChecks`, `fetchAllFleetStats`, `fetchFleetHealthLog` keys
- `context-flow.js`: node tooltips no longer reference Chromebook model names, RAM amounts, or OS details
- `llm-context.js`: `device` field values updated to generic IDs
- `fleet-settings.js`: `fleetIPs` keys updated
- `scenario-1-healthy.jsonl`, `scenario-2-governance.jsonl`: Fleet online messages updated

## Verification
- grep check: zero real device IDs in `dashboard/` (only `localhost:4000` default port in provider-presets.js — not a real IP)
- `npm run lint` green — all files ≤100 lines

G4-impact: privacy-remediation
merge-evidence-deferred-final: #2833
Refs #2833
Refs Epic #2827