### PR TITLE
fix(hooks): stop shell-write guard over-blocking arrow tokens

### DIFF
--- a/.changes/unreleased/3001.md
+++ b/.changes/unreleased/3001.md
@@ -1,0 +1,6 @@
+### Fixed
+- Canonical-main shell-write guard (#2995) no longer over-blocks: the output-redirect pattern is
+  now anchored to a word boundary, so arrow tokens (`->`, `=>`) and inline comparisons inside a
+  command string are no longer mis-parsed as redirects and denied. Genuine ` > file`, ` >> file`,
+  and fd ` 2> file` redirects to tracked main paths are still denied; `2>&1`/`>&2` fd-dups stay
+  excluded. (#3001, refining #2995)

--- a/.changes/unreleased/3001.md
+++ b/.changes/unreleased/3001.md
@@ -1,6 +1,6 @@
 ### Fixed
 - Canonical-main shell-write guard (#2995) no longer over-blocks: the output-redirect pattern is
   now anchored to a word boundary, so arrow tokens (`->`, `=>`) and inline comparisons inside a
-  command string are no longer mis-parsed as redirects and denied. Genuine ` > file`, ` >> file`,
-  and fd ` 2> file` redirects to tracked main paths are still denied; `2>&1`/`>&2` fd-dups stay
-  excluded. (#3001, refining #2995)
+  command string are no longer mis-parsed as redirects and denied. Genuine `>file`, `>>file`, and
+  fd `2>file` redirects to tracked main paths are still denied; `2>&1`/`>&2` fd-dups stay excluded.
+  (#3001, refining #2995)

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -52,8 +52,13 @@ def detect_it_ops_bypass(joined: str, env: dict | None = None) -> tuple[bool, st
 # authority (only tracked, non-gitignored, in-repo paths are denied), so generous
 # extraction is safe; the extractor only narrows WHICH tokens to evaluate.
 _SHELL_DEV_SINKS = {"/dev/null", "/dev/stdout", "/dev/stderr", "/dev/tty"}
-# `>`/`>>` file redirects; lookbehind excludes fd-dup forms (2>, &>, >&N).
-_REDIRECT_RE = re.compile(r"(?<![0-9&>])>>?\s*([^\s;&|<>()`]+)")
+# `>`/`>>` file redirects, anchored to a word boundary (#3001): the operator must be
+# at start-of-string or after whitespace, optionally with a leading fd digit. This
+# excludes arrow tokens (`->`, `=>`) and inline comparisons (`a>b`) that previously
+# matched and over-blocked. fd-dup forms (`2>&1`, `>&2`) are excluded because the
+# capture class rejects a leading `&`. (Residual: `&>file` all-output redirect is not
+# matched — uncommon; tee/redirect/dd cover the usual writers.)
+_REDIRECT_RE = re.compile(r"(?:^|\s)\d*>>?\s*([^\s;&|<>()`]+)")
 _TEE_RE = re.compile(r"\btee\b\s+(?:-{1,2}\S+\s+)*([^\s;&|<>()`]+)")
 # sed in-place: take the last bare token of the sed command segment as the target.
 # (Multi-file `sed -i s f1 f2` checks the last file only — a documented residual.)

--- a/tests/canonical-main-shell-write.spec.js
+++ b/tests/canonical-main-shell-write.spec.js
@@ -5,6 +5,8 @@
 // test-evidence gate only recognizes tests/**/*.spec.{js,ts} for tdd-pyramid (known
 // validator gap #2980), so this spec EXECUTES the Python suite and fails if it fails —
 // genuine evidence, not a stub. Refs #2995, #2980.
+// #3001: the executed Python suite now also covers the arrow-token over-block fix
+// (test_arrow_minus/equals_not_a_redirect, test_fd_redirect_to_file_still_caught).
 const test = require('node:test');
 const assert = require('node:assert');
 const { spawnSync } = require('node:child_process');

--- a/tests/hooks/test_pretool_guard_shell_write_main.py
+++ b/tests/hooks/test_pretool_guard_shell_write_main.py
@@ -65,6 +65,11 @@ class ShellWriteTargetExtractor(unittest.TestCase):
         # A genuine fd redirect to a file IS still a write target.
         self.assertIn("err.log", pretool_guard.shell_write_targets("run 2> err.log"))
 
+    def test_redirect_multiple_spaces_and_tabs(self):
+        # #3001 review nit: whitespace between operator and target is tolerated.
+        self.assertIn("out.txt", pretool_guard.shell_write_targets("echo x >    out.txt"))
+        self.assertIn("o2.txt", pretool_guard.shell_write_targets("echo x >\to2.txt"))
+
     def test_tmp_extracted_but_harmless(self):
         # Extracted, but evaluate_path will ALLOW a non-repo target — extractor stays generous.
         self.assertIn("/tmp/out", pretool_guard.shell_write_targets("ls > /tmp/out"))

--- a/tests/hooks/test_pretool_guard_shell_write_main.py
+++ b/tests/hooks/test_pretool_guard_shell_write_main.py
@@ -49,6 +49,22 @@ class ShellWriteTargetExtractor(unittest.TestCase):
         self.assertEqual(pretool_guard.shell_write_targets("run_cmd 2>&1"), [])
         self.assertEqual(pretool_guard.shell_write_targets("run_cmd >&2"), [])
 
+    def test_arrow_minus_not_a_redirect(self):
+        # #3001: `a -> b` must NOT be parsed as a redirect (was over-blocking).
+        self.assertEqual(pretool_guard.shell_write_targets("echo 'step a -> step b'"), [])
+
+    def test_arrow_equals_not_a_redirect(self):
+        # #3001: `x => y` (fat arrow) must NOT be parsed as a redirect.
+        self.assertEqual(pretool_guard.shell_write_targets("echo 'map x => y'"), [])
+
+    def test_inline_gt_not_a_redirect(self):
+        # #3001: inline `a>b` (no boundary) is not treated as an output redirect.
+        self.assertEqual(pretool_guard.shell_write_targets("test $a>b"), [])
+
+    def test_fd_redirect_to_file_still_caught(self):
+        # A genuine fd redirect to a file IS still a write target.
+        self.assertIn("err.log", pretool_guard.shell_write_targets("run 2> err.log"))
+
     def test_tmp_extracted_but_harmless(self):
         # Extracted, but evaluate_path will ALLOW a non-repo target — extractor stays generous.
         self.assertIn("/tmp/out", pretool_guard.shell_write_targets("ls > /tmp/out"))


### PR DESCRIPTION
Refs #3001

merge-evidence-deferred-final: #3001

## Summary
Refines the #2995 shell-write canonical-main guard, which was **over-blocking**: its
output-redirect pattern treated almost any greater-than character as a redirect, so arrow
tokens (`->`, `=>`) and inline comparisons embedded in any command string were denied
whenever the trailing token resolved to a non-gitignored repo path. This was actively
blocking normal operations (e.g. `node -e` arrow functions, `echo 'a -> b'`).

Fix: anchor the redirect operator to a **word boundary** — it must be at start-of-string or
after whitespace, optionally with a leading fd digit. Arrow tokens and inline `a>b` no longer
match; genuine `>file` / `>>file` / fd `2>file` redirects to tracked main paths are still
denied; `2>&1` / `>&2` fd-dups stay excluded.

## Test evidence
`python3 -m unittest tests.hooks.test_pretool_guard_shell_write_main` → **21/21**; full
`pretool_guard` suite **85/85** (no regression); `ruff` clean. New tests cover arrow-token
exclusion, fd-redirect-to-file still caught, and multi-space targets.

## Cross-family review (non-Anthropic, two families)
- groq:llama-3.3-70b (Meta) → REJECT raising 3 points (fd-quantifier, ampersand-redirect
  residual, space-comparison) — all triaged as non-blocking; actionable nit (multi-space) fixed.
- gemini-2.5-flash (Google) → **ACCEPT 9/10**, findings none — adjudicated all three Groq points
  as acceptable residuals (evaluate_path remains the deny authority).

## Baton artifacts (full set on #3001)
COLLABORATOR_HANDOFF — Orla Harper; 21+85 tests; cross_family gemini 9/10.
ADMIN_HANDOFF — Orla Reyes; signer-independence PASS; deploy:apply required post-merge.
CONSULTANT_CLOSEOUT — Orla Vale; approve_for_merge; rubric G1-9=9; residuals documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
