### PR TITLE
feat(hooks): block shell-level writes to tracked canonical main

### DIFF
--- a/.changes/unreleased/2995.md
+++ b/.changes/unreleased/2995.md
@@ -1,0 +1,8 @@
+### Security
+- Canonical-main read-only enforcement now covers **shell-level writes** (#2995): terminal
+  writes to tracked main-checkout files via `>`/`>>` redirects, `sed -i`, `tee`, and `cp`/`mv`
+  are denied with a worktree-redirect message, closing the documented blind spot where these
+  bypassed the structured-edit-tool enforcer. IT-ops markers do **not** authorize tracked-file
+  edits in main (they waive ticket/baton ceremony only). Fail-open on parse errors (never bricks
+  the hook); `evaluate_path()` remains the deny/allow authority so non-repo/gitignored targets
+  are unaffected. Adds `docs/howto/canonical-main-write-boundary.md` for all teams.

--- a/docs/howto/canonical-main-write-boundary.md
+++ b/docs/howto/canonical-main-write-boundary.md
@@ -1,0 +1,52 @@
+# Canonical-main write boundary (IT vs delivery)
+
+**Audience:** all teams — Claude Code, Copilot, Codex, Antigravity.
+**Rule (G1, #2107/#2995):** the main checkout (`~/devenv-ops/`) is **canonical-only**.
+You may write there **only** to gitignored paths; **all tracked-file work needs a
+ticket + dedicated worktree/branch.** This holds for every team and every role,
+**including IT** — IT markers waive ticket/baton *ceremony*, never this boundary.
+
+## What is allowed where
+
+| Action in `~/devenv-ops/` (main) | Allowed? |
+|---|---|
+| Edit a **gitignored** path (`.env`, `.npmrc`, `node_modules/`, `tmp/`, `.cache/`, …) | ✅ yes |
+| Edit/create a **tracked** file (the codebase) | ❌ no → use a worktree |
+| `git checkout`/`switch` off `main` | ❌ no → use a worktree |
+| Shell write to a tracked file (`> f`, `>> f`, `sed -i f`, `tee f`, `cp/mv … f`) | ❌ no (#2995) |
+
+## The correct path for tracked work
+
+```bash
+# 1. ticket first (every tracked change needs an issue)
+gh issue view <N>
+# 2. dedicated worktree + branch off main (never edit main directly)
+git worktree add ~/devenv-ops-<N> -b fix/<N>-slug origin/main
+ln -s ~/devenv-ops/node_modules ~/devenv-ops-<N>/node_modules   # or: npm run worktree:bootstrap
+# 3. do all edits, commits, and the PR from the worktree
+cd ~/devenv-ops-<N> && <edit/test/commit/push/PR>
+```
+
+## IT role specifically
+
+IT-ops markers (`[it-ops]`, `chore(it-ops):`, `MEGINGJORD_IT_OPS=1`) waive the
+**ticket + baton** requirement for genuine local/fleet maintenance — they do **not**
+authorize editing tracked files in the canonical checkout. An IT change that touches
+a tracked file is delivery work: open a ticket and use a worktree (see
+`instructions/role-baton-routing.instructions.md` IT-role note).
+
+## How it's enforced
+
+`hooks/scripts/canonical_main_enforcer.py` (via `pretool_guard.py`) denies, in the
+main checkout:
+- structured edit-tool writes to tracked/non-gitignored paths,
+- branch switches off `main`,
+- **shell-level writes** to tracked files — redirects, `sed -i`, `tee`, `cp`, `mv`
+  (#2995, closing the prior terminal-write blind spot).
+
+Denials emit a machine-readable message pointing you to a worktree. If you hit one,
+you are editing main directly — stop and follow the correct path above.
+
+> Residual: arbitrary in-process writers (e.g. a `python -c "open(...,'w')"` script)
+> are not parsed; the guard covers the common shell idioms. Prefer the edit tools +
+> a worktree so the structured enforcer always applies.

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -56,23 +56,34 @@ _SHELL_DEV_SINKS = {"/dev/null", "/dev/stdout", "/dev/stderr", "/dev/tty"}
 _REDIRECT_RE = re.compile(r"(?<![0-9&>])>>?\s*([^\s;&|<>()`]+)")
 _TEE_RE = re.compile(r"\btee\b\s+(?:-{1,2}\S+\s+)*([^\s;&|<>()`]+)")
 # sed in-place: take the last bare token of the sed command segment as the target.
+# (Multi-file `sed -i s f1 f2` checks the last file only — a documented residual.)
 _SED_I_RE = re.compile(r"\bsed\b\s+[^|;&\n]*?-i\S*\s+[^|;&\n]*?\s([^\s;&|<>()`]+)(?=\s|$|;|\||&)")
 # cp/mv/install: destination is the last token of the command segment.
 _CP_MV_RE = re.compile(r"\b(?:cp|mv|install)\b\s+[^|;&\n]*?\s([^\s;&|<>()`]+)(?=\s|$|;|\||&)")
+# dd of=PATH (#2995 cross-family review): a common non-redirect file writer.
+_DD_RE = re.compile(r"\bdd\b[^|;&\n]*?\bof=([^\s;&|<>()`]+)")
 
 def shell_write_targets(joined: str) -> list[str]:
     """Best-effort extraction of file-write targets from a shell command.
 
     Covers the common idioms an agent uses to mutate files via the terminal:
-    `> f`, `>> f`, `tee f`, `sed -i ... f`, `cp/mv/install ... f`. fd-redirects
-    (`2>&1`, `>&2`) and `/dev/*` sinks are excluded. Returns raw target tokens;
-    callers MUST pass each through evaluate_path() — that is the deny/allow
+    `> f`, `>> f`, `tee f`, `sed -i ... f`, `cp/mv/install ... f`, `dd of=f`.
+    fd-redirects (`2>&1`, `>&2`) and `/dev/*` sinks are excluded. Returns raw target
+    tokens; callers MUST pass each through evaluate_path() — that is the deny/allow
     authority, so over-extraction here is harmless (non-repo / gitignored targets
     resolve to ALLOW). Fail-open: any parse error yields [] (never brick the hook).
+
+    RESIDUAL (defense-in-depth, not airtight — documented per #2995 cross-family
+    review): arbitrary in-process writers (`python -c "open(...,'w')"`,
+    `node -e fs.writeFileSync`), `patch < diff`, non-interactive editors
+    (`vim -c w`, `emacs --batch`), and multi-file `sed -i` (last file only) are NOT
+    parsed — they cannot be detected by static shell-token analysis. The structured
+    edit-tool enforcer (evaluate_path on Edit/Write/create_file/...) remains the
+    primary guard; this closes the common terminal-write idioms.
     """
     targets: list[str] = []
     try:
-        for regex in (_REDIRECT_RE, _TEE_RE, _SED_I_RE, _CP_MV_RE):
+        for regex in (_REDIRECT_RE, _TEE_RE, _SED_I_RE, _CP_MV_RE, _DD_RE):
             for match in regex.finditer(joined):
                 token = match.group(1).strip().strip("\"'")
                 if not token or token.startswith("-") or token.startswith("&"):

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -46,6 +46,44 @@ def detect_it_ops_bypass(joined: str, env: dict | None = None) -> tuple[bool, st
         return True, "commit-subject-marker"
     return False, None
 
+# #2995: shell-level write-target detection — closes the canonical-main blind spot
+# where terminal writes (redirect / sed -i / tee / cp / mv) mutate tracked files,
+# bypassing the structured-edit-tool enforcer. evaluate_path() is the deny/allow
+# authority (only tracked, non-gitignored, in-repo paths are denied), so generous
+# extraction is safe; the extractor only narrows WHICH tokens to evaluate.
+_SHELL_DEV_SINKS = {"/dev/null", "/dev/stdout", "/dev/stderr", "/dev/tty"}
+# `>`/`>>` file redirects; lookbehind excludes fd-dup forms (2>, &>, >&N).
+_REDIRECT_RE = re.compile(r"(?<![0-9&>])>>?\s*([^\s;&|<>()`]+)")
+_TEE_RE = re.compile(r"\btee\b\s+(?:-{1,2}\S+\s+)*([^\s;&|<>()`]+)")
+# sed in-place: take the last bare token of the sed command segment as the target.
+_SED_I_RE = re.compile(r"\bsed\b\s+[^|;&\n]*?-i\S*\s+[^|;&\n]*?\s([^\s;&|<>()`]+)(?=\s|$|;|\||&)")
+# cp/mv/install: destination is the last token of the command segment.
+_CP_MV_RE = re.compile(r"\b(?:cp|mv|install)\b\s+[^|;&\n]*?\s([^\s;&|<>()`]+)(?=\s|$|;|\||&)")
+
+def shell_write_targets(joined: str) -> list[str]:
+    """Best-effort extraction of file-write targets from a shell command.
+
+    Covers the common idioms an agent uses to mutate files via the terminal:
+    `> f`, `>> f`, `tee f`, `sed -i ... f`, `cp/mv/install ... f`. fd-redirects
+    (`2>&1`, `>&2`) and `/dev/*` sinks are excluded. Returns raw target tokens;
+    callers MUST pass each through evaluate_path() — that is the deny/allow
+    authority, so over-extraction here is harmless (non-repo / gitignored targets
+    resolve to ALLOW). Fail-open: any parse error yields [] (never brick the hook).
+    """
+    targets: list[str] = []
+    try:
+        for regex in (_REDIRECT_RE, _TEE_RE, _SED_I_RE, _CP_MV_RE):
+            for match in regex.finditer(joined):
+                token = match.group(1).strip().strip("\"'")
+                if not token or token.startswith("-") or token.startswith("&"):
+                    continue
+                if token in _SHELL_DEV_SINKS:
+                    continue
+                targets.append(token)
+    except Exception:
+        return []
+    return targets
+
 def current_branch(cwd: str) -> str | None:
     try:
         res = subprocess.run(["git", "branch", "--show-current"], cwd=cwd,
@@ -172,6 +210,18 @@ def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
         sw = RE_BRANCH_SWITCH.search(joined)
         if sw and sw.group(1) not in ("main", "master"):
             return emit("deny", f"Canonical-main read-only: branch switch to '{sw.group(1)}' from main checkout rejected (#2107). Use a worktree (devenv-ops-<team-or-ticket>/) instead.")
+        # #2995: close the shell-level-write blind spot. Terminal writes (redirect,
+        # sed -i, tee, cp, mv) to a tracked main file bypass the structured-edit-tool
+        # enforcer; evaluate_path() denies tracked/non-gitignored in-repo targets.
+        # IT-ops markers are intentionally NOT consulted here — they waive ticket/baton
+        # ceremony only, never the canonical-main read-only policy.
+        for target in shell_write_targets(joined):
+            allowed, reason = evaluate_path(target, cwd)
+            if not allowed:
+                return emit("deny",
+                    f"Canonical-main read-only (#2995): shell write to '{target}' rejected. {reason} "
+                    "IT-ops markers do NOT authorize tracked-file edits in main — use a dedicated "
+                    "worktree (devenv-ops-<team-or-ticket>/) + ticket branch.")
     m = RE_BRANCH_CREATE.search(joined)
     if m and not BRANCH_VALID.match(m.group(1)):
         return emit("deny",f"Branch '{m.group(1)}' violates naming. Use feat/<ticket#>-desc.")

--- a/tests/canonical-main-shell-write.spec.js
+++ b/tests/canonical-main-shell-write.spec.js
@@ -1,0 +1,24 @@
+'use strict';
+// tests/canonical-main-shell-write.spec.js — tdd-pyramid evidence bridge for #2995.
+// The shell-write canonical-main guard lives in a Python hook (pretool_guard.py), so its
+// real tests are pytest (tests/hooks/test_pretool_guard_shell_write_main.py). The
+// test-evidence gate only recognizes tests/**/*.spec.{js,ts} for tdd-pyramid (known
+// validator gap #2980), so this spec EXECUTES the Python suite and fails if it fails —
+// genuine evidence, not a stub. Refs #2995, #2980.
+const test = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+test('python shell-write canonical-main guard suite passes', () => {
+  const result = spawnSync(
+    'python3',
+    ['-m', 'unittest', 'tests.hooks.test_pretool_guard_shell_write_main'],
+    { cwd: REPO_ROOT, encoding: 'utf8' },
+  );
+  // unittest writes its summary to stderr; surface it on failure for diagnosis.
+  assert.strictEqual(result.status, 0,
+    `pytest/unittest suite failed (exit ${result.status}):\n${result.stderr || result.stdout}`);
+});

--- a/tests/hooks/test_pretool_guard_shell_write_main.py
+++ b/tests/hooks/test_pretool_guard_shell_write_main.py
@@ -1,0 +1,119 @@
+"""Canonical-main SHELL-LEVEL-write guard tests (#2995).
+
+Closes the documented blind spot where terminal writes (redirect / sed -i / tee /
+cp / mv) mutate tracked main files, bypassing the structured-edit-tool enforcer.
+evaluate_path() is the deny/allow authority; these tests pin both the extractor
+(shell_write_targets) and the check_terminal integration, incl. the IT-marker
+non-authorization (AC3) and the no-over-block guarantee (AC2)."""
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "hooks" / "scripts"))
+
+import pretool_guard  # noqa: E402
+
+
+class ShellWriteTargetExtractor(unittest.TestCase):
+    """Unit: shell_write_targets covers the common write idioms, excludes fd-dups + dev sinks."""
+
+    def test_redirect_truncate(self):
+        self.assertIn("foo.py", pretool_guard.shell_write_targets("echo x > foo.py"))
+
+    def test_redirect_append(self):
+        self.assertIn("bar.txt", pretool_guard.shell_write_targets("cat a >> bar.txt"))
+
+    def test_sed_inplace(self):
+        self.assertIn("baz.py", pretool_guard.shell_write_targets("sed -i 's/a/b/' baz.py"))
+
+    def test_tee(self):
+        self.assertIn("qux.md", pretool_guard.shell_write_targets("echo x | tee qux.md"))
+
+    def test_cp_dest(self):
+        self.assertIn("dest.js", pretool_guard.shell_write_targets("cp src.js dest.js"))
+
+    def test_mv_dest(self):
+        self.assertIn("b.py", pretool_guard.shell_write_targets("mv a.py b.py"))
+
+    def test_dev_null_excluded(self):
+        self.assertEqual(pretool_guard.shell_write_targets("echo x > /dev/null"), [])
+
+    def test_fd_dup_excluded(self):
+        # 2>&1 and >&2 are fd redirects, not file writes.
+        self.assertEqual(pretool_guard.shell_write_targets("run_cmd 2>&1"), [])
+        self.assertEqual(pretool_guard.shell_write_targets("run_cmd >&2"), [])
+
+    def test_tmp_extracted_but_harmless(self):
+        # Extracted, but evaluate_path will ALLOW a non-repo target — extractor stays generous.
+        self.assertIn("/tmp/out", pretool_guard.shell_write_targets("ls > /tmp/out"))
+
+    def test_malformed_failopen(self):
+        # Never raise — fail-open returns a list (possibly empty).
+        self.assertIsInstance(pretool_guard.shell_write_targets(">>>|&;"), list)
+
+
+class CheckTerminalShellWriteGuard(unittest.TestCase):
+    """Integration: check_terminal denies tracked-main shell writes, allows the rest."""
+
+    def _state(self):
+        return {"flags": {}, "admin_ops": {}, "repo_type": "generic"}
+
+    def _run(self, cmd, *, path_allowed):
+        """Run check_terminal in a simulated main checkout; evaluate_path stubbed
+        to (path_allowed, reason). Returns the captured (decision, reason)."""
+        captured = {}
+
+        def fake_emit(decision, reason, extra=None):
+            captured["decision"] = decision
+            captured["reason"] = reason
+            return 0
+
+        with patch("pretool_guard.is_main_checkout", return_value=True), \
+                patch("pretool_guard.active_ticket_is_no_code_lane", return_value=False), \
+                patch("pretool_guard.evaluate_path",
+                      return_value=(path_allowed, "tracked" if not path_allowed else "gitignored")), \
+                patch("pretool_guard.emit", side_effect=fake_emit):
+            pretool_guard.check_terminal(cmd, self._state(), str(REPO_ROOT))
+        return captured
+
+    def test_tracked_main_shell_write_denied(self):
+        # AC1: write to a tracked main file via redirect is DENIED with worktree guidance.
+        cap = self._run("echo x > hooks/scripts/pretool_guard.py", path_allowed=False)
+        self.assertEqual(cap.get("decision"), "deny")
+        self.assertIn("worktree", cap.get("reason", ""))
+
+    def test_gitignored_shell_write_allowed(self):
+        # AC2: write to a gitignored/non-repo path must NOT be denied by this guard (no over-block).
+        cap = self._run("echo x > .env", path_allowed=True)
+        self.assertNotEqual(cap.get("decision"), "deny")
+
+    def test_it_marker_does_not_authorize_tracked_write(self):
+        # AC3: an IT-ops marker in the command does NOT waive canonical-main read-only.
+        cap = self._run("echo cfg > config/governance-rules.yaml # [it-ops]", path_allowed=False)
+        self.assertEqual(cap.get("decision"), "deny")
+        self.assertIn("IT-ops markers do NOT authorize", cap.get("reason", ""))
+
+    def test_sed_inplace_tracked_main_denied(self):
+        cap = self._run("sed -i 's/a/b/' scripts/lint.js", path_allowed=False)
+        self.assertEqual(cap.get("decision"), "deny")
+
+    def test_non_main_checkout_skips_guard(self):
+        # In a worktree (is_main_checkout False) the shell-write guard does not fire.
+        captured = {}
+
+        def fake_emit(decision, reason, extra=None):
+            captured["decision"] = decision
+            return 0
+
+        with patch("pretool_guard.is_main_checkout", return_value=False), \
+                patch("pretool_guard.active_ticket_is_no_code_lane", return_value=False), \
+                patch("pretool_guard.emit", side_effect=fake_emit):
+            pretool_guard.check_terminal("echo x > hooks/scripts/pretool_guard.py",
+                                         self._state(), "/home/u/devenv-ops-2995")
+        self.assertNotEqual(captured.get("decision"), "deny")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hooks/test_pretool_guard_shell_write_main.py
+++ b/tests/hooks/test_pretool_guard_shell_write_main.py
@@ -37,6 +37,10 @@ class ShellWriteTargetExtractor(unittest.TestCase):
     def test_mv_dest(self):
         self.assertIn("b.py", pretool_guard.shell_write_targets("mv a.py b.py"))
 
+    def test_dd_of(self):
+        # #2995 cross-family review: dd of=PATH is a non-redirect file writer.
+        self.assertIn("out.bin", pretool_guard.shell_write_targets("dd if=/dev/zero of=out.bin bs=1M count=1"))
+
     def test_dev_null_excluded(self):
         self.assertEqual(pretool_guard.shell_write_targets("echo x > /dev/null"), [])
 


### PR DESCRIPTION
Refs #2995

merge-evidence-deferred-final: #2995

## Summary
Closes the **shell-level-write blind spot** in canonical-main enforcement (#2995, self-anneal from the cross-team incident where tracked files were edited directly in main). The structured-edit-tool enforcer already blocks `Edit`/`Write`/`replace_string_in_file`/`create_file` to tracked main paths and IT-markers never bypassed it — but terminal writes (`>`, `>>`, `sed -i`, `tee`, `cp`, `mv`, `dd of=`) were unguarded. This adds a shell-write-target extractor in `pretool_guard.check_terminal` that routes each target through `evaluate_path()` and denies tracked/non-gitignored main writes with a worktree-redirect message.

## Why this guardrails all teams
The deny message explicitly states **IT-ops markers do NOT authorize tracked-file edits** (they waive ticket/baton ceremony only). Applies to every runtime once deployed.

## Test evidence
`python3 -m unittest tests.hooks.test_pretool_guard_shell_write_main` → **16/16**; full `pretool_guard` suite **78/78** (no regression); `ruff` clean.

## Cross-family review (non-Anthropic, two families)
- groq:llama-3.3-70b (Meta) → **ACCEPT 10/10**
- gemini-2.5-flash (Google) → round-1 PARTIAL (found `dd of=` bypass + residuals) → **fixed `dd`, documented unparseable residuals** (interpreter/`patch`/editor writes — defense-in-depth, structured-edit enforcer is primary) → round-2 **ACCEPT 9/10**

## Fail-safety
Fail-open on parse error (never bricks the hook — the #2972 lesson); `evaluate_path()` is the deny authority so non-repo/gitignored targets are unaffected (no over-block).

## Docs
Adds `docs/howto/canonical-main-write-boundary.md` (IT-vs-delivery boundary, correct worktree path).

## Baton artifacts (full set on #2995)
COLLABORATOR_HANDOFF — Orla Harper; 16+78 tests; cross_family 10/10 + 9/10.
ADMIN_HANDOFF — Orla Reyes; signer-independence PASS; deploy-runtime-impact noted (deploy:apply post-merge).
CONSULTANT_CLOSEOUT — Orla Vale; approve_for_merge; rubric G1-9=9; residual follow-on (git-level pre-commit-on-main backstop) noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
