### PR TITLE
fix(scripts): worktree-session-start creates isolated git worktree dir

### DIFF
--- a/.changes/unreleased/2946.md
+++ b/.changes/unreleased/2946.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- `worktree-session-start.sh`: replace in-place `git switch -c` branch creation with `git worktree add ~/devenv-ops-<N>` so task branches always land in an isolated directory. Prevents canonical-main stall when a ticket requires new tracked files. (#2946)
+- `.github/copilot-instructions.md`: add Auto-model capability hint for governance-heavy workspaces. (#2946)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Every task follows the **role baton sequence**: Manager → Collaborator → Adm
 See `role-baton-routing` for rules. Local repos may override via `.github/copilot-instructions.md`.
 Shared governance is provider-neutral; runtime-specific setup belongs in adapters.
 See `instructions/provider-neutral-governance.instructions.md`.
-Completion intent is strict: when the active role identifies complete/finish/ship terminal-delivery intent in task scope, execute full baton delivery through Admin and Consultant gates; do not stop at implementation unless blocked by evidence or explicit design/UAT input.
+Completion intent is strict: when the active role identifies complete/finish/ship terminal-delivery intent in task scope, execute full baton delivery through Admin and Consultant gates; do not stop at implementation unless blocked by evidence or explicit design/UAT input. **Auto model:** prefer premium tier (Claude Sonnet+) — governance baton workflows require it. (Refs #2946)
 
 ## Repo Purpose
 

--- a/scripts/worktree-session-start.sh
+++ b/scripts/worktree-session-start.sh
@@ -63,7 +63,6 @@ case "$agent" in
   copilot|codex|claude-code) ;;
   *) die "invalid agent '$agent' (expected: copilot|codex|claude-code)" ;;
 esac
-
 if [[ -n "$task_branch" && ! "$task_branch" =~ ^(feat|fix|hotfix)/[0-9]+-[a-z0-9][-a-z0-9]*$ ]]; then
   die "invalid task branch '$task_branch' (expected feat/<ticket#>-<slug>)"
 fi
@@ -74,12 +73,10 @@ root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 
 cd "$root"
 log "syncing sandbox launcher branch: $sandbox"
-
 git fetch origin --prune
 if ! git show-ref --verify --quiet "refs/heads/$sandbox"; then
   die "missing local sandbox branch '$sandbox'"
 fi
-
 git switch "$sandbox"
 git reset --hard origin/main
 git clean -fd
@@ -92,9 +89,12 @@ fi
 if git show-ref --verify --quiet "refs/heads/$task_branch"; then
   warn "task branch already exists locally: $task_branch"
 fi
-
-git switch -c "$task_branch"
-bootstrap_node_modules "$root"
-configure_per_worktree_hooks "$root"
-log "ready on task branch: $task_branch"
-log "next: implement scoped changes and open PR with Refs #<ticket>"
+# Refs #2946: isolated worktree dir — not a branch in canonical-main
+ticket_num=$(echo "$task_branch" | grep -oP '(?<=/)[0-9]+(?=-)' | head -1)
+[[ -n "$ticket_num" ]] || die "cannot extract ticket# from task branch '$task_branch'"
+wt_dir="$HOME/devenv-ops-${ticket_num}"
+[[ -d "$wt_dir" ]] && die "worktree dir exists: $wt_dir (remove first)"
+git worktree add "$wt_dir" -b "$task_branch"
+bootstrap_node_modules "$wt_dir"
+configure_per_worktree_hooks "$wt_dir"
+log "worktree ready: $wt_dir ($task_branch) — cd, implement, PR with Refs #$ticket_num"

--- a/tests/worktree-bootstrap-1378.spec.js
+++ b/tests/worktree-bootstrap-1378.spec.js
@@ -17,11 +17,11 @@ test('#1378 AC1: worktree-session-start.sh includes bootstrap_node_modules funct
 
 test('#1378 AC1: bootstrap is called after task-branch creation', () => {
   const content = fs.readFileSync(SESSION_START, 'utf-8');
-  // Must appear after `git switch -c "$task_branch"`
-  const switchPos = content.indexOf('git switch -c "$task_branch"');
-  const bootstrapCallPos = content.indexOf('bootstrap_node_modules "$root"');
-  expect(switchPos).toBeGreaterThan(0);
-  expect(bootstrapCallPos).toBeGreaterThan(switchPos);
+  // Refs #2946: now uses git worktree add + isolated dir, not git switch -c
+  const worktreeAddPos = content.indexOf('git worktree add "$wt_dir"');
+  const bootstrapCallPos = content.indexOf('bootstrap_node_modules "$wt_dir"');
+  expect(worktreeAddPos).toBeGreaterThan(0);
+  expect(bootstrapCallPos).toBeGreaterThan(worktreeAddPos);
 });
 
 test('#1378 AC1: bootstrap is idempotent (skips if node_modules already exists)', () => {


### PR DESCRIPTION
## Summary

Fixes Root Cause B of the Auto-model session early-termination incident (session `701dab5a`).

`scripts/worktree-session-start.sh` was creating task branches **inside the canonical-main checkout** via `git switch -c`, instead of creating isolated worktree directories. Any ticket requiring new tracked files was blocked by the canonical-main enforcer, causing sessions to stall mid-implementation.

## Changes

- **`scripts/worktree-session-start.sh`**: replace in-place branch creation with `git worktree add ~/devenv-ops-<N>` (ticket number extracted from branch name)
- **`.github/copilot-instructions.md`**: add Auto-model capability note (Root Cause C)
- **`tests/worktree-bootstrap-1378.spec.js`**: update AC1 assertions for new worktree add pattern

## Test Evidence

- `npm run lint` — all files within 100-line limit
- worktree-bootstrap-1378 AC1 tests (4 tests) — PASS
- Pre-existing AC3 live invocation test — pre-existing failure on main (unrelated to this change)

merge-evidence-deferred-final: #2946

Refs #2946
