### PR TITLE
fix(hooks): remove advisory-silent || true from lefthook pre-push

### DIFF
--- a/.changes/unreleased/2895.md
+++ b/.changes/unreleased/2895.md
@@ -1,0 +1,7 @@
+### Fixed — #2895 remove advisory-silent || true from lefthook
+
+- `lefthook.yml`: removed `|| true` from `lint-js`, `lint-py`, `lint-sh`, and
+  `git-freshness` pre-push hooks. These hooks were silently absorbing failures,
+  providing zero user-visible feedback. Removing `|| true` restores the advisory
+  and blocking behavior described in the harness instructions. Sprint 0 of
+  Epic #2891 governance guardrails improvement.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,13 +14,13 @@ pre-push:
     lint-readability:
       run: npm run lint:readability:ci
     lint-js:
-      run: npm run lint:js || true
+      run: npm run lint:js
     lint-md:
       run: npm run lint:md
     lint-py:
-      run: npm run lint:py || true
+      run: npm run lint:py
     lint-sh:
-      run: npm run lint:sh || true
+      run: npm run lint:sh
     megalint:
       run: node scripts/global/megalint/index.js
     hydration-lint:
@@ -34,7 +34,7 @@ pre-push:
     # silently failed, and was suppressed by `|| true`. The gate runs
     # server-side via .github/workflows/test-evidence.yml on PR.
     git-freshness:
-      run: node scripts/global/git-freshness-check.js || true
+      run: node scripts/global/git-freshness-check.js
     # #2878: merged-branch-guard — block pushes to already-merged branches.
     merged-branch-guard:
       run: python3 hooks/scripts/merged-branch-guard.py


### PR DESCRIPTION
## Summary

Removes `|| true` from 4 lefthook pre-push hooks that were silently absorbing failures with zero user-visible feedback. These were advisory-silent hooks identified in Epic #2891 Phase-0 research (#2893) as the highest-value Sprint 0 correction.

**Changes:** `lefthook.yml` only — 4 lines changed.

| Hook | Before | After |
|---|---|---|
| lint-js | `npm run lint:js \|\| true` | `npm run lint:js` |
| lint-py | `npm run lint:py \|\| true` | `npm run lint:py` |
| lint-sh | `npm run lint:sh \|\| true` | `npm run lint:sh` |
| git-freshness | `node git-freshness-check.js \|\| true` | `node git-freshness-check.js` |

This is a correction, not a promotion — the underlying scripts and instructions always intended this behavior. The `|| true` was suppressing existing intent.

Refs #2895
merge-evidence-deferred-final: #2895