### PR TITLE
feat(hooks): enforce session blast-radius cap (#2917)

### DIFF
--- a/.changes/unreleased/2917.md
+++ b/.changes/unreleased/2917.md
@@ -1,0 +1,2 @@
+### Added
+- Added a session blast-radius guardrail in pretool flow with caps for file edits, pushes, and estimated provider-call cost, including an audited operator bypass via `MEGINGJORD_BLAST_RADIUS_DISABLED=1`.

--- a/config/governance-rules.yaml
+++ b/config/governance-rules.yaml
@@ -22,6 +22,10 @@
 
 version: 1
 generated_by: seed-rules-v1
+blast_radius_caps:
+  max_files_per_session: 200
+  max_pushes_per_session: 20
+  max_cost_usd_per_session: 5.00
 rules:
 
   - rule_id: refs-not-closes-in-pr

--- a/hooks/scripts/blast_radius_cap.py
+++ b/hooks/scripts/blast_radius_cap.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Session blast-radius caps for file edits, pushes, and estimated provider cost."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+ENV_BYPASS = "MEGINGJORD_BLAST_RADIUS_DISABLED"
+COST_PER_CALL_USD = 0.05
+DEFAULT_CAPS = {
+    "max_files_per_session": 200,
+    "max_pushes_per_session": 20,
+    "max_cost_usd_per_session": 5.00,
+}
+
+
+def load_caps(cwd: str) -> dict[str, float]:
+    path = Path(cwd) / "config" / "governance-rules.yaml"
+    if not path.exists():
+        return dict(DEFAULT_CAPS)
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"^blast_radius_caps:\s*$([\s\S]+?)(?=^\S|\Z)", text, re.MULTILINE)
+    if not match:
+        return dict(DEFAULT_CAPS)
+    block = match.group(1)
+    caps = dict(DEFAULT_CAPS)
+    for key in caps:
+        item = re.search(rf"^\s+{re.escape(key)}:\s*([0-9]+(?:\.[0-9]+)?)\s*$", block, re.MULTILINE)
+        if item:
+            caps[key] = float(item.group(1))
+    return caps
+
+
+def _as_int(d: dict[str, Any], key: str) -> int:
+    try:
+        return int(d.get(key, 0) or 0)
+    except Exception:
+        return 0
+
+
+def estimated_cost_usd(blast: dict[str, Any]) -> float:
+    return round(_as_int(blast, "provider_call_count") * COST_PER_CALL_USD, 2)
+
+
+def check_caps(blast: dict[str, Any], caps: dict[str, float]) -> str | None:
+    files_count = _as_int(blast, "files_edited_count")
+    push_count = _as_int(blast, "push_count")
+    est_cost = estimated_cost_usd(blast)
+    if files_count > int(caps["max_files_per_session"]):
+        return f"files_edited_count={files_count} > max_files_per_session={int(caps['max_files_per_session'])}"
+    if push_count > int(caps["max_pushes_per_session"]):
+        return f"push_count={push_count} > max_pushes_per_session={int(caps['max_pushes_per_session'])}"
+    if est_cost > float(caps["max_cost_usd_per_session"]):
+        cap = float(caps["max_cost_usd_per_session"])
+        return f"estimated_cost_usd={est_cost:.2f} > max_cost_usd_per_session={cap:.2f}"
+    return None
+
+
+def emit_cap_incident(reason: str, cwd: str, override: bool = False) -> None:
+    try:
+        path = Path.home() / ".megingjord" / "incidents.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        event = {
+            "version": 3,
+            "service": "pretool-guard",
+            "env": "local",
+            "event": "SESSION_BLAST_RADIUS_CAP",
+            "pattern_id": "session-blast-radius-cap",
+            "severity": "medium",
+            "cwd": cwd,
+            "reason": reason,
+            "override": bool(override),
+            "override_env": ENV_BYPASS if override else None,
+        }
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event) + "\n")
+    except Exception:
+        pass

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -9,6 +9,7 @@ from admin_patterns import (  # noqa: E501
     RE_GIT_PUSH, RE_GIT_TAG, RE_PR_CHECKS, RE_PR_CREATE, RE_PR_MERGE,
     RE_RELEASE_INTEGRITY, RE_VSCE_PUBLISH, SECRET_FILE_RE, iter_paths, iter_strings)
 from canonical_main_enforcer import is_main_checkout, evaluate_path
