### PR TITLE
feat(scripts): rule-based fleet-dev eligibility router

### DIFF
--- a/.changes/unreleased/2794.md
+++ b/.changes/unreleased/2794.md
@@ -1,0 +1,10 @@
+### Added
+
+- Rule-based fleet-dev eligibility router (#2794, P1-1 of Epic #2791): `isFleetDevEligible(taskFeatures,
+  profile)` decides whether a fleet-lane coding task may run as autonomous fleet-development or must
+  escalate — by MEASURED capability (a per-model `code_dev_profile`), not model size (D1). Fail-closed:
+  default ineligible unless every rule affirms (known pattern + context within the model's stable window +
+  clear schema + capability floor met), each failure naming itself. `model-routing-policy.json` gains
+  `code_dev_profiles` + `code_dev_profile_meta` (dated, sourced, refreshable estimates — D6 currency-aware,
+  not hard-coded to qwen2.5). No change to existing lane/review/escalation routing. New:
+  `scripts/global/fleet-dev-eligibility.js`.

--- a/scripts/global/fleet-dev-eligibility.js
+++ b/scripts/global/fleet-dev-eligibility.js
@@ -1,0 +1,56 @@
+// Rule-based fleet-dev eligibility router (#2794 P1-1 of Epic #2791; design D1, D6). Decides whether a
+// FLEET-lane coding task may run as AUTONOMOUS fleet-development, or must escalate — by MEASURED capability
+// (the model's code_dev_profile), not model size (D1). FAIL-CLOSED: default ineligible unless EVERY rule
+// affirms (a missing/unmeasurable signal escalates, never silently runs on the fleet). Pure; the profile
+// comes from model-routing-policy.json#code_dev_profiles (D6 currency-aware, refreshable). Does NOT touch
+// existing lane/review/escalation routing — this is a distinct gate layered on top (AC4).
+'use strict';
+
+const isNum = (value) => typeof value === 'number' && Number.isFinite(value);
+// OWN-property access only — a safety gate must not read inherited props, else a polluted Object.prototype
+// (e.g. Object.prototype.pattern='known') could fail-OPEN by satisfying a rule on an empty input object.
+const has = (obj, key) => obj != null && Object.prototype.hasOwnProperty.call(obj, key);
+const ownNum = (obj, key) => has(obj, key) && isNum(obj[key]);
+
+// A profile is measurable only if it declares (as own props) the stable context window + a capability
+// score. A malformed/absent profile is itself an escalation signal — capability can't be measured.
+function isValidProfile(profile) {
+  return ownNum(profile, 'context_stability_tokens') && ownNum(profile, 'swe_bench_verified');
+}
+
+// isFleetDevEligible(taskFeatures, profile, opts) -> { eligible, rationale }. Rules — ALL must affirm:
+//   1 profile measurable · 2 known implementation pattern (novel → escalate) · 3 context fits the model's
+//   stable window · 4 clear schema (ambiguous → escalate) · 5 measured capability >= the task's required
+//   floor (opts.minCapability, default 0). The first failing rule names itself in the rationale (G8).
+function isFleetDevEligible(taskFeatures, profile, opts) {
+  // Reads are OWN-property only (has/ownNum) — prototype pollution can't fail-OPEN. `features` is coalesced
+  // so null input can't crash the EAGERLY-built rule array (the loop returns on the first failing rule, but
+  // all rule expressions evaluate when the array is constructed). profile is guarded by `measurable`.
+  const features = taskFeatures || {};
+  const minCapability = ownNum(opts, 'minCapability') ? opts.minCapability : 0;
+  const measurable = isValidProfile(profile);
+  const rules = [
+    [measurable, 'no-or-malformed-profile → escalate (capability unmeasurable)'],
+    [has(features, 'pattern') && features.pattern === 'known', 'novel-pattern → escalate'],
+    [ownNum(features, 'contextTokens') && features.contextTokens >= 0,
+      'context-size-missing-or-negative → escalate'], // distinct from too-large (G8)
+    [measurable && features.contextTokens <= profile.context_stability_tokens,
+      'context-exceeds-stable-window → escalate'],
+    [has(features, 'schemaClarity') && features.schemaClarity === 'clear', 'ambiguous-schema → escalate'],
+    [measurable && profile.swe_bench_verified >= minCapability, 'below-capability-floor → escalate'],
+  ];
+  for (const [affirmed, rationale] of rules) {
+    if (!affirmed) return { eligible: false, rationale };
+  }
+  return { eligible: true, rationale: 'known-pattern + bounded-context + clear-schema + capability-met' };
+}
+
+// profileFor(modelId, policy) -> the model's code_dev_profile, else the meta default (conservative), else
+// null. Own-property lookup (no prototype keys); never throws on a missing policy/section/model.
+function profileFor(modelId, policy = {}) {
+  const profiles = (policy && policy.code_dev_profiles) || {};
+  if (modelId && Object.prototype.hasOwnProperty.call(profiles, modelId)) return profiles[modelId];
+  return ((policy && policy.code_dev_profile_meta) || {}).default_profile || null;
+}
+
+module.exports = { isFleetDevEligible, profileFor, isValidProfile };

--- a/scripts/global/model-routing-policy.json
+++ b/scripts/global/model-routing-policy.json
@@ -235,5 +235,42 @@
       "high": "haiku",
       "_rationale": "Cross-family adversarial review prefers fleet (qwen2.5-coder). Haiku ceiling for high-complexity exploit reasoning."
     }
+  },
+  "code_dev_profile_meta": {
+    "schema_version": "1.0",
+    "_currency_note": "Per-model code_dev_profile values are DATED ESTIMATES (D6), not hard guarantees — refresh from public SWE-bench Verified leaderboards + local eval when a model is upgraded. Consumed by scripts/global/fleet-dev-eligibility.js.",
+    "refreshed": "2026-06-10",
+    "default_profile": {
+      "swe_bench_verified": 0.0,
+      "repo_reasoning": 0.2,
+      "tool_calling": 0.3,
+      "context_stability_tokens": 4000,
+      "latency_tok_per_sec": 7,
+      "refreshed": "2026-06-10",
+      "source": "conservative-default",
+      "estimate": true
+    }
+  },
+  "code_dev_profiles": {
+    "qwen2.5-coder:32b": {
+      "swe_bench_verified": 0.31,
+      "repo_reasoning": 0.55,
+      "tool_calling": 0.6,
+      "context_stability_tokens": 8000,
+      "latency_tok_per_sec": 32,
+      "refreshed": "2026-06-10",
+      "source": "public SWE-bench Verified leaderboard range (estimate; refresh per D6)",
+      "estimate": true
+    },
+    "qwen2.5-coder:7b": {
+      "swe_bench_verified": 0.18,
+      "repo_reasoning": 0.3,
+      "tool_calling": 0.4,
+      "context_stability_tokens": 6000,
+      "latency_tok_per_sec": 7,
+      "refreshed": "2026-06-10",
+      "source": "public benchmark range (estimate; refresh per D6)",
+      "estimate": true
+    }
   }
 }

--- a/tests/fleet-dev-eligibility.spec.js
+++ b/tests/fleet-dev-eligibility.spec.js
@@ -1,0 +1,95 @@
+// Refs #2794 P1-1 of Epic #2791 — rule-based fleet-dev eligibility router. Pure, deterministic.
+const { test, expect } = require('@playwright/test');
+const {
+  isFleetDevEligible, profileFor, isValidProfile,
+} = require('../scripts/global/fleet-dev-eligibility.js');
+const policy = require('../scripts/global/model-routing-policy.json');
+
+const PROFILE = { swe_bench_verified: 0.31, context_stability_tokens: 8000 };
+const KNOWN = { pattern: 'known', contextTokens: 3000, schemaClarity: 'clear' };
+
+test('#2794 AC1 policy carries a code_dev_profile per fleet model with the capability dimensions', () => {
+  const prof = policy.code_dev_profiles['qwen2.5-coder:32b'];
+  expect(prof).toBeTruthy();
+  for (const dim of ['swe_bench_verified', 'repo_reasoning', 'tool_calling', 'context_stability_tokens', 'latency_tok_per_sec']) {
+    expect(typeof prof[dim]).toBe('number');
+  }
+});
+
+test('#2794 AC2 a known-pattern, bounded-context, clear-schema task is eligible', () => {
+  const out = isFleetDevEligible(KNOWN, PROFILE);
+  expect(out.eligible).toBe(true);
+  expect(out.rationale).toMatch(/known-pattern/);
+});
+
+test('#2794 AC2 each rule-failure is ineligible with a naming rationale (escalate)', () => {
+  expect(isFleetDevEligible({ ...KNOWN, pattern: 'novel' }, PROFILE)).toMatchObject({ eligible: false, rationale: /novel-pattern/ });
+  expect(isFleetDevEligible({ ...KNOWN, schemaClarity: 'ambiguous' }, PROFILE)).toMatchObject({ eligible: false, rationale: /ambiguous-schema/ });
+  expect(isFleetDevEligible({ ...KNOWN, contextTokens: 8001 }, PROFILE)).toMatchObject({ eligible: false, rationale: /stable-window/ });
+});
+
+test('#2794 AC2 boundary: contextTokens exactly at the stable window is eligible, one over escalates', () => {
+  expect(isFleetDevEligible({ ...KNOWN, contextTokens: 8000 }, PROFILE).eligible).toBe(true);
+  expect(isFleetDevEligible({ ...KNOWN, contextTokens: 8001 }, PROFILE).eligible).toBe(false);
+});
+
+test('#2794 AC2 a capability floor (opts.minCapability) gates below-floor models', () => {
+  expect(isFleetDevEligible(KNOWN, PROFILE, { minCapability: 0.3 }).eligible).toBe(true);
+  expect(isFleetDevEligible(KNOWN, PROFILE, { minCapability: 0.5 })).toMatchObject({ eligible: false, rationale: /capability-floor/ });
+});
+
+test('#2794 AC2 FAIL-CLOSED: missing/malformed inputs escalate, never default-eligible', () => {
+  expect(isFleetDevEligible(KNOWN, null).eligible).toBe(false);          // no profile
+  expect(isFleetDevEligible(KNOWN, {}).eligible).toBe(false);            // empty profile
+  expect(isFleetDevEligible({}, PROFILE).eligible).toBe(false);          // no task features
+  expect(isFleetDevEligible(undefined, undefined).eligible).toBe(false); // both absent
+  expect(isFleetDevEligible({ ...KNOWN, contextTokens: 'lots' }, PROFILE).eligible).toBe(false); // non-numeric ctx
+});
+
+test('#2794 FAIL-CLOSED: null/garbage arguments escalate without crashing', () => {
+  for (const bad of [null, undefined, 0, 'str', [], NaN]) {
+    expect(() => isFleetDevEligible(bad, PROFILE, bad)).not.toThrow();
+    expect(isFleetDevEligible(bad, PROFILE, bad).eligible).toBe(false);
+  }
+  // a nonsensical NEGATIVE context size escalates (fail-open guard) with a distinct rationale (G8)
+  expect(isFleetDevEligible({ ...KNOWN, contextTokens: -1 }, PROFILE))
+    .toMatchObject({ eligible: false, rationale: /missing-or-negative/ });
+  // a missing context size is reported as missing, NOT as "exceeds window"
+  const { pattern, schemaClarity } = KNOWN;
+  expect(isFleetDevEligible({ pattern, schemaClarity }, PROFILE).rationale).toMatch(/missing-or-negative/);
+});
+
+test('#2794 SECURITY: prototype pollution cannot fail-OPEN the gate', () => {
+  const polluted = ['pattern', 'schemaClarity', 'contextTokens', 'context_stability_tokens', 'swe_bench_verified'];
+  Object.prototype.pattern = 'known'; Object.prototype.schemaClarity = 'clear';
+  Object.prototype.contextTokens = 10; Object.prototype.context_stability_tokens = 8000;
+  Object.prototype.swe_bench_verified = 1;
+  try {
+    // empty objects must NOT inherit eligibility from a polluted prototype — still escalate.
+    expect(isFleetDevEligible({}, {}).eligible).toBe(false);
+    expect(isFleetDevEligible({}, PROFILE).eligible).toBe(false);
+    expect(isValidProfile({})).toBe(false);
+  } finally {
+    for (const key of polluted) delete Object.prototype[key]; // CRITICAL: restore prototype for other tests
+  }
+});
+
+test('#2794 AC3 profileFor resolves a model, falls back to the dated default, and is currency-aware', () => {
+  expect(profileFor('qwen2.5-coder:32b', policy).swe_bench_verified).toBe(0.31);
+  expect(profileFor('some-future-model:99b', policy)).toEqual(policy.code_dev_profile_meta.default_profile);
+  expect(policy.code_dev_profile_meta.default_profile.estimate).toBe(true); // marked an estimate (D6)
+  expect(policy.code_dev_profiles['qwen2.5-coder:32b'].refreshed).toMatch(/^\d{4}-\d{2}-\d{2}$/); // dated
+});
+
+test('#2794 AC3 profileFor never throws + ignores prototype keys', () => {
+  expect(profileFor('qwen2.5-coder:32b', {})).toBe(null);
+  expect(profileFor('__proto__', policy)).toBe(policy.code_dev_profile_meta.default_profile); // not Object.prototype
+  expect(() => profileFor(undefined, undefined)).not.toThrow();
+});
+
+test('#2794 AC4 the router adds NO new routing — escalationRules/cascade/judge are untouched', () => {
+  // the eligibility module exports only the gate; it does not mutate the policy or its routing blocks.
+  expect(isValidProfile(PROFILE)).toBe(true);
+  expect(policy.escalationRules).toBeTruthy();
+  expect(policy.cascade).toBeTruthy(); // existing routing still present, unmodified by this slice
+});


### PR DESCRIPTION
Refs #2794

Closes #2794

## Summary
Rule-based fleet-dev eligibility router (P1-1 of Epic #2791). `isFleetDevEligible(taskFeatures, profile)`
decides whether a fleet-lane coding task may run as autonomous fleet-development or must escalate — by
MEASURED capability (a per-model `code_dev_profile`), not model size (D1).

- `scripts/global/fleet-dev-eligibility.js` — `isFleetDevEligible` / `profileFor` / `isValidProfile`
- `scripts/global/model-routing-policy.json` — adds `code_dev_profiles` + `code_dev_profile_meta`
- tests: `tests/fleet-dev-eligibility.spec.js` (tdd-pyramid, incl. prototype-pollution + boundary)

## Design / safety
**Fail-closed**: default ineligible unless every rule affirms (known pattern + context within the model's
stable window + clear schema + capability floor), each failure naming itself (G8). All input reads are
own-property-only (`hasOwnProperty.call`), so null inputs and **prototype pollution** both escalate, never
crash and never fail-OPEN. Profiles are dated/sourced/refreshable estimates (D6 currency-aware, not
qwen2.5-hardcoded). No change to existing lane/review/escalation routing (AC4).

## Baton artifacts (full text on #2794)
MANAGER / COLLABORATOR (per-AC PASS; tdd-pyramid) / ADMIN (signer-independence PASS, Harper≠Reyes;
sync-verification N/A) / CONSULTANT_CLOSEOUT (approve_for_merge; rubric 9/10; cross_family_verdict ACCEPT).

## Cross-family review
gemini-2.5-pro@google-ai-studio — ACCEPT 10/10 (3 iterations). First verdict REJECT 3/10 on a CRITICAL
prototype-pollution fail-OPEN; also fixed a null crash + a negative-context fail-open. All regression-tested.

## Verification
lint ≤100 ✅ · eslint 0 errors · readability 474 ≤475 · 11/11 tests green · real smoke against the live
policy (eligible for known+bounded+clear; fail-closed for novel/oversize/missing-profile with named rationales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
