### PR TITLE
feat(governance): add deterministic drift sweep scan CLI

### DIFF
--- a/.changes/unreleased/2988.md
+++ b/.changes/unreleased/2988.md
@@ -1,0 +1,3 @@
+### Added
+
+- `governance:drift-sweep` npm script and `scripts/global/governance-drift-sweep.js` scan wrapper for deterministic D1-D8 reporting with no LLM calls.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ the Worker: add `MEGINGJORD_HAMR_ENABLED=1` to your `.env`.
 | `governance:delegation-lint` | `node scripts/global/delegation-phrase-lint.js` |
 | `governance:dispatcher-set-labels:test` | `node --test tests/github-dispatcher-set-labels.spec.js` |
 | `governance:drift` | `node scripts/global/governance-drift-classifier.js --json` |
+| `governance:drift-sweep` | `node scripts/global/governance-drift-sweep.js --scan` |
+| `governance:drift-sweep:test` | `node --test tests/governance-drift-sweep.spec.js` |
 | `governance:duplicate-check` | `node scripts/global/ticket-duplicate-guard.js --scan` |
 | `governance:duplicate-check:test` | `node --test tests/ticket-duplicate-guard.spec.js` |
 | `governance:epic` | `node scripts/global/epic-evidence.js` |

--- a/package.json
+++ b/package.json
@@ -295,7 +295,9 @@
     "deploy:verify": "node scripts/global/verify-deploy.js",
     "deploy:verify:copilot": "node scripts/global/verify-deploy.js copilot",
     "deploy:verify:codex": "node scripts/global/verify-deploy.js codex",
