### PR TITLE
feat(scripts): IDE/native-MCP coexistence + port-collision

### DIFF
--- a/.changes/unreleased/2855.md
+++ b/.changes/unreleased/2855.md
@@ -1,0 +1,9 @@
+### Added
+
+- IDE/native-MCP coexistence for the fleet MCP loop (#2855, P1-0 child of #2802): `resolveCoexistence`
+  picks a free port for the fleet loop while avoiding ports a host IDE's MCP servers declare (read from
+  committed config, e.g. `github.copilot.mcp.servers`), so the fleet loop never collides with the IDE.
+  Binding the chosen port holds the OS-level mutual-exclusion lock — two fleet loops can never
+  double-bind. If no free port is available it degrades to disk-read-only mode (graceful); absent any
+  IDE/MCP config it is a no-op pass-through to a free port (tier-graceful). New:
+  `scripts/global/fleet-mcp-coexist.js`, `scripts/global/fleet-mcp-portbind.js`.

--- a/scripts/global/fleet-mcp-coexist.js
+++ b/scripts/global/fleet-mcp-coexist.js
@@ -1,0 +1,60 @@
+// IDE/native-MCP coexistence resolver for the fleet MCP loop (#2855 P1-0 child of #2802; design D12,
+// Copilot constraint). Picks a FREE port for the fleet loop while AVOIDING ports a host IDE's MCP servers
+// declare (read from committed/saved disk config) — so the fleet loop never collides with e.g.
+// github.copilot.mcp.servers. Binding the chosen port holds the OS-level mutual-exclusion lock, so two
+// fleet loops can never double-bind. If no free port is available it degrades to disk-read-only mode
+// (graceful, G6); absent any IDE/MCP config it is a no-op pass-through to a free port (tier-graceful, G5).
+// Pure decision logic — binder + config reader injectable so tests run with no real socket or disk.
+const { defaultBinder, readHostConfig } = require('./fleet-mcp-portbind');
+
+const DEFAULT_CANDIDATES = [8900, 8901, 8902, 8903, 8904]; // fleet-loop port pool (distinct from dashboard:8090)
+const PORT_IN_URL = /:(\d{2,5})(?:\/|$)/;
+
+// Ports one server entry declares: an explicit `port`, or a port embedded in a `url` (bounded {2,5} →
+// no ReDoS). Returns [] for any other shape.
+function portsFromEntry(entry) {
+  const ports = [];
+  if (entry && Number.isInteger(entry.port)) ports.push(entry.port);
+  const matched = entry && typeof entry.url === 'string' && entry.url.match(PORT_IN_URL);
+  if (matched) ports.push(Number(matched[1]));
+  return ports;
+}
+
+// Ports a host IDE's MCP servers declare (to AVOID). Tolerant of the two common config shapes
+// (`servers` / `mcpServers`); reader injectable; a missing/malformed config yields [] (tier-graceful).
+function detectHostMcpPorts(opts = {}) {
+  const reader = opts.readConfig || readHostConfig;
+  const config = reader(opts.hostConfigPath);
+  if (!config || typeof config !== 'object') return [];
+  const servers = config.servers || config.mcpServers || {};
+  if (!servers || typeof servers !== 'object') return [];
+  return Object.keys(servers).flatMap((key) => portsFromEntry(servers[key]));
+}
+
+// Bind the FIRST candidate port not in `avoid`; the held bind is the coexistence lock. Returns
+// { port, handle } (handle.release closes it) or null when every candidate is busy/avoided. Sequential
+// on purpose — we want the first free port, not to bind them all.
+async function pickBoundPort(candidates, avoid, binder) {
+  for (const port of candidates) {
+    if (avoid.includes(port)) continue;
+    const handle = await binder(port);
+    if (handle) return { port, handle };
+  }
+  return null;
+}
+
+// resolveCoexistence(opts) -> { mode:'port', port, release, avoided } | { mode:'disk-read-only', reason, avoided }.
+//   opts.preferredPort · opts.candidates · opts.hostConfigPath · opts.binder / opts.readConfig (injectable).
+async function resolveCoexistence(opts = {}) {
+  const avoid = detectHostMcpPorts(opts);
+  const binder = opts.binder || defaultBinder;
+  const candidates = [opts.preferredPort, ...(opts.candidates || DEFAULT_CANDIDATES)].filter(Number.isInteger);
+  const bound = await pickBoundPort(candidates, avoid, binder);
+  if (!bound) {
+    return { mode: 'disk-read-only', avoided: avoid,
+      reason: 'no free MCP port (host-IDE coexistence) — degraded to disk-read-only' };
+  }
+  return { mode: 'port', port: bound.port, release: bound.handle.release, avoided: avoid };
+}
+
+module.exports = { resolveCoexistence, detectHostMcpPorts, pickBoundPort, DEFAULT_CANDIDATES };

