### PR TITLE
feat(scripts): cascade-dispatch progress observability (#2842)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ the Worker: add `MEGINGJORD_HAMR_ENABLED=1` to your `.env`.
 | `deps:augment` | `node scripts/global/dep-graph-augment.js` |
 | `deps:render` | `node scripts/global/dep-graph-render.js` |
 | `deps:review` | `node scripts/global/dep-proposals-review.js` |
+| `dispatch:progress:test` | `node --test tests/dispatch-progress.spec.js tests/cascade-observability.spec.js` |
 | `doc-graph` | `node scripts/global/doc-graph-builder.js` |
 | `docs:anchors` | `node scripts/global/docs-anchors.js` |
 | `docs:compile` | `node scripts/docs-compile.js` |

--- a/package.json
+++ b/package.json
@@ -271,6 +271,7 @@
     "test:collaborator-input-shape": "node --test tests/collaborator-handoff-input-shape.spec.js",
     "test:compatibility": "node --test tests/orchestrator-compatibility.spec.js",
     "test:post-merge-sweep": "node --test tests/post-merge-sweep.spec.js",
+    "dispatch:progress:test": "node --test tests/dispatch-progress.spec.js tests/cascade-observability.spec.js",
     "synthesis:init": "node scripts/global/synthesis-init.js",
     "synthesis:status": "node scripts/global/broker-synthesis-status.js",
     "synthesis:snapshot": "node scripts/global/synthesis-snapshot.js",

--- a/scripts/global/cascade-dispatch.js
+++ b/scripts/global/cascade-dispatch.js
@@ -12,6 +12,10 @@ const { backoff, isRateLimitError } = require('./backoff');
 const { dispatchFreeCloud } = require('./free-cloud-dispatch'); // execute free $0 cloud on fleet-down
 // (#2645) shared .env hydration shim — make provider keys visible for the free-cloud fallback (G3)
 const { loadLocalEnvOnce } = require('./load-local-env');
+// (#2842 / Epic #2926 C2) progress observability so the operator sees the free fleet working
+const { withProgress } = require('./dispatch-progress');
+
+const HEARTBEAT_MS = 30_000;
 
 // #2619: G3 lane-order. Availability failures (fleet down -> no answer) fail over to a
 // free $0 cloud tier BEFORE any paid tier; capability failures (fleet answered but
@@ -48,7 +52,12 @@ function assessQuality(content, h) {
 async function tryOllama(prompt, model, attempt = 0) {
   const health = await healthCheck();
   if (!health.ok) return { ok: false, reason: 'ollama_unreachable', tier: 'local' };
-  const result = await ollamaChat(prompt, { model, maxTokens: 1024 });
+  // #2842: emit start + 30s heartbeat to stderr during the multi-minute fleet inference (G3>>G7).
+  const result = await withProgress(
+    `fleet inference (${model})`,
+    () => ollamaChat(prompt, { model, maxTokens: 1024 }),
+    { intervalMs: HEARTBEAT_MS }
+  );
   if (!result.ok) {
     if (isRateLimitError(result) && attempt < 3) {
       await backoff(attempt);
@@ -70,6 +79,8 @@ async function cascade(prompt, opts = {}) {
   if (!local.ok) {
     const esc = escalationTier(local.reason); // #2619: fleet-down -> free-cloud, not paid haiku
     if (esc === 'free-cloud' && opts.executeFreeCloud !== false) {
+      // #2842: surface the (previously silent) availability failover so the operator sees it stay $0.
+      process.stderr.write(`[cascade] fleet unavailable (${local.reason}) → free-cloud failover ($0)\n`);
       // #2621: actually execute a $0 cloud provider; graceful fall-through to advisory signal.
       const fc = await dispatchFreeCloud(prompt, opts.freeCloud || {});
       if (fc.ok) {

--- a/scripts/global/dispatch-progress.js
+++ b/scripts/global/dispatch-progress.js
@@ -1,0 +1,45 @@
+'use strict';
+// tier: 3
+// Progress observability for slow fleet dispatches (#2842 / Epic #2926 C2).
+// (Library only — no CLI entrypoint, so no shebang; per cross-family review #2842.)
+// Generalizes the #2901 `.unref()` 30s-heartbeat pattern: emit a tier-start line plus a
+// periodic heartbeat to stderr so the operator SEES the free fleet working during the
+// multi-minute (now up to 1500s/1800s per #2937) inference, instead of a dark terminal that
+// pushes them to a paid call. stderr-only — stdout stays clean for the answer / `--json`.
+// G3 (zero-cost fleet) >> G7 (speed): patience is tolerable only when progress is visible.
+
+const DEFAULT_INTERVAL_MS = 30_000;
+
+/**
+ * Run `fn` while emitting start + periodic heartbeat progress lines.
+ * @param {string} label - short work label, e.g. "fleet inference (qwen2.5:7b)".
+ * @param {() => Promise<any>} fn - the slow async operation to await.
+ * @param {object} [opts]
+ * @param {number} [opts.intervalMs] - heartbeat cadence (default 30s).
+ * @param {number} [opts.patienceMs] - optional total patience budget, shown as "/ Ns patience".
+ * @param {(line: string) => void} [opts.write] - sink (default process.stderr.write); injectable for tests.
+ * @param {() => number} [opts.now] - clock (default Date.now); injectable for tests.
+ * @returns {Promise<any>} resolves/rejects exactly as `fn` does; timer always cleared.
+ */
+function withProgress(label, fn, opts = {}) {
+  const intervalMs = opts.intervalMs || DEFAULT_INTERVAL_MS;
+  const write = opts.write || ((line) => process.stderr.write(line));
+  const clock = opts.now || Date.now;
+  const patienceSec = opts.patienceMs ? Math.round(opts.patienceMs / 1000) : null;
+  const start = clock();
+  write(`[cascade] ${label} — starting (heartbeat every ${Math.round(intervalMs / 1000)}s)\n`);
+  const timer = setInterval(() => {
+    const elapsedSec = Math.round((clock() - start) / 1000);
+    const cap = patienceSec ? ` / ${patienceSec}s patience` : '';
+    write(`[cascade] ${label} — still working (${elapsedSec}s${cap})...\n`);
+  }, intervalMs);
+  // A progress timer must never hold the event loop open (the #2901 invariant).
+  if (typeof timer.unref === 'function') timer.unref();
+  // Deliberate: the Promise.resolve().then() wrapper routes a SYNCHRONOUS throw from fn()
+  // through .finally too — `fn().finally()` would leak the timer if fn threw before returning.
+  return Promise.resolve()
+    .then(() => fn())
+    .finally(() => clearInterval(timer));
+}
+
+module.exports = { withProgress, DEFAULT_INTERVAL_MS };

--- a/tests/cascade-observability.spec.js
+++ b/tests/cascade-observability.spec.js
@@ -1,0 +1,51 @@
+'use strict';
+// Integration spec: cascade-dispatch wires progress + failover observability (#2842 / C2).
+// AC2 (tier-start heartbeat reaches stderr around the fleet call) + AC3 (free-cloud failover line).
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+const G = (m) => require.resolve(path.join(__dirname, '..', 'scripts', 'global', m));
+function seed(modName, exports) {
+  const id = G(modName);
+  require.cache[id] = { id, filename: id, loaded: true, exports };
+}
+function loadCascadeFresh() {
+  delete require.cache[G('cascade-dispatch')];
+  return require(G('cascade-dispatch'));
+}
+
+// Capture stderr around a single async run; always restore.
+async function captureStderr(fn) {
+  const lines = [];
+  const orig = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk, ...rest) => { lines.push(String(chunk)); return true; };
+  try { await fn(); } finally { process.stderr.write = orig; }
+  return lines.join('');
+}
+
+test('AC2: a healthy fleet inference emits the tier-start heartbeat line to stderr', async () => {
+  seed('litellm-client', {
+    healthCheck: async () => ({ ok: true }),
+    chatComplete: async () => ({ ok: true, content: 'a sufficiently long fleet answer body', model: 'qwen2.5:7b-instruct' }),
+  });
+  seed('model-routing-telemetry', { recordTelemetry: () => {} });
+  seed('local-judge', { judgeResponse: async () => ({ ok: false }) });
+  seed('free-cloud-dispatch', { dispatchFreeCloud: async () => ({ ok: false }) });
+  const { cascade } = loadCascadeFresh();
+  const err = await captureStderr(() => cascade('what is two plus two', { env: true }));
+  assert.match(err, /\[cascade\] fleet inference \(qwen2\.5:7b-instruct\) — starting/);
+});
+
+test('AC3: fleet-unreachable emits the free-cloud failover line to stderr ($0, never paid)', async () => {
+  seed('litellm-client', {
+    healthCheck: async () => ({ ok: false }), // availability failure -> free-cloud
+    chatComplete: async () => ({ ok: false, error: 'ollama_unreachable' }),
+  });
+  seed('model-routing-telemetry', { recordTelemetry: () => {} });
+  seed('local-judge', { judgeResponse: async () => ({ ok: false }) });
+  seed('free-cloud-dispatch', { dispatchFreeCloud: async () => ({ ok: true, content: 'free answer', provider: 'gemini' }) });
+  const { cascade } = loadCascadeFresh();
+  const err = await captureStderr(() => cascade('explain something', { env: true }));
+  assert.match(err, /\[cascade\] fleet unavailable \(ollama_unreachable\) → free-cloud failover \(\$0\)/);
+});

--- a/tests/dispatch-progress.spec.js
+++ b/tests/dispatch-progress.spec.js
@@ -1,0 +1,90 @@
+'use strict';
+// tdd-pyramid spec for scripts/global/dispatch-progress.js (#2842 / Epic #2926 C2).
+// Covers AC1 (start line + heartbeat + clear-on-settle + propagation) and AC4 (unref / no leak).
+const test = require('node:test');
+const assert = require('node:assert');
+const { withProgress, DEFAULT_INTERVAL_MS } = require('../scripts/global/dispatch-progress');
+
+// A controllable clock: each call returns the next value in the supplied sequence (last value sticks).
+function fakeClock(seq) {
+  let i = 0;
+  return () => seq[Math.min(i++, seq.length - 1)];
+}
+
+const delay = (ms) => new Promise((res) => setTimeout(res, ms));
+
+test('default interval is 30s', () => {
+  assert.strictEqual(DEFAULT_INTERVAL_MS, 30_000);
+});
+
+test('AC1: emits a start line with the label and interval before resolving', async () => {
+  const lines = [];
+  const result = await withProgress('fleet inference (qwen)', async () => 'answer', {
+    write: (l) => lines.push(l),
+  });
+  assert.strictEqual(result, 'answer'); // AC1: propagates resolved value
+  assert.strictEqual(lines.length, 1, 'fast fn → start line only, no heartbeat');
+  assert.match(lines[0], /^\[cascade\] fleet inference \(qwen\) — starting \(heartbeat every 30s\)/);
+});
+
+test('AC1: emits >=1 heartbeat when fn outlives the interval, with elapsed seconds', async () => {
+  const lines = [];
+  await withProgress('fleet inference (qwen)', () => delay(45), {
+    intervalMs: 10,
+    now: fakeClock([0, 30_000, 60_000]), // start=0, first heartbeat reads 30000 -> "30s"
+    write: (l) => lines.push(l),
+  });
+  const beats = lines.filter((l) => /still working/.test(l));
+  assert.ok(beats.length >= 1, `expected >=1 heartbeat, got ${beats.length}`);
+  assert.match(beats[0], /still working \(30s\)\.\.\./);
+});
+
+test('AC1: shows the patience budget when patienceMs is provided', async () => {
+  const lines = [];
+  await withProgress('fleet inference', () => delay(25), {
+    intervalMs: 10,
+    patienceMs: 1_500_000, // #2937 fleet-red-team-rate
+    now: fakeClock([0, 30_000, 60_000]),
+    write: (l) => lines.push(l),
+  });
+  const beat = lines.find((l) => /still working/.test(l));
+  assert.match(beat, /\/ 1500s patience/);
+});
+
+test('AC1/AC4: timer is cleared on settle — no heartbeats fire after fn resolves', async () => {
+  const lines = [];
+  await withProgress('quick', async () => 'x', { intervalMs: 5, write: (l) => lines.push(l) });
+  const countAtSettle = lines.length;
+  await delay(40); // would fire several heartbeats if the interval leaked
+  assert.strictEqual(lines.length, countAtSettle, 'no heartbeat after clearInterval');
+});
+
+test('AC4: a SYNCHRONOUS throw from fn still clears the timer (no leak)', async () => {
+  const lines = [];
+  await assert.rejects(
+    // fn throws synchronously (does not return a Promise) — the Promise.resolve().then() wrapper
+    // must still route it through .finally so the interval is cleared.
+    withProgress('sync-boom', () => { throw new Error('sync fleet error'); }, {
+      intervalMs: 5,
+      write: (l) => lines.push(l),
+    }),
+    /sync fleet error/
+  );
+  const countAtSettle = lines.length;
+  await delay(30);
+  assert.strictEqual(lines.length, countAtSettle, 'sync-throw path also clears the timer');
+});
+
+test('AC1: propagates rejection AND clears the timer', async () => {
+  const lines = [];
+  await assert.rejects(
+    withProgress('boom', async () => { throw new Error('fleet exploded'); }, {
+      intervalMs: 5,
+      write: (l) => lines.push(l),
+    }),
+    /fleet exploded/
+  );
+  const countAtSettle = lines.length;
+  await delay(30);
+  assert.strictEqual(lines.length, countAtSettle, 'rejection path also clears the timer');
+});


### PR DESCRIPTION
Refs #2842
Closes #2842

## Summary
Adds `scripts/global/dispatch-progress.js#withProgress` (generalizes the #2901 `.unref()` 30s-heartbeat) and wires it around cascade's fleet `ollamaChat` call so a **tier-start line + periodic heartbeat reach stderr** during the now-up-to-1500s/1800s (#2937) inference. Also surfaces the previously-silent free-cloud availability failover. stderr-only — stdout stays clean for the answer / `--json`.

Closes the #2842 root cause (Epic #2926 **C2**): a dark terminal during multi-minute $0 inference pushes operators to a paid call. **G3 (zero-cost fleet) >> G7 (speed)** — patience is only tolerable when progress is visible. Pairs with #2937's patience bump.

## Tests
- `tests/dispatch-progress.spec.js` + `tests/cascade-observability.spec.js` — **9 pass / 0 fail** (start-line, heartbeat-with-elapsed, patience-budget, clear-on-resolve, async-reject + **sync-throw** timer-clear, AC2 stderr tier-start, AC3 free-cloud failover line).
- Regression: existing cascade suites green (node:test 8, playwright 10). Lint 100-cap green; readability 474 ≤ 475 (new module adds 0).

## Cross-family review (Epic #2926 dogfood, $0)
gemini@google-ai-studio (free-cloud, family ≠ claude author) — **ACCEPT 9/10**. Finding fixed: library shebang removed. Deliberate-keep documented + test-locked: the `Promise.resolve().then()` wrapper routes a synchronous throw through `.finally` (a timer-leak `fn().finally()` would miss).

## Baton artifacts (on #2842)
- MANAGER_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2842#issuecomment-4684382722
- COLLABORATOR_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2842#issuecomment-4684451833
- ADMIN_HANDOFF — https://github.com/chf3198/megingjord-harness/issues/2842#issuecomment-4684454645
- CONSULTANT_CLOSEOUT — https://github.com/chf3198/megingjord-harness/issues/2842#issuecomment-4684458355

🤖 Generated with [Claude Code](https://claude.com/claude-code)