### PR TITLE
feat(scripts): agentic MCP loop driver for fleet dev

### DIFF
--- a/.changes/unreleased/2854.md
+++ b/.changes/unreleased/2854.md
@@ -1,0 +1,9 @@
+### Added
+
+- Agentic MCP loop driver for fleet-model development (#2854, P1-0 child of #2802):
+  `runAgenticLoop(opts)` ties the shipped substrate into one bounded loop — an injectable `step(ctx)`
+  yields the fleet model's next action (governed tool call → `fleet-mcp-broker.invokeTool`, OA2-gated;
+  proposed change → `fleet-sandbox-exec.validateProposedChange`, fail-closed; final answer; or escalate),
+  feeding the running transcript back each iteration. The operator owns the validation `testCommand` (a
+  fleet `propose` action can never choose it); the loop escalates on max-iterations, a consecutive-failure
+  budget, or an explicit fleet escalate. New: `scripts/global/fleet-agentic-loop.js`.

--- a/scripts/global/fleet-agentic-actions.js
+++ b/scripts/global/fleet-agentic-actions.js
@@ -1,0 +1,68 @@
+// Action handlers for the fleet agentic loop (#2854 P1-0 child of #2802; design D12). One fleet action →
+// { record, failed, done? } where `done` short-circuits the loop. Dependency-injected (deps.invokeTool /
+// deps.validate) so the driver stays thin and these stay unit-testable. Untrusted model strings + tool
+// payloads are capped before entering the transcript (anti-bloat, G6); a misbehaving dep or a
+// non-serializable result is treated as a FAILURE, never a crash.
+const MAX_REASON_CHARS = 200; // cap untrusted model strings (escalate reason) recorded in the transcript
+const MAX_RESULT_CHARS = 4000; // cap a tool-result payload recorded in the transcript
+// Coerce to string FIRST so a non-string (a model passing a huge object/array as tool/reason) can't
+// bypass the bound; then truncate. Always returns a bounded string.
+const cap = (text) => {
+  const str = String(text ?? '');
+  return str.length > MAX_REASON_CHARS ? str.slice(0, MAX_REASON_CHARS) + '…' : str;
+};
+
+// Bound a tool result payload → { value, truncated }. Over-budget OR non-serializable (circular refs /
+// BigInt make JSON.stringify throw) becomes a flagged string, so a huge/garbage payload can neither bloat
+// the transcript (functional DoS) nor crash the loop.
+function capResult(payload) {
+  if (payload == null) return { value: payload, truncated: false };
+  let serialized;
+  try { serialized = JSON.stringify(payload); }
+  catch { return { value: '[unserializable tool result]', truncated: true }; }
+  if (serialized == null || serialized.length <= MAX_RESULT_CHARS) return { value: payload, truncated: false };
+  return { value: serialized.slice(0, MAX_RESULT_CHARS) + '…', truncated: true };
+}
+
+// Governed tool call → deps.invokeTool (OA2-gated, #2847). null-safe: a misbehaving dep is a failure, not
+// a crash. Payload capped + placed FLAT at record.result (ok + truncated at top level — no double-nesting).
+function handleTool(action, deps) {
+  const result = deps.invokeTool(action.tool, action.args || {});
+  const ok = Boolean(result && result.ok);
+  const capped = capResult(result && result.result);
+  // cap(action.tool): the tool name is an untrusted model string entering the transcript — bound it too.
+  return { record: { kind: 'tool', tool: cap(action.tool), ok, result: capped.value, truncated: capped.truncated }, failed: !ok };
+}
+
+// Proposed change → validate in the fail-closed sandbox (deps.validate, #2844). Only a trusted change
+// completes; null-safe vs a misbehaving validate. The OPERATOR owns testCommand (passed in, not the action).
+function handlePropose(action, deps, testCommand) {
+  const verdict = deps.validate({ changes: action.changes, testCommand, root: deps.root });
+  const trusted = Boolean(verdict && verdict.trusted);
+  const done = trusted ? { outcome: 'completed', reason: 'change-trusted', result: action.changes } : null;
+  // cap the verdict reason too — the last dep-derived string entering the transcript (anti-bloat, G6).
+  return { record: { kind: 'propose', trusted, reason: cap(verdict && verdict.reason) }, failed: !trusted, done };
+}
+
+// applyAction(action, deps, testCommand) -> { record, failed, done? }. Dispatches one fleet action; an
+// unknown/garbage action shape is a recorded failure (records only typeof, not the raw untrusted body).
+function applyAction(action, deps, testCommand) {
+  switch (action && action.type) {
+    case 'tool': return handleTool(action, deps);
+    case 'propose': return handlePropose(action, deps, testCommand);
+    case 'final':
+      // cap the untrusted free-form answer returned to the caller (DoS guard). NOTE: a `propose` result
+      // (action.changes) is NOT capped — it is the deliverable and is already bounded to <=10MB by the
+      // #2844 validator that just trusted it; truncating it would corrupt the change the operator applies.
+      return { record: { kind: 'final' }, failed: false,
+        done: { outcome: 'completed', reason: 'final', result: capResult(action.answer).value } };
+    case 'escalate': {
+      const reason = action.reason ? cap(action.reason) : 'fleet-escalate';
+      return { record: { kind: 'escalate', reason }, failed: false, done: { outcome: 'escalated', reason } };
+    }
+    default:
+      return { record: { kind: 'invalid', type: typeof action }, failed: true };
+  }
+}
+
+module.exports = { applyAction, capResult, cap };

