### PR TITLE
feat(scripts): escalation-rate governor + hysteresis

### DIFF
--- a/.changes/unreleased/2796.md
+++ b/.changes/unreleased/2796.md
@@ -1,0 +1,10 @@
+### Added
+
+- Escalation-rate governor with hysteresis + shadow re-promotion (#2796, P1-3 of Epic #2791): tracks
+  per-task-class (default unit = area-label) fleet escalation rate over a velocity-relative window (last N
+  attempts, never calendar). Hysteresis prevents flapping — demote a class off the fleet above 40%
+  escalation, re-promote only below 25% (the 25–40% band holds); the window resets on each transition.
+  Demotion emits a Tier-2 anneal (`fleet-dev-class-mis-profiled`) + a re-profile signal. Shadow
+  re-promotion: a demoted class still runs on the fleet in shadow (output discarded, scored), so
+  re-promotion is data-driven after a model refresh (D6), not timer-based. New:
+  `scripts/global/fleet-dev-governor.js`.

--- a/scripts/global/fleet-dev-governor.js
+++ b/scripts/global/fleet-dev-governor.js
@@ -1,0 +1,79 @@
+// Escalation-rate governor with hysteresis + shadow re-promotion (#2796 P1-3 of Epic #2791; design D3).
+// Tracks per-TASK-CLASS (default unit = area-label) fleet escalation rate over a VELOCITY-RELATIVE window
+// (the last N attempts — never a calendar threshold, per the agentic-traffic lesson). Hysteresis prevents
+// flapping: DEMOTE a promoted class off the fleet at >40% escalation, RE-PROMOTE a demoted class only at
+// <25% (the 25-40% band holds). On demotion the window resets (fresh sample) + a Tier-2 anneal
+// `fleet-dev-class-mis-profiled` + a re-profile signal are emitted (G8). SHADOW re-promotion: a demoted
+// class still runs on the fleet in shadow (output discarded, scored vs the accepted result), so
+// re-promotion is DATA-DRIVEN after a model refresh (D6) — the shadow rate drives it, not a timer.
+// Pure: the caller owns the persisted state dict; telemetry emit is injectable.
+const fs = require('fs');
+const path = require('path');
+
+const WINDOW_N = 20;     // velocity-relative window: judge on the last N attempts (not calendar)
+const MIN_SAMPLE = 5;    // never transition on a tiny sample → hold (fail-safe)
+const DEMOTE_AT = 0.40;  // > this fleet-escalation rate demotes a promoted class
+const PROMOTE_AT = 0.25; // < this (shadow) rate re-promotes a demoted class — the gap is the anti-flap band
+const TELEMETRY = path.join(process.env.HOME || '', '.megingjord', 'fleet-dev-governor.jsonl');
+
+// Own-property class entry (default promoted, empty window). The class map is a NULL-prototype object so a
+// hostile class name like '__proto__' becomes a normal own key, never prototype pollution.
+function classEntry(state, taskClass) {
+  let classes = state.classes;
+  if (!classes || Object.getPrototypeOf(classes) !== null) classes = state.classes = Object.assign(Object.create(null), classes);
+  if (!Object.prototype.hasOwnProperty.call(classes, taskClass)) classes[taskClass] = { status: 'promoted', window: [] };
+  return classes[taskClass];
+}
+
+// Record one fleet/shadow outcome (escalated = did the two-part gate fail → escalate?). Bounded window.
+function recordOutcome(state, taskClass, escalated) {
+  const entry = classEntry(state, taskClass);
+  entry.window.push(Boolean(escalated));
+  while (entry.window.length > WINDOW_N) entry.window.shift();
+  return entry;
+}
+
+// Escalation rate over the window, or null when the sample is too small to judge (fail-safe → hold).
+function escalationRate(entry) {
+  const count = entry && entry.window ? entry.window.length : 0;
+  if (count < MIN_SAMPLE) return null;
+  return entry.window.filter(Boolean).length / count;
+}
+
+function emitDemotion(taskClass, rate, opts) {
+  const emit = opts.emit || defaultEmit;
+  try {
+    emit({ event: 'fleet-dev-class-mis-profiled', tier2_anneal: true, task_class: taskClass,
+      escalation_rate: rate, action: 'demote', reprofile_signal: true, ts: opts.now ? opts.now() : null });
+  } catch { /* telemetry is best-effort, never blocks the transition */ }
+}
+
+// Apply hysteresis. Returns { status, transition, rate }. On a transition the window resets so the new
+// mode is judged on FRESH data (prevents oscillation; lets a model refresh show through in shadow).
+function governClass(state, taskClass, opts = {}) {
+  const entry = classEntry(state, taskClass);
+  const rate = escalationRate(entry);
+  let transition = null;
+  if (rate !== null && entry.status === 'promoted' && rate > DEMOTE_AT) transition = 'demote';
+  else if (rate !== null && entry.status === 'demoted' && rate < PROMOTE_AT) transition = 're-promote';
+  if (transition === 'demote') { entry.status = 'demoted'; entry.window = []; emitDemotion(taskClass, rate, opts); }
+  else if (transition === 're-promote') { entry.status = 'promoted'; entry.window = []; }
+  return { status: entry.status, transition, rate };
+}
+
+// Route verdict the execution path consumes: a promoted class runs on the fleet; a demoted class runs on
+// the escalated tier for REAL output but is still SHADOW-run on the fleet (scored) for data-driven re-promotion.
+function routeClass(state, taskClass) {
+  const entry = classEntry(state, taskClass);
+  return { onFleet: entry.status === 'promoted', shadowOnFleet: entry.status === 'demoted', status: entry.status };
+}
+
+function defaultEmit(record) {
+  try { fs.mkdirSync(path.dirname(TELEMETRY), { recursive: true }); fs.appendFileSync(TELEMETRY, JSON.stringify(record) + '\n'); }
+  catch { /* best-effort */ }
+}
+
+module.exports = {
+  recordOutcome, governClass, escalationRate, routeClass, classEntry,
+  WINDOW_N, MIN_SAMPLE, DEMOTE_AT, PROMOTE_AT,
+};

--- a/tests/fleet-dev-governor.spec.js
+++ b/tests/fleet-dev-governor.spec.js
@@ -1,0 +1,91 @@
+// Refs #2796 P1-3 of Epic #2791 — escalation-rate governor. Pure, deterministic.
+const { test, expect } = require('@playwright/test');
+const {
+  recordOutcome, governClass, escalationRate, routeClass, classEntry, WINDOW_N,
+} = require('../scripts/global/fleet-dev-governor.js');
+
+// Feed `total` outcomes for a class, the first `escalated` of which escalated.
+function feed(state, cls, escalated, total) {
+  for (let i = 0; i < total; i += 1) recordOutcome(state, cls, i < escalated);
+  return state;
+}
+
+test('#2796 AC1 the window is velocity-relative — bounded to the last N attempts, not calendar', () => {
+  const state = {};
+  feed(state, 'area:scripts', 0, WINDOW_N + 30); // 50 attempts
+  expect(classEntry(state, 'area:scripts').window.length).toBe(WINDOW_N); // only the last N retained
+});
+
+test('#2796 AC1 escalation rate is per-class and isolated', () => {
+  const state = {};
+  feed(state, 'area:scripts', 2, 20); // 10%
+  feed(state, 'area:dashboard', 18, 20); // 90%
+  expect(escalationRate(classEntry(state, 'area:scripts'))).toBeCloseTo(0.1, 6);
+  expect(escalationRate(classEntry(state, 'area:dashboard'))).toBeCloseTo(0.9, 6);
+});
+
+test('#2796 AC1 a too-small sample yields no rate (fail-safe → hold, never demote on noise)', () => {
+  const state = {};
+  feed(state, 'c', 4, 4); // 4 attempts, all escalated, but < MIN_SAMPLE
+  expect(escalationRate(classEntry(state, 'c'))).toBe(null);
+  expect(governClass(state, 'c').transition).toBe(null); // holds promoted
+  expect(governClass(state, 'c').status).toBe('promoted');
+});
+
+test('#2796 AC2 demote a promoted class above 40% escalation', () => {
+  const state = {};
+  feed(state, 'c', 9, 20); // 45%
+  const out = governClass(state, 'c');
+  expect(out.transition).toBe('demote');
+  expect(out.status).toBe('demoted');
+  expect(classEntry(state, 'c').window).toEqual([]); // window reset on transition
+});
+
+test('#2796 AC2 hysteresis: the 25–40% band HOLDS (no flap), in either state', () => {
+  const promoted = feed({}, 'c', 6, 20); // 30%
+  expect(governClass(promoted, 'c')).toMatchObject({ transition: null, status: 'promoted' });
+  const demoted = { classes: { c: { status: 'demoted', window: [] } } };
+  feed(demoted, 'c', 6, 20); // 30% — still in band
+  expect(governClass(demoted, 'c')).toMatchObject({ transition: null, status: 'demoted' });
+});
+
+test('#2796 AC2/AC3 re-promote a demoted class only below 25% (data-driven, from shadow outcomes)', () => {
+  const state = { classes: { c: { status: 'demoted', window: [] } } };
+  feed(state, 'c', 4, 20); // 20% — shadow-run escalation rate dropped (e.g., after a model refresh)
+  const out = governClass(state, 'c');
+  expect(out.transition).toBe('re-promote');
+  expect(out.status).toBe('promoted');
+});
+
+test('#2796 AC2 boundary: exactly 40% does NOT demote; exactly 25% does NOT re-promote (strict)', () => {
+  const at40 = feed({}, 'c', 8, 20); // 40%
+  expect(governClass(at40, 'c').transition).toBe(null);
+  const at25 = { classes: { c: { status: 'demoted', window: [] } } };
+  feed(at25, 'c', 5, 20); // 25%
+  expect(governClass(at25, 'c').transition).toBe(null);
+});
+
+test('#2796 AC2 demotion emits a Tier-2 anneal + re-profile signal (observable, G8)', () => {
+  const records = [];
+  const state = feed({}, 'area:dashboard', 12, 20); // 60%
+  governClass(state, 'area:dashboard', { emit: (r) => records.push(r), now: () => 1700000000000 });
+  expect(records).toHaveLength(1);
+  expect(records[0]).toMatchObject({
+    event: 'fleet-dev-class-mis-profiled', tier2_anneal: true, task_class: 'area:dashboard',
+    action: 'demote', reprofile_signal: true, ts: 1700000000000,
+  });
+  expect(records[0].escalation_rate).toBeCloseTo(0.6, 6);
+});
+
+test('#2796 a valid epoch-0 timestamp is preserved in telemetry (not coerced to null)', () => {
+  const records = [];
+  const state = feed({}, 'c', 12, 20);
+  governClass(state, 'c', { emit: (r) => records.push(r), now: () => 0 });
+  expect(records[0].ts).toBe(0); // 0 is a valid timestamp, not absence
+});
+
+test('#2796 AC3 routeClass: promoted runs on fleet; demoted runs escalated + shadow-on-fleet', () => {
+  const state = { classes: { p: { status: 'promoted', window: [] }, d: { status: 'demoted', window: [] } } };
+  expect(routeClass(state, 'p')).toMatchObject({ onFleet: true, shadowOnFleet: false });
+  expect(routeClass(state, 'd')).toMatchObject({ onFleet: false, shadowOnFleet: true });
+});

--- a/tests/stress-fleet-dev-governor.spec.js
+++ b/tests/stress-fleet-dev-governor.spec.js
@@ -1,0 +1,72 @@
+// Stress tests for #2796 escalation governor — anti-flap / oscillation chaos (the hysteresis invariant)
+// + adversarial input (G6) + a p99 budget (G7). Pure, deterministic.
+const { test, expect } = require('@playwright/test');
+const {
+  recordOutcome, governClass, routeClass, classEntry, WINDOW_N,
+} = require('../scripts/global/fleet-dev-governor.js');
+
+function feed(state, cls, escalated, total) {
+  for (let i = 0; i < total; i += 1) recordOutcome(state, cls, i < escalated);
+  return state;
+}
+
+test('#2796 ANTI-FLAP: a class hovering in the 25–40% band never oscillates over many cycles', () => {
+  const state = {};
+  let transitions = 0;
+  for (let cycle = 0; cycle < 50; cycle += 1) {
+    // alternate 30% and 35% — both inside the hold band; status must never change
+    feed(state, 'c', cycle % 2 ? 6 : 7, 20);
+    const out = governClass(state, 'c');
+    if (out.transition) transitions += 1;
+  }
+  expect(transitions).toBe(0); // hysteresis band → zero flapping
+  expect(routeClass(state, 'c').status).toBe('promoted');
+});
+
+test('#2796 ANTI-FLAP: demote→re-promote needs a FULL fresh window each way (no instant flip-back)', () => {
+  const state = {};
+  feed(state, 'c', 18, 20); // 90% → demote
+  expect(governClass(state, 'c').status).toBe('demoted');
+  // window was reset; a single good shadow attempt must NOT re-promote (needs MIN_SAMPLE + <25%)
+  recordOutcome(state, 'c', false);
+  expect(governClass(state, 'c').transition).toBe(null);
+  expect(governClass(state, 'c').status).toBe('demoted');
+});
+
+test('#2796 CHAOS: an all-escalate then all-clean stream converges, never thrashes mid-stream', () => {
+  const state = {};
+  feed(state, 'c', 20, 20); // 100% → demote
+  expect(governClass(state, 'c').status).toBe('demoted');
+  feed(state, 'c', 0, 20); // 0% shadow → re-promote
+  expect(governClass(state, 'c').status).toBe('promoted');
+  feed(state, 'c', 20, 20); // 100% again → demote
+  expect(governClass(state, 'c').status).toBe('demoted');
+});
+
+test('#2796 CHAOS: malformed/empty state + unknown class never throw (default promoted)', () => {
+  for (const bad of [{}, { classes: null }, { classes: {} }, undefined]) {
+    expect(() => governClass(bad || {}, 'x')).not.toThrow();
+    expect(governClass(bad || {}, 'x').status).toBe('promoted'); // unknown class defaults promoted
+    expect(routeClass(bad || {}, 'x').onFleet).toBe(true);
+  }
+});
+
+test('#2796 CHAOS: a __proto__ task-class name is an own-property class, not prototype pollution', () => {
+  const state = {};
+  feed(state, '__proto__', 18, 20);
+  expect(governClass(state, '__proto__').status).toBe('demoted'); // handled as a normal class key
+  expect(classEntry({}, 'anything').status).toBe('promoted'); // prototype not polluted
+});
+
+test('#2796 PERF: recordOutcome + governClass p99 < 1ms over a full window', () => {
+  const samples = [];
+  for (let iter = 0; iter < 3000; iter += 1) {
+    const state = {};
+    const start = process.hrtime.bigint();
+    feed(state, 'c', 9, WINDOW_N);
+    governClass(state, 'c');
+    samples.push(Number(process.hrtime.bigint() - start) / 1e6);
+  }
+  samples.sort((first, second) => first - second);
+  expect(samples[Math.floor(samples.length * 0.99)]).toBeLessThan(1);
+});


### PR DESCRIPTION
Refs #2796

Closes #2796

## Summary
Escalation-rate governor with hysteresis + shadow re-promotion (P1-3 of Epic #2791). Tracks per-task-class
(area-label) fleet escalation rate over a velocity-relative window and decides whether each class stays on
the fleet — consuming the escalation telemetry #2795 emits.

- `scripts/global/fleet-dev-governor.js` — recordOutcome / governClass / escalationRate / routeClass
- tests: fleet-dev-governor.spec.js (tdd) + stress-fleet-dev-governor.spec.js (anti-flap + chaos + p99)

## Design / safety
**Hysteresis (anti-flap)**: demote a class off the fleet above 40% escalation, re-promote only below 25% —
the 25–40% band holds, and the window resets on each transition (no oscillation, no instant flip-back).
**Velocity-relative** window (last N attempts, never calendar). **Fail-safe**: a sub-MIN_SAMPLE window
never transitions. Demotion emits a Tier-2 anneal (`fleet-dev-class-mis-profiled`) + a re-profile signal.
**Shadow re-promotion**: a demoted class still runs on the fleet in shadow (scored), so re-promotion is
data-driven after a model refresh (D6). The class map is null-prototype (hostile class names can't pollute).

## Baton artifacts (full text on #2796)
MANAGER / COLLABORATOR (per-AC PASS; tdd-pyramid+stress-test) / ADMIN (signer-independence PASS, Harper≠Reyes;
sync-verification N/A) / CONSULTANT_CLOSEOUT (approve_for_merge; rubric 9/10; cross_family_verdict ACCEPT).

## Cross-family review
gemini-2.5-pro@google-ai-studio — ACCEPT 10/10 (2 iterations). Fixed pre-merge: epoch-0 timestamp coercion.

## Verification
lint ≤100 ✅ · eslint 0 errors · readability 474 ≤475 · 16/16 tests green · real smoke (demote → shadow →
data-driven re-promote after a model refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
