### PR TITLE
test(regression): fleet-hamr corpus for P1-2/P1-3 modules

### DIFF
--- a/.changes/unreleased/2233.md
+++ b/.changes/unreleased/2233.md
@@ -1,0 +1,10 @@
+### Added
+
+- Fleet+HAMR regression corpus gains two entries (#2233, P1-6, last child of Epic #2246):
+  `04-bypass-detection-not-recognized` (asserts `hamr-bypass-detector.detectBypass` flags a direct
+  paid-provider curl) and `05-fleet-direct-block-not-enforced` (asserts `hamr-fleet-direct-block.shouldBlock`
+  blocks a fleet-bypass when `MEGINGJORD_FLEET_DIRECT_BLOCK=1`). To genuinely exercise these modules,
+  `fleet-hamr-replay.js` gained a backward-compatible **generic predicate** (`{ fn, args, result_path?,
+  expected_result }`) — the legacy `childProgressComplete` form (entry 03) still works.
+
+Refs #2233 #2246 #2029

--- a/scripts/regression/fleet-hamr-replay.js
+++ b/scripts/regression/fleet-hamr-replay.js
@@ -43,10 +43,37 @@ function runScenario(scenario) {
     if (ms < assertSpec.policy_check.min_ms) return { ok: false, reason: `timeout ${ms}ms < min ${assertSpec.policy_check.min_ms}` };
   }
   if (assertSpec.predicate_check) {
-    const result = mod.childProgressComplete(assertSpec.predicate_check.input_child, assertSpec.predicate_check.input_comments);
-    if (result !== assertSpec.predicate_check.expected_result) {
-      return { ok: false, reason: `predicate returned ${result}, expected ${assertSpec.predicate_check.expected_result}` };
+    const probe = runPredicate(mod, assertSpec.predicate_check);
+    if (!probe.ok) return probe;
+  }
+  return { ok: true };
+}
+
+// JSON-based deep-equality (the corpus is JSON, so all values are JSON-serializable). #2233.
+function deepEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Evaluate a corpus predicate_check against a loaded module. #2233 (P1-6):
+ * GENERIC form `{ fn, args?, result_path?, expected_result }` calls mod[fn](...args)
+ * and (optionally) plucks a dot-path field before comparing — so any module export can
+ * be exercised, not just childProgressComplete. Legacy form (no `fn`) preserves the
+ * original `childProgressComplete(input_child, input_comments)` behavior (entry 03).
+ */
+function runPredicate(mod, pc) {
+  let result;
+  if (pc.fn) {
+    if (typeof mod[pc.fn] !== 'function') return { ok: false, reason: `predicate fn '${pc.fn}' is not a function` };
+    result = mod[pc.fn](...(pc.args || []));
+    if (pc.result_path) {
+      result = String(pc.result_path).split('.').reduce((obj, key) => (obj == null ? obj : obj[key]), result);
     }
+  } else {
+    result = mod.childProgressComplete(pc.input_child, pc.input_comments);
+  }
+  if (!deepEqual(result, pc.expected_result)) {
+    return { ok: false, reason: `predicate returned ${JSON.stringify(result)}, expected ${JSON.stringify(pc.expected_result)}` };
   }
   return { ok: true };
 }
@@ -64,4 +91,4 @@ if (require.main === module) {
   process.exit(summary.failed.length > 0 ? 1 : 0);
 }
 
-module.exports = { loadCorpus, runScenario, runAll, checkModuleExports };
+module.exports = { loadCorpus, runScenario, runAll, checkModuleExports, runPredicate, deepEqual };

--- a/tests/fleet-hamr-replay.spec.js
+++ b/tests/fleet-hamr-replay.spec.js
@@ -64,3 +64,46 @@ test('runScenario: handles missing assertion gracefully', () => {
   const r = runScenario({ id: 'malformed' });
   assert.equal(r.ok, false);
 });
+
+// --- #2233 (P1-6): generic predicate + new corpus entries exercising P1-2/P1-3 ---
+const { runScenario: runScenario2233, runPredicate, runAll: runAll2233 } = require('../scripts/regression/fleet-hamr-replay.js');
+
+test('#2233 AC3: entry 04 genuinely exercises hamr-bypass-detector.detectBypass (detected:true)', () => {
+  const sc = JSON.parse(require('node:fs').readFileSync(
+    require('node:path').join(__dirname, 'regression/fleet-hamr-corpus/04-bypass-detection-not-recognized.json'), 'utf8'));
+  assert.equal(runScenario2233(sc).ok, true);
+});
+
+test('#2233 AC3: entry 05 genuinely exercises hamr-fleet-direct-block.shouldBlock (block:true)', () => {
+  const sc = JSON.parse(require('node:fs').readFileSync(
+    require('node:path').join(__dirname, 'regression/fleet-hamr-corpus/05-fleet-direct-block-not-enforced.json'), 'utf8'));
+  assert.equal(runScenario2233(sc).ok, true);
+});
+
+test('#2233 AC5: generic predicate calls mod[fn](...args) + plucks result_path', () => {
+  const mod = { foo: (x) => ({ nested: { val: x * 2 } }) };
+  assert.equal(runPredicate(mod, { fn: 'foo', args: [3], result_path: 'nested.val', expected_result: 6 }).ok, true);
+  assert.equal(runPredicate(mod, { fn: 'foo', args: [3], result_path: 'nested.val', expected_result: 99 }).ok, false);
+});
+
+test('#2233 AC5: generic predicate without result_path deep-equals the whole return', () => {
+  const mod = { who: () => ({ a: 1, b: 2 }) };
+  assert.equal(runPredicate(mod, { fn: 'who', args: [], expected_result: { a: 1, b: 2 } }).ok, true);
+});
+
+test('#2233 AC5: missing fn is reported gracefully (no crash)', () => {
+  const r = runPredicate({}, { fn: 'doesNotExist', args: [], expected_result: true });
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /not a function/);
+});
+
+test('#2233 AC5: legacy childProgressComplete predicate path still works (backward-compat)', () => {
+  const mod = { childProgressComplete: (child, comments) => comments.includes('done') };
+  assert.equal(runPredicate(mod, { input_child: { number: 1 }, input_comments: ['done'], expected_result: true }).ok, true);
+});
+
+test('#2233 AC5: full corpus (all entries 01-05) passes via runAll', () => {
+  const summary = runAll2233();
+  assert.equal(summary.failed.length, 0, `failed: ${JSON.stringify(summary.failed)}`);
+  assert.ok(summary.total >= 5);
+});