--- a/scripts/global/fleet-agentic-loop.js
+++ b/scripts/global/fleet-agentic-loop.js
@@ -1,0 +1,53 @@
+// Agentic MCP loop driver for fleet-model development (#2854 P1-0 child of #2802; design D12). Ties the
+// shipped substrate into one bounded loop: an injectable `step(ctx)` yields the fleet model's next action,
+// dispatched by applyAction (fleet-agentic-actions.js) to the governed tool broker (#2847, OA2-gated) or
+// the fail-closed sandbox validator (#2844). The running transcript is fed back each iteration so the
+// model can react to results. SECURITY: the OPERATOR owns `testCommand` (from opts) — a fleet `propose`
+// action can never choose what runs, the #2844 principle. The loop is BOUNDED and escalates on
+// max-iterations / a consecutive-failure budget / an explicit fleet escalate. All side-effects
+// (step/invokeTool/validate) injectable → tests are network/process-free.
+const { invokeTool } = require('./fleet-mcp-broker');
+const { validateProposedChange } = require('./fleet-sandbox-exec');
+const { applyAction } = require('./fleet-agentic-actions');
+
+// Resolve opts → config: injectable side-effects default to the shipped #2847/#2844 fns; bounds default.
+// `??` (not `||`) so a deliberate 0 bound is respected.
+function resolveConfig(opts) {
+  return {
+    invokeTool: opts.invokeTool ?? invokeTool,
+    validate: opts.validate ?? validateProposedChange,
+    root: opts.root,
+    testCommand: opts.testCommand ?? ['true'],
+    maxIterations: opts.maxIterations ?? 8,
+    maxConsecutiveFailures: opts.maxConsecutiveFailures ?? 3,
+  };
+}
+
+// runAgenticLoop(opts) -> { outcome, reason, result?, transcript, iterations }.
+//   opts.step: async (ctx) => action  REQUIRED — the fleet model's next action (injectable; a real
+//     integration backs it with dispatchWithContext + a model-output parser, #2823).
+//   opts.testCommand: [cmd,...args] operator-owned · opts.maxIterations / maxConsecutiveFailures bounds ·
+//   opts.invokeTool / validate / root injectable (default to the shipped #2847/#2844 fns).
+async function runAgenticLoop(opts = {}) {
+  if (typeof opts.step !== 'function') {
+    throw new Error('runAgenticLoop: opts.step (ctx) => Promise<action> is required');
+  }
+  const cfg = resolveConfig(opts);
+  const transcript = [];
+  let consecutiveFailures = 0;
+  for (let iteration = 0; iteration < cfg.maxIterations; iteration += 1) {
+    const action = await opts.step({ task: opts.task, transcript, iteration });
+    const outcome = applyAction(action, cfg, cfg.testCommand);
+    transcript.push(outcome.record);
+    consecutiveFailures = outcome.failed ? consecutiveFailures + 1 : 0;
+    if (outcome.done) return { ...outcome.done, transcript, iterations: iteration + 1 };
+    // > 0 guard: a successful action (streak reset to 0) must never trip failure-escalation, and it makes
+    // maxConsecutiveFailures:0 mean "escalate on the first failure".
+    if (consecutiveFailures > 0 && consecutiveFailures >= cfg.maxConsecutiveFailures) {
+      return { outcome: 'escalated', reason: 'repeated-failure', transcript, iterations: iteration + 1 };
+    }
+  }
+  return { outcome: 'escalated', reason: 'max-iterations', transcript, iterations: cfg.maxIterations };
+}
+
+module.exports = { runAgenticLoop, applyAction };

