### PR TITLE
feat(dashboard): router/ticket events in scenario JSONL and fixture-runner

### DIFF
--- a/dashboard/fixtures/scenario-1-healthy.jsonl
+++ b/dashboard/fixtures/scenario-1-healthy.jsonl
@@ -12,3 +12,11 @@
 {"type":"system","message":"CI green","detail":"lint PASS · test-evidence PASS · admin-gate PASS","ts":12500}
 {"type":"baton","role":"consultant","issue":2809,"message":"Consultant review","detail":"rubric 9/10 · approve_for_merge","ts":14000}
 {"type":"system","message":"Session complete","detail":"cost: $0.00 fleet · $0.04 paid · 74% fleet-routed","ts":15800}
+{"type":"ticket","number":2809,"action":"created","title":"feat(dashboard): add transport demo mode","ts":2100}
+{"type":"router","lane":"fleet","model":"qwen3:32b","tokens":1820,"decision":"code-change: fleet direct (G3)","ts":5500}
+{"type":"router","lane":"fleet","model":"qwen2.5-coder:7b","tokens":340,"decision":"autocomplete: fleet direct","ts":7500}
+{"type":"ticket","number":2809,"action":"in-progress","title":"Collaborator active: transport demo mode","ts":8200}
+{"type":"router","lane":"haiku","model":"claude-haiku-3","tokens":2100,"decision":"4-tool chain: escalated to haiku","ts":9800}
+{"type":"router","lane":"fleet","model":"qwen3:32b","tokens":950,"decision":"code review: fleet direct","ts":12000}
+{"type":"router","lane":"fleet","model":"deepseek-coder-v2:lite","tokens":480,"decision":"test gen: fleet direct","ts":13500}
+{"type":"ticket","number":2809,"action":"merged","title":"feat(dashboard): transport demo mode shipped","ts":15500}

--- a/dashboard/js/fixture-runner.js
+++ b/dashboard/js/fixture-runner.js
@@ -26,6 +26,12 @@ const fixtureRunner = (function () {
       app.batonState = existing.concat([ev]);
       return;
     }
+    if (ev.type === 'router' || ev.type === 'ticket') {
+      const key = ev.type === 'router' ? 'routerLog' : 'ticketLog';
+      window.demoConfig = window.demoConfig || {};
+      window.demoConfig[key] = window.demoConfig[key] || [];
+      window.demoConfig[key].unshift(ev); return;
+    }
     const typeMap = { warn: 'warn', llm: 'llm', tool: 'tool', agent: 'agent', system: 'system' };
     const evType = typeMap[ev.type] || 'system';
     const msg = ev.message || ev.type.replace(/_/g, ' ');

--- a/dashboard/js/transport-mocks-extended.js
+++ b/dashboard/js/transport-mocks-extended.js
@@ -30,6 +30,7 @@ if (window.IS_DEMO) (function () {
 
   /* getTicketLog — synchronous; returns demo ticket entries. */
   window.getTicketLog = function () {
+    if (window.demoConfig && window.demoConfig.ticketLog && window.demoConfig.ticketLog.length) return window.demoConfig.ticketLog;
     return [
       { id: DEMO_TICKET, title: 'Demo Mode Quality Sprint', status: 'in-progress', role: 'collaborator' },
       { id: DEMO_PREV,   title: 'Fix demo device IDs',      status: 'done',         role: null },
@@ -47,6 +48,7 @@ if (window.IS_DEMO) (function () {
 
   /* getRouterLog — synchronous; fallback for buildBatonState when getBatonState absent. */
   window.getRouterLog = function () {
+    if (window.demoConfig && window.demoConfig.routerLog && window.demoConfig.routerLog.length) return window.demoConfig.routerLog;
     return [
       { lane: 'fleet',   model: 'qwen2.5-coder:32b', tokens: TOK_FLEET,   cost: 0,           ts: Date.now() - MS_8S },
       { lane: 'haiku',   model: 'claude-haiku-3',     tokens: TOK_HAIKU,   cost: COST_HAIKU,  ts: Date.now() - MS_5S },


### PR DESCRIPTION
merge-evidence-deferred-final: #2841
Refs #2841
Part of Epic #2827 Demo Mode Quality Sprint



All baton artifacts (MANAGER_HANDOFF, COLLABORATOR_HANDOFF) posted to #2841.
CI gate: npm run lint ✅ | readability ✅ | cross-family: 95/100 (qwen2.5-coder:32b — Epic #2827)