### PR TITLE
feat(hooks): merged-branch-guard in lefthook + pretool_guard #2878

### DIFF
--- a/hooks/scripts/live_checks.py
+++ b/hooks/scripts/live_checks.py
@@ -139,3 +139,22 @@ def linked_issue_has_manager_handoff(cwd: str) -> bool:
         return any("MANAGER_HANDOFF" in c.get("body", "") for c in data.get("comments", []))
     except Exception:
         return True  # on API error → allow (fail open, not block)
+
+
+def check_merged_pr(branch: str, cwd: str) -> int | None:
+    """Return the merged PR number for branch if one exists, None otherwise.
+
+    Fail-open: returns None on any error (gh CLI unavailable, timeout, etc.).
+    Refs #2878 (AC-I3.1).
+    """
+    try:
+        r = subprocess.run(
+            ["gh", "pr", "list", "--head", branch, "--state", "merged", "--json", "number"],
+            capture_output=True, text=True, cwd=cwd, timeout=20,
+        )
+        data = json.loads(r.stdout or "[]")
+        if data:
+            return int(data[0]["number"])
+        return None
+    except Exception:
+        return None  # fail-open — never block on API error

--- a/hooks/scripts/merged-branch-guard.py
+++ b/hooks/scripts/merged-branch-guard.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Merged-branch-guard runner for lefthook pre-push. Refs #2878 (AC-I3.2).
+
+Calls check_merged_pr() from live_checks and exits non-zero if the current
+branch already has a merged PR, preventing stale-branch pushes.
+"""
+import os, subprocess, sys
+from pathlib import Path
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+from live_checks import check_merged_pr
+
+
+def _current_branch() -> str | None:
+    try:
+        return subprocess.check_output(
+            ["git", "branch", "--show-current"],
+            text=True, stderr=subprocess.DEVNULL,
+        ).strip() or None
+    except Exception:
+        return None
+
+
+if __name__ == "__main__":
+    cwd = os.getcwd()
+    branch = _current_branch()
+    if branch:
+        pr = check_merged_pr(branch, cwd)
+        if pr:
+            print(
+                f"merged-branch-guard: BLOCKED — branch '{branch}' was already "
+                f"merged via PR #{pr}. Check out a new branch from main.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    sys.exit(0)

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -10,7 +10,7 @@ from admin_patterns import (  # noqa: E501
     RE_RELEASE_INTEGRITY, RE_VSCE_PUBLISH, SECRET_FILE_RE, iter_paths, iter_strings)
 from canonical_main_enforcer import is_main_checkout, evaluate_path
 from governance_state import ensure_state
-from live_checks import ci_gate_status_stable, linked_issue_has_collab_handoff, linked_issue_has_manager_handoff
+from live_checks import ci_gate_status_stable, linked_issue_has_collab_handoff, linked_issue_has_manager_handoff, check_merged_pr
 from runtime_paths import runtime_hook_paths
 RE_ISSUE_REF = re.compile(r"#\d+")
 RE_BRANCH_TICKET = re.compile(r"^(feat|fix|hotfix)/(\d+)-")
@@ -168,8 +168,15 @@ def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
             mismatched = sorted({ref for ref in refs if ref != expected})
             if mismatched:
                 return emit("deny", f"Commit blocked: one branch = one ticket. Remove mismatched refs: {', '.join(mismatched)}")
-    if RE_GIT_PUSH.search(joined) and not ops.get("commit"):
-        return emit("deny","Push blocked: commit step first (Admin sequencing).")
+    if RE_GIT_PUSH.search(joined):
+        # #2878: merged-branch-guard — block pushes to already-merged branches.
+        branch = current_branch(cwd)
+        if branch:
+            merged_pr = check_merged_pr(branch, cwd)
+            if merged_pr:
+                return emit("deny", f"Push blocked: branch '{branch}' was already merged via PR #{merged_pr}. Check out a new branch from main.")
+        if not ops.get("commit"):
+            return emit("deny", "Push blocked: commit step first (Admin sequencing).")
     if RE_PR_MERGE.search(joined):
         override = require_bypass_exception(joined, state, cwd)
         if override:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -35,3 +35,6 @@ pre-push:
     # server-side via .github/workflows/test-evidence.yml on PR.
     git-freshness:
       run: node scripts/global/git-freshness-check.js || true
+    # #2878: merged-branch-guard — block pushes to already-merged branches.
+    merged-branch-guard:
+      run: python3 hooks/scripts/merged-branch-guard.py

--- a/tests/hooks/test_live_checks_merged_pr.py
+++ b/tests/hooks/test_live_checks_merged_pr.py
@@ -1,0 +1,101 @@
+"""Unit and integration tests for check_merged_pr() and the merged-branch-guard.
+Refs #2878 (AC-I3.4, AC-I3.5).
+"""
+import json, sys, unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOKS_SCRIPTS = REPO_ROOT / "hooks" / "scripts"
+if str(HOOKS_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(HOOKS_SCRIPTS))
+
+from live_checks import check_merged_pr  # noqa: E402
+
+
+def _mock_run(stdout_data, returncode=0):
+    """Return a mock subprocess.CompletedProcess for the given JSON data."""
+    m = MagicMock()
+    m.stdout = json.dumps(stdout_data)
+    m.returncode = returncode
+    return m
+
+
+class TestCheckMergedPr(unittest.TestCase):
+
+    @patch("live_checks.subprocess.run")
+    def test_merged_pr_found_returns_int(self, mock_run):
+        """AC-I3.4: gh returns one merged PR → returns its number as int."""
+        mock_run.return_value = _mock_run([{"number": 2881}])
+        result = check_merged_pr("feat/2876-some-branch", "/tmp")
+        self.assertEqual(result, 2881)
+        call_args = mock_run.call_args[0][0]
+        self.assertIn("--state", call_args)
+        self.assertIn("merged", call_args)
+
+    @patch("live_checks.subprocess.run")
+    def test_no_merged_pr_returns_none(self, mock_run):
+        """AC-I3.4: gh returns empty list → returns None."""
+        mock_run.return_value = _mock_run([])
+        result = check_merged_pr("feat/2876-some-branch", "/tmp")
+        self.assertIsNone(result)
+
+    @patch("live_checks.subprocess.run", side_effect=Exception("gh not found"))
+    def test_gh_cli_error_fails_open(self, _mock_run):
+        """AC-I3.4: gh CLI error → returns None (fail-open, never blocks)."""
+        result = check_merged_pr("feat/2876-some-branch", "/tmp")
+        self.assertIsNone(result)
+
+    @patch("live_checks.subprocess.run")
+    def test_empty_stdout_returns_none(self, mock_run):
+        """AC-I3.4: empty stdout → returns None (fail-open)."""
+        mock_run.return_value = _mock_run(None)
+        # Force empty stdout
+        mock_run.return_value.stdout = ""
+        result = check_merged_pr("main", "/tmp")
+        self.assertIsNone(result)
+
+    @patch("live_checks.subprocess.run")
+    def test_multiple_prs_returns_first(self, mock_run):
+        """check_merged_pr returns the first PR's number when multiple exist."""
+        mock_run.return_value = _mock_run([{"number": 99}, {"number": 100}])
+        result = check_merged_pr("feat/99-old-branch", "/tmp")
+        self.assertEqual(result, 99)
+
+
+import pretool_guard  # noqa: E402  (must be after sys.path setup)
+
+
+class TestPretoolGuardMergedBranch(unittest.TestCase):
+    """Integration tests for the pretool_guard deny path. AC-I3.5."""
+
+    def _run(self, cmd: str, branch: str, merged_pr=None, commit_done=False):
+        captured = {}
+
+        def fake_emit(decision, reason, extra=None):
+            captured["decision"] = decision
+            captured["reason"] = reason
+            return 0
+
+        state = {"flags": {}, "admin_ops": {"commit": commit_done}}
+        with patch("pretool_guard.check_merged_pr", return_value=merged_pr), \
+             patch("pretool_guard.current_branch", return_value=branch), \
+             patch("pretool_guard.emit", side_effect=fake_emit):
+            pretool_guard.check_terminal(cmd, state, "/tmp")
+        return captured
+
+    def test_deny_on_merged_branch_push(self):
+        """AC-I3.5: git push on a merged branch → deny containing PR number."""
+        out = self._run("git push origin feat/2876-old", "feat/2876-old", merged_pr=2881, commit_done=True)
+        self.assertEqual(out.get("decision"), "deny")
+        self.assertIn("2881", out.get("reason", ""))
+        self.assertIn("already merged", out.get("reason", ""))
+
+    def test_no_merged_branch_deny_when_not_merged(self):
+        """AC-I3.5: push on unmerged branch with commit done → no merged-branch deny."""
+        out = self._run("git push origin feat/2878-current", "feat/2878-current", merged_pr=None, commit_done=True)
+        self.assertNotIn("already merged", out.get("reason", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pretool-guard-merged-branch-2878.spec.js
+++ b/tests/pretool-guard-merged-branch-2878.spec.js
@@ -1,0 +1,23 @@
+// #2878 — JS harness that runs the Python unittest suite for the
+// merged-branch-guard. The implementation under test is Python
+// (live_checks.py + pretool_guard.py), so the real assertions live in
+// Python unittest; this spec satisfies the JS-centric test-evidence gate
+// while executing the actual Python coverage in CI.
+'use strict';
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+test('check_merged_pr Python suite passes (unit + integration)', () => {
+  const root = path.resolve(__dirname, '..');
+  let out = '';
+  try {
+    out = execFileSync('python3', [
+      '-m', 'unittest',
+      'tests.hooks.test_live_checks_merged_pr',
+    ], { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (e) {
+    throw new Error(`Python unittest suite failed:\n${e.stdout || ''}\n${e.stderr || ''}`);
+  }
+  expect(typeof out).toBe('string');
+});


### PR DESCRIPTION
feat(hooks): merged-branch-guard in lefthook + pretool_guard #2878

Adds a belt-and-suspenders guard against pushes to already-merged branches.

## Changes

- `hooks/scripts/live_checks.py`: `check_merged_pr(branch, cwd)` — queries gh CLI for merged PRs on the branch; fail-open on any error.
- `hooks/scripts/merged-branch-guard.py`: thin lefthook runner that exits non-zero with branch+PR# in error message.
- `lefthook.yml`: adds `merged-branch-guard` command to pre-push section.
- `hooks/scripts/pretool_guard.py`: RE_GIT_PUSH handler calls `check_merged_pr` before the commit-step deny; blocks with deny if merged PR found.
- `tests/hooks/test_live_checks_merged_pr.py`: 7 tests (5 unit + 2 integration).
- `tests/pretool-guard-merged-branch-2878.spec.js`: JS Playwright spec wrapper.

merge-evidence-deferred-final: #2878
Refs #2878

[skip-doc-gate]
