### PR TITLE
fix(dashboard): correct pollGitHub mock shape and add null-guard

### DIFF
--- a/dashboard/js/github-monitor.js
+++ b/dashboard/js/github-monitor.js
@@ -26,7 +26,10 @@ function renderGitHubMonitor(gh) {
     <span style="font-size:1.5rem">🔄</span>
     <p>Connecting to GitHub API…</p>
     <p style="font-size:0.72rem;color:var(--text-muted)">Data loads on first refresh cycle</p></div>`;
-  const { issues, pulls, actions, branches } = gh;
+  const issues = gh.issues || { open: 0, recent: [] };
+  const pulls = gh.pulls || { open: 0, merged: 0, recent: [] };
+  const actions = gh.actions || { recent: [] };
+  const branches = gh.branches || { count: 0, active: [] };
   const statsHtml = `<div class="gh-stats">
     <div class="gh-stat"><span class="gh-num">${issues.open}</span><span class="gh-lbl">Open Issues</span></div>
     <div class="gh-stat"><span class="gh-num">${pulls.open}</span><span class="gh-lbl">Open PRs</span></div>

--- a/dashboard/js/transport-mocks.js
+++ b/dashboard/js/transport-mocks.js
@@ -43,7 +43,7 @@ if (window.IS_DEMO) (function () {
   window.fetchWikiHealth   = async function () { return { loaded: true, pages: 47, stale: 2 }; };
   window.fetchWikiMetrics  = async function () { return { total: 47, fresh: 45, stale: 2, avgTrust: 0.91 }; };
   window.pollGitHub        = async function () {
-    return { issues: { open: 12, recent: [{ number: DEMO_K.TICKET, title: 'Phase-1 dashboard', state: 'open' }] }, prs: { open: 1, recent: [] } };
+    return { issues: { open: 12, recent: [{ number: DEMO_K.TICKET, title: 'Phase-1 dashboard', state: 'open' }] }, pulls: { open: 1, merged: 3, recent: [] }, actions: { recent: [] }, branches: { count: 2, active: ['main', 'feat/dashboard-demo'] } };
   };
   window.fetchFleetHealthLog = async function () {
     return [ { ts: Date.now() - DEMO_K.MS_60S, node: '36gbwinresource', status: 'healthy', latencyMs: 12 },


### PR DESCRIPTION
merge-evidence-deferred-final: #2834
Refs #2834
Part of Epic #2827 Demo Mode Quality Sprint



All baton artifacts (MANAGER_HANDOFF, COLLABORATOR_HANDOFF) posted to #2834.
CI gate: npm run lint ✅ | readability ✅ | cross-family: 95/100 (qwen2.5-coder:32b — Epic #2827)