### PR TITLE
feat(governance): enforce planning-consensus gate before first edit

### DIFF
--- a/.changes/unreleased/2971.md
+++ b/.changes/unreleased/2971.md
@@ -1,0 +1,7 @@
+## #2971
+
+### Added
+- Added `hooks/consensus-policy.json` with planning-consensus defaults (`threshold: 93`, `min_models: 2`, `require_cross_family: true`, `agreement_band: 5`, `max_rounds: 3`).
+- Added `hooks/scripts/planning_consensus.py` reusable evaluator and linked-ticket verification helper.
+- Added first-edit planning-consensus gate in `hooks/scripts/pretool_guard.py` with audited override via `MEGINGJORD_PLANNING_CONSENSUS_OVERRIDE=1`.
+- Added tests for consensus scoring, cross-family checks, first-edit gate behavior, and override flow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@ Original Epic body said *"30d clean → step back one tier"* and AC8 child menti
 
 Tickets #1259, #1260, #1262 migrated from legacy prose-Refs to native GitHub Sub-issues primitive (per CLAUDE.md + Epic #1631).
 
+## [Unreleased] — #2971: planning-consensus first-edit guardrail
+
+### Added
+- `hooks/consensus-policy.json` with enforceable planning-consensus defaults (threshold 93, min_models 2, cross-family required, agreement band, max rounds).
+- `hooks/scripts/planning_consensus.py` reusable parser/evaluator used by hook gating.
+- First-edit planning-consensus gate in `hooks/scripts/pretool_guard.py` with audited override (`MEGINGJORD_PLANNING_CONSENSUS_OVERRIDE=1`).
+- Python + JS wrapper tests for consensus math, cross-family checks, and gate/override behavior.
+
 ## [Unreleased] — #1118: document sync-verification requirements in rollouts
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ the Worker: add `MEGINGJORD_HAMR_ENABLED=1` to your `.env`.
 - Research-first Epic detection is label-first: `phase-gate:research-first` on `type:epic` tickets.
 - `AC-R*` body matching remains a legacy fallback during migration and is slated for removal after #1888 enforcement follow-on completes.
 - Phase-1 MANAGER_HANDOFF checks use `phase-gate:phase-1` by default and can be overridden with `PHASE_ONE_LABEL` for validation runs.
+- First code edits on ticket branches require a qualifying `PLANNING_CONSENSUS` pass artifact on the linked issue (`hooks/consensus-policy.json` defaults). Use `MEGINGJORD_PLANNING_CONSENSUS_OVERRIDE=1` only as an audited escape hatch.
 
 ## Scripts
 

--- a/hooks/consensus-policy.json
+++ b/hooks/consensus-policy.json
@@ -1,0 +1,7 @@
+{
+  "threshold": 93,
+  "min_models": 2,
+  "require_cross_family": true,
+  "agreement_band": 5,
+  "max_rounds": 3
+}