--- a/tests/fleet-agentic-loop.spec.js
+++ b/tests/fleet-agentic-loop.spec.js
@@ -1,0 +1,89 @@
+// Refs #2854 P1-0 child of #2802 — agentic MCP loop driver. Network/process-free: step/invokeTool/
+// validate are all injected. A `scriptedStep` replays a queue of fleet actions.
+const { test, expect } = require('@playwright/test');
+const { runAgenticLoop, applyAction } = require('../scripts/global/fleet-agentic-loop.js');
+
+// Returns a step() that yields the queued actions in order (then a final once exhausted).
+function scriptedStep(actions) {
+  const queue = actions.slice();
+  return async () => queue.shift() || { type: 'final', answer: 'done' };
+}
+const okTool = () => ({ ok: true, result: { x: 1 } });
+const trusted = () => ({ trusted: true, reason: 'tests passed' });
+const untrusted = () => ({ trusted: false, reason: 'tests failed (exit 1)' });
+
+test('#2854 AC1 a tool call then a final answer completes the loop', async () => {
+  const out = await runAgenticLoop({
+    task: 't', step: scriptedStep([{ type: 'tool', tool: 'github_read', args: { kind: 'issue', number: 1 } },
+      { type: 'final', answer: 'ok' }]), invokeTool: okTool, validate: trusted,
+  });
+  expect(out.outcome).toBe('completed');
+  expect(out.reason).toBe('final');
+  expect(out.result).toBe('ok');
+  expect(out.iterations).toBe(2);
+  expect(out.transcript.map((entry) => entry.kind)).toEqual(['tool', 'final']);
+  // flat tool record: ok + payload directly at .result (no double-nesting), truncated flag present
+  expect(out.transcript[0]).toMatchObject({ kind: 'tool', tool: 'github_read', ok: true, result: { x: 1 }, truncated: false });
+});
+
+test('#2854 AC2 a trusted proposed change is promoted; operator owns testCommand', async () => {
+  let seenTestCommand = null;
+  const out = await runAgenticLoop({
+    step: scriptedStep([{ type: 'propose', changes: [{ path: 'a.js', content: 'x' }], testCommand: ['rm', '-rf'] }]),
+    testCommand: ['node', '--test'],
+    validate: (args) => { seenTestCommand = args.testCommand; return trusted(); },
+  });
+  expect(out.outcome).toBe('completed');
+  expect(out.reason).toBe('change-trusted');
+  expect(out.result).toEqual([{ path: 'a.js', content: 'x' }]);
+  expect(seenTestCommand).toEqual(['node', '--test']); // opts.testCommand, NOT the fleet action's
+});
+
+test('#2854 AC2 an untrusted change does not complete — loop continues then finals', async () => {
+  const out = await runAgenticLoop({
+    step: scriptedStep([{ type: 'propose', changes: [], testCommand: ['x'] }, { type: 'final', answer: 'fixed' }]),
+    validate: untrusted,
+  });
+  expect(out.outcome).toBe('completed');
+  expect(out.result).toBe('fixed');
+  expect(out.transcript[0]).toMatchObject({ kind: 'propose', trusted: false });
+});
+
+test('#2854 AC3 explicit fleet escalate hands back to the operator', async () => {
+  const out = await runAgenticLoop({ step: scriptedStep([{ type: 'escalate', reason: 'low-confidence' }]) });
+  expect(out.outcome).toBe('escalated');
+  expect(out.reason).toBe('low-confidence');
+  expect(out.iterations).toBe(1);
+});
+
+test('#2854 AC3 max-iterations escalates (bounded loop)', async () => {
+  // step always returns a tool call that "succeeds" but never finishes → must hit the iteration bound.
+  const out = await runAgenticLoop({
+    step: async () => ({ type: 'tool', tool: 'wiki_search', args: { query: 'x' } }),
+    invokeTool: okTool, maxIterations: 4,
+  });
+  expect(out.outcome).toBe('escalated');
+  expect(out.reason).toBe('max-iterations');
+  expect(out.iterations).toBe(4);
+});
+
+test('#2854 AC3 a consecutive-failure streak escalates', async () => {
+  const out = await runAgenticLoop({
+    step: async () => ({ type: 'tool', tool: 'github_merge', args: {} }),
+    invokeTool: () => ({ ok: false, reason: 'unknown tool' }), maxConsecutiveFailures: 3, maxIterations: 20,
+  });
+  expect(out.outcome).toBe('escalated');
+  expect(out.reason).toBe('repeated-failure');
+  expect(out.iterations).toBe(3);
+});
+
+test('#2854 AC4 a missing step throws a clear error', async () => {
+  await expect(runAgenticLoop({})).rejects.toThrow(/opts\.step.*required/);
+});
+
+test('#2854 applyAction classifies each action shape', () => {
+  expect(applyAction({ type: 'final', answer: 'a' }, {}, ['x']).done.outcome).toBe('completed');
+  expect(applyAction({ type: 'escalate' }, {}, ['x']).done).toMatchObject({ outcome: 'escalated', reason: 'fleet-escalate' });
+  expect(applyAction({ type: 'bogus' }, {}, ['x']).failed).toBe(true);
+  expect(applyAction({ type: 'tool', tool: 'wiki_search' }, { invokeTool: okTool }, ['x']).failed).toBe(false);
+});

