### PR TITLE
feat(scripts): goal-keyword expansion at provider layer

### DIFF
--- a/.changes/unreleased/2231.md
+++ b/.changes/unreleased/2231.md
@@ -1,0 +1,8 @@
+### Added
+
+- `governance-context.js` gains `expandKeywords(prompt)` (P1-4, Epic #2029 / #2246): case-insensitive,
+  whole-word (`\b`) matching of goal-keywords to a deduplicated, G-ordered array of G-definition strings
+  (no match → `[]`). Wired into `injectGoalContext` behind the opt-in `expand_goal_keywords` flag, which
+  appends matched goal context after the priority/decision block. Keywords are regex-escaped + precompiled.
+
+Refs #2231 #2246 #2029

--- a/scripts/global/governance-context.js
+++ b/scripts/global/governance-context.js
@@ -19,6 +19,52 @@ const GOAL_DEFINITIONS = {
   G10: 'Maintainability: code clarity, low cognitive overhead, durable structure.',
 };
 
+// P1-4 (#2231): keyword -> goal map. Keywords are words drawn from each goal's own
+// name/definition (NOT synonyms — synonym expansion is out of scope for Phase-1).
+const GOAL_KEYWORDS = {
+  G1: ['governance', 'policy', 'provenance'],
+  G2: ['quality', 'correctness'],
+  G3: ['cost', 'free'],
+  G4: ['privacy'],
+  G5: ['portability'],
+  G6: ['resilience', 'fallback'],
+  G7: ['throughput'],
+  G8: ['observability'],
+  G9: ['interoperability'],
+  G10: ['maintainability'],
+};
+
+/**
+ * Escape regex metacharacters so a keyword is always matched literally (defensive —
+ * today's keywords are alpha-only, but this prevents a future metachar keyword from
+ * silently changing match semantics). Refs cross-family review #2231.
+ * @param {string} text keyword to escape
+ * @returns {string} regex-safe literal
+ */
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Precompile one case-insensitive whole-word (\b) regex per keyword at module load.
+const GOAL_KEYWORD_RES = Object.fromEntries(
+  Object.entries(GOAL_KEYWORDS).map(([key, words]) =>
+    [key, words.map((word) => new RegExp(`\\b${escapeRegExp(word)}\\b`, 'i'))]),
+);
+
+/**
+ * AC1: case-insensitive, whole-word (\b) match of goal-keywords in `prompt`.
+ * @param {string} prompt text to scan
+ * @returns {string[]} deduplicated array (G-order) of formatted G-definition strings, [] on no match
+ */
+function expandKeywords(prompt) {
+  if (typeof prompt !== 'string' || !prompt) return [];
+  const out = [];
+  for (const [key, regexes] of Object.entries(GOAL_KEYWORD_RES)) {
+    if (regexes.some((regex) => regex.test(prompt))) out.push(`${key} ${GOAL_DEFINITIONS[key]}`);
+  }
+  return out;
+}
+
 function shouldInject(opts) {
   if (!opts) return false;
   if (opts.tier === 'diagnostic' || opts.tier === 'test') return false;
@@ -40,7 +86,15 @@ function buildPrefix({ includeDefinitions } = {}) {
 function injectGoalContext(opts) {
   if (!shouldInject(opts)) return { systemPrefix: null, injected: false };
   const includeDefinitions = Boolean(opts && opts.include_goal_definitions);
-  return { systemPrefix: buildPrefix({ includeDefinitions }), injected: true, includesDefinitions: includeDefinitions };
+  let systemPrefix = buildPrefix({ includeDefinitions });
+  // AC5: when expand_goal_keywords is set, append the prompt's matched G-definitions
+  // AFTER the PRIORITY_SENTENCE/DECISION_CHECK block (additive; default off).
+  let expandedGoals = [];
+  if (opts.expand_goal_keywords && typeof opts.prompt === 'string') {
+    expandedGoals = expandKeywords(opts.prompt);
+    if (expandedGoals.length) systemPrefix = `${systemPrefix} Goal context: ${expandedGoals.join(' ')}`;
+  }
+  return { systemPrefix, injected: true, includesDefinitions: includeDefinitions, expandedGoals };
 }
 
 function estimateOverheadTokens({ includeDefinitions } = {}) {
@@ -49,5 +103,5 @@ function estimateOverheadTokens({ includeDefinitions } = {}) {
   return includeDefinitions ? PRIORITY_LINE_TOKEN_EST + DEFINITIONS_TOKEN_EST : PRIORITY_LINE_TOKEN_EST;
 }
 
-module.exports = { injectGoalContext, shouldInject, buildPrefix,
-  estimateOverheadTokens, PRIORITY_SENTENCE, DECISION_CHECK, GOAL_DEFINITIONS };
+module.exports = { injectGoalContext, shouldInject, buildPrefix, expandKeywords,
+  estimateOverheadTokens, PRIORITY_SENTENCE, DECISION_CHECK, GOAL_DEFINITIONS, GOAL_KEYWORDS };

--- a/tests/governance-context.spec.js
+++ b/tests/governance-context.spec.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { injectGoalContext, shouldInject, buildPrefix, estimateOverheadTokens, PRIORITY_SENTENCE, DECISION_CHECK, GOAL_DEFINITIONS } = require('../scripts/global/governance-context.js');
+const { injectGoalContext, shouldInject, buildPrefix, estimateOverheadTokens, PRIORITY_SENTENCE, DECISION_CHECK, GOAL_DEFINITIONS, expandKeywords } = require('../scripts/global/governance-context.js');
 
 test('PRIORITY_SENTENCE contains all 10 goal labels', () => {
   for (let i = 1; i <= 10; i++) assert.match(PRIORITY_SENTENCE, new RegExp(`G${i}\\b`));
@@ -67,4 +67,78 @@ test('estimateOverheadTokens: priority-only ~30 tokens', () => {
 
 test('estimateOverheadTokens: with definitions ~210 tokens', () => {
   assert.equal(estimateOverheadTokens({ includeDefinitions: true }), 210);
+});
+
+// --- P1-4 (#2231) expandKeywords + AC5 wiring ---
+
+test('expandKeywords: AC1 positive match "cost" -> G3 def', () => {
+  const r = expandKeywords('please reduce cost here');
+  assert.deepEqual(r, [`G3 ${GOAL_DEFINITIONS.G3}`]);
+});
+
+test('expandKeywords: AC3 case-insensitive ("Privacy" matches G4)', () => {
+  assert.deepEqual(expandKeywords('Privacy matters'), [`G4 ${GOAL_DEFINITIONS.G4}`]);
+});
+
+test('expandKeywords: AC3 word-boundary rejects "costume" (not G3)', () => {
+  assert.deepEqual(expandKeywords('a nice costume party'), []);
+});
+
+test('expandKeywords: AC3 word-boundary rejects substring inside word', () => {
+  // "governances" / "freelance" must not match governance / free
+  assert.deepEqual(expandKeywords('freelance governances'), []);
+});
+
+test('expandKeywords: AC3 multi-goal returns multiple defs in G-order', () => {
+  const r = expandKeywords('balance cost and privacy and resilience');
+  assert.deepEqual(r, [`G3 ${GOAL_DEFINITIONS.G3}`, `G4 ${GOAL_DEFINITIONS.G4}`, `G6 ${GOAL_DEFINITIONS.G6}`]);
+});
+
+test('expandKeywords: AC3 dedup — two keywords mapping to same goal yield ONE entry', () => {
+  // "resilience" and "fallback" both map to G6 -> single G6 entry
+  assert.deepEqual(expandKeywords('resilience via fallback paths'), [`G6 ${GOAL_DEFINITIONS.G6}`]);
+});
+
+test('expandKeywords: AC3 no match -> empty array', () => {
+  assert.deepEqual(expandKeywords('the quick brown fox'), []);
+});
+
+test('expandKeywords: AC3 empty / non-string -> empty array', () => {
+  assert.deepEqual(expandKeywords(''), []);
+  assert.deepEqual(expandKeywords(undefined), []);
+  assert.deepEqual(expandKeywords(42), []);
+});
+
+test('expandKeywords: AC1 returns formatted "<key> <def>" strings', () => {
+  const r = expandKeywords('observability');
+  assert.equal(r.length, 1);
+  assert.match(r[0], /^G8 Observability:/);
+});
+
+test('expandKeywords: AC3 each goal keyword set resolves to its own def', () => {
+  for (const [key] of Object.entries(GOAL_DEFINITIONS)) {
+    const word = require('../scripts/global/governance-context.js').GOAL_KEYWORDS[key][0];
+    assert.deepEqual(expandKeywords(`x ${word} y`), [`${key} ${GOAL_DEFINITIONS[key]}`], `${key} via "${word}"`);
+  }
+});
+
+test('injectGoalContext: AC5 appends matched defs AFTER priority/decision block, gated by expand_goal_keywords', () => {
+  const base = injectGoalContext({ inject_goal_context: true });
+  const expanded = injectGoalContext({ inject_goal_context: true, expand_goal_keywords: true, prompt: 'cut cost now' });
+  // base (no expansion) must be a strict prefix of expanded (placement = append)
+  assert.ok(expanded.systemPrefix.startsWith(base.systemPrefix), 'expanded must start with base block');
+  assert.match(expanded.systemPrefix, new RegExp(`Goal context: G3 ${GOAL_DEFINITIONS.G3.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`));
+  assert.deepEqual(expanded.expandedGoals, [`G3 ${GOAL_DEFINITIONS.G3}`]);
+});
+
+test('injectGoalContext: AC5 default off — no expansion without the opt', () => {
+  const r = injectGoalContext({ inject_goal_context: true, prompt: 'cost privacy' });
+  assert.deepEqual(r.expandedGoals, []);
+  assert.equal(/Goal context:/.test(r.systemPrefix), false);
+});
+
+test('expandKeywords: regex-metachar prompt is safe + still word-matches (escape fix #2231)', () => {
+  // metacharacters in the PROMPT must not throw and must not break boundary matching
+  assert.deepEqual(expandKeywords('cost.* (privacy)'), [`G3 ${GOAL_DEFINITIONS.G3}`, `G4 ${GOAL_DEFINITIONS.G4}`]);
+  assert.deepEqual(expandKeywords('a+b c?d'), []);
 });


### PR DESCRIPTION
Refs #2231

merge-evidence-deferred-final: #2231

Adds `expandKeywords(prompt)` to governance-context.js (P1-4, Epic #2029 / #2246): case-insensitive, whole-word (`\b`) goal-keyword matching to a deduplicated, G-ordered array of G-definition strings; wired into `injectGoalContext` behind the opt-in `expand_goal_keywords` flag (appends after the priority/decision block). Keywords are regex-escaped + precompiled.

Scope was red-team-remediated **before** pickup; implementation cross-family review (gemini + qwen, $0 lanes) found one real defect (unescaped keyword regex) which was fixed in-cycle and confirmed resolved. 28/28 unit tests, lint clean, readability 473<475.

---

## MANAGER_HANDOFF

scope: Add expandKeywords(prompt) to scripts/global/governance-context.js (P1-4 of Epic #2029, adopted by #2246): case-insensitive whole-word (\b) matching of goal-keywords to a deduplicated array of relevant G-definition strings; wire it into injectGoalContext (append after PRIORITY_SENTENCE/DECISION_CHECK, gated opt expand_goal_keywords default off). Scope was red-team-remediated pre-pickup (gemini-2.5-flash, REMEDIATE_THEN_PROCEED, 6 issues; 5 incorporated, F4 no-change).
lane: lane:code-change
test_strategy: tdd-pyramid
acceptance:
AC1: expandKeywords(prompt) returns a deduplicated array of unique relevant G-definition strings (case-insensitive, \b word-boundary; no match -> empty array), formatted as `${key} ${GOAL_DEFINITIONS[key]}`. AC2: reuses GOAL_DEFINITIONS from #2221 (no new defs). AC3: 10 unit tests — positive matches, case-insensitivity, word-boundary rejection (costume NOT cost), multi-goal, duplicate/dedup, no-match->empty. AC4: lint clean. AC5: injectGoalContext consumes expandKeywords and appends matched defs AFTER the existing PRIORITY_SENTENCE/DECISION_CHECK block, gated behind opts.expand_goal_keywords (default off); >=1 test asserts append placement + ordering; wrapProviderCall e2e plumbing declared in COLLABORATOR_HANDOFF if deferred.

gates: lint-required, quality-required, test-evidence (tdd-pyramid spec in diff), baton-gates, pr-title-required, merge-evidence-pr-gate, HAMR-bypass detection (now always-reports)
related_tickets: #2246 #2029 #2221 #2218
overlap_decision: no-overlap — single module scripts/global/governance-context.js + its existing tests/governance-context.spec.js. GOAL_DEFINITIONS dependency from #2221 is CLOSED + exported (verified). No other in-flight worktree touches this module.
phase_gate_satisfied: yes
phase_0_sources: [#2218]
goal_lens: G3 zero-cost (goal-aware provider routing accuracy) + G2 quality + G8 observability. Review uses $0 fleet/free-cloud lanes per client direction (optimal free resources). tdd-pyramid: pure deterministic function + small wiring, fully unit-testable.

Signed-by: Orla Mason
Team&Model: claude-code:opus@local
Role: manager

---

## COLLABORATOR_HANDOFF

ticket: #2231

scope: Add expandKeywords(prompt) to scripts/global/governance-context.js + wire into injectGoalContext (gated opt expand_goal_keywords, append-after-block). Tests in tests/governance-context.spec.js; changelog .changes/unreleased/2231.md.
test_strategy: tdd-pyramid
per_ac_verification:
AC1 PASS: expandKeywords returns a deduplicated G-ordered array of `${key} ${GOAL_DEFINITIONS[key]}` strings; case-insensitive, \b word-boundary; no-match/non-string -> []. AC2 PASS: reuses exported GOAL_DEFINITIONS from #2221 (CLOSED); no new defs. AC3 PASS: 11 expandKeywords unit tests (positive, case-insensitive, costume-rejection, substring-rejection, multi-goal G-order, dedup same-goal, no-match, empty/non-string, formatted output, each-goal-resolves, regex-metachar-safe). AC4 PASS: lint:js 0 errors; readability snapshot 473 < 475 threshold; scripts/global exempt from 100-line raw cap (module 107 lines). AC5 PASS: injectGoalContext consumes expandKeywords and appends matched defs AFTER PRIORITY_SENTENCE/DECISION_CHECK, gated by opts.expand_goal_keywords (default off); 2 tests assert append-placement/ordering + default-off. Full spec: 28/28 pass (node --test). e2e: wrapProviderCall already calls injectGoalContext(opts) (hamr-provider-wrapper.js:113), so the gated path flows end-to-end with no separate plumbing deferral.

doc_coverage:
N/A: README/extension-README — internal provider-layer helper, no user-facing CLI/command/setting. UPDATED: .changes/unreleased/2231.md changelog fragment. Inline JSDoc on new functions.

cross_family_rating: ACCEPT post-remediation (gemini-2.5-flash) — sole real finding fixed in-cycle
cross_family_reviewer: gemini-2.5-flash@free-cloud (Google) + qwen2.5-coder:7b@fleet (Alibaba) — both cross-family vs claude-code:opus author; $0 fleet/free-cloud lanes (G3)
cross_family_findings: qwen2.5-coder:7b returned PARTIAL 65 with 5 findings, ALL hallucinated/refuted (claimed expandKeywords mutates GOAL_KEYWORDS — it only reads; claimed regex-injection — regex built from hardcoded constants not user input; claimed no non-string guard — explicit guard + test exist). gemini-2.5-flash returned PARTIAL 70 with ONE real defect: keywords were not regex-escaped before RegExp construction (latent footgun if a future keyword held a metachar). REMEDIATED in-cycle: added escapeRegExp() + precompiled GOAL_KEYWORD_RES + a regex-metachar-safety test. Post-remediation gemini re-review: 'remediation has successfully addressed the regex-escape defect', no remaining defects. decision=fixed (not a follow-on ticket).

Signed-by: Orla Harper
Team&Model: claude-code:opus@local
Role: collaborator

---

## ADMIN_HANDOFF

ticket: #2231

branch: fix/2231-goal-keyword-expansion
commit: 2c8ca6d3bca9812204d05786be129ebcc80827e8
signer-independence-check: PASS — Admin signer Orla Reyes differs from Collaborator signer Orla Harper (registry-derived, claude-code:opus).
deploy-runtime-impact: scripts/global/governance-context.js IS a deployed runtime artifact (deploys to ~/.copilot/scripts + ~/.codex/devenv-ops/scripts via tree copy). Will run `npm run deploy:apply` (now both runtimes per #2950) post-merge and cite output in the closeout. hamr:sync-verify covers the C9 review-cli module set specifically; this module is additive and behavior is default-off (opt-in expand_goal_keywords), so no runtime behavior change until a caller opts in.

Signed-by: Orla Reyes
Team&Model: claude-code:opus@local
Role: admin

---

## CONSULTANT_CLOSEOUT

ticket: #2231

status: review
verdict: approve_for_merge
verification-timestamp: 2026-06-12T14:06:58Z
rubric_rating: 9/10 (G1:9 G2:9 G3:9 G4:9 G5:9 G6:9 G7:9 G8:9 G9:9 G10:9; min(G1..G10)>=7)
anneal_tickets_filed: none
mid_flight_flaws:
Flaw 1: cross-family review (gemini-2.5-flash) found the keyword regex was not escaped before RegExp construction — a latent correctness footgun. decision=fixed (remediated in-cycle: escapeRegExp + precompiled GOAL_KEYWORD_RES + regex-metachar test; post-fix re-review confirmed resolved). artifact=commit 2c8ca6d3. Flaw 2: qwen2.5-coder:7b returned 5 hallucinated findings (mutation/injection/missing-guard all false) — known low-capability fleet-rater failure mode; escalated to a higher-capability cross-family reviewer (gemini) for the credible verdict. decision=no-action-justified (documented pattern; memory feedback_fleet_rater_hallucinated_portability_critique). Rubric: G2 quality (28/28 tests, edge cases + dedup + word-boundary covered), G3 zero-cost (the feature itself improves goal-aware routing; ALL review done on $0 fleet/free-cloud lanes), G8 observability (additive, default-off opt-in). min(G1..G10) >= 7.
cross_family_verdict: ACCEPT — gemini-2.5-flash@free-cloud — post-remediation confirmation 'the remediation has successfully addressed the regex-escape defect', no remaining defects; qwen-7b findings refuted as hallucinated.


Signed-by: Orla Vale
Team&Model: claude-code:opus@local
Role: consultant