--- a/tests/regression/fleet-hamr-corpus/04-bypass-detection-not-recognized.json
+++ b/tests/regression/fleet-hamr-corpus/04-bypass-detection-not-recognized.json
@@ -1,0 +1,16 @@
+{
+  "id": "bypass-detection-not-recognized",
+  "source": "P1-2 #2220 (Epic #2029, adopted by #2246 P1-6 #2233)",
+  "description": "hamr-bypass-detector.detectBypass MUST flag a direct curl to a known paid-provider endpoint as detected:true — a HAMR-bypassing call must never go unrecognized, or it leaks outside the cost/observability layer (G3/G8). Uses a hardcoded paid-provider URL (api.anthropic.com) so the assertion is deterministic and env-independent (fleet-substring matching is config-dependent and intentionally avoided here).",
+  "assertion": {
+    "type": "module-export-and-predicate",
+    "module": "scripts/global/hamr-bypass-detector.js",
+    "exports": ["detectBypass", "emitIncident"],
+    "predicate_check": {
+      "fn": "detectBypass",
+      "args": ["curl -s https://api.anthropic.com/v1/messages -H 'x-api-key: REDACTED' -d '{}'"],
+      "result_path": "detected",
+      "expected_result": true
+    }
+  }
+}

--- a/tests/regression/fleet-hamr-corpus/05-fleet-direct-block-not-enforced.json
+++ b/tests/regression/fleet-hamr-corpus/05-fleet-direct-block-not-enforced.json
@@ -1,0 +1,21 @@
+{
+  "id": "fleet-direct-block-not-enforced",
+  "source": "P1-3 (Epic #2029, adopted by #2246 P1-6 #2233)",
+  "description": "hamr-fleet-direct-block.shouldBlock MUST return block:true for a fleet-bypass detection when MEGINGJORD_FLEET_DIRECT_BLOCK=1 — otherwise a direct fleet call slips past the env-gated block and the cost-ascending fleet-route enforcement is silently defeated (G3/G6). Uses a synthetic detection object so the assertion is deterministic (no live fleet / config dependency).",
+  "assertion": {
+    "type": "module-export-and-predicate",
+    "module": "scripts/global/hamr-fleet-direct-block.js",
+    "exports": ["shouldBlock", "isEnabled"],
+    "predicate_check": {
+      "fn": "shouldBlock",
+      "args": [
+        {
+          "detection": { "detected": true, "suppressed": false, "severity": "fleet-bypass" },
+          "env": { "MEGINGJORD_FLEET_DIRECT_BLOCK": "1" }
+        }
+      ],
+      "result_path": "block",
+      "expected_result": true
+    }
+  }
+}

