### PR TITLE
fix(agents): use claude-haiku-4-5 for red-team orchestrator (#2927, G3)

### DIFF
--- a/.claude/agents/red-team.md
+++ b/.claude/agents/red-team.md
@@ -5,7 +5,7 @@ description: >
   non-Anthropic fleet model (Qwen via Ollama) for independent adversarial review.
   Returns structured ACCEPT/REJECT/PARTIAL findings with hallucination-risk
   classification. Does not modify implementation; advisory output only.
-model: claude-sonnet-4-6
+model: claude-haiku-4-5
 tools:
   - Bash
   - Read


### PR DESCRIPTION
One-line config fix: red-team agent only dispatches to fleet — Sonnet not needed as orchestrator.

merge-evidence-deferred-final: #2927

Refs #2927