### PR TITLE
feat(scripts): local embeddings/RAG for fleet context

### DIFF
--- a/.changes/unreleased/2856.md
+++ b/.changes/unreleased/2856.md
@@ -1,0 +1,9 @@
+### Added
+
+- Local embeddings / RAG retrieval for fleet context (#2856, P1-0 child of #2802): `localRetrieve`
+  embeds a query with a LOCAL model and ranks a (optionally pre-embedded) corpus by cosine similarity,
+  returning a manifest-compatible top-K. The default embedder calls a local model on loopback only
+  (zero external egress — proprietary context never leaves the machine, G4); when no local model is
+  reachable it degrades gracefully to the shipped wiki-search (tier-graceful, G6 — the optimization is
+  local embeddings, the baseline stays wiki-search, no parallel RAG). New:
+  `scripts/global/fleet-rag-local.js`, `scripts/global/fleet-rag-embedder.js`.

--- a/scripts/global/fleet-rag-embedder.js
+++ b/scripts/global/fleet-rag-embedder.js
@@ -1,0 +1,52 @@
+// Default side-effecting deps for fleet local RAG (#2856 P1-0 child of #2802; design D14, G4).
+// `defaultEmbedder` calls a LOCAL embedding model on loopback ONLY (Ollama /api/embeddings) — zero
+// external egress, so proprietary code/context never leaves the machine. It resolves to a numeric vector,
+// or null on any error / when no local model is reachable (→ caller falls back to wiki-search). Never
+// rejects. `defaultFallback` reuses the shipped compiled-wiki search (#2815). Both injectable in
+// fleet-rag-local.js so unit/stress tests run with no network and no local model.
+const http = require('node:http');
+const { wikiContext } = require('./fleet-context-bundle');
+
+const LOCAL_EMBED_HOST = '127.0.0.1'; // loopback only — never an external host (G4 zero-egress)
+const DEFAULT_EMBED_PORT = 11434; // local Ollama default (read at call time so tests can point at a stub)
+const EMBED_TIMEOUT_MS = 8000;
+const embedPort = () => Number(process.env.MEGINGJORD_EMBED_PORT) || DEFAULT_EMBED_PORT;
+const embedModel = () => process.env.MEGINGJORD_EMBED_MODEL || 'nomic-embed-text';
+const MAX_EMBED_BYTES = 4 * 1024 * 1024; // cap the embed response — a rogue local model can't OOM us (G6)
+
+// A valid embedding is a non-empty array of finite numbers — anything else (strings, NaN, non-array) → null.
+function asVector(embedding) {
+  return Array.isArray(embedding) && embedding.length > 0 && embedding.every(Number.isFinite)
+    ? embedding : null;
+}
+
+function defaultEmbedder(text) {
+  return new Promise((resolve) => {
+    const payload = JSON.stringify({ model: embedModel(), prompt: String(text == null ? '' : text) });
+    const req = http.request({
+      host: LOCAL_EMBED_HOST, port: embedPort(), path: '/api/embeddings', method: 'POST',
+      timeout: EMBED_TIMEOUT_MS, headers: { 'content-type': 'application/json' },
+    }, (res) => {
+      let body = ''; let bytes = 0;
+      res.on('data', (chunk) => {
+        bytes += chunk.length;
+        if (bytes > MAX_EMBED_BYTES) { req.destroy(); resolve(null); return; } // bound response memory
+        body += chunk;
+      });
+      res.on('end', () => {
+        try { resolve(asVector(JSON.parse(body).embedding)); } catch { resolve(null); }
+      });
+    });
+    req.on('error', () => resolve(null)); // no local model reachable → graceful null (caller falls back)
+    req.on('timeout', () => { req.destroy(); resolve(null); });
+    req.write(payload);
+    req.end();
+  });
+}
+
+// Fallback retrieval: the shipped compiled-wiki search (#2815) — keyword/index, not embeddings (G6/D13).
+function defaultFallback(query, topK = 3) {
+  return wikiContext(query, topK);
+}
+
+module.exports = { defaultEmbedder, defaultFallback, asVector, LOCAL_EMBED_HOST };

--- a/scripts/global/fleet-rag-local.js
+++ b/scripts/global/fleet-rag-local.js
@@ -1,0 +1,84 @@
+// Local embeddings / RAG retrieval for fleet context (#2856 P1-0 child of #2802; design D14, G4).
+// `localRetrieve` embeds the query with a LOCAL model and ranks a (optionally pre-embedded) corpus by
+// cosine similarity, returning a manifest-compatible top-K (D15). When no local embedder is present it
+// degrades to wiki-search (tier-graceful, G6) — the optimization is local embeddings, the baseline is the
+// shipped wiki-search (no parallel RAG, D13). Proprietary context never leaves the machine (G4). Pure
+// ranking logic; embed + fallback injectable so tests run with no network and no local model.
+const { defaultEmbedder, defaultFallback, asVector } = require('./fleet-rag-embedder');
+
+const SCHEMA = 'fleet-rag/v1';
+const MAX_CORPUS = 5000; // bound the in-memory scored set — a huge corpus can't OOM us (G6). For a larger
+// working set, pre-filter into an index upstream; this slice ranks a bounded candidate set.
+const EMBED_CONCURRENCY = 8; // embed docs in bounded-parallel windows: fast (G7) without flooding the model
+const MAX_TEXT_CHARS = 256 * 1024; // clamp query/doc text before embedding — a 500MB string can't OOM us (G6)
+const clampText = (text) => String(text == null ? '' : text).slice(0, MAX_TEXT_CHARS);
+
+// Map `items` through async `fn` in windows of `limit` — bounded concurrency (parallel within a window,
+// not a 5000-socket flood). Order-preserving.
+async function mapBounded(items, limit, fn) {
+  const out = [];
+  for (let start = 0; start < items.length; start += limit) {
+    out.push(...await Promise.all(items.slice(start, start + limit).map(fn)));
+  }
+  return out;
+}
+
+// Cosine similarity of two equal-length numeric vectors. Returns 0 (never NaN) for mismatched / empty /
+// zero / non-finite vectors, so ranking is always well-defined on adversarial input.
+function cosineSimilarity(vecA, vecB) {
+  if (!Array.isArray(vecA) || !Array.isArray(vecB) || vecA.length === 0 || vecA.length !== vecB.length) return 0;
+  let dot = 0; let magA = 0; let magB = 0;
+  for (let i = 0; i < vecA.length; i += 1) {
+    dot += vecA[i] * vecB[i]; magA += vecA[i] * vecA[i]; magB += vecB[i] * vecB[i];
+  }
+  if (!(magA > 0) || !(magB > 0)) return 0; // !(>0) also rejects NaN magnitudes
+  const score = dot / (Math.sqrt(magA) * Math.sqrt(magB));
+  return Number.isFinite(score) ? score : 0;
+}
+
+// Embed `text`, returning a non-empty numeric vector or null — never throwing (a throwing/unreachable
+// embedder degrades to null so the caller falls back).
+async function safeEmbed(embed, text) {
+  try { const vec = await embed(clampText(text)); return Array.isArray(vec) && vec.length ? vec : null; }
+  catch { return null; }
+}
+
+// A doc's vector: its pre-embedded `.vector` if it passes the SAME finite-number validation as a freshly
+// fetched embedding (asVector) — no re-embed; otherwise embed its text. Consistent validation either way.
+async function docVector(doc, embed) {
+  const pre = doc && asVector(doc.vector);
+  if (pre) return pre;
+  // nullish check (not truthiness) so a falsy-but-present text (0, false) is embedded, not coerced to ''.
+  const text = typeof doc === 'string' ? doc : (doc && doc.text != null ? doc.text : '');
+  return safeEmbed(embed, text);
+}
+
+// The wiki-search fallback path — never hard-fails even if the injected fallback throws (returns []).
+async function fallbackResult(fallback, query, topK) {
+  let raw;
+  try { raw = await fallback(query, topK); } catch { raw = []; }
+  if (!Array.isArray(raw)) raw = []; // a truthy non-array fallback result must not make .map() throw
+  return { source: 'wiki-fallback', embedded: false, schema: SCHEMA, hits: raw.map((doc) => ({ doc, score: null })) };
+}
+
+// localRetrieve(opts) -> { source, embedded, schema, hits:[{doc,score}] }. opts.query · opts.corpus
+// ([string | {text?, vector?}]) · opts.topK · opts.embed / opts.fallback (injectable).
+async function localRetrieve(opts = {}) {
+  const { query, corpus = [], topK = 3 } = opts;
+  const embed = opts.embed || defaultEmbedder;
+  const fallback = opts.fallback || defaultFallback;
+  const queryVec = await safeEmbed(embed, query);
+  if (!queryVec) return fallbackResult(fallback, query, topK);
+  const candidates = corpus.slice(0, MAX_CORPUS); // bounded candidate set (memory guard)
+  const scored = (await mapBounded(candidates, EMBED_CONCURRENCY, async (doc) => {
+    const vec = await docVector(doc, embed);
+    return vec ? { doc, score: cosineSimilarity(queryVec, vec) } : null;
+  })).filter(Boolean);
+  scored.sort((first, second) => second.score - first.score);
+  return {
+    source: 'local-embeddings', embedded: true, schema: SCHEMA,
+    corpusTruncated: corpus.length > MAX_CORPUS, hits: scored.slice(0, topK),
+  };
+}
+
+module.exports = { localRetrieve, cosineSimilarity, safeEmbed, docVector, SCHEMA };

--- a/tests/fleet-rag-local.spec.js
+++ b/tests/fleet-rag-local.spec.js
@@ -1,0 +1,78 @@
+// Refs #2856 P1-0 child of #2802 — local embeddings / RAG retrieval. Network-free + no local model:
+// the embedder and the wiki-search fallback are injected.
+const { test, expect } = require('@playwright/test');
+const {
+  localRetrieve, cosineSimilarity, SCHEMA,
+} = require('../scripts/global/fleet-rag-local.js');
+const { LOCAL_EMBED_HOST } = require('../scripts/global/fleet-rag-embedder.js');
+
+// Deterministic fake embedder: keyword → vector. Returns null for unknown text.
+const VECS = { query: [1, 0, 0], near: [0.9, 0.1, 0], far: [0, 0, 1] };
+const fakeEmbed = async (text) => VECS[text] || null;
+
+test('#2856 AC1 ranks the corpus by cosine similarity to the query (local embeddings)', async () => {
+  const out = await localRetrieve({ query: 'query', corpus: ['far', 'near'], topK: 2, embed: fakeEmbed });
+  expect(out.source).toBe('local-embeddings');
+  expect(out.embedded).toBe(true);
+  expect(out.hits.map((hit) => hit.doc)).toEqual(['near', 'far']); // near ranks above far
+  expect(out.hits[0].score).toBeGreaterThan(out.hits[1].score);
+});
+
+test('#2856 AC1 the default embedder targets loopback only (zero external egress)', () => {
+  expect(LOCAL_EMBED_HOST).toBe('127.0.0.1');
+});
+
+test('#2856 AC2 falls back to wiki-search when no local embedder is present', async () => {
+  const out = await localRetrieve({
+    query: 'q', corpus: ['near'], embed: async () => null, fallback: async () => ['wiki-A', 'wiki-B'],
+  });
+  expect(out.source).toBe('wiki-fallback');
+  expect(out.embedded).toBe(false);
+  expect(out.hits).toEqual([{ doc: 'wiki-A', score: null }, { doc: 'wiki-B', score: null }]);
+});
+
+test('#2856 AC2 a throwing embedder still degrades to fallback (never propagates)', async () => {
+  const out = await localRetrieve({
+    query: 'q', embed: async () => { throw new Error('model down'); }, fallback: async () => ['safe'],
+  });
+  expect(out.source).toBe('wiki-fallback');
+  expect(out.hits).toEqual([{ doc: 'safe', score: null }]);
+});
+
+test('#2856 AC3 result is manifest-compatible (schema + uniform {doc,score} hits)', async () => {
+  const out = await localRetrieve({ query: 'query', corpus: ['near'], embed: fakeEmbed });
+  expect(out.schema).toBe(SCHEMA);
+  expect(out.schema).toBe('fleet-rag/v1');
+  expect(out.hits[0]).toHaveProperty('doc');
+  expect(out.hits[0]).toHaveProperty('score');
+});
+
+test('#2856 a pre-embedded corpus doc uses its vector without re-embedding', async () => {
+  let embedCalls = 0;
+  const embed = async (text) => { embedCalls += 1; return VECS[text] || [1, 0, 0]; };
+  const out = await localRetrieve({
+    query: 'query', corpus: [{ text: 'cached', vector: [0.8, 0.2, 0] }], embed,
+  });
+  expect(out.hits[0].doc.text).toBe('cached');
+  expect(embedCalls).toBe(1); // only the query was embedded; the doc used its pre-embedded vector
+});
+
+test('#2856 a falsy-but-present doc.text (0) is embedded (as "0"), not coerced to empty', async () => {
+  // if text were coerced to '', embed('') would score low; text is stringified for embedding → "0".
+  const embed = async (text) => (text === 'query' ? [1, 0] : (text === '0' ? [1, 0] : [0, 1]));
+  const out = await localRetrieve({ query: 'query', corpus: [{ text: 0 }], embed });
+  expect(out.hits[0].score).toBeCloseTo(1, 6); // embedded as "0" (high score), not '' (low score)
+});
+
+test('#2856 topK bounds the returned hits', async () => {
+  const embed = async (text) => (text === 'query' ? [1, 0] : [Math.random(), Math.random()]);
+  const out = await localRetrieve({ query: 'query', corpus: ['a', 'b', 'c', 'd'], topK: 2, embed });
+  expect(out.hits.length).toBe(2);
+});
+
+test('#2856 cosineSimilarity: identical=1, orthogonal=0, mismatched/zero=0', () => {
+  expect(cosineSimilarity([1, 2, 3], [1, 2, 3])).toBeCloseTo(1, 6);
+  expect(cosineSimilarity([1, 0], [0, 1])).toBe(0);
+  expect(cosineSimilarity([1, 2], [1, 2, 3])).toBe(0); // length mismatch
+  expect(cosineSimilarity([0, 0], [1, 1])).toBe(0);    // zero vector
+});

--- a/tests/stress-fleet-rag-local.spec.js
+++ b/tests/stress-fleet-rag-local.spec.js
@@ -1,0 +1,130 @@
+// Stress tests for #2856 local RAG — adversarial vector/corpus corpus (G6) + a p99 budget on the cosine
+// ranking (G7). Network-free + no local model (embedder/fallback injected).
+const { test, expect } = require('@playwright/test');
+const http = require('node:http');
+const { localRetrieve, cosineSimilarity } = require('../scripts/global/fleet-rag-local.js');
+const { asVector, defaultEmbedder } = require('../scripts/global/fleet-rag-embedder.js');
+
+test('#2856 asVector accepts only a non-empty array of finite numbers', () => {
+  expect(asVector([1, 2, 3])).toEqual([1, 2, 3]);
+  expect(asVector(['a', 'b'])).toBe(null);     // non-numeric elements
+  expect(asVector([1, NaN])).toBe(null);       // NaN element
+  expect(asVector([1, Infinity])).toBe(null);  // non-finite element
+  expect(asVector([])).toBe(null);             // empty
+  expect(asVector('vector')).toBe(null);       // not an array
+});
+
+// Real loopback stub model: exercises the response-size cap (HIGH) + numeric-element validation end-to-end.
+async function withStubModel(handler, run) {
+  const server = http.createServer(handler);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const prev = process.env.MEGINGJORD_EMBED_PORT;
+  process.env.MEGINGJORD_EMBED_PORT = String(server.address().port);
+  try { await run(); } finally {
+    if (prev === undefined) delete process.env.MEGINGJORD_EMBED_PORT; else process.env.MEGINGJORD_EMBED_PORT = prev;
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test('#2856 REAL embedder: caps an oversize response and rejects a non-numeric embedding', async () => {
+  await withStubModel((req, res) => { res.writeHead(200); res.end(JSON.stringify({ embedding: ['x', 'y'] })); },
+    async () => { expect(await defaultEmbedder('hi')).toBe(null); }); // non-numeric → null
+  await withStubModel((req, res) => { res.writeHead(200); res.end(JSON.stringify({ embedding: [0.1, 0.2, 0.3] })); },
+    async () => { expect(await defaultEmbedder('hi')).toEqual([0.1, 0.2, 0.3]); }); // valid → vector
+  await withStubModel((req, res) => { res.writeHead(200); res.write('['); for (let n = 0; n < 600; n += 1) res.write('0123456789'.repeat(1000)); res.end(']'); },
+    async () => { expect(await defaultEmbedder('hi')).toBe(null); }); // >4MB body → capped → null (no OOM)
+});
+
+test('#2856 CHAOS: cosineSimilarity never returns NaN/Infinity on adversarial vectors', () => {
+  const nasties = [
+    [NaN, 1], [Infinity, 0], [1, undefined], [], [0, 0], [1e308, 1e308], [-1, -1],
+  ];
+  for (const left of nasties) {
+    for (const right of nasties) {
+      const score = cosineSimilarity(left, right);
+      expect(Number.isFinite(score)).toBe(true); // always a finite number, never NaN/Infinity
+    }
+  }
+});
+
+test('#2856 CHAOS: an embedder returning garbage degrades safely (fallback or skip, never throw)', async () => {
+  const garbageEmbed = async () => ({ not: 'a vector' }); // not an array → treated as null
+  const out = await localRetrieve({ query: 'q', corpus: ['a', 'b'], embed: garbageEmbed,
+    fallback: async () => ['fb'] });
+  expect(out.source).toBe('wiki-fallback'); // query embed failed → fell back, no throw
+  expect(out.hits).toEqual([{ doc: 'fb', score: null }]);
+});
+
+test('#2856 CHAOS: docs that fail to embed are skipped, not crashed on', async () => {
+  // query embeds fine; some corpus docs embed to null → silently dropped from results.
+  const embed = async (text) => (text === 'query' ? [1, 0] : (text === 'good' ? [1, 0] : null));
+  const out = await localRetrieve({ query: 'query', corpus: ['good', 'bad1', 'bad2'], embed });
+  expect(out.source).toBe('local-embeddings');
+  expect(out.hits.map((hit) => hit.doc)).toEqual(['good']); // only the embeddable doc survived
+});
+
+test('#2856 CHAOS: a fallback returning nullish or a truthy non-array yields [] hits, never throws', async () => {
+  for (const bad of [null, undefined, 123, { not: 'array' }, 'string', true]) {
+    const out = await localRetrieve({ query: 'q', embed: async () => null, fallback: async () => bad });
+    expect(out.source).toBe('wiki-fallback');
+    expect(out.hits).toEqual([]); // never throws on a non-array fallback result
+  }
+});
+
+test('#2856 a text corpus spanning multiple concurrency windows embeds + ranks all docs', async () => {
+  // 20 docs > EMBED_CONCURRENCY(8) → exercises chunked bounded-parallel embedding; all must be considered.
+  let embedCalls = 0;
+  const embed = async (text) => { embedCalls += 1; return text === 'query' ? [1, 0] : [Number(text) / 20, 1]; };
+  const corpus = Array.from({ length: 20 }, (_unused, idx) => String(idx));
+  const out = await localRetrieve({ query: 'query', corpus, topK: 5, embed });
+  expect(embedCalls).toBe(21); // query + 20 docs, none skipped across windows
+  expect(out.hits.length).toBe(5);
+});
+
+test('#2856 CHAOS: an oversize query/doc text is clamped before embedding (no OOM)', async () => {
+  const huge = 'q'.repeat(2 * 1024 * 1024); // 2MB string
+  let longest = 0;
+  const embed = async (text) => { longest = Math.max(longest, text.length); return [1, 0]; };
+  await localRetrieve({ query: huge, corpus: [{ text: huge }, huge], embed });
+  expect(longest).toBeLessThanOrEqual(256 * 1024); // every embedded text was clamped to MAX_TEXT_CHARS
+});
+
+test('#2856 CHAOS: a throwing fallback still resolves with [] (never hard-fails)', async () => {
+  const out = await localRetrieve({
+    query: 'q', embed: async () => null, fallback: async () => { throw new Error('wiki down'); },
+  });
+  expect(out.source).toBe('wiki-fallback');
+  expect(out.hits).toEqual([]); // contract: resolves, never rejects
+});
+
+test('#2856 CHAOS: a malformed pre-embedded vector is rejected, falling back to text embedding', async () => {
+  // doc.vector has a NaN → must NOT be used as-is; doc embeds its text instead (consistent validation).
+  const embed = async (text) => (text === 'query' ? [1, 0] : (text === 'good-text' ? [1, 0] : null));
+  const out = await localRetrieve({
+    query: 'query', corpus: [{ text: 'good-text', vector: [NaN, 1] }], embed,
+  });
+  expect(out.hits.length).toBe(1);
+  expect(out.hits[0].score).toBeCloseTo(1, 6); // ranked via the text embedding, not the NaN vector
+});
+
+test('#2856 CHAOS: a huge corpus is bounded (MAX_CORPUS) and flagged — no OOM', async () => {
+  const corpus = Array.from({ length: 12000 }, (_unused, idx) => ({ vector: [idx % 7, 1] }));
+  const out = await localRetrieve({ query: 'q', corpus, topK: 3, embed: async () => [1, 0] });
+  expect(out.source).toBe('local-embeddings');
+  expect(out.corpusTruncated).toBe(true);
+  expect(out.hits.length).toBe(3); // top-K only, not 12000
+});
+
+test('#2856 PERF: cosineSimilarity p99 < 1ms on 768-dim vectors', () => {
+  const dim = 768; // nomic-embed-text dimensionality
+  const vecA = Array.from({ length: dim }, (_unused, idx) => Math.sin(idx));
+  const vecB = Array.from({ length: dim }, (_unused, idx) => Math.cos(idx));
+  const samples = [];
+  for (let iter = 0; iter < 3000; iter += 1) {
+    const start = process.hrtime.bigint();
+    cosineSimilarity(vecA, vecB);
+    samples.push(Number(process.hrtime.bigint() - start) / 1e6);
+  }
+  samples.sort((first, second) => first - second);
+  expect(samples[Math.floor(samples.length * 0.99)]).toBeLessThan(1);
+});


### PR DESCRIPTION
Refs #2856

Closes #2856

## Summary
Local embeddings / RAG retrieval for fleet context (#2802 AC5, P1-0 child — the last #2802 deliverable).
`localRetrieve` embeds a query with a LOCAL model and ranks a (optionally pre-embedded) corpus by cosine
similarity, returning a manifest-compatible top-K. When no local model is reachable it degrades to the
shipped wiki-search (tier-graceful) — the optimization is local embeddings, the baseline stays
wiki-search (no parallel RAG, D13).

- `scripts/global/fleet-rag-local.js` — `localRetrieve` / `cosineSimilarity` / `docVector`
- `scripts/global/fleet-rag-embedder.js` — default loopback embedder + wiki-search fallback
- tests: `tests/fleet-rag-local.spec.js` (tdd) + `tests/stress-fleet-rag-local.spec.js` (adversarial + p99)

## Design / security
**Zero external egress** (G4): the embedder binds to 127.0.0.1 only — proprietary context never leaves the
machine. Fully resource-bounded (G6): input text (256K), corpus (5000), embed response (4MB), and
concurrency (8) are all capped. Every fallible op (embed, fallback, parse) degrades gracefully — the
function never rejects. Vectors (fresh + pre-embedded) are validated as non-empty finite-number arrays;
`cosineSimilarity` never returns NaN.

## Baton artifacts (full text on #2856)
MANAGER / COLLABORATOR (per-AC PASS; tdd-pyramid+stress-test) / ADMIN (signer-independence PASS, Harper≠Reyes;
sync-verification N/A) / CONSULTANT_CLOSEOUT (approve_for_merge; rubric 9/10; cross_family_verdict ACCEPT).

## Cross-family review
gemini-2.5-pro@google-ai-studio — ACCEPT 10/10 (8 iterations). Found + fixed pre-merge: unbounded
response/corpus/input-text/sockets, non-array-fallback throw, falsy-text coercion, unvalidated vectors.

## Verification
lint ≤100 ✅ · eslint 0 errors · readability 474 ≤475 · 21/21 tests green · real smoke (graceful
wiki-fallback with no local model; injected embedder ranks correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