--- a/tests/regression/fleet-hamr-corpus/README.md
+++ b/tests/regression/fleet-hamr-corpus/README.md
@@ -9,5 +9,10 @@ Refs Epic #2150 #2203. Captures historic fleet/HAMR regressions that the harness
 | `01-sticky-route-mis-recording.json` | P1-7 #2178 (Epic #2041 P1-1 #2175 Phase-0 dog-food) | wrapProviderCall('ollama', cb, {tier:'fleet'}) mis-records provider as paid sticky-pick (e.g. groq) in cache-stats.jsonl |
 | `02-timeout-budget-undersized.json` | Phase-0 #2174 dog-food → Epic #2150 P1-1 #2201 | qwen2.5-coder:32b fleet dispatch hits 907s p99 against 600s hardcoded bound |
 | `03-consultant-epic-closeout-not-recognized.json` | #1993 fix in lint-epic-drift.js | lintEpicDrift Class C check missed Epic-level CONSULTANT_EPIC_CLOSEOUT artifact |
+| `04-bypass-detection-not-recognized.json` | P1-2 #2220 (Epic #2029 / #2246 #2233) | hamr-bypass-detector.detectBypass fails to flag a direct curl to a known paid-provider endpoint |
+| `05-fleet-direct-block-not-enforced.json` | P1-3 (Epic #2029 / #2246 #2233) | hamr-fleet-direct-block.shouldBlock fails to block a fleet-bypass when MEGINGJORD_FLEET_DIRECT_BLOCK=1 |
 
 Each `*.json` file is a self-contained scenario: input fixture + expected behavior + assertion script.
+
+A `predicate_check` may use the generic form `{ "fn", "args", "result_path"?, "expected_result" }` to
+exercise any module export; the legacy `childProgressComplete` form (entry 03) remains supported.


### PR DESCRIPTION
Refs #2233

merge-evidence-deferred-final: #2233

P1-6 — the **last child of Epic #2246**. Adds two Fleet+HAMR regression corpus entries that genuinely exercise the #2029 modules: `04-bypass-detection-not-recognized` (`hamr-bypass-detector.detectBypass` flags a direct paid-provider curl) and `05-fleet-direct-block-not-enforced` (`hamr-fleet-direct-block.shouldBlock` blocks a fleet-bypass when `MEGINGJORD_FLEET_DIRECT_BLOCK=1`).

To make AC3 ("each entry exercises P1-2/P1-3") achievable, the replay runner gained a **backward-compatible generic predicate** (`{fn,args,result_path?,expected_result}`) — it was previously hardcoded to `childProgressComplete`. Legacy entries 01-03 still pass (**replay 5/5**, **17/17 spec**, lint clean). Pre-pickup red-team + impl review on $0 fleet/free-cloud lanes (gemini ACCEPT 98/100).

---

## MANAGER_HANDOFF

scope: P1-6 (last child of Epic #2246): add 2 fleet-hamr regression corpus entries that genuinely EXERCISE the P1-2 bypass-detector + P1-3 fleet-direct-block modules. Requires a backward-compatible GENERIC-predicate enhancement to scripts/regression/fleet-hamr-replay.js runScenario() — today its predicate_check is HARDCODED to mod.childProgressComplete(), so it cannot exercise other modules (AC3 blocker). Add predicate_check.fn + args + optional result_path + expected_result; keep the legacy childProgressComplete path when fn is absent.
lane: lane:code-change
test_strategy: tdd-pyramid
acceptance:
AC1: tests/regression/fleet-hamr-corpus/04-bypass-detection-not-recognized.json exercises hamr-bypass-detector.detectBypass on a deterministic paid-provider URL (api.anthropic.com), asserting detected===true. AC2: tests/regression/fleet-hamr-corpus/05-fleet-direct-block-not-enforced.json exercises hamr-fleet-direct-block.shouldBlock with a synthetic fleet-bypass detection + MEGINGJORD_FLEET_DIRECT_BLOCK=1, asserting block===true. AC3: both genuinely exercise P1-2/P1-3 via the new generic predicate (fn+args+result_path), NOT a no-op existence check. AC4: lint clean. AC5 (runner): runScenario() generic-predicate enhancement is backward-compatible — entries 01-03 + the legacy childProgressComplete path still pass; result_path-omitted and missing-fn handled gracefully (red-team findings 1/3/4).

gates: lint-required, quality-required, test-evidence (tdd-pyramid spec in diff), baton-gates, pr-title-required, merge-evidence-pr-gate, HAMR-bypass detection
related_tickets: #2246 #2029 #2220 #2218
overlap_decision: no-overlap — edits scripts/regression/fleet-hamr-replay.js + 2 new tests/regression/fleet-hamr-corpus/*.json + tests/fleet-hamr-replay.spec.js. No other in-flight worktree touches the replay corpus.
phase_gate_satisfied: yes
phase_0_sources: [#2218]
goal_lens: G8 observability + G2 quality (regression corpus guards the #2029 bypass-detection + fleet-direct-block modules against re-introduction) + G3 (these modules enforce the fleet/free-cost path). Pre-pickup red-team (qwen2.5-coder:7b@fleet): REMEDIATE_THEN_PROCEED, soft hardening findings (backward-compat, result-structure robustness, edge cases) incorporated into implementation; deterministic-by-design + 2-entry scope are no-action-justified. Review on $0 fleet/free-cloud lanes.

Signed-by: Orla Mason
Team&Model: claude-code:opus@local
Role: manager

---

## COLLABORATOR_HANDOFF

ticket: #2233

scope: Add 2 fleet-hamr regression corpus entries (04 bypass-detection, 05 fleet-direct-block) + a backward-compatible generic-predicate enhancement to scripts/regression/fleet-hamr-replay.js. Files: fleet-hamr-replay.js, 2 corpus json, corpus README, tests/fleet-hamr-replay.spec.js, changelog.
test_strategy: tdd-pyramid
per_ac_verification:
AC1 PASS: 04-bypass-detection-not-recognized.json exercises hamr-bypass-detector.detectBypass on a deterministic paid URL (api.anthropic.com) -> detected===true. AC2 PASS: 05-fleet-direct-block-not-enforced.json exercises hamr-fleet-direct-block.shouldBlock({synthetic fleet-bypass detection, env MEGINGJORD_FLEET_DIRECT_BLOCK:1}) -> block===true. AC3 PASS: both use the new generic predicate (fn+args+result_path) so they invoke the real module functions (not no-op existence). AC4 PASS: lint:js 0 errors, lint:md 0 errors, readability 473<475, both json valid. AC5 PASS: runPredicate is backward-compatible — legacy childProgressComplete path + entries 01-03 still pass (full replay 5/5); missing-fn reported gracefully; result_path-omitted deep-equals whole return. Evidence: node scripts/regression/fleet-hamr-replay.js -> 5/5 pass; node --test tests/fleet-hamr-replay.spec.js -> 17/17 pass.

doc_coverage:
N/A: README/extension-README — internal regression-corpus + test-runner change, no user-facing CLI/setting. UPDATED: tests/regression/fleet-hamr-corpus/README.md (entries table + generic-predicate note); .changes/unreleased/2233.md.

cross_family_rating: ACCEPT 98/100 (gemini-2.5-flash)
cross_family_reviewer: gemini-2.5-flash@free-cloud (Google) — cross-family vs claude-code:opus; pre-pickup red-team qwen2.5-coder:7b@fleet (Alibaba). $0 fleet/free-cloud lanes (G3).
cross_family_findings: Pre-pickup red-team (qwen-7b@fleet) flagged backward-compat + result-structure robustness + edge cases (REMEDIATE_THEN_PROCEED) — all incorporated (legacy path preserved, missing-fn handled, result_path-omitted handled, deterministic inputs). Implementation review (gemini): ACCEPT 98/100, REAL_DEFECTS none — confirmed backward compat (5/5 replay), robust result_path traversal (null-safe reduce), function-existence guard, and that the entries genuinely exercise P1-2/P1-3. No defects to remediate.

Signed-by: Orla Harper
Team&Model: claude-code:opus@local
Role: collaborator

---

## ADMIN_HANDOFF

ticket: #2233

branch: fix/2233-replay-corpus
commit: 31888e8ad5d9beab20840dd6cacf0deeb6c689e6
signer-independence-check: PASS — Admin signer Orla Reyes differs from Collaborator signer Orla Harper (registry-derived, claude-code:opus).
deploy-runtime-impact: scripts/regression/fleet-hamr-replay.js IS a deployed runtime artifact (~/.copilot/scripts + ~/.codex/devenv-ops/scripts); the corpus json + spec live under tests/ (also tree-deployed). Will run `npm run deploy:apply` (both runtimes per #2950) post-merge and cite output in the closeout. Additive change (generic predicate is backward-compatible); no behavior change for existing callers.

Signed-by: Orla Reyes
Team&Model: claude-code:opus@local
Role: admin

---

## CONSULTANT_CLOSEOUT

ticket: #2233

status: review
verdict: approve_for_merge
verification-timestamp: 2026-06-13T03:47:07Z
rubric_rating: 9/10 (G1:9 G2:10 G3:9 G4:9 G5:9 G6:9 G7:9 G8:10 G9:9 G10:9; min(G1..G10)>=7)
anneal_tickets_filed: none
mid_flight_flaws:
Flaw 1: the ticket's AC3 ('each entry exercises P1-2/P1-3') was unachievable as-written because the replay runner's predicate_check was HARDCODED to mod.childProgressComplete — naive entries would crash or be no-op existence checks. decision=fixed (added a backward-compatible generic predicate fn+args+result_path; documented in MANAGER_HANDOFF as AC5). artifact=commit 31888e8a. Flaw 2: detectBypass fleet-substring matching is env/config-dependent (non-deterministic in CI); used a hardcoded paid-provider URL + a synthetic detection object so both entries are deterministic. decision=no-action-justified (deterministic-by-design; red-team finding 2). Pre-pickup red-team (qwen-7b@fleet) soft findings (backward-compat, result-structure, edge cases) all incorporated. Rubric: G8 observability + G2 quality (regression corpus now genuinely guards the #2029 bypass-detection + fleet-direct-block modules; 5/5 replay, 17/17 spec) + G3 (these modules enforce the fleet/free-cost path). min(G1..G10)>=7. All review on $0 fleet/free-cloud lanes.
cross_family_verdict: ACCEPT — gemini-2.5-flash@free-cloud — 98/100, REAL_DEFECTS none; backward-compat (5/5 replay), null-safe result_path traversal, function-existence guard, entries genuinely exercise P1-2/P1-3.


Signed-by: Orla Vale
Team&Model: claude-code:opus@local
Role: consultant