--- a/tests/stress-fleet-agentic-loop.spec.js
+++ b/tests/stress-fleet-agentic-loop.spec.js
@@ -1,0 +1,171 @@
+// Stress tests for #2854 agentic MCP loop driver — MCP loop-lifecycle chaos (G6) + a p99 latency budget
+// on the bounded loop (G7). Satisfies #2802 AC7 for the loop surface. Network/process-free (all injected).
+const { test, expect } = require('@playwright/test');
+const { runAgenticLoop } = require('../scripts/global/fleet-agentic-loop.js');
+
+const okTool = () => ({ ok: true, result: {} });
+
+test('#2854 CHAOS: an unbroken tool-denial stream always escalates, never completes', async () => {
+  for (const limit of [1, 2, 3, 5, 8]) {
+    const out = await runAgenticLoop({
+      step: async () => ({ type: 'tool', tool: 'github_merge', args: {} }),
+      invokeTool: () => ({ ok: false, reason: 'unknown tool' }),
+      maxConsecutiveFailures: limit, maxIterations: 50,
+    });
+    expect(out.outcome).toBe('escalated');
+    expect(out.reason).toBe('repeated-failure');
+    expect(out.iterations).toBe(limit); // escalates exactly at the failure budget
+  }
+});
+
+test('#2854 CHAOS: a never-trusted change stream escalates (no untrusted promotion)', async () => {
+  const out = await runAgenticLoop({
+    step: async () => ({ type: 'propose', changes: [{ path: 'a', content: 'x' }] }),
+    validate: () => ({ trusted: false, reason: 'tests failed' }),
+    maxConsecutiveFailures: 4, maxIterations: 50,
+  });
+  expect(out.outcome).toBe('escalated');
+  expect(out.transcript.every((entry) => entry.trusted === false)).toBe(true); // nothing promoted
+});
+
+test('#2854 CHAOS: garbage/invalid actions are failures and never crash the loop', async () => {
+  const garbage = [null, undefined, {}, { type: 'unknown' }, 42, 'tool', { type: 'tool' }];
+  let index = 0;
+  const out = await runAgenticLoop({
+    step: async () => garbage[index++ % garbage.length],
+    invokeTool: () => ({ ok: false, reason: 'no tool' }), maxConsecutiveFailures: 5, maxIterations: 30,
+  });
+  expect(out.outcome).toBe('escalated'); // bounded + fail-closed, no throw
+});
+
+test('#2854 CHAOS: a recovery (failure then success) resets the failure streak', async () => {
+  // fail twice, succeed once (resets), then finish — must NOT escalate on repeated-failure(=3).
+  const actions = [{ type: 'tool', tool: 'x' }, { type: 'tool', tool: 'x' },
+    { type: 'tool', tool: 'wiki_search' }, { type: 'final', answer: 'ok' }];
+  let oks = [false, false, true];
+  let call = 0;
+  const out = await runAgenticLoop({
+    step: async () => actions.shift(),
+    invokeTool: () => ({ ok: oks[call++] ?? true }),
+    maxConsecutiveFailures: 3, maxIterations: 10,
+  });
+  expect(out.outcome).toBe('completed');
+});
+
+test('#2854 EDGE: a deliberate maxIterations:0 is respected (?? not ||), loop runs zero times', async () => {
+  let stepCalls = 0;
+  const out = await runAgenticLoop({ step: async () => { stepCalls += 1; return { type: 'final', answer: 'x' }; },
+    maxIterations: 0 });
+  expect(stepCalls).toBe(0);
+  expect(out.outcome).toBe('escalated');
+  expect(out.reason).toBe('max-iterations');
+  expect(out.iterations).toBe(0);
+});
+
+test('#2854 EDGE: a successful action never trips the failure escalation (> 0 guard)', async () => {
+  // maxConsecutiveFailures:0 must mean "escalate on first FAILURE", not on a success.
+  const out = await runAgenticLoop({
+    step: async (ctx) => (ctx.iteration < 2 ? { type: 'tool', tool: 'wiki_search' } : { type: 'final', answer: 'ok' }),
+    invokeTool: () => ({ ok: true }), maxConsecutiveFailures: 0, maxIterations: 10,
+  });
+  expect(out.outcome).toBe('completed'); // successes alone never escalate
+});
+
+test('#2854 EDGE: maxConsecutiveFailures:0 escalates on the very first failure', async () => {
+  const out = await runAgenticLoop({ step: async () => ({ type: 'tool', tool: 'github_merge' }),
+    invokeTool: () => ({ ok: false, reason: 'no' }), maxConsecutiveFailures: 0, maxIterations: 10 });
+  expect(out.outcome).toBe('escalated');
+  expect(out.reason).toBe('repeated-failure');
+  expect(out.iterations).toBe(1);
+});
+
+test('#2854 CHAOS: untrusted model strings are capped in the transcript (anti-bloat)', async () => {
+  const huge = 'A'.repeat(50000);
+  const escalated = await runAgenticLoop({ step: async () => ({ type: 'escalate', reason: huge }) });
+  expect(escalated.transcript[0].reason.length).toBeLessThan(300); // truncated, not 50k
+  // an invalid action with a huge body records only its shape, not the body
+  const invalid = await runAgenticLoop({ step: async () => ({ type: 'x', junk: huge }),
+    maxConsecutiveFailures: 1 });
+  expect(JSON.stringify(invalid.transcript)).not.toContain('AAAAA');
+  // a tool returning a multi-megabyte payload is capped in the transcript (functional-DoS guard)
+  const bigTool = await runAgenticLoop({
+    step: async (ctx) => (ctx.iteration < 1 ? { type: 'tool', tool: 'github_read' } : { type: 'final', answer: 'x' }),
+    invokeTool: () => ({ ok: true, result: { body: 'B'.repeat(2_000_000) } }),
+  });
+  const toolEntry = bigTool.transcript.find((entry) => entry.kind === 'tool');
+  expect(toolEntry.truncated).toBe(true); // flat record: truncated flag at top level
+  expect(toolEntry.ok).toBe(true);
+  expect(JSON.stringify(toolEntry).length).toBeLessThan(8000); // bounded, not 2MB
+});
+
+test('#2854 CHAOS: untrusted tool name + final answer are capped (anti-bloat / DoS)', async () => {
+  const huge = 'Z'.repeat(60000);
+  const toolRun = await runAgenticLoop({
+    step: async (ctx) => (ctx.iteration < 1 ? { type: 'tool', tool: huge } : { type: 'final', answer: 'x' }),
+    invokeTool: () => ({ ok: true, result: {} }),
+  });
+  expect(toolRun.transcript[0].tool.length).toBeLessThan(300); // tool name bounded in the transcript
+  const finalRun = await runAgenticLoop({ step: async () => ({ type: 'final', answer: huge }) });
+  expect(String(finalRun.result).length).toBeLessThan(5000); // final answer bounded to the caller
+});
+
+test('#2854 CHAOS: a non-string tool name / escalate reason is coerced + bounded', async () => {
+  const bigArray = new Array(50000).fill('q'); // non-string the model might smuggle in
+  const toolRun = await runAgenticLoop({
+    step: async (ctx) => (ctx.iteration < 1 ? { type: 'tool', tool: bigArray } : { type: 'final', answer: 'x' }),
+    invokeTool: () => ({ ok: false, reason: 'no' }), maxIterations: 4,
+  });
+  expect(typeof toolRun.transcript[0].tool).toBe('string');
+  expect(toolRun.transcript[0].tool.length).toBeLessThan(300);
+  const escRun = await runAgenticLoop({ step: async () => ({ type: 'escalate', reason: { huge: bigArray } }) });
+  expect(typeof escRun.reason).toBe('string');
+  expect(escRun.reason.length).toBeLessThan(300);
+  // a validate verdict with a huge reason is bounded in the transcript too
+  const verdictRun = await runAgenticLoop({ step: async () => ({ type: 'propose', changes: [] }),
+    validate: () => ({ trusted: false, reason: 'R'.repeat(40000) }), maxConsecutiveFailures: 1 });
+  expect(verdictRun.transcript[0].reason.length).toBeLessThan(300);
+});
+
+test('#2854 a trusted propose returns the FULL change set (deliverable not truncated)', async () => {
+  const changes = [{ path: 'a.js', content: 'X'.repeat(20000) }]; // bounded by #2844 (<=10MB), kept whole
+  const out = await runAgenticLoop({
+    step: async () => ({ type: 'propose', changes }), validate: () => ({ trusted: true }),
+  });
+  expect(out.result).toEqual(changes); // operator gets the exact validated changes to apply
+});
+
+test('#2854 CHAOS: a misbehaving dep returning nullish is a failure, not a crash', async () => {
+  const nullTool = await runAgenticLoop({ step: async () => ({ type: 'tool', tool: 'x' }),
+    invokeTool: () => null, maxConsecutiveFailures: 2, maxIterations: 10 });
+  expect(nullTool.outcome).toBe('escalated'); // recorded as failure, no throw
+  const nullValidate = await runAgenticLoop({ step: async () => ({ type: 'propose', changes: [] }),
+    validate: () => undefined, maxConsecutiveFailures: 2, maxIterations: 10 });
+  expect(nullValidate.outcome).toBe('escalated'); // untrusted by default, no throw, never promoted
+});
+
+test('#2854 CHAOS: a circular / non-serializable tool result never crashes the loop', async () => {
+  const circular = {}; circular.self = circular; // JSON.stringify would throw
+  const out = await runAgenticLoop({
+    step: async (ctx) => (ctx.iteration < 1 ? { type: 'tool', tool: 'github_read' } : { type: 'final', answer: 'x' }),
+    invokeTool: () => ({ ok: true, result: circular }),
+  });
+  expect(out.outcome).toBe('completed'); // no throw
+  const toolEntry = out.transcript.find((entry) => entry.kind === 'tool');
+  expect(toolEntry.truncated).toBe(true);
+  expect(toolEntry.result).toBe('[unserializable tool result]');
+});
+
+test('#2854 PERF: a bounded loop p99 < 5ms (injected step)', async () => {
+  const samples = [];
+  for (let iter = 0; iter < 1000; iter += 1) {
+    const start = process.hrtime.bigint();
+    // eslint-disable-next-line no-await-in-loop
+    await runAgenticLoop({
+      step: async (ctx) => (ctx.iteration < 3 ? { type: 'tool', tool: 'wiki_search' } : { type: 'final', answer: 'x' }),
+      invokeTool: okTool, maxIterations: 8,
+    });
+    samples.push(Number(process.hrtime.bigint() - start) / 1e6);
+  }
+  samples.sort((first, second) => first - second);
+  expect(samples[Math.floor(samples.length * 0.99)]).toBeLessThan(5);
+});


