### PR TITLE
feat(governance): fail-closed lane:trivial diff gate

### DIFF
--- a/.changes/unreleased/2906.md
+++ b/.changes/unreleased/2906.md
@@ -1,0 +1,2 @@
+### Added
+- Lane-classification gate: `manager-handoff` validator now blocks a `lane:trivial` MANAGER_HANDOFF whose declared diff size exceeds a configurable threshold (default 50, via `config/governance-rules.yaml` or `TRIVIAL_DIFF_THRESHOLD`). The check is **fail-closed** — a `lane:trivial` declaration with missing/`NaN`/`Infinity`/negative `diffLines` is itself a violation, closing the fail-open bypass surfaced by cross-family review (#2906).

--- a/config/governance-rules.yaml
+++ b/config/governance-rules.yaml
@@ -197,3 +197,19 @@ rules:
     severity: hard-mandatory
     cross_runtime_applicability:
       - all
+
+  - rule_id: lane-trivial-diff-size
+    class: context-substituting-for-guardrail
+    statement: >
+      A MANAGER_HANDOFF declaring lane:trivial must not have an actual PR diff
+      exceeding the configured line threshold; over-threshold trivial declarations
+      skip gates intended for real code changes (Gap G-03 / OWASP ASI09).
+    source: scripts/global/megalint/manager-handoff.js
+    threshold: 50
+    enum_values: []
+    severity: hard-mandatory
+    cross_runtime_applicability:
+      - claude-code
+      - codex
+      - copilot
+      - antigravity

--- a/scripts/global/megalint/manager-handoff.js
+++ b/scripts/global/megalint/manager-handoff.js
@@ -67,11 +67,21 @@ function checkLaneConsistency(body, expectedLane) {
     : [];
 }
 // AC #2906 — block lane:trivial declarations when actual diff size exceeds threshold.
-// diffLines: total added+removed lines from the PR diff (caller-supplied; null/undefined = skip).
+// FAIL-CLOSED (CWE-754): missing/invalid diffLines on a lane:trivial declaration is
+// itself a violation. Callers MUST supply a finite non-negative integer diff count.
+// diffLines: total added+removed lines from the PR diff (caller-supplied).
 function checkLaneTrivialDiffSize(body, diffLines, threshold) {
   const declared = extractField(body, 'lane');
   if (!declared || !/lane:trivial/i.test(declared)) return [];
-  if (diffLines == null || !Number.isFinite(diffLines)) return [];
+  // Reject null/undefined/NaN/Infinity/negative — absence of evidence = violation.
+  if (diffLines == null || !Number.isFinite(diffLines) || diffLines < 0) {
+    return [{
+      rule: 'lane:trivial-diff-missing',
+      detail: 'MANAGER_HANDOFF declares lane:trivial but diff line count is absent or invalid ' +
+        `(got: ${String(diffLines)}). Caller must supply a finite non-negative integer diff count.`,
+      severity: 'hard',
+    }];
+  }
   const limit = Number.isFinite(threshold) ? threshold : TRIVIAL_DIFF_THRESHOLD;
   if (diffLines > limit) {
     return [{

--- a/scripts/global/megalint/manager-handoff.js
+++ b/scripts/global/megalint/manager-handoff.js
@@ -1,10 +1,27 @@
 'use strict';
 // manager-handoff — validates MANAGER_HANDOFF schema + crypto signature fields.
+// AC #2906: lane:trivial diff-size gate (Gap G-03 / OWASP ASI09).
 
+const fs = require('node:fs');
+const path = require('node:path');
 const sig = require('../governance-artifact-signature');
 const { isValidStrategy } = require('../test-strategy-enum');
 const REQUIRED_FIELDS = ['scope', 'lane', 'test_strategy', 'acceptance', 'gates', 'related_tickets', 'overlap_decision'];
 const PHASE_ONE_LABEL = process.env.PHASE_ONE_LABEL || 'phase-gate:phase-1';
+
+// Load trivial-lane diff threshold from governance-rules.yaml or env override.
+function loadTrivialThreshold() {
+  if (process.env.TRIVIAL_DIFF_THRESHOLD) return Number(process.env.TRIVIAL_DIFF_THRESHOLD);
+  try {
+    const rulesPath = path.resolve(__dirname, '..', '..', '..', 'config', 'governance-rules.yaml');
+    const raw = fs.readFileSync(rulesPath, 'utf8');
+    const match = raw.match(/rule_id:\s*lane-trivial-diff-size[\s\S]*?threshold:\s*(\d+)/);
+    if (match) return Number(match[1]);
+  } catch { /* config absent: use default */ }
+  return 50;
+}
+
+const TRIVIAL_DIFF_THRESHOLD = loadTrivialThreshold();
 
 function findManagerHandoff(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?MANAGER_HANDOFF\b/;
@@ -49,6 +66,23 @@ function checkLaneConsistency(body, expectedLane) {
     ? [{ rule: 'lane-mismatch', detail: `MANAGER_HANDOFF lane='${declared}' but issue has label='${expectedLane}'` }]
     : [];
 }
+// AC #2906 — block lane:trivial declarations when actual diff size exceeds threshold.
+// diffLines: total added+removed lines from the PR diff (caller-supplied; null/undefined = skip).
+function checkLaneTrivialDiffSize(body, diffLines, threshold) {
+  const declared = extractField(body, 'lane');
+  if (!declared || !/lane:trivial/i.test(declared)) return [];
+  if (diffLines == null || !Number.isFinite(diffLines)) return [];
+  const limit = Number.isFinite(threshold) ? threshold : TRIVIAL_DIFF_THRESHOLD;
+  if (diffLines > limit) {
+    return [{
+      rule: 'lane:trivial-diff-too-large',
+      detail: `MANAGER_HANDOFF declares lane:trivial but diff is ${diffLines} lines (threshold: ${limit}). ` +
+        'Re-classify to an appropriate lane (lane:code-change, lane:config-only, etc.).',
+      severity: 'hard',
+    }];
+  }
+  return [];
+}
 function checkCrypto(body) {
   if (!/Crypto-Algorithm:/i.test(body)) return [];
   const result = sig.verifyArtifact(body, 'manager');
@@ -88,10 +122,14 @@ function validate(input) {
     ...checkRequiredFields(handoff.body),
     ...checkTestStrategy(handoff.body),
     ...checkLaneConsistency(handoff.body, input.lane),
+    ...checkLaneTrivialDiffSize(handoff.body, input.diffLines, TRIVIAL_DIFF_THRESHOLD),
     ...checkPhaseOneFields(handoff.body, input.labels),
     ...checkCrypto(handoff.body),
   ];
   return { ok: violations.length === 0, violations, found: true };
 }
 
-module.exports = { validate, findManagerHandoff, extractField, REQUIRED_FIELDS };
+module.exports = {
+  validate, findManagerHandoff, extractField, REQUIRED_FIELDS,
+  checkLaneTrivialDiffSize, TRIVIAL_DIFF_THRESHOLD,
+};

--- a/tests/lane-classification.spec.js
+++ b/tests/lane-classification.spec.js
@@ -3,7 +3,8 @@
 // Hardened per cross-family review: fail-closed on null/NaN/Infinity/negative.
 // Refs #2906 (Gap G-03 / OWASP ASI09).
 
-const { test, expect } = require('@playwright/test');
+const test = require('node:test');
+const assert = require('node:assert');
 const {
   checkLaneTrivialDiffSize,
   validate,
@@ -28,164 +29,108 @@ const CODE_HANDOFF = BASE_HANDOFF.replace('lane: lane:trivial', 'lane: lane:code
 // ── TRIVIAL_DIFF_THRESHOLD constant ──────────────────────────────────────────
 
 test('TRIVIAL_DIFF_THRESHOLD is a positive integer', () => {
-  expect(Number.isFinite(TRIVIAL_DIFF_THRESHOLD)).toBe(true);
-  expect(TRIVIAL_DIFF_THRESHOLD).toBeGreaterThan(0);
+  assert.strictEqual(Number.isFinite(TRIVIAL_DIFF_THRESHOLD), true);
+  assert.ok(TRIVIAL_DIFF_THRESHOLD > 0);
 });
 
 // ── Gate is inactive for non-trivial lanes ────────────────────────────────────
 
 test('no violation when lane is not trivial (large diff OK)', () => {
-  const result = checkLaneTrivialDiffSize(CODE_HANDOFF, 999, 50);
-  expect(result).toEqual([]);
+  assert.deepStrictEqual(checkLaneTrivialDiffSize(CODE_HANDOFF, 999, 50), []);
 });
 
 test('no violation when lane is not trivial and diffLines is null', () => {
-  const result = checkLaneTrivialDiffSize(CODE_HANDOFF, null, 50);
-  expect(result).toEqual([]);
+  assert.deepStrictEqual(checkLaneTrivialDiffSize(CODE_HANDOFF, null, 50), []);
 });
 
 // ── FAIL-CLOSED: missing/invalid diffLines on lane:trivial is a violation ────
-// These are the MUTATION-ANCHOR tests: if the fail-closed guard is removed,
-// these tests MUST fail (they assert violations where old code returned []).
+// MUTATION-ANCHOR tests: if the fail-closed guard is removed, these MUST fail
+// (they assert a violation where the pre-fix fail-open code returned []).
 
-test('[mutation-anchor] null diffLines on lane:trivial emits lane:trivial-diff-missing', () => {
-  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, null, 50);
-  expect(result).toHaveLength(1);
-  expect(result[0].rule).toBe('lane:trivial-diff-missing');
-  expect(result[0].severity).toBe('hard');
-});
-
-test('[mutation-anchor] undefined diffLines on lane:trivial emits lane:trivial-diff-missing', () => {
-  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, undefined, 50);
-  expect(result).toHaveLength(1);
-  expect(result[0].rule).toBe('lane:trivial-diff-missing');
-  expect(result[0].severity).toBe('hard');
-});
-
-test('[mutation-anchor] NaN diffLines on lane:trivial emits lane:trivial-diff-missing', () => {
-  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, NaN, 50);
-  expect(result).toHaveLength(1);
-  expect(result[0].rule).toBe('lane:trivial-diff-missing');
-  expect(result[0].severity).toBe('hard');
-});
-
-test('[mutation-anchor] Infinity diffLines on lane:trivial emits lane:trivial-diff-missing', () => {
-  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, Infinity, 50);
-  expect(result).toHaveLength(1);
-  expect(result[0].rule).toBe('lane:trivial-diff-missing');
-  expect(result[0].severity).toBe('hard');
-});
-
-test('[mutation-anchor] negative diffLines on lane:trivial emits lane:trivial-diff-missing', () => {
-  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, -1, 50);
-  expect(result).toHaveLength(1);
-  expect(result[0].rule).toBe('lane:trivial-diff-missing');
-  expect(result[0].severity).toBe('hard');
-});
+for (const [label, value] of [
+  ['null', null], ['undefined', undefined], ['NaN', NaN],
+  ['Infinity', Infinity], ['negative', -1],
+]) {
+  test(`[mutation-anchor] ${label} diffLines on lane:trivial emits lane:trivial-diff-missing`, () => {
+    const result = checkLaneTrivialDiffSize(BASE_HANDOFF, value, 50);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].rule, 'lane:trivial-diff-missing');
+    assert.strictEqual(result[0].severity, 'hard');
+  });
+}
 
 test('lane:trivial-diff-missing detail includes the invalid value for diagnostics', () => {
   const result = checkLaneTrivialDiffSize(BASE_HANDOFF, null, 50);
-  expect(result[0].detail).toMatch(/null/);
+  assert.match(result[0].detail, /null/);
 });
 
 // ── Valid diffLines on lane:trivial: within-threshold and over-threshold ──────
 
 test('no violation when diffLines equals threshold exactly', () => {
-  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, 50, 50);
-  expect(result).toEqual([]);
+  assert.deepStrictEqual(checkLaneTrivialDiffSize(BASE_HANDOFF, 50, 50), []);
 });
 
 test('no violation when diffLines is below threshold', () => {
-  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, 10, 50);
-  expect(result).toEqual([]);
+  assert.deepStrictEqual(checkLaneTrivialDiffSize(BASE_HANDOFF, 10, 50), []);
 });
 
 test('no violation when diffLines is 0 (empty diff counts as trivial)', () => {
-  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, 0, 50);
-  expect(result).toEqual([]);
+  assert.deepStrictEqual(checkLaneTrivialDiffSize(BASE_HANDOFF, 0, 50), []);
 });
 
 test('emits lane:trivial-diff-too-large when diff exceeds threshold', () => {
   const result = checkLaneTrivialDiffSize(BASE_HANDOFF, 51, 50);
-  expect(result).toHaveLength(1);
-  expect(result[0].rule).toBe('lane:trivial-diff-too-large');
-  expect(result[0].severity).toBe('hard');
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].rule, 'lane:trivial-diff-too-large');
+  assert.strictEqual(result[0].severity, 'hard');
 });
 
 test('violation detail contains actual and threshold line counts', () => {
   const result = checkLaneTrivialDiffSize(BASE_HANDOFF, 120, 50);
-  expect(result[0].detail).toMatch(/120/);
-  expect(result[0].detail).toMatch(/50/);
+  assert.match(result[0].detail, /120/);
+  assert.match(result[0].detail, /50/);
 });
 
 test('uses explicit threshold arg (env-configurable threshold)', () => {
   const smallThreshold = 5;
-  const under = checkLaneTrivialDiffSize(BASE_HANDOFF, 4, smallThreshold);
+  assert.deepStrictEqual(checkLaneTrivialDiffSize(BASE_HANDOFF, 4, smallThreshold), []);
   const over = checkLaneTrivialDiffSize(BASE_HANDOFF, 6, smallThreshold);
-  expect(under).toEqual([]);
-  expect(over[0].rule).toBe('lane:trivial-diff-too-large');
+  assert.strictEqual(over[0].rule, 'lane:trivial-diff-too-large');
 });
 
 // ── validate() integration tests ─────────────────────────────────────────────
 
 test('validate passes for lane:trivial with small explicit diff', () => {
-  const input = {
-    comments: [{ body: BASE_HANDOFF }],
-    diffLines: 10,
-  };
-  const result = validate(input);
-  const trivialViolations = result.violations.filter(
-    (v) => v.rule === 'lane:trivial-diff-too-large',
-  );
-  expect(trivialViolations).toHaveLength(0);
+  const result = validate({ comments: [{ body: BASE_HANDOFF }], diffLines: 10 });
+  const hits = result.violations.filter((v) => v.rule === 'lane:trivial-diff-too-large');
+  assert.strictEqual(hits.length, 0);
 });
 
 test('validate blocks for lane:trivial with oversized diff', () => {
-  const input = {
-    comments: [{ body: BASE_HANDOFF }],
-    diffLines: 200,
-  };
-  const result = validate(input);
-  const trivialViolations = result.violations.filter(
-    (v) => v.rule === 'lane:trivial-diff-too-large',
-  );
-  expect(trivialViolations).toHaveLength(1);
-  expect(result.ok).toBe(false);
+  const result = validate({ comments: [{ body: BASE_HANDOFF }], diffLines: 200 });
+  const hits = result.violations.filter((v) => v.rule === 'lane:trivial-diff-too-large');
+  assert.strictEqual(hits.length, 1);
+  assert.strictEqual(result.ok, false);
 });
 
 test('[mutation-anchor] validate blocks when diffLines absent from input (fail-closed)', () => {
-  // Absence of diffLines on lane:trivial is a gate violation, not a pass.
-  const input = { comments: [{ body: BASE_HANDOFF }] };
-  const result = validate(input);
-  const missingViolations = result.violations.filter(
-    (v) => v.rule === 'lane:trivial-diff-missing',
-  );
-  expect(missingViolations).toHaveLength(1);
-  expect(result.ok).toBe(false);
+  const result = validate({ comments: [{ body: BASE_HANDOFF }] });
+  const hits = result.violations.filter((v) => v.rule === 'lane:trivial-diff-missing');
+  assert.strictEqual(hits.length, 1);
+  assert.strictEqual(result.ok, false);
 });
 
 test('validate does not emit trivial-diff violation for lane:code-change', () => {
-  const input = {
-    comments: [{ body: CODE_HANDOFF }],
-    diffLines: 500,
-  };
-  const result = validate(input);
-  const trivialViolations = result.violations.filter(
-    (v) => v.rule === 'lane:trivial-diff-too-large' ||
-            v.rule === 'lane:trivial-diff-missing',
+  const result = validate({ comments: [{ body: CODE_HANDOFF }], diffLines: 500 });
+  const hits = result.violations.filter(
+    (v) => v.rule === 'lane:trivial-diff-too-large' || v.rule === 'lane:trivial-diff-missing',
   );
-  expect(trivialViolations).toHaveLength(0);
+  assert.strictEqual(hits.length, 0);
 });
 
 test('[mutation-anchor] bypass attempt via NaN diffLines is blocked by validate()', () => {
-  const input = {
-    comments: [{ body: BASE_HANDOFF }],
-    diffLines: NaN,
-  };
-  const result = validate(input);
-  const missingViolations = result.violations.filter(
-    (v) => v.rule === 'lane:trivial-diff-missing',
-  );
-  expect(missingViolations).toHaveLength(1);
-  expect(result.ok).toBe(false);
+  const result = validate({ comments: [{ body: BASE_HANDOFF }], diffLines: NaN });
+  const hits = result.violations.filter((v) => v.rule === 'lane:trivial-diff-missing');
+  assert.strictEqual(hits.length, 1);
+  assert.strictEqual(result.ok, false);
 });

--- a/tests/lane-classification.spec.js
+++ b/tests/lane-classification.spec.js
@@ -1,0 +1,133 @@
+'use strict';
+// tests/lane-classification.spec.js — AC #2906: lane:trivial diff-size gate.
+// Refs #2906 (Gap G-03 / OWASP ASI09).
+
+const { test, expect } = require('@playwright/test');
+const {
+  checkLaneTrivialDiffSize,
+  validate,
+  findManagerHandoff,
+  TRIVIAL_DIFF_THRESHOLD,
+} = require('../scripts/global/megalint/manager-handoff.js');
+
+// Minimal valid MANAGER_HANDOFF body used across tests.
+const BASE_HANDOFF = `## MANAGER_HANDOFF
+scope: trivial typo fix
+lane: lane:trivial
+test_strategy: none
+acceptance: fix typo
+gates: lint
+related_tickets: #1
+overlap_decision: none
+Signed-by: Orla Mason
+Team&Model: claude-code:sonnet-4-6@anthropic
+Role: manager`;
+
+const CODE_HANDOFF = BASE_HANDOFF.replace('lane: lane:trivial', 'lane: lane:code-change');
+
+// ── checkLaneTrivialDiffSize unit tests ──────────────────────────────────────
+
+test('TRIVIAL_DIFF_THRESHOLD is a positive integer', () => {
+  expect(Number.isFinite(TRIVIAL_DIFF_THRESHOLD)).toBe(true);
+  expect(TRIVIAL_DIFF_THRESHOLD).toBeGreaterThan(0);
+});
+
+test('no violation when lane is not trivial', () => {
+  const result = checkLaneTrivialDiffSize(CODE_HANDOFF, 999, 50);
+  expect(result).toEqual([]);
+});
+
+test('no violation when diffLines is null (caller did not supply diff)', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, null, 50);
+  expect(result).toEqual([]);
+});
+
+test('no violation when diffLines is undefined', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, undefined, 50);
+  expect(result).toEqual([]);
+});
+
+test('no violation when diffLines equals threshold exactly', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, 50, 50);
+  expect(result).toEqual([]);
+});
+
+test('no violation when diffLines is below threshold', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, 10, 50);
+  expect(result).toEqual([]);
+});
+
+test('emits lane:trivial-diff-too-large when diff exceeds threshold', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, 51, 50);
+  expect(result).toHaveLength(1);
+  expect(result[0].rule).toBe('lane:trivial-diff-too-large');
+  expect(result[0].severity).toBe('hard');
+});
+
+test('violation detail contains actual and threshold line counts', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, 120, 50);
+  expect(result[0].detail).toMatch(/120/);
+  expect(result[0].detail).toMatch(/50/);
+});
+
+test('uses env-configurable threshold when provided', () => {
+  // Direct call with explicit threshold arg overrides module-level constant.
+  const smallThreshold = 5;
+  const under = checkLaneTrivialDiffSize(BASE_HANDOFF, 4, smallThreshold);
+  const over = checkLaneTrivialDiffSize(BASE_HANDOFF, 6, smallThreshold);
+  expect(under).toEqual([]);
+  expect(over[0].rule).toBe('lane:trivial-diff-too-large');
+});
+
+test('non-finite diffLines value is ignored gracefully', () => {
+  expect(checkLaneTrivialDiffSize(BASE_HANDOFF, NaN, 50)).toEqual([]);
+  expect(checkLaneTrivialDiffSize(BASE_HANDOFF, Infinity, 50)).toEqual([]);
+});
+
+// ── validate() integration tests ─────────────────────────────────────────────
+
+test('validate passes for lane:trivial with small diff', () => {
+  const input = {
+    comments: [{ body: BASE_HANDOFF }],
+    diffLines: 10,
+  };
+  const result = validate(input);
+  const trivialViolations = result.violations.filter(
+    (violation) => violation.rule === 'lane:trivial-diff-too-large',
+  );
+  expect(trivialViolations).toHaveLength(0);
+});
+
+test('validate blocks for lane:trivial with oversized diff', () => {
+  const input = {
+    comments: [{ body: BASE_HANDOFF }],
+    diffLines: 200,
+  };
+  const result = validate(input);
+  const trivialViolations = result.violations.filter(
+    (violation) => violation.rule === 'lane:trivial-diff-too-large',
+  );
+  expect(trivialViolations).toHaveLength(1);
+  expect(result.ok).toBe(false);
+});
+
+test('validate skips diff check when diffLines absent from input', () => {
+  const input = { comments: [{ body: BASE_HANDOFF }] };
+  const result = validate(input);
+  const trivialViolations = result.violations.filter(
+    (violation) => violation.rule === 'lane:trivial-diff-too-large',
+  );
+  expect(trivialViolations).toHaveLength(0);
+});
+
+test('validate does not emit trivial-diff violation for lane:code-change', () => {
+  const input = {
+    comments: [{ body: CODE_HANDOFF }],
+    diffLines: 500,
+  };
+  const result = validate(input);
+  const trivialViolations = result.violations.filter(
+    (violation) => violation.rule === 'lane:trivial-diff-too-large',
+  );
+  expect(trivialViolations).toHaveLength(0);
+});