--- a/scripts/global/fleet-mcp-portbind.js
+++ b/scripts/global/fleet-mcp-portbind.js
@@ -1,0 +1,31 @@
+// Default side-effecting deps for fleet MCP coexistence (#2855 P1-0 child of #2802; design D12).
+// `defaultBinder` claims a TCP port by binding a server and KEEPING it open — the held socket is the
+// OS-level coexistence lock (a second loop's bind of the same port fails with EADDRINUSE). `readHostConfig`
+// reads a committed IDE MCP config from disk. Both are injectable in fleet-mcp-coexist.js so unit + stress
+// tests run with no real socket or disk. Graceful: a bind failure → null (port busy); a bad config → null.
+const net = require('node:net');
+const fs = require('node:fs');
+
+const LOOPBACK = '127.0.0.1'; // bind fleet MCP ports to loopback only — never externally exposed (G4)
+
+// Claim `port` on loopback (127.0.0.1 — local-only, never externally exposed, G4). Resolves to
+// { release } holding the socket, or null if the port is in use / unbindable. Never rejects.
+function defaultBinder(port) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    // EADDRINUSE / EACCES → unavailable. close() the server so its FD is released immediately, not at GC
+    // (avoids slow FD exhaustion under repeated bind failures). close() on a non-listening server is safe.
+    server.once('error', () => { try { server.close(); } catch { /* not listening */ } resolve(null); });
+    server.listen(port, LOOPBACK, () => resolve({ release: () => { try { server.close(); } catch { /* already closed */ } } }));
+  });
+}
+
+// Read + parse a committed IDE MCP config (the host's saved disk state). Missing path / unreadable /
+// malformed JSON all degrade to null (the resolver then avoids nothing — tier-graceful, G5/G6).
+function readHostConfig(configPath) {
+  if (!configPath) return null;
+  try { return JSON.parse(fs.readFileSync(configPath, 'utf8')); }
+  catch { return null; }
+}
+
+module.exports = { defaultBinder, readHostConfig };