### PR DESCRIPTION
Refs #2854

Closes #2854

## Summary
The agentic MCP loop driver — the critical-path P1-0 deliverable that ties the shipped substrate into an
iterative loop (P1-0 child of #2802). An injectable `step(ctx)` yields the fleet model's next action;
the loop dispatches it to the governed tool broker (#2847, OA2-gated), the fail-closed sandbox validator
(#2844), or completes/escalates — feeding the transcript back each iteration.

- `scripts/global/fleet-agentic-loop.js` — `runAgenticLoop` (bounded loop + config)
- `scripts/global/fleet-agentic-actions.js` — `applyAction` handlers (tool/propose/final/escalate)
- tests: `tests/fleet-agentic-loop.spec.js` (tdd) + `tests/stress-fleet-agentic-loop.spec.js` (loop-lifecycle chaos + p99)

## Security / robustness (untrusted-LLM threat surface)
Operator owns `testCommand` (a fleet `propose` can never choose it); only authorized tools run and only
sandbox-trusted changes are promoted; the loop is **bounded** and escalates on max-iterations /
consecutive-failure budget / explicit escalate. Every untrusted model/dep-derived string is capped before
entering the transcript (anti-bloat / functional-DoS); circular/non-serializable tool results and
misbehaving (nullish) deps are handled as failures, never crashes. The validated `propose` changes are
returned whole (the deliverable, already ≤10MB-bounded by #2844).

## Baton artifacts (full text on #2854)
MANAGER / COLLABORATOR (per-AC PASS; tdd-pyramid+stress-test) / ADMIN (signer-independence PASS, Harper≠Reyes;
sync-verification N/A) / CONSULTANT_CLOSEOUT (approve_for_merge; rubric 9/10; cross_family_verdict ACCEPT).

## Cross-family review
gemini-2.5-pro@google-ai-studio — ACCEPT 10/10 (9 iterations). Found + fixed pre-merge: 0-bound discard,
success-escalate, multiple anti-bloat gaps, circular-ref crash, null-dep crash, record nesting.

## Verification
lint ≤100 ✅ · eslint 0 errors · readability 474 ≤475 · 22/22 tests green · real end-to-end smoke
(github_read ok → github_merge denied → propose trusted → completed, no sandbox leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
