### PR TITLE
fix(dashboard): fix pollGitHub mock shape and null-guards

### DIFF
--- a/dashboard/js/github-monitor.js
+++ b/dashboard/js/github-monitor.js
@@ -26,7 +26,10 @@ function renderGitHubMonitor(gh) {
     <span style="font-size:1.5rem">🔄</span>
     <p>Connecting to GitHub API…</p>
     <p style="font-size:0.72rem;color:var(--text-muted)">Data loads on first refresh cycle</p></div>`;
-  const { issues, pulls, actions, branches } = gh;
+  const issues = gh.issues || { open: 0, recent: [] };
+  const pulls = gh.pulls || { open: 0, merged: 0, recent: [] };
+  const actions = gh.actions || { recent: [] };
+  const branches = gh.branches || { count: 0, active: [] };
   const statsHtml = `<div class="gh-stats">
     <div class="gh-stat"><span class="gh-num">${issues.open}</span><span class="gh-lbl">Open Issues</span></div>
     <div class="gh-stat"><span class="gh-num">${pulls.open}</span><span class="gh-lbl">Open PRs</span></div>

--- a/dashboard/js/transport-mocks.js
+++ b/dashboard/js/transport-mocks.js
@@ -43,7 +43,7 @@ if (window.IS_DEMO) (function () {
   window.fetchWikiHealth   = async function () { return { loaded: true, pages: 47, stale: 2 }; };
   window.fetchWikiMetrics  = async function () { return { total: 47, fresh: 45, stale: 2, avgTrust: 0.91 }; };
   window.pollGitHub        = async function () {
-    return { issues: { open: 12, recent: [{ number: DEMO_K.TICKET, title: 'Phase-1 dashboard', state: 'open' }] }, prs: { open: 1, recent: [] } };
+    return { issues: { open: 12, recent: [{ number: DEMO_K.TICKET, title: 'Phase-1 dashboard', state: 'open' }] }, pulls: { open: 1, merged: 3, recent: [] }, actions: { recent: [] }, branches: { count: 2, active: ['main', 'feat/dashboard-demo'] } };
   };
   window.fetchFleetHealthLog = async function () {
     return [ { ts: Date.now() - DEMO_K.MS_60S, node: '36gbwinresource', status: 'healthy', latencyMs: 12 },


### PR DESCRIPTION
## Summary
Fixes TypeError every 5 seconds in demo mode. `renderGitHubMonitor` destructures `{issues, pulls, actions, branches}` but the mock returned `{issues, prs}` — wrong key + missing fields.

## Changes
- `transport-mocks.js`: renamed `prs`→`pulls`, added `merged: 3`, `actions: { recent: [] }`, `branches: { count: 2, active: [...] }`
- `github-monitor.js`: replaced single destructuring with null-guarded individual assignments

merge-evidence-deferred-final: #2834
Refs #2834
Refs Epic #2827