--- a/tests/fleet-mcp-coexist.spec.js
+++ b/tests/fleet-mcp-coexist.spec.js
@@ -1,0 +1,66 @@
+// Refs #2855 P1-0 child of #2802 — IDE/native-MCP coexistence resolver. Network/disk-free: the port
+// binder and the host-config reader are injected.
+const { test, expect } = require('@playwright/test');
+const {
+  resolveCoexistence, detectHostMcpPorts, pickBoundPort, DEFAULT_CANDIDATES,
+} = require('../scripts/global/fleet-mcp-coexist.js');
+
+const freeBinder = () => ({ release: () => {} });            // every port bindable
+const busyBinder = () => null;                                // every port in use
+const onlyFree = (free) => (port) => (free.includes(port) ? { release: () => {} } : null);
+
+test('#2855 AC1 binds the preferred free port (no host config)', async () => {
+  const out = await resolveCoexistence({ preferredPort: 8900, binder: freeBinder, readConfig: () => null });
+  expect(out.mode).toBe('port');
+  expect(out.port).toBe(8900);
+  expect(out.avoided).toEqual([]);
+  expect(typeof out.release).toBe('function');
+});
+
+test('#2855 AC1 falls through to the next free candidate when the preferred port is busy', async () => {
+  const out = await resolveCoexistence({ preferredPort: 8900, binder: onlyFree([8902]), readConfig: () => null });
+  expect(out.mode).toBe('port');
+  expect(out.port).toBe(8902);
+});
+
+test('#2855 AC1 degrades to disk-read-only when every candidate is busy (never hard-fails)', async () => {
+  const out = await resolveCoexistence({ binder: busyBinder, readConfig: () => null });
+  expect(out.mode).toBe('disk-read-only');
+  expect(out.reason).toMatch(/disk-read-only/);
+});
+
+test('#2855 AC3 avoids ports a host IDE MCP config declares (servers.port + url)', async () => {
+  const config = { servers: { a: { port: 8900 }, b: { url: 'http://127.0.0.1:8901/mcp' } } };
+  const ports = detectHostMcpPorts({ readConfig: () => config });
+  expect(ports.sort()).toEqual([8900, 8901]);
+  // the resolver must skip those and bind a non-avoided candidate
+  const out = await resolveCoexistence({ binder: freeBinder, readConfig: () => config });
+  expect(out.mode).toBe('port');
+  expect([8900, 8901]).not.toContain(out.port);
+  expect(out.avoided.sort()).toEqual([8900, 8901]);
+});
+
+test('#2855 AC3 tier-graceful: a missing/malformed config avoids nothing', () => {
+  expect(detectHostMcpPorts({ readConfig: () => null })).toEqual([]);
+  expect(detectHostMcpPorts({ readConfig: () => 'not-an-object' })).toEqual([]);
+  expect(detectHostMcpPorts({ readConfig: () => ({ mcpServers: { x: {} } }) })).toEqual([]);
+});
+
+test('#2855 AC3 reads the alternate mcpServers config shape', () => {
+  const ports = detectHostMcpPorts({ readConfig: () => ({ mcpServers: { g: { port: 7777 } } }) });
+  expect(ports).toEqual([7777]);
+});
+
+test('#2855 AC2 pickBoundPort returns the held handle; release is callable', async () => {
+  let released = false;
+  const binder = (port) => (port === 8901 ? { release: () => { released = true; } } : null);
+  const bound = await pickBoundPort([8900, 8901, 8902], [], binder);
+  expect(bound.port).toBe(8901);
+  bound.handle.release();
+  expect(released).toBe(true);
+});
+
+test('#2855 default candidate pool is distinct from the dashboard port', () => {
+  expect(DEFAULT_CANDIDATES).not.toContain(8090);
+  expect(DEFAULT_CANDIDATES.every((port) => Number.isInteger(port))).toBe(true);
+});

--- a/tests/stress-fleet-mcp-coexist.spec.js
+++ b/tests/stress-fleet-mcp-coexist.spec.js
@@ -1,0 +1,83 @@
+// Stress tests for #2855 IDE/MCP coexistence — port-collision + lock-coexistence chaos (G6) + a p99
+// budget on resolution (G7). Satisfies #2802 AC7 for the port/lock surface. Network/disk-free (injected).
+const { test, expect } = require('@playwright/test');
+const net = require('node:net');
+const { resolveCoexistence, detectHostMcpPorts } = require('../scripts/global/fleet-mcp-coexist.js');
+const { defaultBinder } = require('../scripts/global/fleet-mcp-portbind.js');
+
+// This one test exercises the REAL defaultBinder over loopback (not injected) to cover the bind-failure
+// path + FD release; everything else is injected and network-free.
+test('#2855 REAL defaultBinder: returns null for an in-use port and rebinds after release', async () => {
+  const held = await new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => resolve({ port: srv.address().port, close: () => srv.close() }));
+  });
+  const busy = await defaultBinder(held.port); // port in use → null (error path closes its server, no FD leak)
+  expect(busy).toBe(null);
+  held.close();
+  const free = await defaultBinder(held.port); // freed → bindable
+  expect(free).not.toBe(null);
+  free.release();
+});
+
+// A stateful fake binder that models the OS port mutex: a bound port is unavailable until released.
+function osLikeBinder() {
+  const bound = new Set();
+  return {
+    binder: (port) => {
+      if (bound.has(port)) return null; // EADDRINUSE — already held
+      bound.add(port);
+      return { release: () => bound.delete(port) };
+    },
+    bound,
+  };
+}
+
+test('#2855 LOCK: two concurrent loops never bind the same port (held bind is the lock)', async () => {
+  const { binder } = osLikeBinder();
+  const runA = await resolveCoexistence({ binder, readConfig: () => null });
+  const runB = await resolveCoexistence({ binder, readConfig: () => null });
+  expect(runA.mode).toBe('port');
+  expect(runB.mode).toBe('port');
+  expect(runA.port).not.toBe(runB.port); // second loop got a different port — no double-bind
+});
+
+test('#2855 LOCK: releasing a port lets the next loop reuse it', async () => {
+  const { binder } = osLikeBinder();
+  const runA = await resolveCoexistence({ preferredPort: 8900, binder, readConfig: () => null });
+  expect(runA.port).toBe(8900);
+  runA.release();
+  const runB = await resolveCoexistence({ preferredPort: 8900, binder, readConfig: () => null });
+  expect(runB.port).toBe(8900); // freed → reusable
+});
+
+test('#2855 CHAOS: a config declaring every candidate port forces disk-read-only', async () => {
+  const { binder } = osLikeBinder();
+  const config = { servers: Object.fromEntries(
+    [8900, 8901, 8902, 8903, 8904].map((port, idx) => [`s${idx}`, { port }])) };
+  const out = await resolveCoexistence({ binder, readConfig: () => config });
+  expect(out.mode).toBe('disk-read-only');
+  expect(out.avoided.sort((first, second) => first - second)).toEqual([8900, 8901, 8902, 8903, 8904]);
+});
+
+test('#2855 CHAOS: adversarial / malformed host configs degrade to [] (never throw)', () => {
+  const cases = [null, undefined, 42, 'str', [], { servers: null }, { servers: 'x' },
+    { mcpServers: { a: null, b: { port: 'NaN' }, c: { url: 'no-port-here' } } },
+    { servers: { d: { url: `http://h:${'9'.repeat(9000)}/x` } } }];
+  for (const config of cases) {
+    expect(() => detectHostMcpPorts({ readConfig: () => config })).not.toThrow();
+    expect(Array.isArray(detectHostMcpPorts({ readConfig: () => config }))).toBe(true);
+  }
+});
+
+test('#2855 PERF: resolveCoexistence p99 < 5ms (injected binder)', async () => {
+  const samples = [];
+  const binder = () => ({ release: () => {} });
+  for (let iter = 0; iter < 1000; iter += 1) {
+    const start = process.hrtime.bigint();
+    await resolveCoexistence({ preferredPort: 8900, binder, readConfig: () => null });
+    samples.push(Number(process.hrtime.bigint() - start) / 1e6);
+  }
+  samples.sort((first, second) => first - second);
+  expect(samples[Math.floor(samples.length * 0.99)]).toBeLessThan(5);
+});


