### PR TITLE
fix(scripts): wire C9 review-cli parity into hamr-sync-verify #2950

### DIFF
--- a/.changes/unreleased/2950.md
+++ b/.changes/unreleased/2950.md
@@ -1,10 +1,10 @@
-## [fix] Wire C9 review-cli parity verifier into hamr:sync-verify (#2950)
+### Fixed
 
-`hamr-sync-verify.js` now imports `verifyRuntimeParity` from `review-cli-parity.js`
-and runs the C9 parity check as part of `npm run hamr:sync-verify`. The check
-verifies all 6 review pipeline modules (`cascade-dispatch.js`, `fleet-backend-select.js`,
-`fleet-escalation-policy.js`, `review-stakes-router.js`, `review-cost-telemetry.js`,
-`review-privacy-gate.js`) are present and hash-matching in both `~/.copilot/scripts/`
-and `~/.codex/devenv-ops/scripts/`. Exit code 1 when any mismatch or absence is found.
+- `hamr-sync-verify.js` now imports `verifyRuntimeParity` from `review-cli-parity.js`
+  and runs the C9 parity check as part of `npm run hamr:sync-verify`. The check
+  verifies all 6 review pipeline modules (`cascade-dispatch.js`, `fleet-backend-select.js`,
+  `fleet-escalation-policy.js`, `review-stakes-router.js`, `review-cost-telemetry.js`,
+  `review-privacy-gate.js`) are present and hash-matching in both `~/.copilot/scripts/`
+  and `~/.codex/devenv-ops/scripts/`. Exit code 1 when any mismatch or absence is found.
 
 Refs #2950 #2935 #2926

--- a/.changes/unreleased/2950.md
+++ b/.changes/unreleased/2950.md
@@ -1,0 +1,10 @@
+## [fix] Wire C9 review-cli parity verifier into hamr:sync-verify (#2950)
+
+`hamr-sync-verify.js` now imports `verifyRuntimeParity` from `review-cli-parity.js`
+and runs the C9 parity check as part of `npm run hamr:sync-verify`. The check
+verifies all 6 review pipeline modules (`cascade-dispatch.js`, `fleet-backend-select.js`,
+`fleet-escalation-policy.js`, `review-stakes-router.js`, `review-cost-telemetry.js`,
+`review-privacy-gate.js`) are present and hash-matching in both `~/.copilot/scripts/`
+and `~/.codex/devenv-ops/scripts/`. Exit code 1 when any mismatch or absence is found.
+
+Refs #2950 #2935 #2926

