### PR TITLE
feat(governance): closeout flaw-fields hard-blocking gate

### DIFF
--- a/.changes/unreleased/2909.md
+++ b/.changes/unreleased/2909.md
@@ -1,0 +1,3 @@
+### Security
+
+- `consultant-closeout.js`: promote `anneal_tickets_filed` and `mid_flight_flaws` from unvalidated to hard-blocking required fields (#2909). Absent or empty declarations now produce a non-advisory violation that sets `ok: false` in `validate()`. `verification-timestamp` was already blocking; no change to its severity. `baton-gates.yml` consultant-gate updated to call full `validate()` and `setFailed` on any blocking violation, replacing the advisory-only cross-family check path. Cross-family verdict remains advisory per #2537.

--- a/.github/workflows/baton-gates.yml
+++ b/.github/workflows/baton-gates.yml
@@ -116,8 +116,6 @@ jobs:
     name: consultant-gate
     needs: [admin-gate]
     runs-on: ubuntu-latest
-    env:
-      GATE_ADVISORY_MODE: '1'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -139,19 +137,30 @@ jobs:
               );
               return;
             }
-            const advisory = process.env.GATE_ADVISORY_MODE === '1';
+            // Hard-blocking schema validation (#2909): validate() returns ok=false when any
+            // required field (anneal_tickets_filed, mid_flight_flaws, verification-timestamp,
+            // rubric, verdict, signer fields) is absent. Advisory-only violations are excluded
+            // from the ok=false determination inside validate() itself.
+            const { validate, checkCrossFamilyVerdict } =
+              require('./scripts/global/megalint/consultant-closeout.js');
             const { checkConsultantFamilyIndependence } =
               require('./scripts/global/megalint/signer-fidelity.js');