### PR DESCRIPTION
Refs #2855

Closes #2855

## Summary
IDE/native-MCP coexistence + port-collision handling (#2802 AC3, P1-0 child). `resolveCoexistence` picks
a free local port for the fleet MCP loop while avoiding ports a host IDE's MCP servers declare (read from
committed config, e.g. `github.copilot.mcp.servers`) — so the fleet loop never collides with the IDE.

- `scripts/global/fleet-mcp-coexist.js` — `resolveCoexistence` / `detectHostMcpPorts` / `pickBoundPort`
- `scripts/global/fleet-mcp-portbind.js` — default loopback net-binder (release handle) + config reader
- tests: `tests/fleet-mcp-coexist.spec.js` (tdd) + `tests/stress-fleet-mcp-coexist.spec.js` (port-collision + lock chaos + p99)

## Design / security
The **held OS port-bind is the coexistence lock** (EADDRINUSE) — two fleet loops can never double-bind;
this is the correct primitive, not a parallel lock-file system (`worktree-active-session-lock` is a
team-keyed single-session mutex, semantically wrong here). No free port → disk-read-only degrade
(graceful); absent IDE config → no-op pass-through (tier-graceful). Bind is **loopback-only** (127.0.0.1,
never externally exposed); the URL-port regex is `{2,5}`-bounded (ReDoS-safe); config parsing is
prototype-safe and crash-safe on adversarial input.

## Baton artifacts (full text on #2855)
MANAGER / COLLABORATOR (per-AC PASS; tdd-pyramid+stress-test) / ADMIN (signer-independence PASS, Harper≠Reyes;
sync-verification N/A) / CONSULTANT_CLOSEOUT (approve_for_merge; rubric 9/10; cross_family_verdict ACCEPT).

## Cross-family review
gemini-2.5-pro@google-ai-studio — ACCEPT 10/10 (2 iterations). Fixed pre-merge: net.Server FD leak on the
bind-error path. Verified clean across all 6 threat vectors (ReDoS, collision logic, graceful-degrade,
leak, config-crash, non-loopback bind).

## Verification
lint ≤100 ✅ · eslint 0 errors · readability 474 ≤475 · 14/14 tests green · real net-bind smoke
(two resolves → distinct ports; host-config port avoided; released port reused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
