### PR TITLE
fix(hooks): code_touched only on real mutations, not reads

### DIFF
--- a/.changes/unreleased/2978.md
+++ b/.changes/unreleased/2978.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- The PostToolUse activity tracker (`tool_activity.py`) no longer flips `code_touched`/`docs_touched`
+  on **read-only** tools (#2978, Epic #2647). Read/Grep/Glob (and `read_file`/`grep_search`/… ) on a
+  code path previously set `code_touched=true`, manufacturing a phantom "Admin baton incomplete" nag
+  and false-blocking legitimate `gh issue close` (G8/G1). Now a **read-only denylist** excludes those
+  tools while staying fail-safe (unknown non-Bash tools still flip — a governance gate errs toward
+  flagging); Claude mutators (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`) are recognized; and raw-Bash
+  mutations are caught via a real `git diff --name-only HEAD` (behind a cheap mutating-pattern pre-filter).
+
+Refs #2978 #2647

--- a/hooks/scripts/tool_activity.py
+++ b/hooks/scripts/tool_activity.py
@@ -2,7 +2,9 @@
 """Tool activity tracking for governance state."""
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 from typing import Any
 
 from baton_event_emitter import emit_role_handoff
@@ -34,8 +36,43 @@ EDIT_TOOLS = {
     "apply_patch", "create_file", "edit_notebook_file", "create_new_jupyter_notebook",
     "write_to_file", "replace_file_content", "multi_replace_file_content",
     "replace_string_in_file", "multi_replace_string_in_file",
+    # #2978: Claude Code mutator tools (were previously caught only via path-classification —
+    # the same branch that mis-fired on read-only Read/Grep/Glob).
+    "Edit", "Write", "MultiEdit", "NotebookEdit",
 }
+# #2978: READ-ONLY tools whose inputs contain file paths but NEVER mutate. Excluded from
+# path-classification so they cannot set code_touched/docs_touched. This is a DENYLIST (not a
+# mutator whitelist): an UNKNOWN non-Bash tool still flips the flags — for a governance gate a
+# false-positive (extra nag) is safer than a false-negative (silent mutation bypasses the gate).
+READ_ONLY_TOOLS = {
+    "Read", "Grep", "Glob", "NotebookRead", "read_file", "grep_search", "file_search",
+    "list_dir", "semantic_search", "read_notebook_file", "list_code_usages", "test_search",
+}
+# #2978: cheap pre-filter for raw-Bash mutations; a match triggers a real `git diff` confirm.
+BASH_MUTATE_RE = re.compile(
+    r"(>>?\s|\bsed\s+-i\b|\btee\b|\bgit\s+apply\b|\bgit\s+checkout\s+--|\bcp\s|\bmv\s|\bdd\s|\btruncate\b|\bpatch\b)"
+)
 _PROVIDER_RE = re.compile(r"\b(cascade-dispatch|hamr-client|hamr\.workers\.dev|dispatchRedTeam)\b", re.IGNORECASE)
+
+
+def _bash_mutated_tracked_paths(command: str) -> list[str]:
+    """#2978: when a Bash command looks mutating (cheap pre-filter), CONFIRM via a real
+    `git diff --name-only HEAD` and return the tracked paths that actually changed. A read-only
+    command (no pre-filter match) or any git failure returns [] — never raises, never blocks the
+    hook. Cross-cwd / worktree state-isolation stays Epic #2091's scope (runs in the hook's cwd).
+    """
+    if not BASH_MUTATE_RE.search(command):
+        return []
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "HEAD"],
+            cwd=os.getcwd(), capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode != 0:
+            return []
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    except Exception:
+        return []
 
 
 def mark_tool_activity(state: dict[str, Any], payload: dict[str, Any]) -> None:
@@ -55,20 +92,22 @@ def mark_tool_activity(state: dict[str, Any], payload: dict[str, Any]) -> None:
         roles["collaborator"] = True
         blast["files_edited_count"] += 1
 
-    # #1960: Do not classify Bash command strings as file paths.
-    # Only extract explicit patch-file names from Bash inputs.
+    # #1960 + #2978: derive candidate_paths ONLY from genuine mutations, never from read-only tools.
+    # - Bash: explicit patch-file names (apply_patch) + paths a real `git diff` confirms changed.
+    # - Non-Bash, non-read-only (mutators + UNKNOWN tools): classify inputs (fail-safe — a governance
+    #   gate must not silently miss a mutation, so unknown tools still flip).
+    # - READ_ONLY_TOOLS (Read/Grep/Glob/...): skipped entirely → no false code_touched (the #2978 fix).
     candidate_paths: list[str] = []
-    if tool not in BASH_TOOLS:
+    if tool in BASH_TOOLS:
+        for value in values:
+            if "***" in value and "File:" in value:
+                candidate_paths.extend(m.strip() for m in PATCH_FILE_RE.findall(value))
+        candidate_paths.extend(_bash_mutated_tracked_paths(joined))
+    elif tool not in READ_ONLY_TOOLS:
         for value in values:
             candidate_paths.append(value)
             if "***" in value and "File:" in value:
-                for m in PATCH_FILE_RE.findall(value):
-                    candidate_paths.append(m.strip())
-    else:
-        for value in values:
-            if "***" in value and "File:" in value:
-                for m in PATCH_FILE_RE.findall(value):
-                    candidate_paths.append(m.strip())
+                candidate_paths.extend(m.strip() for m in PATCH_FILE_RE.findall(value))
 
     for value in candidate_paths:
         if "/" not in value and "." not in value:

--- a/tests/hooks/test_tool_activity_code_touched.py
+++ b/tests/hooks/test_tool_activity_code_touched.py
@@ -1,0 +1,67 @@
+"""Tests for #2978: code_touched set only on real mutations, never on read-only tools."""
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOKS = REPO_ROOT / "hooks" / "scripts"
+sys.path.insert(0, str(HOOKS))
+
+import tool_activity as ta  # noqa: E402
+from admin_patterns import required_admin_ops  # noqa: E402
+
+
+def _mark(tool, tool_input):
+    state: dict = {}
+    ta.mark_tool_activity(state, {"tool_name": tool, "tool_input": tool_input})
+    return state.get("flags", {})
+
+
+class CodeTouchedReadOnly(unittest.TestCase):
+    def test_AC1_read_only_tools_do_not_flip_code_touched(self):
+        for tool in ("Read", "Grep", "Glob", "read_file", "grep_search", "file_search"):
+            flags = _mark(tool, {"file_path": "scripts/global/cascade-dispatch.js", "pattern": "foo"})
+            self.assertNotEqual(flags.get("code_touched"), True, f"{tool} must not flip code_touched")
+
+    def test_AC1_readonly_bash_grep_does_not_flip(self):
+        flags = _mark("Bash", {"command": "grep -rn 'foo' scripts/global/*.js && sed -n '1,5p' a.md"})
+        self.assertNotEqual(flags.get("code_touched"), True)
+
+    def test_AC2_no_mutation_means_required_admin_ops_empty(self):
+        flags = _mark("Grep", {"pattern": "x", "path": "scripts/global/foo.js"})
+        self.assertEqual(required_admin_ops(flags, "node"), [])
+
+    def test_AC3_edit_write_flip_code_touched(self):
+        for tool in ("Edit", "Write", "MultiEdit", "apply_patch"):
+            flags = _mark(tool, {"file_path": "scripts/global/foo.js"})
+            self.assertEqual(flags.get("code_touched"), True, f"{tool} must flip code_touched")
+
+    def test_AC3_bash_mutation_confirmed_by_git_diff_flips(self):
+        # cheap pre-filter matches AND git diff reports a tracked code file changed -> code_touched
+        with patch.object(ta, "_bash_mutated_tracked_paths", return_value=["scripts/global/foo.js"]):
+            flags = _mark("Bash", {"command": "echo 'x' > scripts/global/foo.js"})
+        self.assertEqual(flags.get("code_touched"), True)
+
+    def test_AC4_failsafe_unknown_nonbash_tool_with_code_path_flips(self):
+        # an unknown (non-read-only, non-Bash) tool still flips — denylist, not whitelist
+        flags = _mark("some_future_mutator", {"file_path": "scripts/global/foo.js"})
+        self.assertEqual(flags.get("code_touched"), True)
+
+    def test_docs_only_read_does_not_flip_docs_touched(self):
+        flags = _mark("Read", {"file_path": "docs/howto/thing.md"})
+        self.assertNotEqual(flags.get("docs_touched"), True)
+
+
+class BashMutatedPaths(unittest.TestCase):
+    def test_read_only_command_short_circuits_no_git_call(self):
+        # no mutating pattern -> returns [] without invoking git
+        self.assertEqual(ta._bash_mutated_tracked_paths("grep -rn foo scripts/"), [])
+
+    def test_git_failure_returns_empty_never_raises(self):
+        with patch.object(ta.subprocess, "run", side_effect=Exception("boom")):
+            self.assertEqual(ta._bash_mutated_tracked_paths("echo x > a.js"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tool-activity-code-touched-2978.spec.js
+++ b/tests/tool-activity-code-touched-2978.spec.js
@@ -1,0 +1,23 @@
+// #2978 — Wraps the Python unittest suite at tests/hooks/test_tool_activity_code_touched.py
+// (Epic #2647). The Python tests are the source of truth (code_touched set only on real
+// mutations, not read-only tools); this JS wrapper makes the tdd-pyramid evidence discoverable
+// to the test-evidence gate and runs the suite in `npm test` / CI.
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+test('#2978: Python unittest suite for tool_activity code_touched passes', () => {
+  let stdout = '';
+  try {
+    stdout = execFileSync('python3', [
+      '-m', 'unittest', 'tests.hooks.test_tool_activity_code_touched', '-v',
+    ], { cwd: REPO_ROOT, encoding: 'utf8', stdio: 'pipe' });
+  } catch (e) {
+    throw new Error(
+      `Python unittest failed:\nstdout: ${e.stdout || ''}\nstderr: ${e.stderr || ''}`,
+    );
+  }
+  expect(stdout.length).toBeGreaterThanOrEqual(0);
+});


### PR DESCRIPTION
Refs #2978

merge-evidence-deferred-final: #2978

Implementation child of **Epic #2647**. The PostToolUse activity tracker flipped `code_touched` on **read-only** tools (Read/Grep/Glob/…) because every non-Bash tool's path inputs were classified — manufacturing a phantom "Admin baton incomplete" nag and false-blocking legitimate `gh issue close` (G8/G1).

Fix (cross-family-red-team-remediated — swapped a false-negative-prone whitelist for a fail-safe denylist): read-only tools are excluded from path-classification; **unknown** non-Bash tools still flip (fail-safe); Claude mutators added to `EDIT_TOOLS`; raw-Bash mutations caught via a real `git diff --name-only HEAD` behind a cheap pre-filter. **9 new tests, hooks suite 281/281, gemini ACCEPT 100/100.** (Cross-cwd state-isolation stays Epic #2091.)

---

## MANAGER_HANDOFF

scope: Fix hooks/scripts/tool_activity.py mark_tool_activity so code_touched/docs_touched are set only by genuine mutations, not by read-only tools. Remediated (cross-family red-team REMEDIATE_THEN_PROCEED, 2 false-negative findings): use a READ-ONLY DENYLIST (not a mutator whitelist) for non-Bash path classification (fail-safe: unknown tools still flip); add a real git diff --name-only HEAD confirm (behind a cheap mutating-pattern pre-filter) for raw-Bash mutations; add Claude mutator names (Edit/Write/MultiEdit/NotebookEdit) to EDIT_TOOLS for role/blast tracking.
lane: lane:code-change
test_strategy: tdd-pyramid
acceptance:
AC1: a read-only session (Read/Grep/Glob + gh + read-only Bash) leaves code_touched false; legitimate gh issue close not blocked. AC2: no real mutation -> required_admin_ops()==[] (no phantom Admin-baton-incomplete nag). AC3: code_touched flips true on a genuine Edit/Write/MultiEdit/apply_patch AND on a raw-Bash mutation confirmed by git diff --name-only HEAD (no false-negative regression). AC4 (fail-safe): an unknown non-Bash non-read-only tool with a code path still flips code_touched (denylist not whitelist). AC5: pytest regression covers AC1-AC4; lint clean.

gates: lint-required, quality-required, test-evidence (tdd-pyramid pytest), baton-gates, pr-title-required, merge-evidence-pr-gate, HAMR-bypass detection
related_tickets: #2647 #2091 #2615 #2623
overlap_decision: no-overlap — single module hooks/scripts/tool_activity.py + a new pytest. Cross-cwd state-isolation (admin_ops not updated across worktrees) is explicitly Epic #2091's scope, NOT here. No other in-flight worktree touches tool_activity.py.
goal_lens: G8 observability (kills the alert-fatigue: false code_touched manufactures a phantom admin obligation + masks real ones) + G1 governance (false code_touched false-blocks legitimate gh issue close) + G2 quality. Fail-safe denylist chosen over whitelist because for a governance gate a false-negative (silent mutation bypasses admin gate) is worse than a false-positive — cited from cross-family red-team. Review on $0 fleet/free-cloud lanes (G3).

Signed-by: Orla Mason
Team&Model: claude-code:opus@local
Role: manager

---

## COLLABORATOR_HANDOFF

ticket: #2978

scope: Fix tool_activity.py so code_touched/docs_touched are set only on real mutations, not read-only tools. Files: hooks/scripts/tool_activity.py + tests/hooks/test_tool_activity_code_touched.py + changelog.
test_strategy: tdd-pyramid
per_ac_verification:
AC1 PASS: Read/Grep/Glob/read_file/grep_search/file_search + read-only Bash grep leave code_touched false (test). AC2 PASS: required_admin_ops(flags,'node')==[] for a read-only session (test). AC3 PASS: Edit/Write/MultiEdit/apply_patch flip code_touched; a Bash mutation confirmed by git diff --name-only HEAD flips it (test mocks the git-diff result). AC4 PASS: an unknown non-Bash non-read-only tool with a code path still flips code_touched (fail-safe denylist, test). AC5 PASS: 9 new unittest cases; full hooks suite 281/281 pass (no regression); ruff All checks passed; readability 473<475. Evidence: python3 -m unittest discover -s tests/hooks -> Ran 281 OK.

doc_coverage:
N/A: README/extension-README — internal hook behavior, no user-facing CLI/setting. UPDATED: .changes/unreleased/2978.md. Inline comments cite #2978 + the denylist/fail-safe rationale.

cross_family_rating: ACCEPT 100/100 (gemini-2.5-flash)
cross_family_reviewer: gemini-2.5-flash@free-cloud (Google) — cross-family vs claude-code:opus; $0 free-cloud lane (G3). Pre-pickup red-team also gemini (REMEDIATE_THEN_PROCEED, 2 findings).
cross_family_findings: Pre-pickup red-team flagged 2 false-NEGATIVE risks: (HIGH) raw-Bash mutations uncaught; (LOW) mutator-whitelist misses future tools. BOTH remediated in the design BEFORE coding: denylist (not whitelist) keeps unknown non-Bash mutators flagging (fail-safe); _bash_mutated_tracked_paths runs a real git diff behind a cheap pre-filter to catch raw-Bash edits. Post-implementation review (gemini): ACCEPT 100/100, REAL_DEFECTS none — confirmed both findings resolved, git helper exception-safe, no new defect. Scope boundary honored: cross-cwd/worktree state-isolation remains Epic #2091.

Signed-by: Orla Harper
Team&Model: claude-code:opus@local
Role: collaborator

---

## ADMIN_HANDOFF

ticket: #2978

branch: fix/2978-code-touched-real-mutations
commit: ffe7c5ee669af415dd358c6d824d0d88ae12a105
signer-independence-check: PASS — Admin signer Orla Reyes differs from Collaborator signer Orla Harper (registry-derived, claude-code:opus).
deploy-runtime-impact: hooks/scripts/tool_activity.py IS a deployed runtime hook (~/.copilot/hooks/scripts + ~/.codex/devenv-ops/hooks). Will run `npm run deploy:apply` (both runtimes per #2950) post-merge so the false-positive fix takes effect in live sessions; cite output in the closeout.

Signed-by: Orla Reyes
Team&Model: claude-code:opus@local
Role: admin

---

## CONSULTANT_CLOSEOUT

ticket: #2978

status: review
verdict: approve_for_merge
verification-timestamp: 2026-06-13T04:33:08Z
rubric_rating: 9/10 (G1:9 G2:9 G3:9 G4:9 G5:9 G6:9 G7:9 G8:10 G9:9 G10:9; min(G1..G10)>=7)
anneal_tickets_filed: none
mid_flight_flaws:
Flaw 1: initial plan used a mutator WHITELIST (per the Epic's literal proposed fix); pre-pickup cross-family red-team flagged it introduces false-NEGATIVES (HIGH: raw-Bash mutations uncaught; LOW: unlisted future mutators). decision=fixed pre-implementation — switched to a fail-safe read-only DENYLIST + real git-diff Bash confirm. artifact=commit ffe7c5ee + MANAGER_HANDOFF. Flaw 2: a meta-observation — this false-positive fired on essentially every read-only command across the whole session (alert fatigue), which is exactly the G8 symptom the Epic targets. decision=memory-note-only (the fix itself is the remediation). Scope boundary: cross-cwd/worktree admin_ops staleness deliberately left to Epic #2091. Rubric: G8 observability (removes phantom admin obligation + unmasks real ones) + G1 governance (unblocks legitimate gh issue close) headline; G2 (9 tests + 281/281 hooks regression). All review on $0 fleet/free-cloud lanes.
cross_family_verdict: ACCEPT — gemini-2.5-flash@free-cloud — 100/100, REAL_DEFECTS none; both red-team false-negative findings resolved, git helper exception-safe, fail-safe denylist confirmed.


Signed-by: Orla Vale
Team&Model: claude-code:opus@local
Role: consultant