--- a/tests/lane-classification.spec.js
+++ b/tests/lane-classification.spec.js
@@ -1,12 +1,12 @@
 'use strict';
 // tests/lane-classification.spec.js — AC #2906: lane:trivial diff-size gate.
+// Hardened per cross-family review: fail-closed on null/NaN/Infinity/negative.
 // Refs #2906 (Gap G-03 / OWASP ASI09).
 
 const { test, expect } = require('@playwright/test');
 const {
   checkLaneTrivialDiffSize,
   validate,
-  findManagerHandoff,
   TRIVIAL_DIFF_THRESHOLD,
 } = require('../scripts/global/megalint/manager-handoff.js');
 
@@ -25,27 +25,70 @@ Role: manager`;
 
 const CODE_HANDOFF = BASE_HANDOFF.replace('lane: lane:trivial', 'lane: lane:code-change');
 
-// ── checkLaneTrivialDiffSize unit tests ──────────────────────────────────────
+// ── TRIVIAL_DIFF_THRESHOLD constant ──────────────────────────────────────────
 
 test('TRIVIAL_DIFF_THRESHOLD is a positive integer', () => {
   expect(Number.isFinite(TRIVIAL_DIFF_THRESHOLD)).toBe(true);
   expect(TRIVIAL_DIFF_THRESHOLD).toBeGreaterThan(0);
 });
 
-test('no violation when lane is not trivial', () => {
+// ── Gate is inactive for non-trivial lanes ────────────────────────────────────
+
+test('no violation when lane is not trivial (large diff OK)', () => {
   const result = checkLaneTrivialDiffSize(CODE_HANDOFF, 999, 50);
   expect(result).toEqual([]);
 });
 
-test('no violation when diffLines is null (caller did not supply diff)', () => {
-  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, null, 50);
+test('no violation when lane is not trivial and diffLines is null', () => {
+  const result = checkLaneTrivialDiffSize(CODE_HANDOFF, null, 50);
   expect(result).toEqual([]);
 });
 
-test('no violation when diffLines is undefined', () => {
-  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, undefined, 50);
-  expect(result).toEqual([]);
+// ── FAIL-CLOSED: missing/invalid diffLines on lane:trivial is a violation ────
+// These are the MUTATION-ANCHOR tests: if the fail-closed guard is removed,
+// these tests MUST fail (they assert violations where old code returned []).
+
+test('[mutation-anchor] null diffLines on lane:trivial emits lane:trivial-diff-missing', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, null, 50);
+  expect(result).toHaveLength(1);
+  expect(result[0].rule).toBe('lane:trivial-diff-missing');
+  expect(result[0].severity).toBe('hard');
 });
+
+test('[mutation-anchor] undefined diffLines on lane:trivial emits lane:trivial-diff-missing', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, undefined, 50);
+  expect(result).toHaveLength(1);
+  expect(result[0].rule).toBe('lane:trivial-diff-missing');
+  expect(result[0].severity).toBe('hard');
+});
+
+test('[mutation-anchor] NaN diffLines on lane:trivial emits lane:trivial-diff-missing', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, NaN, 50);
+  expect(result).toHaveLength(1);
+  expect(result[0].rule).toBe('lane:trivial-diff-missing');
+  expect(result[0].severity).toBe('hard');
+});
+
+test('[mutation-anchor] Infinity diffLines on lane:trivial emits lane:trivial-diff-missing', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, Infinity, 50);
+  expect(result).toHaveLength(1);
+  expect(result[0].rule).toBe('lane:trivial-diff-missing');
+  expect(result[0].severity).toBe('hard');
+});
+
+test('[mutation-anchor] negative diffLines on lane:trivial emits lane:trivial-diff-missing', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, -1, 50);
+  expect(result).toHaveLength(1);
+  expect(result[0].rule).toBe('lane:trivial-diff-missing');
+  expect(result[0].severity).toBe('hard');
+});
+
+test('lane:trivial-diff-missing detail includes the invalid value for diagnostics', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, null, 50);
+  expect(result[0].detail).toMatch(/null/);
+});
+
+// ── Valid diffLines on lane:trivial: within-threshold and over-threshold ──────
 
 test('no violation when diffLines equals threshold exactly', () => {
   const result = checkLaneTrivialDiffSize(BASE_HANDOFF, 50, 50);
@@ -54,6 +97,11 @@ test('no violation when diffLines equals threshold exactly', () => {
 
 test('no violation when diffLines is below threshold', () => {
   const result = checkLaneTrivialDiffSize(BASE_HANDOFF, 10, 50);
+  expect(result).toEqual([]);
+});
+
+test('no violation when diffLines is 0 (empty diff counts as trivial)', () => {
+  const result = checkLaneTrivialDiffSize(BASE_HANDOFF, 0, 50);
   expect(result).toEqual([]);
 });
 
@@ -70,8 +118,7 @@ test('violation detail contains actual and threshold line counts', () => {
   expect(result[0].detail).toMatch(/50/);
 });
 
-test('uses env-configurable threshold when provided', () => {
-  // Direct call with explicit threshold arg overrides module-level constant.
+test('uses explicit threshold arg (env-configurable threshold)', () => {
   const smallThreshold = 5;
   const under = checkLaneTrivialDiffSize(BASE_HANDOFF, 4, smallThreshold);
   const over = checkLaneTrivialDiffSize(BASE_HANDOFF, 6, smallThreshold);
@@ -79,21 +126,16 @@ test('uses env-configurable threshold when provided', () => {
   expect(over[0].rule).toBe('lane:trivial-diff-too-large');
 });
 
-test('non-finite diffLines value is ignored gracefully', () => {
-  expect(checkLaneTrivialDiffSize(BASE_HANDOFF, NaN, 50)).toEqual([]);
-  expect(checkLaneTrivialDiffSize(BASE_HANDOFF, Infinity, 50)).toEqual([]);
-});
-
 // ── validate() integration tests ─────────────────────────────────────────────
 
-test('validate passes for lane:trivial with small diff', () => {
+test('validate passes for lane:trivial with small explicit diff', () => {
   const input = {
     comments: [{ body: BASE_HANDOFF }],
     diffLines: 10,
   };
   const result = validate(input);
   const trivialViolations = result.violations.filter(
-    (violation) => violation.rule === 'lane:trivial-diff-too-large',
+    (v) => v.rule === 'lane:trivial-diff-too-large',
   );
   expect(trivialViolations).toHaveLength(0);
 });
@@ -105,19 +147,21 @@ test('validate blocks for lane:trivial with oversized diff', () => {
   };
   const result = validate(input);
   const trivialViolations = result.violations.filter(
-    (violation) => violation.rule === 'lane:trivial-diff-too-large',
+    (v) => v.rule === 'lane:trivial-diff-too-large',
   );
   expect(trivialViolations).toHaveLength(1);
   expect(result.ok).toBe(false);
 });
 
-test('validate skips diff check when diffLines absent from input', () => {
+test('[mutation-anchor] validate blocks when diffLines absent from input (fail-closed)', () => {
+  // Absence of diffLines on lane:trivial is a gate violation, not a pass.
   const input = { comments: [{ body: BASE_HANDOFF }] };
   const result = validate(input);
-  const trivialViolations = result.violations.filter(
-    (violation) => violation.rule === 'lane:trivial-diff-too-large',
+  const missingViolations = result.violations.filter(
+    (v) => v.rule === 'lane:trivial-diff-missing',
   );
-  expect(trivialViolations).toHaveLength(0);
+  expect(missingViolations).toHaveLength(1);
+  expect(result.ok).toBe(false);
 });
 
 test('validate does not emit trivial-diff violation for lane:code-change', () => {
@@ -127,7 +171,21 @@ test('validate does not emit trivial-diff violation for lane:code-change', () =>
   };
   const result = validate(input);
   const trivialViolations = result.violations.filter(
-    (violation) => violation.rule === 'lane:trivial-diff-too-large',
+    (v) => v.rule === 'lane:trivial-diff-too-large' ||
+            v.rule === 'lane:trivial-diff-missing',
   );
   expect(trivialViolations).toHaveLength(0);
+});
+
+test('[mutation-anchor] bypass attempt via NaN diffLines is blocked by validate()', () => {
+  const input = {
+    comments: [{ body: BASE_HANDOFF }],
+    diffLines: NaN,
+  };
+  const result = validate(input);
+  const missingViolations = result.violations.filter(
+    (v) => v.rule === 'lane:trivial-diff-missing',
+  );
+  expect(missingViolations).toHaveLength(1);
+  expect(result.ok).toBe(false);
 });


### PR DESCRIPTION
Refs #2906

merge-evidence-deferred-final: #2906

## Summary
Adds a **fail-closed** lane-classification gate to the `manager-handoff` validator: a
`lane:trivial` MANAGER_HANDOFF whose declared diff exceeds a configurable threshold
(default 50) is blocked, and — critically — a `lane:trivial` declaration with
missing/`NaN`/`Infinity`/negative `diffLines` is itself a violation
(`lane:trivial-diff-missing`). Closes the fail-open bypass that cross-family review found
in the Wave-1 draft. Part of Epic #2891 (governance guardrails → enforced gates).

## Test evidence
`node --test tests/lane-classification.spec.js` → **20/20 pass** (incl. 7 mutation-anchor
tests that fail if the fail-closed guard is removed). Spec uses the repo `node:test`
convention (Wave-1 draft wrongly used `@playwright/test`; converted).

## Cross-family review (non-Anthropic)
groq:llama-3.3-70b-versatile (Meta) → **ACCEPT 10/10, no findings**.

## Baton artifacts (full set on #2906)

COLLABORATOR_HANDOFF — Signed-by Orla Harper, Role collaborator; per-AC PASS; cross_family_rating 10/10.

ADMIN_HANDOFF — Signed-by Orla Reyes, Role admin; branch fix/2906-lane-classification-gate; signer-independence PASS (Harper≠Reyes); deploy-runtime-impact none.

CONSULTANT_CLOSEOUT — Signed-by Orla Vale, Role consultant; verdict approve_for_merge; rubric 9; mid_flight_flaws accounted (fail-open fixed, framework-mismatch fixed, review-degradation logged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
