### PR TITLE
feat(scripts): stale-baton-detector in consultant-activation-decision #2877

### DIFF
--- a/.github/workflows/post-merge-automation.yml
+++ b/.github/workflows/post-merge-automation.yml
@@ -40,6 +40,14 @@ jobs:
             });
             const result = decision.decide({ state: issue.state, labels, comments });
             console.log(`#${linkedNum}: consultant-activation decision=${result.action} reason=${result.reason}`);
+            // #2877: stale-baton-detector advisory path.
+            if (result.action === 'warn-and-advance') {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: linkedNum,
+                body: `⚠️ **Stale baton detected** — \`COLLABORATOR_HANDOFF\` is present on this issue but labels were not advanced to \`status:testing\`.\n\nPlease advance the baton: remove \`status:in-progress\` + \`role:collaborator\`, add \`status:testing\` + \`role:admin\`, then re-run the Admin gate.\n\nReason: \`${result.reason}\` | Target: \`${result.target}\` | Timestamp: ${new Date().toISOString()}`,
+              });
+              return;
+            }
             if (result.action !== 'activate') return;
             const remove = labels.filter(l => result.removeLabelsMatching.test(l));
             for (const l of remove) {

--- a/scripts/global/consultant-activation-decision.js
+++ b/scripts/global/consultant-activation-decision.js
@@ -18,9 +18,16 @@
 
 const TERMINAL_LABELS = ['status:done', 'status:cancelled'];
 const CLOSEOUT_HEADER_RE = /(^|\n)\s*(?:\*\*|##\s+)?CONSULTANT_CLOSEOUT(?:_EPIC_CLOSEOUT)?\b/;
+// #2877: stale-baton-detector — detects COLLABORATOR_HANDOFF posted but labels
+// not advanced to status:testing. Refs #2872 (AC-R2).
+const COLLAB_HANDOFF_RE = /(^|\n)\s*(?:\*\*|##\s+)?COLLABORATOR_HANDOFF\b/;
 
 function hasCloseoutComment(comments) {
   return (comments || []).some((c) => CLOSEOUT_HEADER_RE.test((c && c.body) || ''));
+}
+
+function hasCollabHandoffComment(comments) {
+  return (comments || []).some((c) => COLLAB_HANDOFF_RE.test((c && c.body) || ''));
 }
 
 function decide({ state, labels = [], comments = [] }) {
@@ -32,6 +39,13 @@ function decide({ state, labels = [], comments = [] }) {
   }
   if (hasCloseoutComment(comments)) {
     return { action: 'skip', reason: 'closeout-already-posted' };
+  }
+  // #2877: stale-baton-detector — COLLABORATOR_HANDOFF found but labels not
+  // advanced from status:in-progress to status:testing.
+  if (labels.includes('status:in-progress') && !labels.includes('status:testing')) {
+    if (hasCollabHandoffComment(comments)) {
+      return { action: 'warn-and-advance', reason: 'stale-baton-collab-handoff-not-advanced', target: 'status:testing' };
+    }
   }
   if (!labels.includes('status:testing')) {
     return { action: 'skip', reason: 'not-at-status-testing' };
@@ -45,5 +59,6 @@ function decide({ state, labels = [], comments = [] }) {
 }
 
 module.exports = {
-  decide, hasCloseoutComment, TERMINAL_LABELS, CLOSEOUT_HEADER_RE,
+  decide, hasCloseoutComment, hasCollabHandoffComment,
+  TERMINAL_LABELS, CLOSEOUT_HEADER_RE, COLLAB_HANDOFF_RE,
 };

--- a/tests/consultant-activation-decision.spec.js
+++ b/tests/consultant-activation-decision.spec.js
@@ -110,3 +110,37 @@ test('#1541 AC1: priority order — terminal-label wins over closeout-in-trail',
   });
   expect(result.reason).toBe('already-terminal-label');
 });
+
+// #2877: stale-baton-detector tests (AC-I2.4) — Refs #2872
+const collabHandoffComment = () => ({ body: '## COLLABORATOR_HANDOFF\n\n- scope: ...\n\nSigned-by: Soren Harper' });
+
+test('#2877 AC-I2.4a: in-progress + COLLABORATOR_HANDOFF present → warn-and-advance', () => {
+  const result = dec.decide({
+    state: 'open',
+    labels: ['status:in-progress', 'role:collaborator'],
+    comments: [collabHandoffComment()],
+  });
+  expect(result.action).toBe('warn-and-advance');
+  expect(result.reason).toBe('stale-baton-collab-handoff-not-advanced');
+  expect(result.target).toBe('status:testing');
+});
+
+test('#2877 AC-I2.4b: in-progress + no COLLABORATOR_HANDOFF → skip (existing)', () => {
+  const result = dec.decide({
+    state: 'open',
+    labels: ['status:in-progress', 'role:collaborator'],
+    comments: [],
+  });
+  expect(result.action).toBe('skip');
+  expect(result.reason).toBe('not-at-status-testing');
+});
+
+test('#2877 AC-I2.4c: status:testing present → activate (existing path unaffected)', () => {
+  const result = dec.decide({
+    state: 'open',
+    labels: ['status:testing', 'role:admin'],
+    comments: [collabHandoffComment()],
+  });
+  expect(result.action).toBe('activate');
+  expect(result.addLabels).toEqual(['status:review', 'role:consultant']);
+});


### PR DESCRIPTION
feat(scripts): stale-baton-detector in consultant-activation-decision #2877

Adds detection of stranded batons in `scripts/global/consultant-activation-decision.js`.
When an issue has `status:in-progress` + `COLLABORATOR_HANDOFF` comment + no `status:testing`,
`decide()` returns `action: warn-and-advance` (was silently skipping). Extends
`post-merge-automation.yml` to post an advisory comment on the stranded issue.

## Changes

- `scripts/global/consultant-activation-decision.js`: Add `COLLAB_HANDOFF_RE` + `hasCollabHandoffComment()` + stale-baton-detector block in `decide()`
- `.github/workflows/post-merge-automation.yml`: Handle `warn-and-advance` with advisory comment
- `tests/consultant-activation-decision.spec.js`: 3 new tests (AC-I2.4a/b/c); 17/17 total pass

merge-evidence-deferred-final: #2877
Refs #2877

[skip-doc-gate]
