### PR TITLE
fix(fleet): outage stays $0 free-cloud, never premium

### DIFF
--- a/.changes/unreleased/2973.md
+++ b/.changes/unreleased/2973.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- `cascade-dispatch` no longer escalates a fleet **outage** (no answer produced) to premium haiku —
+  it now stays on the $0 free-cloud lane (#2973, G3/G6). Root cause: `escalate()` inferred
+  availability-vs-capability from a free-text reason string, and a down fleet returns strings
+  (`gateway-unhealthy`, `HTTP 4xx/5xx`, `empty_response`, `litellm-threw`, …) that defaulted to
+  *capability → haiku*. Fix: `escalate()` gains a structural `outcome: 'no-answer'` input
+  (availability unconditionally; cascade's no-content branch passes it); `classifyFailure` also
+  recognizes fleet-outage reason strings and `/HTTP \d{3}/i` as availability; `tryOllama` preserves
+  the upstream `fallback_reason`. Capability → haiku routing is unchanged.
+
+Refs #2973 #2619 #2930

--- a/scripts/global/cascade-dispatch.js
+++ b/scripts/global/cascade-dispatch.js
@@ -63,7 +63,9 @@ async function tryOllama(prompt, model, attempt = 0) {
       await backoff(attempt);
       return tryOllama(prompt, model, attempt + 1);
     }
-    return { ok: false, reason: result.error || 'ollama_unreachable', tier: 'local' };
+    // #2973 (F3): preserve dispatchFleet's fallback_reason (e.g. gateway-unhealthy) so the true
+    // outage signal survives — not just the last attempt's result.error.
+    return { ok: false, reason: result.error || 'ollama_unreachable', fallback_reason: result.fallback_reason, tier: 'local' };
   }
   return { ok: true, content: result.content, model: result.model, tier: 'local' };
 }
