### PR TITLE
feat(governance): GOV-009 EDD required CI gate

### DIFF
--- a/.changes/unreleased/2915.md
+++ b/.changes/unreleased/2915.md
@@ -1,0 +1,2 @@
+### Added
+- GOV-009 EDD required CI gate (`edd-required`): lane:code-change implementation tickets must carry an EDD artifact (scope:, acceptance:, risk:, implementation-plan:) before implementation. Blocking (severity: hard). Exempt: lane:trivial, lane:config-only, lane:docs-research, lane:no-code-remediation. New: `scripts/global/megalint/edd-required.js`, `.github/workflows/edd-required.yml`, `tests/edd-gate.spec.js`. Refs #2915.

--- a/.github/workflows/edd-required.yml
+++ b/.github/workflows/edd-required.yml
@@ -1,0 +1,54 @@
+name: EDD Required
+# GOV-009 (#2915): lane:code-change implementation tickets must carry an EDD artifact.
+# EDD required fields: scope:, acceptance:, risk:, implementation-plan:.
+# Exempt: lane:trivial, lane:config-only, lane:docs-research, lane:no-code-remediation.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  issues: read
+  pull-requests: read
+  contents: read
+
+jobs:
+  edd-required:
+    name: edd-required
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const { validate } = require('./scripts/global/megalint/edd-required.js');
+            const body = context.payload.pull_request.body || '';
+            const refsMatch = body.match(/Refs\s+#(\d+)/i);
+            if (!refsMatch) {
+              core.setFailed(
+                'No linked issue found. Add "Refs #N" to PR body so the EDD gate can verify.'
+              );
+              return;
+            }
+            const linkedIssue = parseInt(refsMatch[1], 10);
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: linkedIssue,
+            });
+            const labels = issue.labels.map((label) => label.name);
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: linkedIssue, per_page: 100,
+            });
+            const result = validate({ labels, prBody: body, comments });
+            if (result.exempt) {
+              console.log(`Issue #${linkedIssue}: EDD gate exempt (lane label: ${labels.filter((l) => l.startsWith('lane:')).join(', ') || 'none'}).`);
+              return;
+            }
+            if (!result.ok) {
+              const detail = (result.violations || [])
+                .map((viol) => viol.rule + (viol.detail ? ': ' + viol.detail : '')).join('; ');
+              core.setFailed(`edd-required: GOV-009 violations on #${linkedIssue}: ${detail}`);
+            } else {
+              console.log(`edd-required: EDD artifact verified on #${linkedIssue}.`);
+            }

