### PR TITLE
fix(hooks): extend canonical-main enforcer to block absolute-path writes

### DIFF
--- a/.changes/unreleased/2945.md
+++ b/.changes/unreleased/2945.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `canonical_main_enforcer`: extend canonical-main write guard to block absolute-path writes regardless of session CWD. Adds `main_checkout_root()` helper and updates `pretool_guard.py` enforcement logic. Closes the gap where VS Code Copilot tool calls with absolute `filePath` bypassed `is_main_checkout(cwd)`. (#2945)

--- a/hooks/scripts/canonical_main_enforcer.py
+++ b/hooks/scripts/canonical_main_enforcer.py
@@ -17,6 +17,11 @@ import subprocess
 from pathlib import Path
 
 
+def main_checkout_root() -> str:
+    """Return the canonical main checkout path as a string."""
+    return str(Path.home() / "devenv-ops")
+
+
 def is_main_checkout(cwd: str) -> bool:
     """Return True if cwd is the canonical main checkout path.
 

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -8,7 +8,7 @@ from admin_patterns import (  # noqa: E501
     DANGEROUS_CMD_RE, RE_GH_ISSUE_CLOSE, RE_GH_RELEASE_CREATE, RE_GIT_COMMIT,
     RE_GIT_PUSH, RE_GIT_TAG, RE_PR_CHECKS, RE_PR_CREATE, RE_PR_MERGE,
     RE_RELEASE_INTEGRITY, RE_VSCE_PUBLISH, SECRET_FILE_RE, iter_paths, iter_strings)
-from canonical_main_enforcer import is_main_checkout, evaluate_path
+from canonical_main_enforcer import is_main_checkout, evaluate_path, main_checkout_root
 from blast_radius_cap import ENV_BYPASS, check_caps, emit_cap_incident, load_caps
 from governance_state import ensure_state
 from live_checks import ci_gate_status_stable, linked_issue_has_collab_handoff, linked_issue_has_manager_handoff, check_merged_pr
@@ -273,13 +273,24 @@ def main() -> int:
                     "Raw file writes to /memories/ are a governance injection vector (G-07, #2903).")
         if active_ticket_is_no_code_lane(state, cwd):
             return emit("deny", "File edit blocked: lane:no-code-remediation is issue-only. Re-route ticket to lane:code-change.")
-        if is_main_checkout(cwd):
-            for path_val in iter_paths(payload.get("tool_input", {})):
-                if not (path_val.startswith("/") or path_val.startswith("./") or "/" in path_val):
+        # Canonical-main write guard: block writes whether cwd is main checkout
+        # OR target path is an absolute path inside canonical-main (Refs #2945).
+        _main_rt = main_checkout_root()
+        for path_val in iter_paths(payload.get("tool_input", {})):
+            if is_main_checkout(cwd):
+                check_root = cwd
+            elif path_val.startswith("/"):
+                try:
+                    Path(os.path.normpath(path_val)).relative_to(
+                        os.path.normpath(_main_rt))
+                except ValueError:
                     continue
-                allowed, reason = evaluate_path(path_val, cwd)
-                if not allowed:
-                    return emit("deny", f"Canonical-main read-only (#2107): {reason}")
+                check_root = _main_rt  # absolute path targets canonical-main
+            else:
+                continue
+            allowed, reason = evaluate_path(path_val, check_root)
+            if not allowed:
+                return emit("deny", f"Canonical-main read-only (#2107): {reason}")
         if not state.get("active_ticket"):
             from worktree_ticket import resolve_ticket_from_paths, any_path_in_governed_repo
             edit_paths = list(iter_paths(payload.get("tool_input", {})))


### PR DESCRIPTION
## Summary

Fixes Root Cause A of the Auto-model session early-termination incident — closes the enforcement gap where VS Code Copilot tool calls with absolute paths bypassed the canonical-main write guard.

## Root Cause

`is_main_checkout(cwd)` checks whether the session CWD is `~/devenv-ops/`. When VS Code Copilot dispatches `replace_string_in_file` with an absolute `filePath`, the `cwd` in the hook payload is NOT the canonical-main path, so the guard was never entered — even when the target file was inside canonical-main.

## Changes

- **`hooks/scripts/canonical_main_enforcer.py`**: add `main_checkout_root()` helper that returns `str(Path.home() / "devenv-ops")`
- **`hooks/scripts/pretool_guard.py`**: update write-tool enforcement to also check absolute target paths against canonical-main root (regardless of CWD)

## Test Evidence

- `npm run lint` — all files within 100-line limit
- `canonical-main-enforcer.spec.js` (18 tests) — PASS
- `pretool-guard-worktree-gate.spec.js` (3 tests) — PASS
- `stress-canonical-main-enforcer.spec.js` (4 tests) — PASS, p99 latency 70ms

merge-evidence-deferred-final: #2945

Refs #2945