@@ -86,6 +88,9 @@ async function cascade(prompt, opts = {}) {
     // #2930 C4: availability failures record into the breaker (only when we actually tried fleet —
     // a skipped attempt must not re-stamp the cooloff) and NEVER escalate an outage to a paid tier.
     const decision = fleetPolicy.escalate({
+      // #2973 (F1): the fleet produced NO content here, so this is STRUCTURALLY an availability
+      // failure — classify it as such regardless of the (telemetry-only) reason string.
+      outcome: 'no-answer',
       reason: local.reason, currentTier: 'fleet',
       breaker: breakerBlocksFleet ? null : fleetBreaker, nowMs,
     });

--- a/scripts/global/fleet-escalation-policy.js
+++ b/scripts/global/fleet-escalation-policy.js
@@ -13,12 +13,23 @@ const cb = require('./circuit-breaker');
 
 // Reasons that mean "no usable answer was produced" — an availability failure, not a quality one.
 // 'circuit-open' = the breaker skipped the fleet attempt (known-down) — an availability condition.
-const AVAILABILITY_REASONS = new Set(['ollama_unreachable', 'fleet_unavailable', 'cascade_script_not_found', 'circuit-open']);
+const AVAILABILITY_REASONS = new Set([
+  'ollama_unreachable', 'fleet_unavailable', 'cascade_script_not_found', 'circuit-open',
+  // #2973: fleet-outage reasons from fleet-backend-select.js + litellm-client.js when the fleet
+  // produced NO usable answer. These are availability failures, not quality ones.
+  'gateway-unhealthy', 'probe-failed', 'litellm-call-failed', 'litellm-threw',
+  'litellm_error', 'no_litellm_url', 'empty_response',
+]);
 const CONNECTION_RE = /econnrefused|fetch failed|timeout|network|enotfound|socket hang|connect/i;
+// #2973: a fleet attempt that returns an HTTP status error produced no usable content -> availability.
+const HTTP_STATUS_RE = /HTTP \d{3}/i;
 
 function classifyFailure(reason) {
   if (!reason) return 'capability';
-  if (AVAILABILITY_REASONS.has(reason) || CONNECTION_RE.test(String(reason))) return 'availability';
+  const text = String(reason);
+  if (AVAILABILITY_REASONS.has(reason) || CONNECTION_RE.test(text) || HTTP_STATUS_RE.test(text)) {
+    return 'availability';
+  }
   return 'capability';
 }
 
@@ -29,10 +40,14 @@ const CAPABILITY_NEXT = Object.freeze({ fleet: 'haiku', 'free-cloud': 'premium',
 /**
  * Decide the next tier for a failure. Availability failures are hard-pinned to free-cloud and
  * record a breaker failure; capability failures step exactly one rung up the paid ladder.
+ * #2973: `outcome` lets a caller that STRUCTURALLY knows the result classify deterministically
+ * instead of inferring from a free-text reason — `'no-answer'` ⇒ availability unconditionally
+ * (the reason string is then telemetry only). Default `'answered'` preserves reason-string inference.
+ * @param {{reason?, currentTier?, breaker?, nowMs?, outcome?: 'no-answer'|'answered'}} input
  * @returns {{tier, failureClass, breakerOpen, premiumBlocked}}
  */
-function escalate({ reason, currentTier = 'fleet', breaker = null, nowMs = 0 } = {}) {
-  const failureClass = classifyFailure(reason);
+function escalate({ reason, currentTier = 'fleet', breaker = null, nowMs = 0, outcome } = {}) {
+  const failureClass = outcome === 'no-answer' ? 'availability' : classifyFailure(reason);
   if (failureClass === 'availability') {
     if (breaker) cb.recordFailure(breaker, nowMs);
     const breakerOpen = breaker ? cb.status(breaker).state === cb.STATES.open : false;

--- a/tests/cascade-free-cloud-failover.spec.js
+++ b/tests/cascade-free-cloud-failover.spec.js
@@ -49,3 +49,13 @@ test('task_router.py: cascade-script-not-found availability failure suggests fre
   expect(result.suggested_tier).toBe('free-cloud');
   expect(result.reason).toBe('cascade_script_not_found');
 });
+
+test('#2973: fleet-outage reason strings route to free-cloud (not paid haiku)', () => {
+  for (const reason of ['gateway-unhealthy', 'probe-failed', 'empty_response',
+    'litellm-threw', 'HTTP 400', 'HTTP 503']) {
+    expect(escalationTier(reason)).toBe('free-cloud');
+  }
+  // capability paths unchanged (regression guard)
+  expect(escalationTier('too_short')).toBe('haiku');
+  expect(escalationTier('judge_low_score')).toBe('haiku');
+});

--- a/tests/fleet-escalation-policy.spec.js
+++ b/tests/fleet-escalation-policy.spec.js
@@ -55,3 +55,39 @@ test('AC4: tierFor back-compat — availability→free-cloud, capability/null→
   assert.strictEqual(tierFor('judge_low_score'), 'haiku');
   assert.strictEqual(tierFor(undefined), 'haiku');
 });
+
+// --- #2973: availability classification for fleet-outage reason strings + structural outcome ---
+
+test('#2973 AC3: fleet-outage reason strings classify as availability', () => {
+  for (const r of ['gateway-unhealthy', 'probe-failed', 'litellm-call-failed', 'litellm-threw',
+    'litellm_error', 'no_litellm_url', 'empty_response', 'HTTP 400', 'HTTP 503', 'http 502']) {
+    assert.strictEqual(classifyFailure(r), 'availability', `${r} should be availability`);
+  }
+});
+
+test('#2973 AC3: a 3-digit HTTP status is availability; non-status text stays capability', () => {
+  assert.strictEqual(classifyFailure('HTTP 429'), 'availability');
+  assert.strictEqual(classifyFailure('judge_low_score'), 'capability'); // unchanged
+  assert.strictEqual(classifyFailure('too_short'), 'capability');
+});
+
+test('#2973 AC1: outcome=no-answer forces availability/free-cloud regardless of reason', () => {
+  // even a capability-looking reason must route to free-cloud when no answer was produced
+  const d = escalate({ outcome: 'no-answer', reason: 'judge_low_score', currentTier: 'fleet' });
+  assert.strictEqual(d.failureClass, 'availability');
+  assert.strictEqual(d.tier, 'free-cloud');
+  assert.strictEqual(d.premiumBlocked, true);
+});
+
+test('#2973 AC2: the bug shape (gateway-unhealthy + HTTP 400) escalates to free-cloud, never premium', () => {
+  for (const reason of ['gateway-unhealthy', 'HTTP 400']) {
+    const d = escalate({ reason, currentTier: 'fleet' });
+    assert.strictEqual(d.tier, 'free-cloud', `${reason} -> free-cloud`);
+    assert.strictEqual(d.premiumBlocked, true);
+  }
+});
+
+test('#2973 AC6: default outcome (answered) preserves capability->haiku step-up', () => {
+  assert.strictEqual(escalate({ reason: 'judge_low_score', currentTier: 'fleet' }).tier, 'haiku');
+  assert.strictEqual(escalate({ outcome: 'answered', reason: 'too_short', currentTier: 'fleet' }).tier, 'haiku');
+});


### PR DESCRIPTION
Refs #2973

merge-evidence-deferred-final: #2973

Fixes `cascade-dispatch` escalating a fleet **outage** (no answer produced) to premium haiku instead of the $0 free-cloud lane (G3/G6). Root cause: `escalate()` inferred availability-vs-capability from a free-text reason string, and a down fleet returns strings (`gateway-unhealthy`, `HTTP 4xx/5xx`, `empty_response`, `litellm-threw`…) that defaulted to *capability → haiku*.

**Fix:** F1 structural `outcome:'no-answer'` input to `escalate()` (availability unconditionally; cascade's no-content branch passes it) · F2 broadened `classifyFailure` for reason-only callers (+ `/HTTP \d{3}/i`) · F3 `tryOllama` preserves `fallback_reason`. Capability → haiku routing unchanged.

**Research & planning** reached a >93 cross-model consensus (mean **96.0/100**, all ACCEPT) across 3 free fleet/free-cloud families before implementation; implementation review (gemini, $0) **ACCEPT 100/100, no defects**. 12/12 node:test, lint clean.

---

## MANAGER_HANDOFF

scope: Fix #2973: cascade-dispatch escalates to premium (haiku) on an availability/no-answer fleet failure instead of $0 free-cloud. Root cause: escalate() infers availability-vs-capability from a free-text reason string; a down fleet returns strings (gateway-unhealthy, HTTP 4xx/5xx, empty_response, litellm-threw, ...) that default to capability->haiku. Fix (root-cause): F1 add structural outcome:'no-answer' input to fleet-escalation-policy.escalate() (availability unconditionally); F2 broaden classifyFailure for reason-only callers; F3 preserve dispatchFleet fallback_reason in cascade-dispatch.tryOllama. Research consensus: 3 free fleet/free-cloud families, mean 96.0/100 (>93), all ACCEPT.
lane: lane:code-change
test_strategy: tdd-pyramid
acceptance:
AC1: escalate() accepts outcome ('no-answer'|'answered'); outcome=='no-answer' => failureClass=='availability', tier=='free-cloud', premiumBlocked==true, regardless of reason. AC2: cascade-dispatch !local.ok branch calls escalate({outcome:'no-answer', reason: local.reason, ...}) -> routes to free-cloud, never haiku/premium. AC3: classifyFailure returns 'availability' for gateway-unhealthy, probe-failed, litellm-call-failed, litellm-threw, litellm_error, no_litellm_url, empty_response, and any /HTTP \d{3}/i. AC4: tryOllama preserves fallback_reason from dispatchFleet on failure. AC5 (regression): a test reproduces gateway-unhealthy + Ollama HTTP 400 and asserts decision is free-cloud / premiumBlocked / never premium. AC6: lint clean; capability paths (judge_low_score, too_short -> haiku) UNCHANGED.

gates: lint-required, quality-required, test-evidence (tdd-pyramid spec in diff), baton-gates, pr-title-required, merge-evidence-pr-gate, HAMR-bypass detection
related_tickets: #2619 #2621 #2930 #2926
overlap_decision: no-overlap — edits scripts/global/fleet-escalation-policy.js (outcome param + classifier broadening) + scripts/global/cascade-dispatch.js (pass outcome:'no-answer'; preserve fallback_reason) + their existing specs tests/fleet-escalation-policy.spec.js / tests/cascade-free-cloud-failover.spec.js. No other in-flight worktree touches the fleet escalation path.
phase_gate_satisfied: yes
phase_0_sources: [#2973]
goal_lens: G3 zero-cost (outage stays $0, never reaches a paid model when free works) + G6 resilience (returns the free-lane answer instead of nothing) headline; G2 correctness, G8 observability (telemetry keeps the true outage reason). Backward-compat: outcome optional (default 'answered'); classifier only ADDS availability strings. Review on $0 fleet/free-cloud lanes.

Signed-by: Orla Mason
Team&Model: claude-code:opus@local
Role: manager

---

## COLLABORATOR_HANDOFF

ticket: #2973

scope: Fix cascade-dispatch escalating a fleet outage to premium haiku. 2 source files: fleet-escalation-policy.js (structural outcome:no-answer input + broadened classifyFailure incl. /HTTP \d{3}/i) + cascade-dispatch.js (pass outcome:no-answer on !local.ok; preserve fallback_reason). Tests added to tests/fleet-escalation-policy.spec.js + tests/cascade-free-cloud-failover.spec.js. Changelog .changes/unreleased/2973.md.
test_strategy: tdd-pyramid
per_ac_verification:
AC1 PASS: escalate({outcome:'no-answer', reason:'judge_low_score'}) -> failureClass availability, tier free-cloud, premiumBlocked true (test). AC2 PASS: cascade !local.ok branch passes outcome:'no-answer'; escalationTier('gateway-unhealthy'|'HTTP 400') -> 'free-cloud' verified. AC3 PASS: classifyFailure availability for gateway-unhealthy/probe-failed/litellm-call-failed/litellm-threw/litellm_error/no_litellm_url/empty_response + /HTTP \d{3}/i (incl. HTTP 429/502/503); judge_low_score/too_short stay capability (test). AC4 PASS: tryOllama return now carries fallback_reason: result.fallback_reason. AC5 PASS: regression tests in both specs reproduce the bug shape (gateway-unhealthy + HTTP 400 -> free-cloud, never premium). AC6 PASS: lint:js 0 errors; readability 473<475; node:test fleet-escalation-policy.spec.js 12/12; capability->haiku regression-guarded.

doc_coverage:
N/A: README/extension-README — internal fleet-routing fix, no user-facing CLI/command/setting. UPDATED: .changes/unreleased/2973.md. Inline comments cite #2973 F1/F2/F3.

cross_family_rating: Plan consensus mean 96.0/100 (3 families); implementation ACCEPT 100/100 (gemini-2.5-flash)
cross_family_reviewer: PLAN: qwen2.5-coder:7b@fleet (Alibaba 95) + gemini-2.5-flash (Google 98) + llama-3.3-70b@groq (Meta 95). IMPL: gemini-2.5-flash@free-cloud (Google). All cross-family vs claude-code:opus; $0 fleet/free-cloud lanes (G3).
cross_family_findings: Research & planning reached >93 consensus on round 1 (mean 96.0, all ACCEPT); one refinement folded in (AC3 pinned to /HTTP \d{3}/i). Implementation review (gemini): ACCEPT 100/100, REAL_DEFECTS none — confirmed F1 is the strongest/correct structural fix (only fires when local.ok is false = no content), F2 a sound defensive backstop for reason-only callers, and no regression to capability->haiku (capability reasons contain no HTTP-status substring). No defects to remediate.

Signed-by: Orla Harper
Team&Model: claude-code:opus@local
Role: collaborator

---

## ADMIN_HANDOFF

ticket: #2973

branch: fix/2973-availability-free-cloud
commit: 05c87575f210a479361f99c802d123d1c73aecff
signer-independence-check: PASS — Admin signer Orla Reyes differs from Collaborator signer Orla Harper (registry-derived, claude-code:opus).
deploy-runtime-impact: scripts/global/{fleet-escalation-policy,cascade-dispatch}.js ARE deployed runtime artifacts (~/.copilot/scripts + ~/.codex/devenv-ops/scripts). Will run `npm run deploy:apply` (both runtimes per #2950) post-merge and cite output in the closeout. Change is additive (outcome optional; classifier only adds availability strings); no behavior change for capability routing.

Signed-by: Orla Reyes
Team&Model: claude-code:opus@local
Role: admin

---

## CONSULTANT_CLOSEOUT

ticket: #2973

status: review
verdict: approve_for_merge
verification-timestamp: 2026-06-12T21:34:32Z
rubric_rating: 9/10 (G1:9 G2:9 G3:10 G4:9 G5:9 G6:10 G7:9 G8:9 G9:9 G10:9; min(G1..G10)>=7)
anneal_tickets_filed: none
mid_flight_flaws:
Flaw 1: the ticket body's hypothesized cause (classifier mis-labels gateway-unhealthy+fleet-unreachable) was directionally right but incomplete — the deeper cause is that the no-answer branch delegates classification to a free-text reason heuristic at all. decision=fixed structurally (F1 outcome:no-answer makes the no-content branch availability by construction, not by string-match). artifact=commit 05c87575. Flaw 2: F2/F3 are defense-in-depth (broaden classifier for reason-only callers + preserve fallback_reason) beyond the minimal F1 fix. decision=no-action-justified (prevention-over-enumeration; the consensus panel + impl review endorsed it; additive/backward-compat). Research & planning: 3 free fleet/free-cloud families reached >93 consensus on round 1 (mean 96.0, all ACCEPT); implementation review gemini ACCEPT 100/100 no defects. Rubric: G3 (outage stays $0, never reaches a paid model when free works) + G6 (returns the free-lane answer instead of nothing) are headline; G2 (12/12 node:test, capability->haiku regression-guarded). min(G1..G10) >= 7. All review on $0 fleet/free-cloud lanes.
cross_family_verdict: ACCEPT — gemini-2.5-flash@free-cloud — impl 100/100, REAL_DEFECTS none; plan consensus 96.0/100 across qwen-7b@fleet(Alibaba)+gemini(Google)+llama-3.3-70b@groq(Meta).


Signed-by: Orla Vale
Team&Model: claude-code:opus@local
Role: consultant