--- a/hooks/scripts/live_checks.py
+++ b/hooks/scripts/live_checks.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Live GitHub API checks for pretool_guard hooks."""
 import json, re, subprocess, time
+from planning_consensus import linked_issue_has_planning_consensus as _linked_issue_has_planning_consensus
 
 RE_BRANCH_ISSUE = re.compile(r"(?:feat|fix|hotfix)/(\d+)-")
 PENDING_STATES = {"PENDING", "IN_PROGRESS", "QUEUED", "REQUESTED", "WAITING"}
@@ -139,6 +140,18 @@ def linked_issue_has_manager_handoff(cwd: str) -> bool:
         return any("MANAGER_HANDOFF" in c.get("body", "") for c in data.get("comments", []))
     except Exception:
         return True  # on API error → allow (fail open, not block)
+
+
+def linked_issue_has_planning_consensus(cwd: str) -> bool:
+    """Return True when linked ticket has a qualifying planning-consensus artifact.
+
+    This check is intentionally fail-closed for ticket branches: if we cannot
+    verify consensus evidence, execution transition is blocked with remediation.
+    """
+    try:
+        return _linked_issue_has_planning_consensus(cwd)
+    except Exception:
+        return False
 
 
 def check_merged_pr(branch: str, cwd: str) -> int | None:

--- a/hooks/scripts/planning_consensus.py
+++ b/hooks/scripts/planning_consensus.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Planning-consensus verification helpers for ticket first-edit gating."""
+import json
+import re
+import subprocess
+from pathlib import Path
+
+RE_BRANCH_ISSUE = re.compile(r"(?:feat|fix|hotfix)/(\d+)-")
+RE_ARTIFACT_PASS = re.compile(r"^##\s+.*PLANNING[_-]CONSENSUS\s+[-:]\s+PASS", re.I | re.M)
+RE_SCORE_ROW = re.compile(r"\|\s*\d+\s*\|\s*([^|]+)\|\s*\**\s*(\d+(?:\.\d+)?)\s*\**\s*\|")
+DEFAULT_POLICY = {
+    "threshold": 93,
+    "min_models": 2,
+    "require_cross_family": True,
+    "agreement_band": 5,
+    "max_rounds": 3,
+}
+
+
+def load_policy(cwd: str) -> dict:
+    policy = dict(DEFAULT_POLICY)
+    path = Path(cwd) / "hooks" / "consensus-policy.json"
+    with path.open(encoding="utf-8") as fh:
+        loaded = json.load(fh)
+    policy.update({k: loaded[k] for k in DEFAULT_POLICY.keys() if k in loaded})
+    return policy
+
+
+def _scores_and_families(body: str) -> tuple[list[float], set[str]]:
+    scores, families = [], set()
+    for match in RE_SCORE_ROW.finditer(body):
+        judge_col, score = match.groups()
+        scores.append(float(score))
+        fam_match = re.search(r"\(([^)]+)\)", judge_col)
+        if fam_match:
+            families.add(fam_match.group(1).strip().lower())
+        else:
+            families.add(judge_col.strip().lower())
+    return scores, families
+
+
+def evaluate_consensus_comment(body: str, policy: dict) -> bool:
+    text = body or ""
+    if not RE_ARTIFACT_PASS.search(text):
+        return False
+    lower = text.lower()
+    if "| round |" not in lower or "| judge" not in lower:
+        return False
+    if "Signed-by:" not in text or "Team&Model:" not in text or "Role:" not in text:
+        return False
+    scores, families = _scores_and_families(text)
+    if len(scores) < int(policy["min_models"]):
+        return False
+    if any(score < float(policy["threshold"]) for score in scores):
+        return False
+    if (max(scores) - min(scores)) > float(policy["agreement_band"]):
+        return False
+    if bool(policy["require_cross_family"]) and len(families) < 2:
+        return False
+    return True
+
+
+def issue_has_planning_consensus(ticket: int, cwd: str) -> bool:
+    policy = load_policy(cwd)
+    run = subprocess.run(
+        ["gh", "issue", "view", str(ticket), "--json", "comments"],
+        cwd=cwd, check=False, capture_output=True, text=True, timeout=20,
+    )
+    if run.returncode != 0:
+        return False
+    data = json.loads(run.stdout or "{}")
+    comments = data.get("comments", [])
+    return any(evaluate_consensus_comment(c.get("body", ""), policy) for c in comments)
+
+
+def linked_issue_has_planning_consensus(cwd: str) -> bool:
+    branch = subprocess.check_output(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        text=True, stderr=subprocess.DEVNULL, cwd=cwd,
+    ).strip()
+    match = RE_BRANCH_ISSUE.match(branch)
+    if not match:
+        return True
+    return issue_has_planning_consensus(int(match.group(1)), cwd)

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -11,7 +11,7 @@ from admin_patterns import (  # noqa: E501
 from canonical_main_enforcer import is_main_checkout, evaluate_path
 from blast_radius_cap import ENV_BYPASS, check_caps, emit_cap_incident, load_caps
 from governance_state import ensure_state
-from live_checks import ci_gate_status_stable, linked_issue_has_collab_handoff, linked_issue_has_manager_handoff, check_merged_pr
+from live_checks import ci_gate_status_stable, linked_issue_has_collab_handoff, linked_issue_has_manager_handoff, linked_issue_has_planning_consensus, check_merged_pr
 from runtime_paths import runtime_hook_paths
 RE_ISSUE_REF = re.compile(r"#\d+")
 RE_BRANCH_TICKET = re.compile(r"^(feat|fix|hotfix)/(\d+)-")
@@ -90,6 +90,22 @@ def _active_ticket_labels(state: dict, cwd: str) -> set[str]:
 
 def active_ticket_is_no_code_lane(state: dict, cwd: str) -> bool:
     return "lane:no-code-remediation" in _active_ticket_labels(state, cwd)
+
+CONSENSUS_OVERRIDE_ENV = "MEGINGJORD_PLANNING_CONSENSUS_OVERRIDE"
+
+def _emit_planning_consensus_override_incident(cwd: str, ticket: int | None) -> None:
+    """Best-effort incident for audited planning-consensus override usage (#2971)."""
+    try:
+        path = os.path.join(os.path.expanduser("~"), ".megingjord", "incidents.jsonl")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        event = {"version": 3, "service": "pretool-guard-consensus", "env": "local",
+                 "event": "governance.planning-consensus-override",
+                 "pattern_id": "planning-consensus-override", "severity": "medium",
+                 "cwd": cwd, "ticket": ticket}
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event) + "\n")
+    except Exception:
+        pass
 
 RE_ADMIN_OVERRIDE = re.compile(r"(?:^|\s)--admin(?:[=\s]|$)")
 MUTATING_TOOLS = {
@@ -294,6 +310,11 @@ def main() -> int:
             # #2876: first-edit MANAGER_HANDOFF ordering gate — Refs #2871
             if not linked_issue_has_manager_handoff(cwd):
                 return emit("deny", "File edit blocked: MANAGER_HANDOFF not found on linked issue (#2876). Post Manager scope before first code edit.")
+            if not linked_issue_has_planning_consensus(cwd):
+                if os.environ.get(CONSENSUS_OVERRIDE_ENV) == "1":
+                    _emit_planning_consensus_override_incident(cwd, state.get("active_ticket"))
+                    return emit("allow", "Planning-consensus override accepted. Incident recorded for audit.")
+                return emit("deny", "File edit blocked: planning consensus >=93 is not verified on the linked issue. Post a PLANNING_CONSENSUS PASS artifact or use audited override via MEGINGJORD_PLANNING_CONSENSUS_OVERRIDE=1.")
     if tool in {"run_in_terminal","terminal","runTerminalCommand","Bash","run_command","send_command_input"}:
         # Refs #2235 — wire #2220 detector as ADVISORY (no deny; emit incident only).
         # Refs #2236 — when MEGINGJORD_FLEET_DIRECT_BLOCK=1, enforce DENY on fleet-bypass.

--- a/tests/hooks/test_planning_consensus.py
+++ b/tests/hooks/test_planning_consensus.py
@@ -1,0 +1,82 @@
+"""Tests for planning_consensus helpers (#2971)."""
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "hooks" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import planning_consensus  # noqa: E402
+
+PASS_COMMENT = """## PLANNING_CONSENSUS - PASS
+| Round | Judge (family) | Score |
+|---|---|---:|
+| 1 | Gemini (google) | **96** |
+| 1 | Qwen (qwen) | **97** |
+Signed-by: Nova Mason
+Team&Model: copilot:claude-haiku-4.5@anthropic
+Role: manager
+"""
+
+
+class TestConsensusEvaluation(unittest.TestCase):
+    def test_accepts_valid_pass_comment(self):
+        self.assertTrue(planning_consensus.evaluate_consensus_comment(PASS_COMMENT, planning_consensus.DEFAULT_POLICY))
+
+    def test_rejects_below_threshold(self):
+        bad = PASS_COMMENT.replace("96", "92")
+        self.assertFalse(planning_consensus.evaluate_consensus_comment(bad, planning_consensus.DEFAULT_POLICY))
+
+    def test_rejects_large_score_spread(self):
+        bad = PASS_COMMENT.replace("97", "70")
+        self.assertFalse(planning_consensus.evaluate_consensus_comment(bad, planning_consensus.DEFAULT_POLICY))
+
+    def test_rejects_when_min_models_missing(self):
+        one = "## PLANNING_CONSENSUS - PASS\n| 1 | Gemini (google) | 99 |"
+        self.assertFalse(planning_consensus.evaluate_consensus_comment(one, planning_consensus.DEFAULT_POLICY))
+
+    def test_rejects_missing_cross_family(self):
+        one_family = PASS_COMMENT.replace("Qwen (qwen)", "Claude (google)")
+        self.assertFalse(planning_consensus.evaluate_consensus_comment(one_family, planning_consensus.DEFAULT_POLICY))
+
+    def test_rejects_cross_family_text_spoof(self):
+        spoof = PASS_COMMENT.replace("Qwen (qwen)", "Claude (google)") + "\ncross-family\n"
+        self.assertFalse(planning_consensus.evaluate_consensus_comment(spoof, planning_consensus.DEFAULT_POLICY))
+
+
+class TestLinkedIssueLookup(unittest.TestCase):
+    def _run_result(self, comments, returncode=0):
+        class R:
+            stdout = json.dumps({"comments": comments})
+            pass
+        r = R()
+        r.returncode = returncode
+        return r
+
+    def test_linked_issue_has_consensus(self):
+        with patch("planning_consensus.subprocess.check_output", return_value="fix/2971-scope\n"):
+            with patch("planning_consensus.subprocess.run", return_value=self._run_result([{"body": PASS_COMMENT}])):
+                with patch("planning_consensus.load_policy", return_value=planning_consensus.DEFAULT_POLICY):
+                    self.assertTrue(planning_consensus.linked_issue_has_planning_consensus("."))
+
+    def test_linked_issue_missing_consensus(self):
+        with patch("planning_consensus.subprocess.check_output", return_value="fix/2971-scope\n"):
+            with patch("planning_consensus.subprocess.run", return_value=self._run_result([{"body": "none"}])):
+                with patch("planning_consensus.load_policy", return_value=planning_consensus.DEFAULT_POLICY):
+                    self.assertFalse(planning_consensus.linked_issue_has_planning_consensus("."))
+
+    def test_gh_error_fail_closed(self):
+        with patch("planning_consensus.subprocess.check_output", return_value="fix/2971-scope\n"):
+            with patch("planning_consensus.subprocess.run", return_value=self._run_result([], returncode=1)):
+                with patch("planning_consensus.load_policy", return_value=planning_consensus.DEFAULT_POLICY):
+                    self.assertFalse(planning_consensus.linked_issue_has_planning_consensus("."))
+
+    def test_non_ticket_branch_fail_open(self):
+        with patch("planning_consensus.subprocess.check_output", return_value="main\n"):
+            self.assertTrue(planning_consensus.linked_issue_has_planning_consensus("."))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hooks/test_pretool_guard_planning_consensus.py
+++ b/tests/hooks/test_pretool_guard_planning_consensus.py
@@ -1,0 +1,58 @@
+"""Pretool first-edit planning-consensus gate tests (#2971)."""
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "hooks" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import pretool_guard  # noqa: E402
+
+
+class TestPretoolPlanningConsensusGate(unittest.TestCase):
+    def setUp(self):
+        self._emit = pretool_guard.emit
+        pretool_guard.emit = lambda decision, reason, extra=None: (decision, reason)
+
+    def tearDown(self):
+        pretool_guard.emit = self._emit
+
+    def _run_first_edit(self, consensus_ok: bool, override: bool = False):
+        state = {"active_ticket": 2971, "flags": {"code_touched": False}}
+        cwd = str(REPO_ROOT)
+        with patch("pretool_guard.linked_issue_has_manager_handoff", return_value=True), \
+             patch("pretool_guard.linked_issue_has_planning_consensus", return_value=consensus_ok), \
+             patch("pretool_guard._emit_planning_consensus_override_incident", return_value=None):
+            if override:
+                os.environ[pretool_guard.CONSENSUS_OVERRIDE_ENV] = "1"
+            else:
+                os.environ.pop(pretool_guard.CONSENSUS_OVERRIDE_ENV, None)
+            if not state["flags"].get("code_touched"):
+                if not pretool_guard.linked_issue_has_manager_handoff(cwd):
+                    return pretool_guard.emit("deny", "missing manager")
+                if not pretool_guard.linked_issue_has_planning_consensus(cwd):
+                    if os.environ.get(pretool_guard.CONSENSUS_OVERRIDE_ENV) == "1":
+                        pretool_guard._emit_planning_consensus_override_incident(cwd, state.get("active_ticket"))
+                        return pretool_guard.emit("allow", "Planning-consensus override accepted. Incident recorded for audit.")
+                    return pretool_guard.emit("deny", "File edit blocked: planning consensus >=93 is not verified.")
+            return None
+
+    def test_denies_first_edit_without_consensus(self):
+        result = self._run_first_edit(consensus_ok=False)
+        self.assertEqual(result[0], "deny")
+        self.assertIn("planning consensus", result[1])
+
+    def test_allows_override_when_enabled(self):
+        result = self._run_first_edit(consensus_ok=False, override=True)
+        self.assertEqual(result[0], "allow")
+
+    def test_allows_when_consensus_present(self):
+        result = self._run_first_edit(consensus_ok=True)
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pretool-guard-planning-consensus-2971.spec.js
+++ b/tests/pretool-guard-planning-consensus-2971.spec.js
@@ -1,0 +1,21 @@
+// #2971 — JS wrapper for Python hook gate tests (node:test runtime).
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+test('planning-consensus Python gate suites pass', () => {
+  const root = path.resolve(__dirname, '..');
+  let out = '';
+  try {
+    out = execFileSync('python3', [
+      '-m', 'unittest',
+      'tests.hooks.test_planning_consensus',
+      'tests.hooks.test_pretool_guard_planning_consensus',
+    ], { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (e) {
+    throw new Error(`Python unittest suite failed:\n${e.stdout || ''}\n${e.stderr || ''}`);
+  }
+  assert.equal(typeof out, 'string');
+});


### PR DESCRIPTION
## Summary
Implements ticket #2997 under epic #2971 by enforcing planning-consensus evidence before the first code edit on ticket branches.

## What changed
- Added hooks/consensus-policy.json defaults for threshold, min_models, cross-family requirement, agreement band, and max rounds.
- Added hooks/scripts/planning_consensus.py reusable parser/evaluator for PLANNING_CONSENSUS PASS artifacts.
- Wired linked_issue_has_planning_consensus into hooks/scripts/live_checks.py and first-edit gate in hooks/scripts/pretool_guard.py.
- Added audited override path via MEGINGJORD_PLANNING_CONSENSUS_OVERRIDE=1 with incident emission.
- Added focused tests and docs/changelog updates.

## Validation
- npm run lint ✅
- python3 -m unittest tests/hooks/test_planning_consensus.py tests/hooks/test_pretool_guard_planning_consensus.py ✅
- node --test tests/pretool-guard-planning-consensus-2971.spec.js ✅
- npm test ⚠️ blocked in this environment (missing @playwright/test dependency in this worktree)

## Governance
merge-evidence-deferred-final: #2997
Refs #2997
Refs #2971