-    "deploy:verify:claude": "node scripts/global/verify-deploy.js claude"
+    "deploy:verify:claude": "node scripts/global/verify-deploy.js claude",
+    "governance:drift-sweep": "node scripts/global/governance-drift-sweep.js --scan",
+    "governance:drift-sweep:test": "node --test tests/governance-drift-sweep.spec.js"
   },
   "keywords": [
     "devops",

--- a/scripts/global/governance-drift-sweep.js
+++ b/scripts/global/governance-drift-sweep.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { loadLocalEnvOnce } = require('./load-local-env');
+const { listOpenTickets } = require('./governance-audit');
+const { parseBody } = require('../ticket-normalizer');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const REPORT_FILE = path.join(ROOT, 'logs', 'governance-drift-sweep.json');
+const D_CLASS_IDS = ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7', 'D8'];
+
+function labelNames(issue) {
+  return (issue.labels || []).map((label) => (typeof label === 'string' ? label : label.name));
+}
+
+function hasLabel(labels, prefix) {
+  return labels.some((label) => label === prefix || label.startsWith(`${prefix}:`));
+}
+
+function classifyIssue(issue, byNumber = new Map()) {
+  const labels = labelNames(issue);
+  const classes = [];
+  const body = parseBody(issue.body || null);
+  const parent = body.parent_issue ? byNumber.get(body.parent_issue) : null;
+  const parentLabels = parent ? labelNames(parent) : [];
+  const parentActive = parentLabels.includes('type:epic')
+    && !parentLabels.some((label) => ['status:backlog', 'status:done', 'status:cancelled'].includes(label));
+
+  if (!hasLabel(labels, 'type') && !hasLabel(labels, 'status') && !hasLabel(labels, 'priority')) classes.push('D1');
+  if (labels.includes('status:in-progress') && !labels.some((label) => label.startsWith('role:'))) classes.push('D2');
+  if (/^(?:[a-z]+(?:\([^)]+\))?:\s|\[[^\]]+\]\s)/i.test(issue.title || '')) classes.push('D3');
+  if (issue.state === 'open' && hasLabel(labels, 'resolution')) classes.push('D4');
+  if (labels.includes('status:backlog') && parentActive) classes.push('D5');
+  if (labels.includes('type:epic') && (labels.includes('status:dormant') || labels.includes('status:deferred'))
+    && !/EPIC_REVIEW/i.test(issue.body || '')) classes.push('D6');
+  if (labels.includes('coordinator:cross-team-needs-hand-off')) classes.push('D7');
+  if (labels.includes('type:epic') && labels.includes('phase-gate:phase-1')) classes.push('D8');
+
+  return classes;
+}
+
+function classifyIssues(issues) {
+  const byNumber = new Map(issues.map((issue) => [issue.number, issue]));
+  const details = Object.fromEntries(D_CLASS_IDS.map((id) => [id, []]));
+  for (const issue of issues) {
+    for (const classId of classifyIssue(issue, byNumber)) details[classId].push(issue.number);
+  }
+  const counts = Object.fromEntries(D_CLASS_IDS.map((id) => [id, details[id].length]));
+  return { counts, details, total: Object.values(counts).reduce((sum, value) => sum + value, 0) };
+}
+
+function buildReport(issues = []) {
+  const scan = classifyIssues(issues);
+  return {
+    generatedAt: new Date().toISOString(),
+    mode: 'scan',
+    route: 'deterministic',
+    premiumLaneProhibited: true,
+    totalDrift: scan.total,
+    counts: scan.counts,
+    details: scan.details,
+    status: scan.total === 0 ? 'pass' : 'fail',
+  };
+}
+
+async function run(argv = process.argv.slice(2), deps = {}) {
+  loadLocalEnvOnce();
+  if (argv.includes('--help')) {
+    console.log('Usage: node scripts/global/governance-drift-sweep.js [--scan] [--json]');
+    return true;
+  }
+  if (argv.includes('--fix') || argv.includes('--rollback')) {
+    console.error('governance-drift-sweep: only --scan is implemented in Phase-1 child #2988.');
+    return false;
+  }
+  const issues = deps.listOpenTickets ? deps.listOpenTickets() : listOpenTickets();
+  const report = buildReport(issues);
+  fs.mkdirSync(path.dirname(REPORT_FILE), { recursive: true });
+  fs.writeFileSync(REPORT_FILE, JSON.stringify(report, null, 2));
+  if (argv.includes('--json') || !argv.includes('--scan')) console.log(JSON.stringify(report, null, 2));
+  else {
+    const summary = D_CLASS_IDS.map((id) => `${id}=${report.counts[id]}`).join(' ');
+    console.log(`governance-drift-sweep: ${report.status.toUpperCase()} | ${summary}`);
+  }
+  return report.status === 'pass';
+}
+
+if (require.main === module) {
+  run().then((ok) => process.exit(ok ? 0 : 1)).catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { run, buildReport, classifyIssue, classifyIssues, REPORT_FILE };

--- a/tests/governance-drift-sweep-contract.spec.js
+++ b/tests/governance-drift-sweep-contract.spec.js
@@ -1,0 +1,12 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { buildReport } = require('../scripts/global/governance-drift-sweep');
+
+test('contract report includes required top-level keys', () => {
+  const report = buildReport([]);
+  assert.equal(report.mode, 'scan');
+  assert.equal(report.route, 'deterministic');
+  assert.equal(report.premiumLaneProhibited, true);
+  assert.ok(report.counts && typeof report.counts === 'object');
+  assert.ok(report.details && typeof report.details === 'object');
+});

--- a/tests/governance-drift-sweep.spec.js
+++ b/tests/governance-drift-sweep.spec.js
@@ -1,0 +1,35 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { buildReport, classifyIssue, classifyIssues } = require('../scripts/global/governance-drift-sweep');
+
+test('classifies the seed D1-D8 patterns', () => {
+  const issues = [
+    { number: 1, state: 'open', title: 'plain ticket', body: '', labels: [] },
+    { number: 2, state: 'open', title: 'in progress', body: '', labels: ['status:in-progress'] },
+    { number: 3, state: 'open', title: 'fix: title drift', body: '', labels: ['status:triage'] },
+    { number: 4, state: 'open', title: 'open resolution', body: '', labels: ['resolution:released'] },
+    { number: 5, state: 'open', title: 'child', body: 'Parent: #9', labels: ['status:backlog'] },
+    { number: 6, state: 'open', title: 'epic', body: '', labels: ['type:epic', 'status:dormant'] },
+    { number: 7, state: 'open', title: 'coord', body: '', labels: ['coordinator:cross-team-needs-hand-off'] },
+    { number: 8, state: 'open', title: 'epic', body: '', labels: ['type:epic', 'phase-gate:phase-1'] },
+    { number: 9, state: 'open', title: 'parent epic', body: '', labels: ['type:epic', 'status:in-progress', 'role:manager'] },
+  ];
+  const result = classifyIssues(issues);
+  assert.ok(classifyIssue(issues[0], new Map([[9, issues[8]]])).includes('D1'));
+  assert.deepEqual(result.details.D2, [2]);
+  assert.deepEqual(result.details.D3, [3]);
+  assert.deepEqual(result.details.D4, [4]);
+  assert.deepEqual(result.details.D5, [5]);
+  assert.deepEqual(result.details.D6, [6]);
+  assert.deepEqual(result.details.D7, [7]);
+  assert.deepEqual(result.details.D8, [8]);
+});
+
+test('builds a deterministic scan report', () => {
+  const report = buildReport([{ number: 1, state: 'open', title: 'plain ticket', body: '', labels: [] }]);
+  assert.equal(report.mode, 'scan');
+  assert.equal(report.route, 'deterministic');
+  assert.equal(report.premiumLaneProhibited, true);
+  assert.equal(report.counts.D1, 1);
+  assert.equal(report.status, 'fail');
+});


### PR DESCRIPTION
## Summary
- add deterministic scan-only governance drift sweep CLI (`scripts/global/governance-drift-sweep.js`)
- add focused classifier/report tests (`tests/governance-drift-sweep.spec.js`)
- expose commands in `package.json` and `README.md`
- add changelog fragment for #2988

## Validation
- `node --test tests/governance-drift-sweep.spec.js`
- `npm run governance:drift-sweep:test`
- `node scripts/global/governance-drift-sweep.js --scan --json`

## Notes
- cross-family fleet review attempted on free lane; fleet degradation evidence captured on issue #2988
- repo-wide `npm test` has unrelated baseline failures outside this diff

Refs #2988
merge-evidence-deferred-final: #2988