--- a/scripts/global/hamr-sync-verify.js
+++ b/scripts/global/hamr-sync-verify.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
-// hamr-sync-verify.js — HAMR Wave 7 child E (#955).
-// Read-only: confirms HAMR scripts are present in ~/.copilot/scripts/ and
-// ~/.codex/devenv-ops/scripts/ so all 3 teams have local access.
+// hamr-sync-verify.js — HAMR Wave 7 child E (#955). Refs #2950.
+// Read-only: confirms HAMR scripts and the C9 review pipeline modules are
+// present in ~/.copilot/scripts/ and ~/.codex/devenv-ops/scripts/.
 'use strict';
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const { verifyRuntimeParity, REVIEW_CLI_MODULES } = require('./review-cli-parity');
 
 const HAMR_SCRIPTS = [
   'cache-hit-gate.js', 'cache-stats-emit.js', 'cache-stats-push.js',
@@ -19,6 +20,11 @@ const HAMR_SCRIPTS = [
 const TARGETS = [
   { team: 'copilot', dir: path.join(os.homedir(), '.copilot', 'scripts') },
   { team: 'codex', dir: path.join(os.homedir(), '.codex', 'devenv-ops', 'scripts') },
+];
+
+const REVIEW_TARGETS = [
+  { runtime: 'copilot', scriptsDir: path.join(os.homedir(), '.copilot', 'scripts') },
+  { runtime: 'codex', scriptsDir: path.join(os.homedir(), '.codex', 'devenv-ops', 'scripts') },
 ];
 
 function checkTarget(target) {
@@ -37,13 +43,11 @@ function checkTarget(target) {
 function run() {
   const results = TARGETS.map(checkTarget);
   const totalMissing = results.reduce((sum, r) => sum + r.missing.length, 0);
-  const summary = {
-    ok: totalMissing === 0,
-    targets: results,
-    total_missing: totalMissing,
-    hint: totalMissing > 0 ? 'run `npm run sync:both:apply` to deploy HAMR scripts' : null,
-  };
-  return summary;
+  const reviewParity = verifyRuntimeParity({ sourceDir: __dirname, targets: REVIEW_TARGETS });
+  const ok = totalMissing === 0 && reviewParity.parity;
+  const hint = totalMissing > 0 ? 'run `npm run sync:both:apply` to deploy HAMR scripts' :
+    !reviewParity.parity ? 'review pipeline gap: run `npm run deploy:both:apply`' : null;
+  return { ok, targets: results, total_missing: totalMissing, review_parity: reviewParity, hint };
 }
 
 if (require.main === module) {
@@ -52,4 +56,4 @@ if (require.main === module) {
   process.exit(result.ok ? 0 : 1);
 }
 
-module.exports = { run, HAMR_SCRIPTS, TARGETS };
+module.exports = { run, HAMR_SCRIPTS, TARGETS, REVIEW_CLI_MODULES, REVIEW_TARGETS };

--- a/tests/hamr-sync-verify.spec.js
+++ b/tests/hamr-sync-verify.spec.js
@@ -33,7 +33,7 @@ test('run() reports per-team missing/present split with summary', () => {
     expect(Array.isArray(t.missing)).toBe(true);
     expect(Array.isArray(t.present)).toBe(true);
   }
-  if (!result.ok) expect(result.hint).toContain('sync:both');
+  if (!result.ok) expect(result.hint).toBeTruthy(); // hint is set for either HAMR or review-parity gap
 });
 
 test('run() reports ok:true when both targets fully populated (mock)', () => {
@@ -41,5 +41,25 @@ test('run() reports ok:true when both targets fully populated (mock)', () => {
   const result = VERIFY.run();
   const totalMissing = result.targets.reduce((sum, t) => sum + t.missing.length, 0);
   expect(result.total_missing).toBe(totalMissing);
-  expect(result.ok).toBe(totalMissing === 0);
+  // ok is false when HAMR scripts are missing OR review pipeline parity fails
+  expect(result.ok).toBe(totalMissing === 0 && result.review_parity.parity);
+});
+
+// C9 parity integration tests — Refs #2950
+test('run() result includes review_parity key with C9 parity shape (#2950)', () => {
+  const result = VERIFY.run();
+  expect(result).toHaveProperty('review_parity');
+  const rp = result.review_parity;
+  expect(typeof rp.parity).toBe('boolean');
+  expect(typeof rp.coverage).toBe('number');
+  expect(Array.isArray(rp.mismatches)).toBe(true);
+  expect(Array.isArray(rp.absentTargets)).toBe(true);
+});
+
+test('REVIEW_CLI_MODULES exported and contains all 6 review pipeline modules (#2950)', () => {
+  expect(Array.isArray(VERIFY.REVIEW_CLI_MODULES)).toBe(true);
+  expect(VERIFY.REVIEW_CLI_MODULES).toContain('cascade-dispatch.js');
+  expect(VERIFY.REVIEW_CLI_MODULES).toContain('fleet-backend-select.js');
+  expect(VERIFY.REVIEW_CLI_MODULES).toContain('fleet-escalation-policy.js');
+  expect(VERIFY.REVIEW_CLI_MODULES.length).toBe(6);
 });


### PR DESCRIPTION
merge-evidence-deferred-final: #2950

Refs #2950

Wire the C9 review-cli parity verifier into `hamr-sync-verify.js` so stale Codex runtime deploy gaps are detected automatically.

## Changes
- `scripts/global/hamr-sync-verify.js`: imports `verifyRuntimeParity` + `REVIEW_CLI_MODULES` from `review-cli-parity.js`; `run()` now includes `review_parity` in output; `ok` is false when review parity fails
- `tests/hamr-sync-verify.spec.js`: 2 new tests for C9 parity integration; 6 total pass
- `.changes/unreleased/2950.md`: changelog fragment