### PR TITLE
fix(ci): HAMR-bypass detection always reports status

### DIFF
--- a/.changes/unreleased/2940.md
+++ b/.changes/unreleased/2940.md
@@ -1,0 +1,9 @@
+### fix(ci): make HAMR-bypass detection always report (#2940)
+
+- `HAMR-bypass detection` (`hamr-bypass-lint.yml`) is a required status check but
+  used a workflow-level `paths:` filter, so PRs touching none of
+  `scripts/`/`dashboard/`/`hooks/`/`tests/` (e.g. config-only or docs-only) skipped
+  it — leaving the required check "Expected" forever and **blocking every such
+  merge** (hit live on #2939/#2937). Moved the path logic to a step-level git-diff
+  gate (GitHub-recommended, same fix as #2812); the job now always runs and reports
+  success, linting only when HAMR-relevant files change.

--- a/.github/workflows/hamr-bypass-lint.yml
+++ b/.github/workflows/hamr-bypass-lint.yml
@@ -1,13 +1,16 @@
 name: HAMR Bypass Lint
 
+# #2940: HAMR-bypass detection is a REQUIRED status check, so it must ALWAYS run
+# and report. A workflow-level `paths:` filter made it SKIP (→ "Expected" forever
+# → blocked the merge) on every PR that touched none of scripts/dashboard/hooks/
+# tests (e.g. config-only or docs/instructions-only PRs — hit live on #2939/#2937).
+# Per GitHub's guidance, the path logic now lives in a step-level git-diff gate;
+# the job ALWAYS reports success and runs the real lint only when HAMR-relevant
+# files change. Same defect class + fix as #2812 (validate-config-schemas).
+
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'scripts/**'
-      - 'dashboard/**'
-      - 'hooks/**'
-      - 'tests/**'
   schedule:
     - cron: '23 7 * * *'
 
@@ -20,10 +23,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect HAMR-relevant changes (step-level gate, #2940)
+        id: changes
+        run: |
+          base="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ -z "$base" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            base="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
+          fi
+          pattern='^(scripts/|dashboard/|hooks/|tests/|\.github/workflows/hamr-bypass-lint\.yml)'
+          if [ "${{ github.event_name }}" = "schedule" ] || git diff --name-only "$base" HEAD | grep -qE "$pattern"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No HAMR-relevant files changed — lint N/A; reporting success (#2940)."
+          fi
       - uses: actions/setup-node@v4
+        if: steps.changes.outputs.changed == 'true'
         with:
           node-version: '20'
       - name: Run HAMR-bypass lint (required gate)
+        if: steps.changes.outputs.changed == 'true'
         env:
           HAMR_BYPASS_GATE: '1'
         run: node scripts/global/lint-hamr-bypass.js
@@ -32,3 +53,4 @@ jobs:
           echo "Promoted to required per #1157: HAMR_BYPASS_GATE=1, continue-on-error removed."
           echo "Stability evidence at promotion: 29/30 recent runs successful (#1158 close cycle)."
           echo "Required-status-checks list updated separately via Admin gh api PATCH (#1157 AC3)."
+          echo "#2940: always-report via step-level git-diff gate (mirrors #2812)."


### PR DESCRIPTION
Refs #2940

merge-evidence-deferred-final: #2940

Make the required `HAMR-bypass detection` check always report. It used a workflow-level `paths:` filter, so PRs touching none of scripts/dashboard/hooks/tests (config-only, docs-only) skipped the job, leaving the required check "Expected" forever and blocking the merge. Path logic now lives in a step-level git-diff gate (GitHub-recommended; mirrors the already-merged #2812 fix for validate-config-schemas). The job always runs and reports success, linting only when HAMR-relevant files change.

Evidence: gate simulation — config-only diff -> changed=false -> success; scripts/hooks diff -> changed=true -> lint runs; workflow self-edit -> changed=true. Cross-family review qwen2.5-coder:7b@fleet (findings are hallucinated CI critiques restating the intended always-report design).

---

## MANAGER_HANDOFF

scope: Remove the workflow-level paths filter on .github/workflows/hamr-bypass-lint.yml and replace it with a step-level git-diff gate (mirroring #2812 commit c94f73dc for validate-config-schemas). The HAMR-bypass detection required check then ALWAYS reports a status; the real lint runs only when HAMR-relevant files (scripts, dashboard, hooks, tests, the lint script, or the workflow itself) change, and reports success (N/A) otherwise.
lane: lane:code-change
test_strategy: manual-verify
acceptance:
AC1: hamr-bypass-lint.yml has no workflow-level paths filter (job triggers on every PR to main). AC2: a step-level Detect-changes gate computes base SHA via pull_request.base.sha with HEAD~1 fallback and sets changed true/false on a git-diff path pattern. AC3: the lint step and node setup are guarded by steps.changes.outputs.changed == true; on changed == false the job echoes an N/A note and reports success. AC4: before/after manual-verify evidence shows a config/docs-only PR now reports success instead of staying expected. AC5: changelog fragment .changes/unreleased/2940.md added.

gates: lint-required, quality-required, baton-gates, pr-title-required, merge-evidence-pr-gate, and the HAMR-bypass detection check reporting on this PR
related_tickets: #2810 #2812 #2937 #2926
overlap_decision: no-overlap — sole edit is .github/workflows/hamr-bypass-lint.yml + a changelog fragment; no other in-flight worktree touches that workflow. Sibling fix #2812 already shipped the same pattern for validate-config-schemas.yml and is closed.
goal_lens: G1 governance (a required gate that cannot be satisfied is a broken gate) + G6 resilience (no admin-bypass workaround needed) + G10 maintainability (generalize #2812 rather than re-patch). manual-verify mirrors sibling fix #2812: a CI control-flow change with no runtime module to unit-test; before/after status reporting is the objective evidence.

Signed-by: Orla Mason
Team&Model: claude-code:opus@local
Role: manager

---

## COLLABORATOR_HANDOFF

ticket: #2940

scope: Replace the workflow-level paths filter on .github/workflows/hamr-bypass-lint.yml with a step-level git-diff gate so the required HAMR-bypass detection check always reports. Add changelog fragment .changes/unreleased/2940.md.
test_strategy: manual-verify
per_ac_verification:
AC1 PASS: PyYAML parse confirms on.pull_request has only {branches:[main]} — no paths key; job triggers on every PR to main. AC2 PASS: step id=changes computes base via pull_request.base.sha with HEAD~1 fallback and grep -qE on pattern '^(scripts/|dashboard/|hooks/|tests/|\.github/workflows/hamr-bypass-lint\.yml)'. AC3 PASS: setup-node + lint steps carry if: steps.changes.outputs.changed == 'true'; changed==false echoes an N/A note and the job reports success. AC4 PASS (manual-verify simulation): config/timeout-policy.json -> NO MATCH -> changed=false -> success; scripts/global/foo.js -> MATCH -> lint runs; workflow self-edit -> MATCH -> lint runs. AC5 PASS: .changes/unreleased/2940.md present. Full npm test (npx playwright) has pre-existing environmental drift (node:test files under the playwright runner: 'describe is not defined', undefined .forEach) in files NOT in this YAML-only diff — Admin baseline-drift authority applies.

doc_coverage:
N/A: README/extension-README — no user-facing CLI/command/setting change; this is a CI workflow internal control-flow fix. Changelog fragment .changes/unreleased/2940.md UPDATED. Inline workflow comment block documents the #2940 rationale.

cross_family_rating: 75/100 (PARTIAL)
cross_family_reviewer: qwen2.5-coder:7b@fleet (100.91.113.16:11434) — Alibaba family, cross-family vs claude-code:opus author
cross_family_findings: Iter-1 misread diff polarity (flagged the REMOVED paths filter as if present, which confirms the defect this PR removes). Iter-2 with explicit before/after framing returned PARTIAL 75/100; all six findings are generic/hallucinated CI concerns (concurrency-load, 'always-report bypasses checks', perf, docs) that restate the INTENDED always-report design rather than identify a real defect — the always-report-on-no-relevant-change pattern is GitHub-recommended and identical to already-merged-and-validated #2812. No actionable defect surfaced; lint coverage is preserved (runs whenever scripts/hooks/dashboard/tests change). Known fleet-rater failure mode (memory: hallucinated CI critique on workflow files).

Signed-by: Orla Harper
Team&Model: claude-code:opus@local
Role: collaborator

---

## ADMIN_HANDOFF

ticket: #2940

branch: fix/2940-hamr-bypass-always-report
commit: dee161fa18901007bde3cea0132f5716920880b0
signer-independence-check: PASS — Admin signer Orla Reyes differs from Collaborator signer Orla Harper (both registry-derived for claude-code:opus).
deploy-runtime-impact: sync-verification: N/A — change is a CI workflow file (.github/workflows/hamr-bypass-lint.yml) plus a changelog fragment; neither is a deployed runtime artifact (~/.copilot, ~/.codex, ~/.agents/skills). No npm run sync:codex / sync:claude / hamr:sync-verify needed.

Signed-by: Orla Reyes
Team&Model: claude-code:opus@local
Role: admin

---

## CONSULTANT_CLOSEOUT

ticket: #2940

status: review
verdict: approve_for_merge
verification-timestamp: 2026-06-12T03:45:37Z
rubric_rating: 9/10 (G1:9 G2:9 G3:9 G4:9 G5:9 G6:9 G7:8 G8:9 G9:9 G10:9; min(G1..G10)>=7)
anneal_tickets_filed: none
mid_flight_flaws:
Flaw 1: concurrent-writer collision — the Copilot Team independently picked up #2940, posted its own MANAGER_HANDOFF x2 + COLLABORATOR_HANDOFF, and took a cross-team-lease while Claude Code was mid-baton. Detected via interleaved comment timeline; Claude Code paused and surfaced to the client, who confirmed Claude Code was first; Copilot then posted COPILOT_WITHDRAWAL_NOTE + closed its lease. decision=log-incident-only (one-off cross-team coordination event; pattern_id=concurrent-writer-same-ticket-no-lease). Contributing factor: Claude Code did not itself create a cross-team-lease at pickup, which would have advertised the claim earlier. decision=memory-note-only (operator-local: take a lease at pickup on shared tickets). artifact=this CONSULTANT_CLOSEOUT + incidents.jsonl. Flaw 2: full npm test (npx playwright) shows pre-existing environmental drift (node:test files under the playwright runner) unrelated to this YAML-only diff; manual-verify gate simulation used instead. decision=no-action-justified (not in this diff; Admin baseline-drift authority). Rubric: G9 interop / G1 governance restored (the required HAMR-bypass check can now be satisfied on config/docs-only PRs), G6 resilience (no admin-bypass workaround), G10 maintainability (generalizes #2812). Cross-family review qwen2.5-coder:7b@fleet PARTIAL 75/100 — all findings are hallucinated CI critiques restating the intended always-report design; no real defect.
cross_family_verdict: PARTIAL — qwen2.5-coder:7b@100.91.113.16:11434 — 75/100; findings restate the intended always-report design (GitHub-recommended, identical to merged #2812) rather than identify a real defect; lint coverage preserved.


Signed-by: Orla Vale
Team&Model: claude-code:opus@local
Role: consultant
