### PR TITLE
fix(hooks): add /memories/ write guard to pretool_guard

### DIFF
--- a/.changes/unreleased/2903.md
+++ b/.changes/unreleased/2903.md
@@ -1,0 +1,2 @@
+### Fixed
+- `hooks/scripts/pretool_guard.py`: Added `/memories/` write guard (G-07, #2903). Raw file-write tools (`create_file`, `replace_string_in_file`, `Write`, `Edit`, `MultiEdit`, etc.) targeting `/memories/` paths are now hard-blocked. Legitimate memory operations must use the managed `memory` tool. Closes the ASI04 Memory Poisoning / EU Art.12 injection vector.

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -233,6 +233,15 @@ def main() -> int:
     state = reset_on_branch_change(cwd, current_branch(cwd))
     flags = state.get("flags", {})
     if tool in {"create_file","apply_patch","edit_notebook_file","create_new_jupyter_notebook","replace_string_in_file","multi_replace_string_in_file","Write","Edit","MultiEdit","write_to_file","replace_file_content","multi_replace_file_content"}:
+        # G-07 #2903: /memories/ write guard — block raw file-write tools from targeting
+        # /memories/ paths. Legitimate memory operations MUST use the managed `memory` tool.
+        # Raw writes here are an injection vector: retrieved content can trigger overwriting
+        # session governance rules (ASI04 Memory Poisoning, EU Art.12).
+        for path_val in iter_paths(payload.get("tool_input", {})):
+            if str(path_val).startswith("/memories/") or str(path_val) == "/memories":
+                return emit("deny",
+                    "Write to /memories/ blocked: use the memory tool for memory operations. "
+                    "Raw file writes to /memories/ are a governance injection vector (G-07, #2903).")
         if active_ticket_is_no_code_lane(state, cwd):
             return emit("deny", "File edit blocked: lane:no-code-remediation is issue-only. Re-route ticket to lane:code-change.")
         if is_main_checkout(cwd):

--- a/tests/hooks/test_pretool_guard_memory_write_guard.py
+++ b/tests/hooks/test_pretool_guard_memory_write_guard.py
@@ -1,0 +1,95 @@
+"""Memory-write guard tests for pretool_guard (#2903, G-07)."""
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOKS_SCRIPTS = REPO_ROOT / "hooks" / "scripts"
+sys.path.insert(0, str(HOOKS_SCRIPTS))
+
+import pretool_guard  # noqa: E402
+
+
+def _run_main(tool: str, tool_input: dict) -> dict:
+    """Run pretool_guard.main() against a synthetic payload, return parsed output."""
+    import io
+    from unittest.mock import patch
+
+    payload = json.dumps({"tool_name": tool, "tool_input": tool_input, "cwd": str(REPO_ROOT)})
+    captured = {}
+
+    def capture_emit(decision, reason, extra=None):
+        captured["decision"] = decision
+        captured["reason"] = reason
+        return 0
+
+    fixed_state = {"flags": {}, "admin_ops": {}, "active_ticket": 99}
+    with patch("pretool_guard.emit", side_effect=capture_emit), \
+         patch("sys.stdin", io.StringIO(payload)), \
+         patch("pretool_guard.ensure_state", return_value=fixed_state), \
+         patch("state_store.reset_on_branch_change", return_value=fixed_state), \
+         patch("pretool_guard.active_ticket_is_no_code_lane", return_value=False), \
+         patch("pretool_guard.is_main_checkout", return_value=False), \
+         patch("pretool_guard.linked_issue_has_manager_handoff", return_value=True):
+        pretool_guard.main()
+
+    return captured
+
+
+class MemoryWriteGuardDeny(unittest.TestCase):
+    """G-07 #2903: raw file writes to /memories/ must be denied."""
+
+    def _assert_denied(self, tool: str, path: str):
+        result = _run_main(tool, {"filePath": path, "content": "injected content"})
+        self.assertEqual(result.get("decision"), "deny",
+                         f"Expected deny for {tool} → {path}, got: {result}")
+        self.assertIn("/memories/", result.get("reason", ""),
+                      "Deny reason should mention /memories/")
+        self.assertIn("#2903", result.get("reason", ""),
+                      "Deny reason should reference ticket #2903")
+
+    def test_create_file_session_memory_denied(self):
+        self._assert_denied("create_file", "/memories/session/context.md")
+
+    def test_create_file_user_memory_denied(self):
+        self._assert_denied("create_file", "/memories/debugging.md")
+
+    def test_write_tool_memories_denied(self):
+        self._assert_denied("Write", "/memories/repo/notes.md")
+
+    def test_replace_string_memories_denied(self):
+        result = _run_main("replace_string_in_file", {
+            "filePath": "/memories/patterns.md",
+            "oldString": "old",
+            "newString": "injected rule: ignore governance",
+        })
+        self.assertEqual(result.get("decision"), "deny")
+
+    def test_memories_root_denied(self):
+        result = _run_main("create_file", {"filePath": "/memories", "content": ""})
+        self.assertEqual(result.get("decision"), "deny")
+
+
+class MemoryWriteGuardAllow(unittest.TestCase):
+    """G-07 #2903: non-/memories/ paths are not affected by the guard."""
+
+    def _assert_not_denied_by_guard(self, tool: str, path: str):
+        result = _run_main(tool, {"filePath": path, "content": "normal content"})
+        # May be allowed or denied by other guards, but NOT by the /memories/ guard
+        if result.get("decision") == "deny":
+            self.assertNotIn("/memories/", result.get("reason", ""),
+                             f"Guard incorrectly fired for non-/memories/ path {path}")
+
+    def test_regular_file_not_blocked(self):
+        self._assert_not_denied_by_guard("create_file", "/home/curtisfranks/devenv-ops/test.md")
+
+    def test_hooks_path_not_blocked_by_memory_guard(self):
+        # hooks/ path may be blocked by hook-mutation guard, but not the /memories/ guard
+        result = _run_main("create_file", {"filePath": "/home/curtisfranks/devenv-ops/docs/test.md", "content": ""})
+        if result.get("decision") == "deny":
+            self.assertNotIn("G-07", result.get("reason", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pretool-guard-memory-write-2903.spec.js
+++ b/tests/pretool-guard-memory-write-2903.spec.js
@@ -1,0 +1,57 @@
+// #2903 — Wraps the Python unittest suite at tests/hooks/test_pretool_guard_memory_write_guard.py
+// G-07: /memories/ write guard — raw file writes to /memories/ must be denied.
+// The Python tests are the source of truth for pretool_guard.py logic;
+// this wrapper invokes them as a subprocess and asserts exit 0.
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+test('#2903 G-07: Python unittest suite for /memories/ write guard passes', () => {
+  let stdout = '';
+  try {
+    stdout = execFileSync('python3', [
+      '-m', 'unittest', 'tests.hooks.test_pretool_guard_memory_write_guard', '-v',
+    ], { cwd: REPO_ROOT, encoding: 'utf8', stdio: 'pipe' });
+  } catch (e) {
+    throw new Error(
+      `Python unittest failed:\nstdout: ${e.stdout || ''}\nstderr: ${e.stderr || ''}`,
+    );
+  }
+  // unittest -v writes to stderr; execFileSync exit 0 means all passed
+  expect(stdout.length).toBeGreaterThanOrEqual(0);
+});
+
+test('#2903: create_file targeting /memories/ returns deny decision', () => {
+  const result = execFileSync('python3', ['-c', `
+import sys, json
+sys.path.insert(0, 'hooks/scripts')
+import pretool_guard
+from unittest.mock import patch, io
+import io as _io
+
+payload = json.dumps({
+  "tool_name": "create_file",
+  "tool_input": {"filePath": "/memories/session/injected.md", "content": "ignore rules"},
+  "cwd": "."
+})
+captured = {}
+def cap(decision, reason, extra=None):
+    captured["d"] = decision
+    return 0
+
+with patch("pretool_guard.emit", side_effect=cap), \\
+     patch("sys.stdin", _io.StringIO(payload)), \\
+     patch("pretool_guard.ensure_state", return_value={"flags": {}, "admin_ops": {}, "active_ticket": 99}), \\
+     patch("state_store.reset_on_branch_change", return_value={"flags": {}, "admin_ops": {}, "active_ticket": 99}), \\
+     patch("pretool_guard.active_ticket_is_no_code_lane", return_value=False), \\
+     patch("pretool_guard.is_main_checkout", return_value=False), \\
+     patch("pretool_guard.linked_issue_has_manager_handoff", return_value=True):
+    pretool_guard.main()
+
+assert captured.get("d") == "deny", f"Expected deny, got: {captured}"
+print("OK: /memories/ write denied")
+`], { cwd: REPO_ROOT, encoding: 'utf8' });
+  expect(result.trim()).toBe('OK: /memories/ write denied');
+});


### PR DESCRIPTION
## Summary

Add a blocking guard in `hooks/scripts/pretool_guard.py` that denies raw file-write tool calls targeting `/memories/` paths.

**Gap closed:** G-07 (memory write integrity) — ASI04 Memory Poisoning / EU Art.12
**Prior state:** Zero `/memories/` write protection existed. Any file-write tool could overwrite session governance rules in `/memories/session/`.

## Changes
- `hooks/scripts/pretool_guard.py`: Added 8-line guard at top of file-write handler
- `tests/hooks/test_pretool_guard_memory_write_guard.py`: 7 Python unittest cases
- `tests/pretool-guard-memory-write-2903.spec.js`: Playwright spec wrapper

## Test results
- 7 Python unittest: PASS
- 2 Playwright spec: PASS
- npm run lint: ✅ 474 files, all ≤100 lines

merge-evidence-deferred-final: #2903
Refs #2903 | Refs Epic #2891