+from blast_radius_cap import ENV_BYPASS, check_caps, emit_cap_incident, load_caps
 from governance_state import ensure_state
 from live_checks import ci_gate_status_stable, linked_issue_has_collab_handoff, linked_issue_has_manager_handoff, check_merged_pr
 from runtime_paths import runtime_hook_paths
@@ -91,6 +92,25 @@ def active_ticket_is_no_code_lane(state: dict, cwd: str) -> bool:
     return "lane:no-code-remediation" in _active_ticket_labels(state, cwd)
 
 RE_ADMIN_OVERRIDE = re.compile(r"(?:^|\s)--admin(?:[=\s]|$)")
+MUTATING_TOOLS = {
+    "create_file", "apply_patch", "edit_notebook_file", "create_new_jupyter_notebook",
+    "replace_string_in_file", "multi_replace_string_in_file", "Write", "Edit", "MultiEdit",
+    "write_to_file", "replace_file_content", "multi_replace_file_content",
+    "run_in_terminal", "terminal", "runTerminalCommand", "Bash", "run_command", "send_command_input",
+}
+
+
+def enforce_blast_radius(tool: str, state: dict, cwd: str) -> int | None:
+    if tool not in MUTATING_TOOLS:
+        return None
+    reason = check_caps(state.get("blast_radius", {}), load_caps(cwd))
+    if not reason:
+        return None
+    override = os.environ.get(ENV_BYPASS, "0") == "1"
+    emit_cap_incident(reason, cwd, override=override)
+    if override:
+        return None
+    return emit("deny", f"Session blast-radius cap exceeded: {reason}")
 
 def require_bypass_exception(joined: str, state: dict, cwd: str) -> bool:
     """True when this is an admin-OVERRIDE merge lacking the Epic #2517 exception (#2706).
@@ -237,6 +257,9 @@ def main() -> int:
     state = ensure_state(cwd)
     from state_store import reset_on_branch_change
     state = reset_on_branch_change(cwd, current_branch(cwd))
+    blast_result = enforce_blast_radius(tool, state, cwd)
+    if blast_result is not None:
+        return blast_result
     flags = state.get("flags", {})
     if tool in {"create_file","apply_patch","edit_notebook_file","create_new_jupyter_notebook","replace_string_in_file","multi_replace_string_in_file","Write","Edit","MultiEdit","write_to_file","replace_file_content","multi_replace_file_content"}:
         # G-07 #2903: /memories/ write guard — block raw file-write tools from targeting

--- a/hooks/scripts/state_store.py
+++ b/hooks/scripts/state_store.py
@@ -39,6 +39,7 @@ def _default_state(cwd: str) -> dict[str, Any]:
         "admin_ops": {"version_check": False, "commit": False, "push": False, "pr_create": False,
             "ci_green": False, "merge": False, "publish": False, "release_integrity": False,
             "gh_release": False, "issue_close": False, "issue_linked": False, "visual_qa": False},
+        "blast_radius": {"files_edited_count": 0, "push_count": 0, "provider_call_count": 0},
         "drift": {"commits": 0, "commits_with_ticket": 0, "branches": 0,
             "branches_compliant": 0, "edits_gated": 0, "edits_ungated": 0}}
 
@@ -50,7 +51,7 @@ def load_state(cwd: str) -> dict[str, Any]:
         data = json.loads(path.read_text(encoding="utf-8"))
         if not isinstance(data, dict):
             return _default_state(cwd)
-        defaults, keys = _default_state(cwd), ("routing", "roles", "flags", "admin_ops", "drift")
+        defaults, keys = _default_state(cwd), ("routing", "roles", "flags", "admin_ops", "blast_radius", "drift")
         data.setdefault("cwd", cwd)
         data.setdefault("repo_type", detect_repo_type(cwd))
         data.setdefault("current_phase", defaults["current_phase"])

--- a/hooks/scripts/tool_activity.py
+++ b/hooks/scripts/tool_activity.py
@@ -30,6 +30,12 @@ _BATON_ROLE_MAP = {
 # Bash/terminal tools: inputs are shell commands, not file paths.
 # Path classification is skipped for these to prevent false code_touched.
 BASH_TOOLS = {"run_in_terminal", "terminal", "runTerminalCommand", "Bash", "run_command", "send_command_input"}
+EDIT_TOOLS = {
+    "apply_patch", "create_file", "edit_notebook_file", "create_new_jupyter_notebook",
+    "write_to_file", "replace_file_content", "multi_replace_file_content",
+    "replace_string_in_file", "multi_replace_string_in_file",
+}
+_PROVIDER_RE = re.compile(r"\b(cascade-dispatch|hamr-client|hamr\.workers\.dev|dispatchRedTeam)\b", re.IGNORECASE)
 
 
 def mark_tool_activity(state: dict[str, Any], payload: dict[str, Any]) -> None:
@@ -40,13 +46,14 @@ def mark_tool_activity(state: dict[str, Any], payload: dict[str, Any]) -> None:
     roles = state.setdefault("roles", {})
     flags = state.setdefault("flags", {})
     ops = state.setdefault("admin_ops", {})
+    blast = state.setdefault("blast_radius", {})
+    blast.setdefault("files_edited_count", 0)
+    blast.setdefault("push_count", 0)
+    blast.setdefault("provider_call_count", 0)
 
-    if tool in {
-        "apply_patch", "create_file",
-        "edit_notebook_file", "create_new_jupyter_notebook",
-        "write_to_file", "replace_file_content", "multi_replace_file_content",
-    }:
+    if tool in EDIT_TOOLS:
         roles["collaborator"] = True
+        blast["files_edited_count"] += 1
 
     # #1960: Do not classify Bash command strings as file paths.
     # Only extract explicit patch-file names from Bash inputs.
@@ -100,6 +107,10 @@ def mark_tool_activity(state: dict[str, Any], payload: dict[str, Any]) -> None:
     for pattern, key in _match_ops:
         if pattern.search(joined):
             ops[key] = True
+    if RE_GIT_PUSH.search(joined):
+        blast["push_count"] += 1
+    if _PROVIDER_RE.search(joined):
+        blast["provider_call_count"] += 1
 
     # #2444: auto-emit roles.admin once all required ops complete.
     # Mirrors check_admin_ops base/ext logic via shared helper.

--- a/tests/blast-radius-cap.spec.js
+++ b/tests/blast-radius-cap.spec.js
@@ -1,0 +1,20 @@
+// #2917 - JS shim for test-evidence; authoritative logic tests are in Python.
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+test('#2917: Python unittest suite for blast-radius cap passes', () => {
+  let stdout = '';
+  try {
+    stdout = execFileSync('python3', [
+      '-m', 'unittest', 'tests.hooks.test_blast_radius_cap', '-v',
+    ], { cwd: REPO_ROOT, encoding: 'utf8', stdio: 'pipe' });
+  } catch (e) {
+    throw new Error(
+      `Python unittest failed:\nstdout: ${e.stdout || ''}\nstderr: ${e.stderr || ''}`,
+    );
+  }
+  expect(stdout.length).toBeGreaterThanOrEqual(0);
+});

--- a/tests/hooks/test_blast_radius_cap.py
+++ b/tests/hooks/test_blast_radius_cap.py
@@ -1,0 +1,86 @@
+"""Tests for #2917 session blast-radius cap controls."""
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOKS = REPO_ROOT / "hooks" / "scripts"
+sys.path.insert(0, str(HOOKS))
+
+import blast_radius_cap as br  # noqa: E402
+import pretool_guard  # noqa: E402
+
+
+class BlastRadiusCapTests(unittest.TestCase):
+    def test_check_caps_detects_file_breach(self):
+        reason = br.check_caps({"files_edited_count": 201}, br.DEFAULT_CAPS)
+        self.assertIn("files_edited_count=201", reason)
+
+    def test_check_caps_detects_push_breach(self):
+        reason = br.check_caps({"push_count": 21}, br.DEFAULT_CAPS)
+        self.assertIn("push_count=21", reason)
+
+    def test_check_caps_detects_cost_breach(self):
+        reason = br.check_caps({"provider_call_count": 101}, br.DEFAULT_CAPS)
+        self.assertIn("estimated_cost_usd=5.05", reason)
+
+    def test_load_caps_reads_yaml_block(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "config"
+            cfg.mkdir(parents=True)
+            (cfg / "governance-rules.yaml").write_text(
+                "blast_radius_caps:\n  max_files_per_session: 3\n"
+                "  max_pushes_per_session: 4\n  max_cost_usd_per_session: 0.50\n",
+                encoding="utf-8",
+            )
+            caps = br.load_caps(tmp)
+        self.assertEqual(caps["max_files_per_session"], 3.0)
+        self.assertEqual(caps["max_pushes_per_session"], 4.0)
+        self.assertEqual(caps["max_cost_usd_per_session"], 0.5)
+
+    def test_emit_cap_incident_writes_event(self):
+        with tempfile.TemporaryDirectory() as home:
+            with patch("pathlib.Path.home", return_value=Path(home)):
+                br.emit_cap_incident("test-reason", cwd="/tmp/demo", override=True)
+            log = Path(home) / ".megingjord" / "incidents.jsonl"
+            payload = json.loads(log.read_text(encoding="utf-8").strip())
+        self.assertEqual(payload["event"], "SESSION_BLAST_RADIUS_CAP")
+        self.assertTrue(payload["override"])
+
+
+class PretoolGuardIntegrationTests(unittest.TestCase):
+    def test_pretool_guard_denies_when_cap_exceeded(self):
+        payload = {"tool_name": "run_in_terminal", "tool_input": {"command": "echo hi"}, "cwd": str(REPO_ROOT)}
+        state = {"flags": {}, "admin_ops": {}, "blast_radius": {"files_edited_count": 999}, "active_ticket": 2917}
+        captured = {}
+
+        def fake_emit(decision, reason, extra=None):
+            captured["decision"], captured["reason"] = decision, reason
+            return 0
+
+        with patch("pretool_guard.ensure_state", return_value=state), \
+             patch("state_store.reset_on_branch_change", return_value=state), \
+             patch("pretool_guard.emit", side_effect=fake_emit), \
+             patch("sys.stdin", io.StringIO(json.dumps(payload))):
+            pretool_guard.main()
+        self.assertEqual(captured.get("decision"), "deny")
+        self.assertIn("Session blast-radius cap exceeded", captured.get("reason", ""))
+
+    def test_pretool_guard_allows_with_override_env(self):
+        payload = {"tool_name": "run_in_terminal", "tool_input": {"command": "echo hi"}, "cwd": str(REPO_ROOT)}
+        state = {"flags": {}, "admin_ops": {}, "blast_radius": {"files_edited_count": 999}, "active_ticket": 2917}
+        with patch("pretool_guard.ensure_state", return_value=state), \
+             patch("state_store.reset_on_branch_change", return_value=state), \
+             patch.dict(os.environ, {br.ENV_BYPASS: "1"}, clear=False), \
+             patch("sys.stdin", io.StringIO(json.dumps(payload))):
+            code = pretool_guard.main()
+        self.assertEqual(code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements G-06 session blast-radius enforcement with persisted counters and pretool deny path.

merge-evidence-deferred-final: #2917

Refs #2917