-            const { checkCrossFamilyVerdict } =
-              require('./scripts/global/megalint/consultant-closeout.js');
-            const allViols = [
+            const schemaResult = validate({ comments });
+            if (!schemaResult.ok) {
+              const blocking = (schemaResult.violations || [])
+                .filter(v => v.severity !== 'advisory')
+                .map(v => `${v.rule}${v.detail ? ': ' + v.detail : ''}`).join('; ');
+              core.setFailed(`consultant-closeout schema violations in #${linkedIssue}: ${blocking}`);
+              return;
+            }
+            // Cross-family independence and verdict remain advisory (#2537).
+            const advisoryViols = [
               ...checkConsultantFamilyIndependence(trail),
               ...checkCrossFamilyVerdict(trail),
             ];
-            if (allViols.length > 0) {
-              const msg = allViols.map(v => `${v.rule}${v.detail ? ': ' + v.detail : ''}`).join('; ');
-              if (advisory) { core.warning(`[advisory] cross-family gate: ${msg}`); }
-              else { core.setFailed(`cross-family gate: ${msg}`); }
+            if (advisoryViols.length > 0) {
+              const msg = advisoryViols.map(v => `${v.rule}${v.detail ? ': ' + v.detail : ''}`).join('; ');
+              core.warning(`[advisory] cross-family gate: ${msg}`);
             }
 
   changelog-fragment:

--- a/scripts/global/megalint/consultant-closeout.js
+++ b/scripts/global/megalint/consultant-closeout.js
@@ -18,8 +18,8 @@ function checkFleetBundleProvenance(body, input) {
     return [{ rule: 'fleet-bundle-unverifiable', severity: 'advisory',
       detail: 'CLOSEOUT cites governance-bundle-hash but no bundle was supplied to verify provenance.' }];
   }
-  const r = fleetCloseoutParity(body, input.governanceBundle, input.nowMs || Date.now());
-  return r.ok ? [] : [{ rule: 'fleet-bundle-parity-failed', detail: `fleet CLOSEOUT bundle parity: ${r.reason}` }];
+  const parity = fleetCloseoutParity(body, input.governanceBundle, input.nowMs || Date.now());
+  return parity.ok ? [] : [{ rule: 'fleet-bundle-parity-failed', detail: `fleet CLOSEOUT bundle parity: ${parity.reason}` }];
 }
 
 function findConsultantCloseout(comments) {

--- a/scripts/global/megalint/consultant-closeout.js
+++ b/scripts/global/megalint/consultant-closeout.js
@@ -71,40 +71,36 @@ function checkEvidenceFields(body) {
  * @param {string} body
  * @returns {{ rule: string, detail: string }[]}
  */
+// A required closeout field has a value when it is non-empty on the same line
+// (`field: value`) OR on the immediately-following line — the canonical
+// baton-comment-build format renders longer values on the next line. A next
+// line that is itself another `Key:` field is treated as bleed, not a value,
+// so a genuinely-empty field is still caught (#2909, builder-compat fix).
+function flawFieldState(body, field) {
+  const match = body.match(
+    new RegExp(`${field}[ \\t]*:[ \\t]*([^\\n\\r]*)(?:\\r?\\n[ \\t]*([^\\n\\r]*))?`, 'i'));
+  if (!match) return 'missing';
+  if ((match[1] || '').trim()) return 'ok';
+  const next = (match[2] || '').trim();
+  if (next && !/^[A-Za-z][\w&-]*[ \t]*:/.test(next)) return 'ok';
+  return 'empty';
+}
+
 function checkRequiredFlawFields(body) {
   const violations = [];
-  // anneal_tickets_filed must be present and non-empty after the colon.
-  // Matches: anneal_tickets_filed: none | anneal_tickets_filed: [#123] etc.
-  const annealPresent = /anneal_tickets_filed[ \t]*:/i.test(body);
-  if (!annealPresent) {
-    violations.push({
-      rule: 'missing-anneal-tickets-filed',
-      detail: 'CONSULTANT_CLOSEOUT missing anneal_tickets_filed field (required; declare [#N,...] or none)',
-    });
-  } else {
-    // Capture only the same line after the colon — [^\n\r]* prevents next-line bleed.
-    const annealValue = (body.match(/anneal_tickets_filed[ \t]*:[ \t]*([^\n\r]*)/i) || [])[1];
-    if (!annealValue || !annealValue.trim()) {
-      violations.push({
-        rule: 'empty-anneal-tickets-filed',
-        detail: 'CONSULTANT_CLOSEOUT anneal_tickets_filed has no value (declare [#N,...] or none)',
-      });
-    }
-  }
-  // mid_flight_flaws must be present and non-empty after the colon.
-  const flawsPresent = /mid_flight_flaws[ \t]*:/i.test(body);
-  if (!flawsPresent) {
-    violations.push({
-      rule: 'missing-mid-flight-flaws',
-      detail: 'CONSULTANT_CLOSEOUT missing mid_flight_flaws field (required; declare [...] or none)',
-    });
-  } else {
-    const flawsValue = (body.match(/mid_flight_flaws[ \t]*:[ \t]*([^\n\r]*)/i) || [])[1];
-    if (!flawsValue || !flawsValue.trim()) {
-      violations.push({
-        rule: 'empty-mid-flight-flaws',
-        detail: 'CONSULTANT_CLOSEOUT mid_flight_flaws has no value (declare [...] or none)',
-      });
+  const fields = [
+    ['anneal_tickets_filed', 'declare [#N,...] or none'],
+    ['mid_flight_flaws', 'declare [...] or none'],
+  ];
+  for (const [field, hint] of fields) {
+    const state = flawFieldState(body, field);
+    const key = field.replace(/_/g, '-');
+    if (state === 'missing') {
+      violations.push({ rule: `missing-${key}`,
+        detail: `CONSULTANT_CLOSEOUT missing ${field} field (required; ${hint})` });
+    } else if (state === 'empty') {
+      violations.push({ rule: `empty-${key}`,
+        detail: `CONSULTANT_CLOSEOUT ${field} has no value (${hint})` });
     }
   }
   return violations;

--- a/scripts/global/megalint/consultant-closeout.js
+++ b/scripts/global/megalint/consultant-closeout.js
@@ -55,6 +55,60 @@ function checkEvidenceFields(body) {
   return violations;
 }
 
+/**
+ * checkRequiredFlawFields — hard-blocking gate for flaw-accounting fields (#2909).
+ *
+ * The baton-routing contract (role-baton-routing.instructions.md §"review → done") requires
+ * every CONSULTANT_CLOSEOUT to declare anneal_tickets_filed and mid_flight_flaws so that
+ * the recurrence detector and closeout-schema validator have reliable signal. Absence of
+ * either field is a G1 governance violation (missing evidence = silent pass, fail-open).
+ *
+ * Accepted forms:
+ *   anneal_tickets_filed: [#N, ...] | none
+ *   mid_flight_flaws: [...] | none
+ *
+ * @param {string} body
+ * @returns {{ rule: string, detail: string }[]}
+ */
+function checkRequiredFlawFields(body) {
+  const violations = [];
+  // anneal_tickets_filed must be present and non-empty after the colon.
+  // Matches: anneal_tickets_filed: none | anneal_tickets_filed: [#123] etc.
+  const annealPresent = /anneal_tickets_filed[ \t]*:/i.test(body);
+  if (!annealPresent) {
+    violations.push({
+      rule: 'missing-anneal-tickets-filed',
+      detail: 'CONSULTANT_CLOSEOUT missing anneal_tickets_filed field (required; declare [#N,...] or none)',
+    });
+  } else {
+    // Capture only the same line after the colon — [^\n\r]* prevents next-line bleed.
+    const annealValue = (body.match(/anneal_tickets_filed[ \t]*:[ \t]*([^\n\r]*)/i) || [])[1];
+    if (!annealValue || !annealValue.trim()) {
+      violations.push({
+        rule: 'empty-anneal-tickets-filed',
+        detail: 'CONSULTANT_CLOSEOUT anneal_tickets_filed has no value (declare [#N,...] or none)',
+      });
+    }
+  }
+  // mid_flight_flaws must be present and non-empty after the colon.
+  const flawsPresent = /mid_flight_flaws[ \t]*:/i.test(body);
+  if (!flawsPresent) {
+    violations.push({
+      rule: 'missing-mid-flight-flaws',
+      detail: 'CONSULTANT_CLOSEOUT missing mid_flight_flaws field (required; declare [...] or none)',
+    });
+  } else {
+    const flawsValue = (body.match(/mid_flight_flaws[ \t]*:[ \t]*([^\n\r]*)/i) || [])[1];
+    if (!flawsValue || !flawsValue.trim()) {
+      violations.push({
+        rule: 'empty-mid-flight-flaws',
+        detail: 'CONSULTANT_CLOSEOUT mid_flight_flaws has no value (declare [...] or none)',
+      });
+    }
+  }
+  return violations;
+}
+
 function checkCrypto(body) {
   if (!/Crypto-Algorithm:/i.test(body)) return [];
   const result = sig.verifyArtifact(body, 'consultant');
@@ -99,6 +153,7 @@ function validate(input) {
   const violations = [
     ...checkSignerFields(body),
     ...checkEvidenceFields(body),
+    ...checkRequiredFlawFields(body),
     ...checkCrypto(body),
     ...checkTier3Emission(body, input),
     ...checkGovTokenResolution(body, input),
@@ -109,4 +164,10 @@ function validate(input) {
   return { ok: violations.filter(v => v.severity !== 'advisory').length === 0, violations, found: true };
 }
 
-module.exports = { validate, findConsultantCloseout, checkCrossFamilyVerdict, checkFleetBundleProvenance };
+module.exports = {
+  validate,
+  findConsultantCloseout,
+  checkCrossFamilyVerdict,
+  checkFleetBundleProvenance,
+  checkRequiredFlawFields,
+};

--- a/scripts/global/megalint/consultant-closeout.js
+++ b/scripts/global/megalint/consultant-closeout.js
@@ -77,8 +77,11 @@ function checkEvidenceFields(body) {
 // line that is itself another `Key:` field is treated as bleed, not a value,
 // so a genuinely-empty field is still caught (#2909, builder-compat fix).
 function flawFieldState(body, field) {
+  if (typeof body !== 'string') return 'missing'; // non-string body → field is absent (fail-closed)
+  // Anchor the field to line-start (after optional whitespace) so a longer token like
+  // `prefix_<field>:` does not satisfy the check (cross-family review #2909).
   const match = body.match(
-    new RegExp(`${field}[ \\t]*:[ \\t]*([^\\n\\r]*)(?:\\r?\\n[ \\t]*([^\\n\\r]*))?`, 'i'));
+    new RegExp(`(?:^|\\n)[ \\t]*${field}[ \\t]*:[ \\t]*([^\\n\\r]*)(?:\\r?\\n[ \\t]*([^\\n\\r]*))?`, 'i'));
   if (!match) return 'missing';
   if ((match[1] || '').trim()) return 'ok';
   const next = (match[2] || '').trim();

--- a/tests/consultant-closeout-required-fields.spec.js
+++ b/tests/consultant-closeout-required-fields.spec.js
@@ -63,6 +63,21 @@ test('MUTATION: genuinely-empty field followed by another Key: field → empty v
   assert.ok(rules.includes('empty-mid-flight-flaws'), `expected empty-mid-flight-flaws; got ${rules.join(',')}`);
 });
 
+test('checkRequiredFlawFields: line-anchored — prefix_<field>: does not satisfy the check', () => {
+  // #2909 review: a longer token like x_mid_flight_flaws: must NOT count as the field.
+  const body = [
+    'anneal_tickets_filed: none',
+    'x_mid_flight_flaws: bogus',
+  ].join('\n');
+  const rules = checkRequiredFlawFields(body).map((v) => v.rule);
+  assert.ok(rules.includes('missing-mid-flight-flaws'), `expected missing-mid-flight-flaws; got ${rules.join(',')}`);
+});
+
+test('checkRequiredFlawFields: non-string body → both fields missing (no throw)', () => {
+  assert.doesNotThrow(() => checkRequiredFlawFields(null));
+  assert.strictEqual(checkRequiredFlawFields(null).length, 2);
+});
+
 // MUTATION tests — these assert the promoted BLOCKING behavior and would fail
 // if checkRequiredFlawFields were removed or made advisory-only.
 

--- a/tests/consultant-closeout-required-fields.spec.js
+++ b/tests/consultant-closeout-required-fields.spec.js
@@ -42,6 +42,27 @@ test('checkRequiredFlawFields: mid_flight_flaws with list value → no violation
   assert.strictEqual(viols.length, 0);
 });
 
+test('checkRequiredFlawFields: value on the NEXT line (canonical builder format) → no violations', () => {
+  // baton-comment-build renders longer values on the line after the field name.
+  const body = [
+    'anneal_tickets_filed: none',
+    'mid_flight_flaws:',
+    '[flaw=x, decision=fixed, artifact=#99]; [flaw=y, decision=logged, artifact=incidents.jsonl]',
+  ].join('\n');
+  assert.strictEqual(checkRequiredFlawFields(body).length, 0);
+});
+
+test('MUTATION: genuinely-empty field followed by another Key: field → empty violation (no bleed)', () => {
+  // mid_flight_flaws empty, next line is a different field → must still be caught.
+  const body = [
+    'anneal_tickets_filed: none',
+    'mid_flight_flaws:',
+    'Signed-by: Orla Vale',
+  ].join('\n');
+  const rules = checkRequiredFlawFields(body).map((v) => v.rule);
+  assert.ok(rules.includes('empty-mid-flight-flaws'), `expected empty-mid-flight-flaws; got ${rules.join(',')}`);
+});
+
 // MUTATION tests — these assert the promoted BLOCKING behavior and would fail
 // if checkRequiredFlawFields were removed or made advisory-only.
 

--- a/tests/consultant-closeout-required-fields.spec.js
+++ b/tests/consultant-closeout-required-fields.spec.js
@@ -1,0 +1,219 @@
+'use strict';
+// Tests for #2909: promotion of anneal_tickets_filed and mid_flight_flaws
+// from advisory-only to hard-blocking in consultant-closeout.js.
+// Strategy: tdd-pyramid per test-methodology-matrix (scripts/global/megalint validator).
+// Uses node:test + node:assert — no playwright, no mocks of the blocking path.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  checkRequiredFlawFields,
+  validate,
+} = require('../scripts/global/megalint/consultant-closeout');
+
+// ---------------------------------------------------------------------------
+// Unit tests for checkRequiredFlawFields
+// ---------------------------------------------------------------------------
+
+test('checkRequiredFlawFields: both fields present with values → no violations', () => {
+  const body = [
+    'anneal_tickets_filed: none',
+    'mid_flight_flaws: none',
+  ].join('\n');
+  const viols = checkRequiredFlawFields(body);
+  assert.strictEqual(viols.length, 0);
+});
+
+test('checkRequiredFlawFields: anneal_tickets_filed with ticket list → no violations', () => {
+  const body = [
+    'anneal_tickets_filed: [#123, #456]',
+    'mid_flight_flaws: none',
+  ].join('\n');
+  const viols = checkRequiredFlawFields(body);
+  assert.strictEqual(viols.length, 0);
+});
+
+test('checkRequiredFlawFields: mid_flight_flaws with list value → no violations', () => {
+  const body = [
+    'anneal_tickets_filed: none',
+    'mid_flight_flaws: [lint-miss, decision=file-ticket, artifact=#99]',
+  ].join('\n');
+  const viols = checkRequiredFlawFields(body);
+  assert.strictEqual(viols.length, 0);
+});
+
+// MUTATION tests — these assert the promoted BLOCKING behavior and would fail
+// if checkRequiredFlawFields were removed or made advisory-only.
+
+test('MUTATION: missing anneal_tickets_filed → blocking violation emitted', () => {
+  const body = 'mid_flight_flaws: none\nSome other content';
+  const viols = checkRequiredFlawFields(body);
+  const rules = viols.map(v => v.rule);
+  assert.ok(rules.includes('missing-anneal-tickets-filed'),
+    `expected missing-anneal-tickets-filed in [${rules.join(', ')}]`);
+  // Critically: no severity:'advisory' — this is a hard block.
+  const annealViol = viols.find(v => v.rule === 'missing-anneal-tickets-filed');
+  assert.strictEqual(annealViol.severity, undefined,
+    'missing-anneal-tickets-filed must be hard-blocking (no severity:advisory)');
+});
+
+test('MUTATION: missing mid_flight_flaws → blocking violation emitted', () => {
+  const body = 'anneal_tickets_filed: none\nSome other content';
+  const viols = checkRequiredFlawFields(body);
+  const rules = viols.map(v => v.rule);
+  assert.ok(rules.includes('missing-mid-flight-flaws'),
+    `expected missing-mid-flight-flaws in [${rules.join(', ')}]`);
+  const flawViol = viols.find(v => v.rule === 'missing-mid-flight-flaws');
+  assert.strictEqual(flawViol.severity, undefined,
+    'missing-mid-flight-flaws must be hard-blocking (no severity:advisory)');
+});
+
+test('MUTATION: both fields missing → two blocking violations', () => {
+  const body = 'verdict: approve\nG1: 8\nSigned-by: Orla Vale';
+  const viols = checkRequiredFlawFields(body);
+  assert.strictEqual(viols.length, 2, 'should emit exactly two violations when both fields absent');
+  const rules = viols.map(v => v.rule);
+  assert.ok(rules.includes('missing-anneal-tickets-filed'));
+  assert.ok(rules.includes('missing-mid-flight-flaws'));
+  // Neither is advisory.
+  for (const viol of viols) {
+    assert.strictEqual(viol.severity, undefined,
+      `violation ${viol.rule} must not carry severity:'advisory'`);
+  }
+});
+
+test('MUTATION: anneal_tickets_filed present but empty value → blocking', () => {
+  // "anneal_tickets_filed:" with nothing after is an empty declaration — still blocking.
+  const body = 'anneal_tickets_filed:   \nmid_flight_flaws: none';
+  const viols = checkRequiredFlawFields(body);
+  const rules = viols.map(v => v.rule);
+  assert.ok(
+    rules.includes('empty-anneal-tickets-filed') || rules.includes('missing-anneal-tickets-filed'),
+    `expected empty/missing-anneal-tickets-filed in [${rules.join(', ')}]`
+  );
+  const relevant = viols.find(v =>
+    v.rule === 'empty-anneal-tickets-filed' || v.rule === 'missing-anneal-tickets-filed');
+  assert.strictEqual(relevant.severity, undefined, 'empty anneal_tickets_filed must be hard-blocking');
+});
+
+test('MUTATION: mid_flight_flaws present but empty value → blocking', () => {
+  const body = 'anneal_tickets_filed: none\nmid_flight_flaws:   ';
+  const viols = checkRequiredFlawFields(body);
+  const rules = viols.map(v => v.rule);
+  assert.ok(
+    rules.includes('empty-mid-flight-flaws') || rules.includes('missing-mid-flight-flaws'),
+    `expected empty/missing-mid-flight-flaws in [${rules.join(', ')}]`
+  );
+  const relevant = viols.find(v =>
+    v.rule === 'empty-mid-flight-flaws' || v.rule === 'missing-mid-flight-flaws');
+  assert.strictEqual(relevant.severity, undefined, 'empty mid_flight_flaws must be hard-blocking');
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: validate() returns ok:false when flaw fields absent
+// ---------------------------------------------------------------------------
+
+// Minimal valid body helper — satisfies all other required fields.
+function minimalBody(overrides = '') {
+  return [
+    'CONSULTANT_CLOSEOUT',
+    'verdict: approve_for_merge',
+    'G1: 8 G2: 8 G3: 8 G4: 8 G5: 8 G6: 8 G7: 8 G8: 8 G9: 8',
+    'verification-timestamp: 2026-06-14T12:00:00Z',
+    'Signed-by: Orla Vale',
+    'Team&Model: claude-code:claude-sonnet-4-6@anthropic',
+    'Role: consultant',
+    'anneal_tickets_filed: none',
+    'mid_flight_flaws: none',
+    overrides,
+  ].join('\n');
+}
+
+function makeComments(body) {
+  return [{ body }];
+}
+
+test('validate: complete closeout with both flaw fields → ok:true', () => {
+  const result = validate({ comments: makeComments(minimalBody()) });
+  assert.strictEqual(result.found, true);
+  const hardViols = (result.violations || []).filter(v => v.severity !== 'advisory');
+  assert.strictEqual(hardViols.length, 0,
+    `unexpected hard violations: ${hardViols.map(v => v.rule).join(', ')}`);
+  assert.strictEqual(result.ok, true);
+});
+
+test('MUTATION: validate() ok:false when anneal_tickets_filed absent', () => {
+  const body = minimalBody().replace(/anneal_tickets_filed.*\n?/, '');
+  const result = validate({ comments: makeComments(body) });
+  assert.strictEqual(result.ok, false,
+    'validate() must return ok:false when anneal_tickets_filed is absent');
+  const rules = (result.violations || []).map(v => v.rule);
+  assert.ok(rules.includes('missing-anneal-tickets-filed'),
+    `expected missing-anneal-tickets-filed in violations: [${rules.join(', ')}]`);
+});
+
+test('MUTATION: validate() ok:false when mid_flight_flaws absent', () => {
+  const body = minimalBody().replace(/mid_flight_flaws.*\n?/, '');
+  const result = validate({ comments: makeComments(body) });
+  assert.strictEqual(result.ok, false,
+    'validate() must return ok:false when mid_flight_flaws is absent');
+  const rules = (result.violations || []).map(v => v.rule);
+  assert.ok(rules.includes('missing-mid-flight-flaws'),
+    `expected missing-mid-flight-flaws in violations: [${rules.join(', ')}]`);
+});
+
+test('MUTATION: validate() ok:false when both flaw fields absent', () => {
+  const body = minimalBody()
+    .replace(/anneal_tickets_filed.*\n?/, '')
+    .replace(/mid_flight_flaws.*\n?/, '');
+  const result = validate({ comments: makeComments(body) });
+  assert.strictEqual(result.ok, false,
+    'validate() must return ok:false when both flaw fields absent');
+  const rules = (result.violations || []).map(v => v.rule);
+  assert.ok(rules.includes('missing-anneal-tickets-filed'));
+  assert.ok(rules.includes('missing-mid-flight-flaws'));
+});
+
+test('advisory-only violations do not flip ok to false', () => {
+  // rubric_provisional + no structured rubric = advisory only; flaw fields present.
+  const body = [
+    'CONSULTANT_CLOSEOUT',
+    'verdict: approve_for_merge',
+    'rubric_provisional: true',
+    'G1: 8',
+    'verification-timestamp: 2026-06-14T12:00:00Z',
+    'Signed-by: Orla Vale',
+    'Team&Model: claude-code:claude-sonnet-4-6@anthropic',
+    'Role: consultant',
+    'anneal_tickets_filed: none',
+    'mid_flight_flaws: none',
+  ].join('\n');
+  const result = validate({ comments: makeComments(body) });
+  const hardViols = (result.violations || []).filter(v => v.severity !== 'advisory');
+  assert.strictEqual(hardViols.length, 0,
+    `unexpected hard violations: ${hardViols.map(v => v.rule).join(', ')}`);
+  assert.strictEqual(result.ok, true,
+    'advisory-only violations must not set ok:false');
+});
+
+// ---------------------------------------------------------------------------
+// Scope-correctness: unrelated closeouts (batch sibling form) still pass
+// ---------------------------------------------------------------------------
+
+test('batch-sibling closeout form still satisfies flaw fields if declared', () => {
+  const body = [
+    '## CONSULTANT_CLOSEOUT',
+    'ticket: #999 (resolved as part of batch with #800)',
+    'status: review',
+    'verdict: approve_for_merge',
+    'verification-timestamp: 2026-06-14T12:00:00Z',
+    'rubric_rating: 8/10. Full evidence on #800.',
+    'Signed-by: Orla Vale',
+    'Team&Model: claude-code:claude-sonnet-4-6@anthropic',
+    'Role: consultant',
+    'anneal_tickets_filed: none',
+    'mid_flight_flaws: none',
+  ].join('\n');
+  const viols = checkRequiredFlawFields(body);
+  assert.strictEqual(viols.length, 0, 'batch sibling with flaw fields declared → no flaw violations');
+});


### PR DESCRIPTION
Refs #2909

merge-evidence-deferred-final: #2909

## Summary
Promotes CONSULTANT_CLOSEOUT `anneal_tickets_filed` + `mid_flight_flaws` from advisory to
**hard-blocking** in `consultant-closeout.js` + `baton-gates.yml` consultant-gate (Epic #2891).

## Bootstrap fix (caught during merge)
The initial line-anchored value check (`[^\n\r]*`) only read the *same line*, but the canonical
`baton-comment-build` renders longer values on the *next* line — so it would have rejected **every
standard closeout**. Fixed `flawFieldState` to accept a value on the same line OR the next
non-field line, while still catching genuinely-empty fields (next line is another `Key:` → bleed,
not a value). Also line-anchored the field match (no `prefix_<field>:` false match) and guarded
non-string input.

## Test evidence
`node --test tests/consultant-closeout-required-fields.spec.js` → **18/18** (mutation tests for
blocking behavior + next-line value + bleed-prevention + line-anchor + non-string). Readability
PASS (≤475); closeout-preflight PASS on this PR's own closeout.

## Cross-family review (non-Anthropic, two families)
- groq:llama-3.3-70b → initial ACCEPT 10/10 (Wave-2); on the bootstrap-fix diff returned REJECT
  with findings later adjudicated mostly spurious.
- gemini-2.5-flash → adjudicated: TOCTOU + injection findings **SPURIOUS** (in-memory string;
  hardcoded field literal); anchor + non-string-guard findings **REAL** → both applied. Net 7/10 PARTIAL → addressed.

## Baton artifacts (full set on #2909)
MANAGER/COLLABORATOR/ADMIN/CONSULTANT posted; signer-independence PASS; rubric G1-9=9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
