### PR TITLE
feat(scripts): gen_ai.system attribution in cache-stats

### DIFF
--- a/.changes/unreleased/2232.md
+++ b/.changes/unreleased/2232.md
@@ -1,0 +1,10 @@
+### Added
+
+- `hamr-provider-wrapper.js` cache-stats events now carry an OpenTelemetry `gen_ai.system` field
+  (P1-5, Epic #2029 / #2246), derived from `effectiveProvider` via a new
+  `providerToGenAiSystem()` map in `event-schema-otel-genai.js`: identity for valid semconv systems,
+  `other_system` for `openrouter`/`litellm`/`copilot`/`groq`/`cerebras` and any unknown provider
+  (so the value is always schema-valid). The raw `provider` field is retained, and the new field is
+  additive — pre-#2232 `cache-stats.jsonl` records are byte-identical.
+
+Refs #2232 #2246 #2029

--- a/scripts/global/cache-stats-emit.js
+++ b/scripts/global/cache-stats-emit.js
@@ -57,6 +57,11 @@ function appendCacheStat(record, opts = {}) {
     tier: typeof record.tier === 'string' ? record.tier : null,
   };
   normalized.cache_eligible = isCacheEligible(normalized);
+  // P1-5 (#2232): additive OTel attribution — only present when the caller supplies it,
+  // so pre-#2232 records remain byte-identical (backward-compatible).
+  if (typeof record['gen_ai.system'] === 'string') {
+    normalized['gen_ai.system'] = record['gen_ai.system'];
+  }
   if (!isInformativeRecord(normalized)) {
     return { ok: false, skipped: true, reason: 'non_informative_record', file, line: null };
   }

--- a/scripts/global/event-schema-otel-genai.js
+++ b/scripts/global/event-schema-otel-genai.js
@@ -17,6 +17,14 @@ const OTEL_GENAI_SYSTEMS = [
 
 const GENAI_PREFIX = 'gen_ai.';
 
+// P1-5 (#2232): map a wrapper provider id -> a valid OTel gen_ai.system value.
+// Providers that are not semconv systems (openrouter/litellm/copilot/groq/cerebras)
+// and any unknown provider fall back to the semconv catch-all 'other_system'.
+// Return is ALWAYS a member of OTEL_GENAI_SYSTEMS.
+function providerToGenAiSystem(provider) {
+  return OTEL_GENAI_SYSTEMS.includes(provider) ? provider : 'other_system';
+}
+
 function validateUsageField(event, field, errors) {
   const value = event[field];
   if (value !== undefined && (!Number.isInteger(value) || value < 0)) {
@@ -49,4 +57,4 @@ function isValidGenAI(event) {
   return { ok: errors.length === 0, errors, warnings: [] };
 }
 
-module.exports = { isValidGenAI, OTEL_GENAI_SYSTEMS, GENAI_PREFIX };
+module.exports = { isValidGenAI, OTEL_GENAI_SYSTEMS, GENAI_PREFIX, providerToGenAiSystem };

--- a/scripts/global/hamr-provider-wrapper.js
+++ b/scripts/global/hamr-provider-wrapper.js
@@ -10,6 +10,7 @@ const os = require('node:os');
 const { cacheHeaders } = require('./litellm-client');
 const { appendCacheStat } = require('./cache-stats-emit');
 const ADAPTERS = require('./token-provider-adapters');
+const { providerToGenAiSystem } = require('./event-schema-otel-genai');
 const { maybeSpillover } = require('./header-spillover');
 const { pickStickyProvider } = require('./sticky-route');
 // (#2645) shared .env hydration shim (G3); hydrate once at load so wrapped calls find provider keys
@@ -55,12 +56,14 @@ function emitStatSafe(provider, payload, opts = {}) {
     const tokenRecord = adapter(payload || {}, { provider });
     appendCacheStat({
       provider, model: tokenRecord.model ?? null,
+      // P1-5 (#2232): semconv-normalized companion to raw `provider` (always a valid OTel system).
+      'gen_ai.system': providerToGenAiSystem(provider),
       cache_read_tokens: tokenRecord.cache_read_tokens ?? 0,
       input_tokens: tokenRecord.input_tokens ?? 0,
       output_tokens: tokenRecord.output_tokens ?? 0,
       executed: 'hamr-provider-wrapper',
       tier: opts.tier ?? null,
-    });
+    }, opts.file ? { file: opts.file } : {});
   } catch { /* never let stats break the call */ }
 }
 
@@ -130,4 +133,4 @@ if (require.main === module) {
   console.log(JSON.stringify({ exports: ['wrapProviderCall'], hamr_disabled: isDisabled() }));
 }
 
-module.exports = { wrapProviderCall, makeResult, isDisabled, readTeamConfig, TEAM_CONFIG_PATHS };
+module.exports = { wrapProviderCall, makeResult, emitStatSafe, isDisabled, readTeamConfig, TEAM_CONFIG_PATHS };

--- a/tests/event-schema-otel-genai.spec.js
+++ b/tests/event-schema-otel-genai.spec.js
@@ -1,0 +1,41 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { providerToGenAiSystem, OTEL_GENAI_SYSTEMS, isValidGenAI } = require('../scripts/global/event-schema-otel-genai.js');
+
+// --- P1-5 (#2232) providerToGenAiSystem ---
+
+test('providerToGenAiSystem: AC2 identity for valid semconv systems', () => {
+  for (const sys of ['anthropic', 'openai', 'gemini', 'ollama', 'cohere', 'vertex_ai', 'bedrock']) {
+    assert.equal(providerToGenAiSystem(sys), sys, `${sys} should map to itself`);
+  }
+});
+
+test('providerToGenAiSystem: AC2 non-semconv providers -> other_system', () => {
+  for (const provider of ['openrouter', 'litellm', 'copilot', 'groq', 'cerebras']) {
+    assert.equal(providerToGenAiSystem(provider), 'other_system', `${provider} -> other_system`);
+  }
+});
+
+test('providerToGenAiSystem: AC2 unknown/empty/undefined -> other_system', () => {
+  assert.equal(providerToGenAiSystem('zzz-unknown'), 'other_system');
+  assert.equal(providerToGenAiSystem(''), 'other_system');
+  assert.equal(providerToGenAiSystem(undefined), 'other_system');
+  assert.equal(providerToGenAiSystem(null), 'other_system');
+});
+
+test('providerToGenAiSystem: AC3 result is ALWAYS a valid OTEL_GENAI_SYSTEMS value', () => {
+  const providers = ['anthropic', 'openai', 'gemini', 'ollama', 'openrouter', 'litellm',
+    'copilot', 'groq', 'cerebras', 'cohere', 'vertex_ai', 'bedrock', 'mystery-provider', '', undefined];
+  for (const provider of providers) {
+    assert.ok(OTEL_GENAI_SYSTEMS.includes(providerToGenAiSystem(provider)),
+      `providerToGenAiSystem(${provider}) must be in OTEL_GENAI_SYSTEMS`);
+  }
+});
+
+test('isValidGenAI: accepts a mapped gen_ai.system value', () => {
+  assert.equal(isValidGenAI({ 'gen_ai.system': providerToGenAiSystem('groq') }).ok, true);
+});
+
+test('isValidGenAI: rejects a raw non-semconv provider as gen_ai.system', () => {
+  assert.equal(isValidGenAI({ 'gen_ai.system': 'groq' }).ok, false);
+});

--- a/tests/genai-system-attribution.spec.js
+++ b/tests/genai-system-attribution.spec.js
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+const { emitStatSafe } = require('../scripts/global/hamr-provider-wrapper.js');
+const { appendCacheStat } = require('../scripts/global/cache-stats-emit.js');
+
+// P1-5 (#2232): gen_ai.system attribution end-to-end through emitStatSafe + appendCacheStat.
+
+function tmpStats() {
+  return path.join(os.tmpdir(), `cs-2232-${process.pid}-${Math.floor(performance.now() * 1000)}.jsonl`);
+}
+function lastLine(file) {
+  const lines = fs.readFileSync(file, 'utf8').trim().split('\n').filter(Boolean);
+  return JSON.parse(lines[lines.length - 1]);
+}
+
+test('emitStatSafe: AC1/AC5 sets gen_ai.system + retains raw provider (groq -> other_system)', () => {
+  const file = tmpStats();
+  emitStatSafe('groq', { usage: { prompt_tokens: 5, completion_tokens: 3 } }, { file });
+  const rec = lastLine(file);
+  assert.equal(rec['gen_ai.system'], 'other_system');
+  assert.equal(rec.provider, 'groq'); // raw provider preserved alongside the semconv value
+  fs.unlinkSync(file);
+});
+
+test('emitStatSafe: AC5 identity provider keeps its system (anthropic)', () => {
+  const file = tmpStats();
+  emitStatSafe('anthropic', { usage: { input_tokens: 7, output_tokens: 2 } }, { file });
+  assert.equal(lastLine(file)['gen_ai.system'], 'anthropic');
+  fs.unlinkSync(file);
+});
+
+test('emitStatSafe: AC5 unknown provider with no adapter is a safe no-op (no throw)', () => {
+  const file = tmpStats();
+  assert.doesNotThrow(() => emitStatSafe('mystery-no-adapter', { usage: {} }, { file }));
+  assert.equal(fs.existsSync(file), false); // no adapter -> nothing written
+});
+
+test('appendCacheStat: AC4 additive — gen_ai.system written when present', () => {
+  const file = tmpStats();
+  appendCacheStat({ provider: 'openai', input_tokens: 4, 'gen_ai.system': 'openai' }, { file });
+  assert.equal(lastLine(file)['gen_ai.system'], 'openai');
+  fs.unlinkSync(file);
+});
+
+test('appendCacheStat: AC4 backward-compat — no gen_ai.system key when caller omits it', () => {
+  const file = tmpStats();
+  appendCacheStat({ provider: 'openai', input_tokens: 4 }, { file });
+  assert.equal(Object.prototype.hasOwnProperty.call(lastLine(file), 'gen_ai.system'), false);
+  fs.unlinkSync(file);
+});


### PR DESCRIPTION
Refs #2232

merge-evidence-deferred-final: #2232

Emits an OpenTelemetry `gen_ai.system` field on each `cache-stats.jsonl` entry from the HAMR wrapper (P1-5, Epic #2029 / #2246). A new `providerToGenAiSystem()` map (in `event-schema-otel-genai.js`) returns identity for valid semconv systems and `other_system` for non-semconv providers (`openrouter/litellm/copilot/groq/cerebras`) + unknowns — so the value is **always** in `OTEL_GENAI_SYSTEMS`. Raw `provider` retained; the field is additive (pre-#2232 records byte-identical).

The provider→system mapping gap was caught by a **pre-pickup** free fleet red-team and remediated into the ACs before implementation; the implementation cross-family review (gemini, $0) returned ACCEPT 100/100, no defects. 11 unit tests; lint clean; readability 473<475.

---

## MANAGER_HANDOFF

scope: Add gen_ai.system attribution to hamr-provider-wrapper.js cache-stats events (P1-5 of Epic #2029, adopted by #2246). emitStatSafe sets gen_ai.system = providerToGenAiSystem(effectiveProvider), a new centralized map in event-schema-otel-genai.js: identity for valid OTEL_GENAI_SYSTEMS, other_system for openrouter/litellm/copilot/groq/cerebras + unknown. Raw provider field retained. Scope red-team-remediated pre-pickup (qwen2.5-coder:7b@fleet, REMEDIATE_THEN_PROCEED).
lane: lane:code-change
test_strategy: tdd-pyramid
acceptance:
AC1: emitStatSafe sets gen_ai.system = providerToGenAiSystem(effectiveProvider) on the appendCacheStat event; raw provider retained. AC2: providerToGenAiSystem(provider) added to event-schema-otel-genai.js — identity for valid systems, other_system for openrouter/litellm/copilot/groq/cerebras + unknown; return always in OTEL_GENAI_SYSTEMS. AC3: a test asserts OTEL_GENAI_SYSTEMS.includes(value) for every wrapper provider incl. unknown. AC4: additive/backward-compat — no cache-stats field removed/renamed; test asserts prior fields persist. AC5: >=6 unit tests (identity, other_system fallback, unknown->other_system, schema-validity, additive preservation, e2e emit). AC6: lint clean.

gates: lint-required, quality-required, test-evidence (tdd-pyramid spec in diff), baton-gates, pr-title-required, merge-evidence-pr-gate, HAMR-bypass detection
related_tickets: #2246 #2029 #2221 #2218
overlap_decision: no-overlap — edits scripts/global/event-schema-otel-genai.js (new providerToGenAiSystem export) + scripts/global/hamr-provider-wrapper.js (emitStatSafe one-field add) + their tests. No other in-flight worktree touches these.
phase_gate_satisfied: yes
phase_0_sources: [#2218]
goal_lens: G8 observability (per-call provider attribution in cost telemetry) + G9 interoperability (OpenTelemetry GenAI semconv compliance) + G2 quality. Review on $0 fleet/free-cloud lanes (G3). tdd-pyramid: pure mapping fn + one wrapper field, fully unit-testable.

Signed-by: Orla Mason
Team&Model: claude-code:opus@local
Role: manager

---

## COLLABORATOR_HANDOFF

ticket: #2232

scope: Add gen_ai.system attribution to cache-stats events. 3 source files: event-schema-otel-genai.js (new providerToGenAiSystem map), hamr-provider-wrapper.js (emitStatSafe sets gen_ai.system + exports emitStatSafe + forwards opts.file), cache-stats-emit.js (additive passthrough of gen_ai.system). Tests: tests/event-schema-otel-genai.spec.js + tests/genai-system-attribution.spec.js. Changelog .changes/unreleased/2232.md.
test_strategy: tdd-pyramid
per_ac_verification:
AC1 PASS: emitStatSafe sets gen_ai.system=providerToGenAiSystem(effectiveProvider) on the appendCacheStat record; raw provider retained (e2e test: groq->other_system, provider stays 'groq'). AC2 PASS: providerToGenAiSystem added to event-schema-otel-genai.js — identity for valid systems, other_system for openrouter/litellm/copilot/groq/cerebras + unknown/null/undefined. AC3 PASS: test asserts OTEL_GENAI_SYSTEMS.includes(result) for 14 providers incl. unknown/empty/undefined; isValidGenAI accepts mapped value, rejects raw 'groq'. AC4 PASS: additive — cache-stats-emit.js only adds gen_ai.system when caller supplies it; test asserts the key is ABSENT when omitted (pre-#2232 records unchanged) and PRESENT when supplied. AC5 PASS: 11 tests total (6 mapping + 5 emit/additive; >=6). AC6 PASS: lint:js 0 errors; readability 473 < 475; scripts/global exempt from 100-line cap. Note vs MANAGER_HANDOFF: a 3rd file (cache-stats-emit.js) was required because appendCacheStat normalizes to a field allowlist and would otherwise DROP gen_ai.system — the additive passthrough is the actual emit mechanism.

doc_coverage:
N/A: README/extension-README — internal telemetry field, no user-facing CLI/command/setting. UPDATED: .changes/unreleased/2232.md. Inline comments + JSDoc on new map.

cross_family_rating: ACCEPT 100/100 (gemini-2.5-flash)
cross_family_reviewer: gemini-2.5-flash@free-cloud (Google) — cross-family vs claude-code:opus author; $0 free-cloud lane (G3). Pre-pickup red-team: qwen2.5-coder:7b@fleet (Alibaba).
cross_family_findings: Pre-pickup red-team (qwen2.5-coder:7b@fleet) found the provider->valid-system MAPPING gap (groq/openrouter/litellm/copilot/cerebras not in OTEL_GENAI_SYSTEMS) — remediated into the ticket ACs BEFORE implementation. Implementation review (gemini-2.5-flash): ACCEPT 100/100, REAL_DEFECTS none — validated correctness, schema-validity (return always in OTEL_GENAI_SYSTEMS), backward-compat (additive field), and non-string edge-case robustness across all 3 files. No defects to remediate.

Signed-by: Orla Harper
Team&Model: claude-code:opus@local
Role: collaborator

---

## ADMIN_HANDOFF

ticket: #2232

branch: fix/2232-genai-system-attribution
commit: 0f20f9d13b8f69eaa408571ab441dbcdac5ea113
signer-independence-check: PASS — Admin signer Orla Reyes differs from Collaborator signer Orla Harper (registry-derived, claude-code:opus).
deploy-runtime-impact: scripts/global/{event-schema-otel-genai,hamr-provider-wrapper,cache-stats-emit}.js ARE deployed runtime artifacts (~/.copilot/scripts + ~/.codex/devenv-ops/scripts). Will run `npm run deploy:apply` (both runtimes per #2950) post-merge and cite output in the closeout. Change is additive + the new field is only emitted by the wrapper path; no runtime behavior change for existing readers.

Signed-by: Orla Reyes
Team&Model: claude-code:opus@local
Role: admin

---

## CONSULTANT_CLOSEOUT

ticket: #2232

status: review
verdict: approve_for_merge
verification-timestamp: 2026-06-12T14:57:13Z
rubric_rating: 9/10 (G1:9 G2:9 G3:9 G4:9 G5:9 G6:9 G7:9 G8:10 G9:10 G10:9; min(G1..G10)>=7)
anneal_tickets_filed: none
mid_flight_flaws:
Flaw 1: the pre-pickup red-team (qwen2.5-coder:7b@fleet) surfaced the provider->valid-system mapping gap; the ticket ACs under-specified it. decision=remediated-pre-pickup (Manager tightened the ACs with the other_system mapping before implementation; the design shipped correct). artifact=#2232 remediation comment. Flaw 2: MANAGER_HANDOFF scoped 2 files but appendCacheStat normalizes to a field allowlist and would DROP gen_ai.system, so a 3rd file (cache-stats-emit.js additive passthrough) was required. decision=no-action-justified (honest scope expansion disclosed in COLLABORATOR_HANDOFF; the passthrough is the actual emit mechanism and is backward-compatible). artifact=this closeout + COLLABORATOR_HANDOFF. Flaw 3 (recovery): VS Code closed mid-flight during the read-only pre-pickup red-team; on resume, state was verified clean (main current, no orphan worktree, #2232 unadvanced) — no corruption to remediate. decision=log-incident-only is NOT warranted (external interruption, clean state, no recurrence). Rubric: G8 observability (per-call provider attribution in cost telemetry) + G9 interop (OTel GenAI semconv: value always in OTEL_GENAI_SYSTEMS) are the headline deliverables; G2 quality (11 tests incl. additive/backward-compat + schema-validity). ALL review on $0 fleet/free-cloud lanes (G3).
cross_family_verdict: ACCEPT — gemini-2.5-flash@free-cloud — 100/100, REAL_DEFECTS none; validated correctness, schema-validity, additive backward-compat, and non-string edge-case robustness across all 3 source files.


Signed-by: Orla Vale
Team&Model: claude-code:opus@local
Role: consultant
