### PR TITLE
fix(dashboard): context flow mobile scale, demo CTA, picker click

### DIFF
--- a/dashboard/css/context-flow-anim.css
+++ b/dashboard/css/context-flow-anim.css
@@ -60,3 +60,8 @@
     stroke-dashoffset: 0;
   }
 }
+
+/* Scale SVG diagram for narrow viewports where 9px node text would be unreadable */
+@media (max-width: 480px) {
+  .cf-wrap { transform: scale(0.7); transform-origin: top left; }
+}

--- a/dashboard/css/demo.css
+++ b/dashboard/css/demo.css
@@ -48,3 +48,7 @@
   margin-top: 1.5rem; width: 100%; padding: 0.5rem;
   background: #334155; border: none; color: #e2e8f0; border-radius: 4px; cursor: pointer;
 }
+/* Scenario picker: full-width card buttons for reliable click targets */
+.demo-picker-card button[data-name] {
+  width: 100%; cursor: pointer; text-align: left;
+}

--- a/dashboard/js/demo-overlay.js
+++ b/dashboard/js/demo-overlay.js
@@ -25,7 +25,7 @@ if (window.IS_DEMO) (function () {
       + '<button id="demo-switch-btn">Switch Scenario</button>'
       + '<button id="demo-glossary-btn">\uD83D\uDCD6 Concepts</button>'
       + '<a href="https://github.com/chf3198/megingjord-harness#readme"'
-      + ' target="_blank" rel="noopener noreferrer">\uD83D\uDE80 Install locally \u2192</a>';
+      + ' target="_blank" rel="noopener noreferrer">Learn how it works</a>';
     document.body.prepend(banner);
     document.getElementById('demo-switch-btn').addEventListener('click', showPicker);
     document.getElementById('demo-glossary-btn').addEventListener('click', toggleGlossary);


### PR DESCRIPTION
merge-evidence-deferred-final: #2840
Refs #2840
Part of Epic #2827 Demo Mode Quality Sprint

All baton artifacts (MANAGER_HANDOFF, COLLABORATOR_HANDOFF) posted to #2840.
CI gate: npm run lint ✅ | cross-family: 95/100 (qwen2.5-coder:32b — Epic #2827)

## Changes
- `dashboard/css/context-flow-anim.css`: @media (max-width:480px) scale(0.7) for SVG readability
- `dashboard/js/demo-overlay.js`: CTA text → 'Learn how it works'
- `dashboard/css/demo.css`: full-width cursor:pointer for picker card buttons