--- a/scripts/global/megalint/edd-required.js
+++ b/scripts/global/megalint/edd-required.js
@@ -1,0 +1,153 @@
+'use strict';
+// tier: 1
+// edd-required (GOV-009, #2915): validates EDD artifact presence for lane:code-change tickets.
+// Implementation tickets above the trivial threshold MUST reference an EDD before first commit.
+// EDD artifact requires at minimum: scope:, acceptance:, risk:, implementation-plan: fields.
+// Exempt lanes: lane:trivial, lane:config-only, lane:docs-research, lane:no-code-remediation.
+
+/** Lanes exempt from the EDD requirement. */
+const EXEMPT_LANES = new Set([
+  'lane:trivial',
+  'lane:config-only',
+  'lane:docs-research',
+  'lane:docs-only',
+  'lane:research',
+  'lane:no-code-remediation',
+]);
+
+/** Required fields that must appear in the EDD artifact body. */
+const EDD_REQUIRED_FIELDS = ['scope', 'acceptance', 'risk', 'implementation-plan'];
+
+/** Header patterns that signal the start of an EDD artifact. */
+const EDD_HEADER_RE = /(?:^|\n)\s*(?:##\s+)?EDD\b|engineering\s+design\s+doc(?:ument)?/im;
+
+/**
+ * Determine if the ticket's lanes exempt it from the EDD gate.
+ * @param {string[]} labels - Array of label name strings.
+ * @returns {boolean}
+ */
+function isExempt(labels) {
+  if (!Array.isArray(labels)) return false;
+  return labels.some((label) => EXEMPT_LANES.has(label));
+}
+
+/**
+ * Find the EDD artifact text within combined issue+PR text.
+ * Searches both PR body and issue comment trail.
+ * Returns the matched EDD section text or null if absent.
+ * @param {string} text - Combined body text to scan.
+ * @returns {string|null}
+ */
+function findEddSection(text) {
+  if (typeof text !== 'string' || text.length === 0) return null;
+  const match = EDD_HEADER_RE.exec(text);
+  if (!match) return null;
+  // Return the text from the EDD header to end (full artifact, bounded by caller).
+  return text.slice(match.index);
+}
+
+/**
+ * Check that all required EDD fields are present in the artifact section.
+ * FAIL-CLOSED: each field must be present as a colon-key line.
+ * @param {string} eddText - The EDD artifact body text.
+ * @returns {{ rule: string, detail: string, severity: string }[]}
+ */
+function checkEddFields(eddText) {
+  const violations = [];
+  for (const field of EDD_REQUIRED_FIELDS) {
+    const re = new RegExp(`(?:^|\\n)[-*]?\\s*${field}\\s*:`, 'i');
+    if (!re.test(eddText)) {
+      violations.push({
+        rule: 'edd-missing-field',
+        detail: `EDD artifact is missing required field '${field}:' (GOV-009 §Requirement)`,
+        severity: 'hard',
+      });
+    }
+  }
+  return violations;
+}
+
+/**
+ * Validate EDD presence for a pull request / issue pair.
+ *
+ * @param {object} input
+ * @param {string[]}  input.labels        - Issue label name strings.
+ * @param {string}    [input.prBody]      - PR body text (may be empty).
+ * @param {object[]}  [input.comments]    - Issue comment objects with `.body` string.
+ * @returns {{ ok: boolean, violations: object[], exempt: boolean }}
+ */
+function validate(input) {
+  // Defensive: treat null/undefined input as invalid — FAIL-CLOSED.
+  if (input == null || typeof input !== 'object') {
+    return {
+      ok: false,
+      exempt: false,
+      violations: [{
+        rule: 'edd-gate-invalid-input',
+        detail: 'validate() received null/non-object input; failing closed (GOV-009)',
+        severity: 'hard',
+      }],
+    };
+  }
+
+  const labels = Array.isArray(input.labels) ? input.labels : [];
+
+  // Exempt lanes skip the gate entirely.
+  if (isExempt(labels)) {
+    return { ok: true, exempt: true, violations: [] };
+  }
+
+  // Only apply to lane:code-change (the default implementation lane).
+  // If no lane label is present, treat as code-change (fail-closed default).
+  const hasCodeChangeLane = labels.some((label) => label === 'lane:code-change');
+  const hasAnyLane = labels.some((label) => label.startsWith('lane:'));
+  if (hasAnyLane && !hasCodeChangeLane) {
+    // Non-exempt, non-code-change lane: not in scope.
+    return { ok: true, exempt: true, violations: [] };
+  }
+
+  // Build the full text corpus: PR body + all issue comments.
+  const prBodyText = typeof input.prBody === 'string' ? input.prBody : '';
+  const commentTexts = Array.isArray(input.comments)
+    ? input.comments.map((comment) => (comment && typeof comment.body === 'string' ? comment.body : '')).join('\n\n')
+    : '';
+  const fullText = [prBodyText, commentTexts].filter(Boolean).join('\n\n');
+
+  // FAIL-CLOSED: empty corpus = missing EDD.
+  if (fullText.trim().length === 0) {
+    return {
+      ok: false,
+      exempt: false,
+      violations: [{
+        rule: 'edd-missing',
+        detail: 'No EDD artifact found. lane:code-change tickets require an EDD before implementation ' +
+          '(GOV-009). Add an EDD comment to the linked issue with scope:, acceptance:, risk:, implementation-plan:',
+        severity: 'hard',
+      }],
+    };
+  }
+
+  const eddSection = findEddSection(fullText);
+  if (!eddSection) {
+    return {
+      ok: false,
+      exempt: false,
+      violations: [{
+        rule: 'edd-missing',
+        detail: 'No EDD artifact found. lane:code-change tickets require an EDD before implementation ' +
+          '(GOV-009). Add an EDD comment to the linked issue with scope:, acceptance:, risk:, implementation-plan:',
+        severity: 'hard',
+      }],
+    };
+  }
+
+  // EDD header found — validate required fields.
+  const fieldViolations = checkEddFields(eddSection);
+  return {
+    ok: fieldViolations.length === 0,
+    exempt: false,
+    violations: fieldViolations,
+  };
+}
+
+module.exports = { validate, isExempt, findEddSection, checkEddFields, EXEMPT_LANES, EDD_REQUIRED_FIELDS };

--- a/scripts/global/megalint/edd-required.js
+++ b/scripts/global/megalint/edd-required.js
@@ -21,6 +21,41 @@ const EDD_REQUIRED_FIELDS = ['scope', 'acceptance', 'risk', 'implementation-plan
 /** Header patterns that signal the start of an EDD artifact. */
 const EDD_HEADER_RE = /(?:^|\n)\s*(?:##\s+)?EDD\b|engineering\s+design\s+doc(?:ument)?/im;
 
+/** Governance control id this gate enforces (named to keep it out of magic-number lint). */
+const GOV_CONTROL = 'GOV-009';
+
+/** The standard "EDD artifact absent" hard violation result. */
+function eddMissingResult() {
+  return {
+    ok: false,
+    exempt: false,
+    violations: [{
+      rule: 'edd-missing',
+      detail: 'No EDD artifact found. lane:code-change tickets require an EDD before implementation ' +
+        `(${GOV_CONTROL}). Add an EDD comment to the linked issue with ` +
+        'scope:, acceptance:, risk:, implementation-plan:',
+      severity: 'hard',
+    }],
+  };
+}
+
+/** Lane scoping decision: 'exempt' (skip gate) or 'in-scope' (apply gate). */
+function laneScope(labels) {
+  if (isExempt(labels)) return 'exempt';
+  const hasCodeChange = labels.some((label) => label === 'lane:code-change');
+  const hasAnyLane = labels.some((label) => label.startsWith('lane:'));
+  return (hasAnyLane && !hasCodeChange) ? 'exempt' : 'in-scope';
+}
+
+/** Concatenate PR body + all issue comment bodies into one corpus string. */
+function buildCorpus(input) {
+  const prBodyText = typeof input.prBody === 'string' ? input.prBody : '';
+  const commentTexts = Array.isArray(input.comments)
+    ? input.comments.map((c) => (c && typeof c.body === 'string' ? c.body : '')).join('\n\n')
+    : '';
+  return [prBodyText, commentTexts].filter(Boolean).join('\n\n');
+}
+
 /**
  * Determine if the ticket's lanes exempt it from the EDD gate.
  * @param {string[]} labels - Array of label name strings.
@@ -59,7 +94,7 @@ function checkEddFields(eddText) {
     if (!re.test(eddText)) {
       violations.push({
         rule: 'edd-missing-field',
-        detail: `EDD artifact is missing required field '${field}:' (GOV-009 §Requirement)`,
+        detail: `EDD artifact is missing required field '${field}:' (${GOV_CONTROL} §Requirement)`,
         severity: 'hard',
       });
     }
@@ -84,62 +119,20 @@ function validate(input) {
       exempt: false,
       violations: [{
         rule: 'edd-gate-invalid-input',
-        detail: 'validate() received null/non-object input; failing closed (GOV-009)',
+        detail: `validate() received null/non-object input; failing closed (${GOV_CONTROL})`,
         severity: 'hard',
       }],
     };
   }
-
   const labels = Array.isArray(input.labels) ? input.labels : [];
+  // Exempt lanes (and non-exempt non-code-change lanes) skip the gate entirely.
+  if (laneScope(labels) === 'exempt') return { ok: true, exempt: true, violations: [] };
 
-  // Exempt lanes skip the gate entirely.
-  if (isExempt(labels)) {
-    return { ok: true, exempt: true, violations: [] };
-  }
-
-  // Only apply to lane:code-change (the default implementation lane).
-  // If no lane label is present, treat as code-change (fail-closed default).
-  const hasCodeChangeLane = labels.some((label) => label === 'lane:code-change');
-  const hasAnyLane = labels.some((label) => label.startsWith('lane:'));
-  if (hasAnyLane && !hasCodeChangeLane) {
-    // Non-exempt, non-code-change lane: not in scope.
-    return { ok: true, exempt: true, violations: [] };
-  }
-
-  // Build the full text corpus: PR body + all issue comments.
-  const prBodyText = typeof input.prBody === 'string' ? input.prBody : '';
-  const commentTexts = Array.isArray(input.comments)
-    ? input.comments.map((comment) => (comment && typeof comment.body === 'string' ? comment.body : '')).join('\n\n')
-    : '';
-  const fullText = [prBodyText, commentTexts].filter(Boolean).join('\n\n');
-
-  // FAIL-CLOSED: empty corpus = missing EDD.
-  if (fullText.trim().length === 0) {
-    return {
-      ok: false,
-      exempt: false,
-      violations: [{
-        rule: 'edd-missing',
-        detail: 'No EDD artifact found. lane:code-change tickets require an EDD before implementation ' +
-          '(GOV-009). Add an EDD comment to the linked issue with scope:, acceptance:, risk:, implementation-plan:',
-        severity: 'hard',
-      }],
-    };
-  }
-
+  const fullText = buildCorpus(input);
+  // FAIL-CLOSED: empty corpus or no EDD header = missing EDD.
+  if (fullText.trim().length === 0) return eddMissingResult();
   const eddSection = findEddSection(fullText);
-  if (!eddSection) {
-    return {
-      ok: false,
-      exempt: false,
-      violations: [{
-        rule: 'edd-missing',
-        detail: 'No EDD artifact found. lane:code-change tickets require an EDD before implementation ' +
-          '(GOV-009). Add an EDD comment to the linked issue with scope:, acceptance:, risk:, implementation-plan:',
-        severity: 'hard',
-      }],
-    };
-  }
+  if (!eddSection) return eddMissingResult();
 
   // EDD header found — validate required fields.
   const fieldViolations = checkEddFields(eddSection);

--- a/tests/edd-gate.spec.js
+++ b/tests/edd-gate.spec.js
@@ -1,0 +1,249 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  validate,
+  isExempt,
+  findEddSection,
+  checkEddFields,
+  EXEMPT_LANES,
+  EDD_REQUIRED_FIELDS,
+} = require('../scripts/global/megalint/edd-required');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const FULL_EDD = `## EDD
+scope: Add GOV-009 gate
+acceptance: gate blocks missing EDD
+risk: low — read-only validator
+implementation-plan: add validator + workflow + tests`;
+
+const FULL_EDD_COMMENT = { body: FULL_EDD };
+const CODE_CHANGE_LABELS = ['lane:code-change', 'status:in-progress', 'type:task'];
+const TRIVIAL_LABELS = ['lane:trivial'];
+const CONFIG_LABELS = ['lane:config-only'];
+const NO_LANE_LABELS = ['status:in-progress', 'type:task'];
+
+// ---------------------------------------------------------------------------
+// isExempt
+// ---------------------------------------------------------------------------
+test('isExempt: lane:trivial is exempt', () => {
+  assert.strictEqual(isExempt(TRIVIAL_LABELS), true);
+});
+test('isExempt: lane:config-only is exempt', () => {
+  assert.strictEqual(isExempt(CONFIG_LABELS), true);
+});
+test('isExempt: lane:docs-research is exempt', () => {
+  assert.strictEqual(isExempt(['lane:docs-research']), true);
+});
+test('isExempt: lane:no-code-remediation is exempt', () => {
+  assert.strictEqual(isExempt(['lane:no-code-remediation']), true);
+});
+test('isExempt: lane:code-change is NOT exempt', () => {
+  assert.strictEqual(isExempt(CODE_CHANGE_LABELS), false);
+});
+test('isExempt: null/non-array returns false (fail-closed)', () => {
+  assert.strictEqual(isExempt(null), false);
+  assert.strictEqual(isExempt(undefined), false);
+});
+
+// ---------------------------------------------------------------------------
+// findEddSection
+// ---------------------------------------------------------------------------
+test('findEddSection: finds ## EDD header', () => {
+  const result = findEddSection('Some preamble\n## EDD\nscope: x');
+  assert.ok(result !== null);
+  assert.ok(result.includes('scope:'));
+});
+test('findEddSection: finds "EDD" standalone header', () => {
+  const result = findEddSection('## EDD\nscope: x');
+  assert.ok(result !== null);
+});
+test('findEddSection: finds "Engineering Design Doc" phrase', () => {
+  const result = findEddSection('## Engineering Design Document\nscope: y');
+  assert.ok(result !== null);
+});
+test('findEddSection: returns null when no EDD header', () => {
+  const result = findEddSection('Just a normal PR body with no design doc');
+  assert.strictEqual(result, null);
+});
+test('findEddSection: null/empty input returns null', () => {
+  assert.strictEqual(findEddSection(null), null);
+  assert.strictEqual(findEddSection(''), null);
+});
+
+// ---------------------------------------------------------------------------
+// checkEddFields
+// ---------------------------------------------------------------------------
+test('checkEddFields: all fields present → no violations', () => {
+  const violations = checkEddFields(FULL_EDD);
+  assert.strictEqual(violations.length, 0);
+});
+test('checkEddFields: missing scope → violation', () => {
+  const text = '## EDD\nacceptance: ok\nrisk: low\nimplementation-plan: x';
+  const violations = checkEddFields(text);
+  assert.ok(violations.some((viol) => viol.rule === 'edd-missing-field' && viol.detail.includes('scope')));
+});
+test('checkEddFields: missing risk → violation', () => {
+  const text = '## EDD\nscope: x\nacceptance: ok\nimplementation-plan: x';
+  const violations = checkEddFields(text);
+  assert.ok(violations.some((viol) => viol.detail.includes('risk')));
+});
+test('checkEddFields: missing implementation-plan → violation', () => {
+  const text = '## EDD\nscope: x\nacceptance: ok\nrisk: low';
+  const violations = checkEddFields(text);
+  assert.ok(violations.some((viol) => viol.detail.includes('implementation-plan')));
+});
+test('checkEddFields: all violations have severity hard', () => {
+  const violations = checkEddFields('## EDD\nno fields here');
+  assert.ok(violations.length > 0);
+  assert.ok(violations.every((viol) => viol.severity === 'hard'));
+});
+
+// ---------------------------------------------------------------------------
+// validate — exempt lanes
+// ---------------------------------------------------------------------------
+test('validate: lane:trivial → exempt=true, ok=true', () => {
+  const result = validate({ labels: TRIVIAL_LABELS, prBody: '', comments: [] });
+  assert.strictEqual(result.ok, true);
+  assert.strictEqual(result.exempt, true);
+});
+test('validate: lane:config-only → exempt=true, ok=true', () => {
+  const result = validate({ labels: CONFIG_LABELS, prBody: '', comments: [] });
+  assert.strictEqual(result.ok, true);
+  assert.strictEqual(result.exempt, true);
+});
+
+// ---------------------------------------------------------------------------
+// validate — blocking (MUTATION TEST TARGET)
+// This test asserts the gate BLOCKS (severity hard) when EDD is absent on
+// lane:code-change. It would FAIL if someone reverted the gate to advisory.
+// ---------------------------------------------------------------------------
+test('MUTATION: missing EDD on lane:code-change → ok=false, hard severity', () => {
+  const result = validate({ labels: CODE_CHANGE_LABELS, prBody: 'No EDD here', comments: [] });
+  assert.strictEqual(result.ok, false);
+  assert.strictEqual(result.exempt, false);
+  // At least one violation must exist.
+  assert.ok(result.violations.length > 0);
+  // MUTATION SENTINEL: all violations must be severity:hard (not advisory).
+  // If gate is reverted to advisory this assertion fails.
+  assert.ok(
+    result.violations.every((viol) => viol.severity === 'hard'),
+    'Expected all EDD violations to be severity:hard (blocking), not advisory'
+  );
+  assert.ok(result.violations.some((viol) => viol.rule === 'edd-missing'));
+});
+
+test('MUTATION: EDD with missing fields → ok=false, hard severity', () => {
+  const incompleteEdd = '## EDD\nscope: only scope here';
+  const result = validate({
+    labels: CODE_CHANGE_LABELS,
+    prBody: incompleteEdd,
+    comments: [],
+  });
+  assert.strictEqual(result.ok, false);
+  assert.strictEqual(result.exempt, false);
+  assert.ok(result.violations.length > 0);
+  // MUTATION SENTINEL: must remain hard blocking, not advisory.
+  assert.ok(
+    result.violations.every((viol) => viol.severity === 'hard'),
+    'Expected field violations to be severity:hard (blocking), not advisory'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// validate — valid EDD in PR body
+// ---------------------------------------------------------------------------
+test('validate: full EDD in prBody → ok=true', () => {
+  const result = validate({ labels: CODE_CHANGE_LABELS, prBody: FULL_EDD, comments: [] });
+  assert.strictEqual(result.ok, true);
+  assert.strictEqual(result.exempt, false);
+  assert.strictEqual(result.violations.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// validate — valid EDD in issue comments
+// ---------------------------------------------------------------------------
+test('validate: full EDD in comment trail → ok=true', () => {
+  const result = validate({ labels: CODE_CHANGE_LABELS, prBody: '', comments: [FULL_EDD_COMMENT] });
+  assert.strictEqual(result.ok, true);
+  assert.strictEqual(result.violations.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// validate — no lane label (fail-closed: treated as code-change)
+// ---------------------------------------------------------------------------
+test('validate: no lane label → applies gate (fail-closed), blocks absent EDD', () => {
+  const result = validate({ labels: NO_LANE_LABELS, prBody: 'No EDD', comments: [] });
+  assert.strictEqual(result.ok, false);
+  assert.strictEqual(result.exempt, false);
+});
+
+test('validate: no lane label + full EDD → ok=true', () => {
+  const result = validate({ labels: NO_LANE_LABELS, prBody: FULL_EDD, comments: [] });
+  assert.strictEqual(result.ok, true);
+});
+
+// ---------------------------------------------------------------------------
+// validate — invalid input (fail-closed)
+// ---------------------------------------------------------------------------
+test('validate: null input → ok=false (fail-closed)', () => {
+  const result = validate(null);
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.violations.some((viol) => viol.rule === 'edd-gate-invalid-input'));
+});
+test('validate: undefined input → ok=false (fail-closed)', () => {
+  const result = validate(undefined);
+  assert.strictEqual(result.ok, false);
+});
+
+// ---------------------------------------------------------------------------
+// validate — empty corpus (fail-closed)
+// ---------------------------------------------------------------------------
+test('validate: empty prBody and empty comments → ok=false (fail-closed)', () => {
+  const result = validate({ labels: CODE_CHANGE_LABELS, prBody: '', comments: [] });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.violations.some((viol) => viol.rule === 'edd-missing'));
+});
+
+// ---------------------------------------------------------------------------
+// validate — EDD field case-insensitivity
+// ---------------------------------------------------------------------------
+test('validate: EDD field labels are case-insensitive', () => {
+  const mixedCase = `## EDD
+Scope: x
+Acceptance: y
+Risk: z
+Implementation-Plan: a`;
+  const result = validate({ labels: CODE_CHANGE_LABELS, prBody: mixedCase, comments: [] });
+  assert.strictEqual(result.ok, true);
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial: injected EDD-like text in non-EDD prose should not satisfy gate
+// ---------------------------------------------------------------------------
+test('ADVERSARIAL: "scope:" in random prose without EDD header → not found', () => {
+  const proseOnly = 'The scope of this PR is to fix a bug. Risk is low. Acceptance pending.';
+  const section = findEddSection(proseOnly);
+  // No EDD header means findEddSection returns null.
+  assert.strictEqual(section, null);
+  const result = validate({ labels: CODE_CHANGE_LABELS, prBody: proseOnly, comments: [] });
+  assert.strictEqual(result.ok, false);
+});
+
+// ---------------------------------------------------------------------------
+// Constant exports sanity
+// ---------------------------------------------------------------------------
+test('EXEMPT_LANES includes the four documented exempt lanes', () => {
+  assert.ok(EXEMPT_LANES.has('lane:trivial'));
+  assert.ok(EXEMPT_LANES.has('lane:config-only'));
+  assert.ok(EXEMPT_LANES.has('lane:docs-research'));
+  assert.ok(EXEMPT_LANES.has('lane:no-code-remediation'));
+});
+test('EDD_REQUIRED_FIELDS has all four required fields', () => {
+  assert.ok(EDD_REQUIRED_FIELDS.includes('scope'));
+  assert.ok(EDD_REQUIRED_FIELDS.includes('acceptance'));
+  assert.ok(EDD_REQUIRED_FIELDS.includes('risk'));
+  assert.ok(EDD_REQUIRED_FIELDS.includes('implementation-plan'));
+});


### PR DESCRIPTION
Refs #2915

merge-evidence-deferred-final: #2915

## Summary
Adds the **GOV-009 EDD (Engineering Design Doc) required CI gate** (Epic #2891): lane:code-change
implementation tickets must reference an EDD artifact (`scope:`, `acceptance:`, `risk:`,
`implementation-plan:`) before implementation. Exempt lanes (trivial/config-only/docs-research/
no-code-remediation) skip; fail-closed on empty corpus / invalid input.

## Test evidence
`node --test tests/edd-gate.spec.js` → **31/31**. Readability refactored to ≤475 (extracted the
`GOV-009` control id to a named constant — the lint mis-read `009` as a magic number — and split
the 73-line `validate` into `laneScope`/`buildCorpus`/`eddMissingResult` helpers).

## Cross-family review (non-Anthropic)
groq:llama-3.3-70b-versatile (Meta) → **ACCEPT 10/10** (clean re-review vs origin/main).

## Baton artifacts (full set on #2915)
MANAGER/COLLABORATOR/ADMIN/CONSULTANT posted; phase_gate_satisfied; signer-independence PASS; rubric G1-9=9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
