### PR TITLE
feat(governance): drift sweep --propose review queue

### DIFF
--- a/.changes/unreleased/2990.md
+++ b/.changes/unreleased/2990.md
@@ -1,0 +1,2 @@
+### Added
+- Governance drift sweeper gains a propose-only review queue via `npm run governance:drift-sweep -- --propose` for the ambiguous drift classes D1 (unlabeled), D2 (in-progress with no role), D6 (dormant/deferred Epic past EPIC_REVIEW), and D7 (stalled cross-team hand-off). The queue is read-only — it emits each proposal's class, rationale, suggested action, the role whose verdict is required, and the free/fleet inference lane (premium prohibited), and never mutates issue state. Complements the `--fix` auto-remediation of safe classes (#2989). (#2990)

--- a/scripts/global/governance-drift-propose.js
+++ b/scripts/global/governance-drift-propose.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// governance-drift-propose (#2990, Epic #2981 Phase-1) — PROPOSE-ONLY review queue
+// for the AMBIGUOUS drift classes that must NOT be auto-fixed:
+//   D1  fully unlabeled issue (needs type inference)
+//   D2  status:in-progress with no role:* baton holder
+//   D6  dormant/deferred Epic past its EPIC_REVIEW window
+//   D7  stalled coordinator:cross-team-needs-hand-off
+// These need a Manager/Consultant verdict, so this module DELIBERATELY has no
+// gh-write path. It only emits a JSON queue (to logs/, gitignored) describing
+// each proposal — class, rationale, suggested action, who must adjudicate, and
+// the lane any language-judgment residue may use (free/fleet only — never
+// premium). Zero LLM tokens: detection is deterministic; the module itself
+// makes no model calls. Auto-fix-safe classes (D3/D4/D5/D8) belong to #2989.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const QUEUE_FILE = path.join(ROOT, 'logs', 'governance-drift-propose-queue.json');
+
+// Disjoint from #2989's SAFE_CLASSES — these are the classes that require a verdict.
+const PROPOSE_META = {
+  D1: {
+    rationale: 'Issue carries no type/status/priority label.',
+    suggested_action: 'Infer and apply type + status + priority labels.',
+    verdict_required: 'manager',
+    inference_lane: 'fleet', // type inference needs language judgment
+  },
+  D2: {
+    rationale: 'status:in-progress with no role:* baton holder.',
+    suggested_action: 'Assign the active baton role (role:collaborator default) or revert status.',
+    verdict_required: 'manager',
+    inference_lane: 'free',
+  },
+  D6: {
+    rationale: 'Dormant/deferred Epic with no EPIC_REVIEW marker past its review window.',
+    suggested_action: 'Manager posts an EPIC_REVIEW verdict (stay-dormant | reclassify | cancel).',
+    verdict_required: 'manager',
+    inference_lane: 'free',
+  },
+  D7: {
+    rationale: 'coordinator:cross-team-needs-hand-off present and possibly stalled.',
+    suggested_action: 'Re-route the hand-off or clear the orphan coordinator label.',
+    verdict_required: 'consultant',
+    inference_lane: 'free',
+  },
+};
+
+const PROPOSE_CLASSES = Object.keys(PROPOSE_META);
+const ALLOWED_LANES = new Set(['free', 'fleet']); // premium is never permitted for residue
+
+// Pure: build the propose-only queue from the open-issue corpus. Never mutates.
+function buildProposeQueue(issues = [], classify) {
+  if (typeof classify !== 'function') throw new Error('buildProposeQueue: classify function is required');
+  const byNumber = new Map(issues.map((issue) => [issue.number, issue]));
+  const proposals = [];
+  for (const issue of issues) {
+    const detected = classify(issue, byNumber).filter((driftClass) => PROPOSE_CLASSES.includes(driftClass));
+    for (const driftClass of detected) {
+      const meta = PROPOSE_META[driftClass];
+      if (!ALLOWED_LANES.has(meta.inference_lane)) {
+        throw new Error(`governance-drift-propose: class ${driftClass} routes to forbidden lane '${meta.inference_lane}'`);
+      }
+      proposals.push({ ticket: issue.number, class: driftClass, mutates: false, ...meta });
+    }
+  }
+  return {
+    generatedAt: new Date().toISOString(),
+    mode: 'propose',
+    route: 'deterministic',
+    premiumLaneProhibited: true,
+    total: proposals.length,
+    classes: PROPOSE_CLASSES,
+    proposals,
+  };
+}
+
+function writeQueue(queue, file = QUEUE_FILE) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(queue, null, 2));
+  return file;
+}
+
+module.exports = {
+  buildProposeQueue,
+  writeQueue,
+  PROPOSE_CLASSES,
+  PROPOSE_META,
+  ALLOWED_LANES,
+  QUEUE_FILE,
+};

--- a/scripts/global/governance-drift-propose.js
+++ b/scripts/global/governance-drift-propose.js
@@ -56,7 +56,13 @@ function buildProposeQueue(issues = [], classify) {
   const byNumber = new Map(issues.map((issue) => [issue.number, issue]));
   const proposals = [];
   for (const issue of issues) {
-    const detected = classify(issue, byNumber).filter((driftClass) => PROPOSE_CLASSES.includes(driftClass));
+    const result = classify(issue, byNumber);
+    // Enforce the classify contract (fail-closed): a non-array return would
+    // otherwise throw on .filter or silently mis-process (#2990 review finding).
+    if (!Array.isArray(result)) {
+      throw new Error(`buildProposeQueue: classify(#${issue.number}) must return an array of class strings`);
+    }
+    const detected = result.filter((driftClass) => PROPOSE_CLASSES.includes(driftClass));
     for (const driftClass of detected) {
       const meta = PROPOSE_META[driftClass];
       if (!ALLOWED_LANES.has(meta.inference_lane)) {

--- a/scripts/global/governance-drift-sweep.js
+++ b/scripts/global/governance-drift-sweep.js
@@ -6,6 +6,7 @@ const { loadLocalEnvOnce } = require('./load-local-env');
 const { listOpenTickets } = require('./governance-audit');
 const { parseBody } = require('../ticket-normalizer');
 const { applyFixes, rollback } = require('./governance-drift-fix');
+const { buildProposeQueue, writeQueue } = require('./governance-drift-propose');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const REPORT_FILE = path.join(ROOT, 'logs', 'governance-drift-sweep.json');
@@ -90,17 +91,26 @@ function runFix(argv, issues, deps) {
   return result.errors.length === 0;
 }
 
+function runPropose(issues, deps) {
+  const queue = (deps.buildProposeQueue || buildProposeQueue)(issues, classifyIssue);
+  (deps.writeQueue || writeQueue)(queue);
+  console.log(JSON.stringify(queue, null, 2));
+  return true; // propose is read-only; always succeeds (the queue itself is the output)
+}
+
 async function run(argv = process.argv.slice(2), deps = {}) {
   loadLocalEnvOnce();
   if (argv.includes('--help')) {
     console.log('Usage: node scripts/global/governance-drift-sweep.js [--scan] [--json]\n'
       + '       [--fix [--apply] [--classes D4,D5,D8,D3]]   (dry-run unless --apply)\n'
+      + '       [--propose]   (read-only review queue for D1,D2,D6,D7)\n'
       + '       [--rollback <run_id>]');
     return true;
   }
   const getIssues = () => (deps.listOpenTickets ? deps.listOpenTickets() : listOpenTickets());
   if (argv.includes('--rollback')) return runRollback(argv, deps);
   if (argv.includes('--fix')) return runFix(argv, getIssues(), deps);
+  if (argv.includes('--propose')) return runPropose(getIssues(), deps);
 
   const issues = getIssues();
   const report = buildReport(issues);

--- a/tests/governance-drift-propose.spec.js
+++ b/tests/governance-drift-propose.spec.js
@@ -1,0 +1,87 @@
+'use strict';
+
+// @megalint:test-discoverability:opt-out — node:test runner spec (run via `node --test`).
+// Unit coverage for the #2990 propose-only drift review queue.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  buildProposeQueue,
+  PROPOSE_CLASSES,
+  PROPOSE_META,
+  ALLOWED_LANES,
+} = require('../scripts/global/governance-drift-propose');
+const { classifyIssue } = require('../scripts/global/governance-drift-sweep');
+
+function labelObjs(names) {
+  return names.map((name) => ({ name }));
+}
+
+test('PROPOSE_CLASSES is exactly the ambiguous set D1/D2/D6/D7 (disjoint from auto-fix)', () => {
+  assert.deepEqual([...PROPOSE_CLASSES].sort(), ['D1', 'D2', 'D6', 'D7']);
+  for (const safe of ['D3', 'D4', 'D5', 'D8']) assert.ok(!PROPOSE_CLASSES.includes(safe));
+});
+
+test('D2 (in-progress, no role) yields a manager-verdict proposal with rationale + action', () => {
+  const issue = { number: 10, title: 'plain', state: 'open', labels: labelObjs(['status:in-progress']) };
+  const queue = buildProposeQueue([issue], classifyIssue);
+  const d2 = queue.proposals.find((proposal) => proposal.class === 'D2');
+  assert.ok(d2);
+  assert.equal(d2.mutates, false);
+  assert.equal(d2.verdict_required, 'manager');
+  assert.ok(d2.rationale.length > 0 && d2.suggested_action.length > 0);
+});
+
+test('D6 (dormant Epic, no EPIC_REVIEW) yields a proposal', () => {
+  const issue = { number: 11, title: 'epic', state: 'open', labels: labelObjs(['type:epic', 'status:dormant']) };
+  const queue = buildProposeQueue([issue], classifyIssue);
+  assert.ok(queue.proposals.some((proposal) => proposal.class === 'D6'));
+});
+
+test('D7 (stalled coordinator label) yields a consultant-verdict proposal', () => {
+  const issue = { number: 12, title: 'x', state: 'open', labels: labelObjs(['coordinator:cross-team-needs-hand-off']) };
+  const queue = buildProposeQueue([issue], classifyIssue);
+  const d7 = queue.proposals.find((proposal) => proposal.class === 'D7');
+  assert.ok(d7);
+  assert.equal(d7.verdict_required, 'consultant');
+});
+
+test('every proposal is read-only (mutates:false) and routes only to free/fleet lane', () => {
+  const issues = [
+    { number: 20, title: 'x', state: 'open', labels: [] }, // D1 unlabeled
+    { number: 21, title: 'y', state: 'open', labels: labelObjs(['status:in-progress']) }, // D2
+    { number: 22, title: 'z', state: 'open', labels: labelObjs(['type:epic', 'status:deferred']) }, // D6
+  ];
+  const queue = buildProposeQueue(issues, classifyIssue);
+  assert.ok(queue.proposals.length >= 3);
+  assert.equal(queue.premiumLaneProhibited, true);
+  for (const proposal of queue.proposals) {
+    assert.equal(proposal.mutates, false);
+    assert.ok(ALLOWED_LANES.has(proposal.inference_lane), `lane ${proposal.inference_lane} must be free/fleet`);
+    assert.notEqual(proposal.inference_lane, 'premium');
+  }
+});
+
+test('safe-only corpus produces an empty propose queue', () => {
+  // Fully labeled (no D1) + status:testing with role (no D2) + resolution on open (D4) + title prefix (D3).
+  // Only auto-fix-safe classes fire, so the propose queue stays empty.
+  const issue = {
+    number: 30,
+    title: 'fix: thing',
+    state: 'open',
+    labels: labelObjs(['type:task', 'status:testing', 'priority:P2', 'role:admin', 'resolution:released']),
+  };
+  const queue = buildProposeQueue([issue], classifyIssue);
+  assert.equal(queue.total, 0);
+  assert.deepEqual(queue.proposals, []);
+});
+
+test('buildProposeQueue requires a classify function (fail-closed)', () => {
+  assert.throws(() => buildProposeQueue([], null), /classify function is required/);
+});
+
+test('every PROPOSE_META lane is in the allowed set', () => {
+  for (const cls of PROPOSE_CLASSES) {
+    assert.ok(ALLOWED_LANES.has(PROPOSE_META[cls].inference_lane));
+  }
+});

--- a/tests/governance-drift-propose.spec.js
+++ b/tests/governance-drift-propose.spec.js
@@ -80,6 +80,14 @@ test('buildProposeQueue requires a classify function (fail-closed)', () => {
   assert.throws(() => buildProposeQueue([], null), /classify function is required/);
 });
 
+test('buildProposeQueue fails closed when classify returns a non-array (#2990 review)', () => {
+  const badClassify = () => null;
+  assert.throws(
+    () => buildProposeQueue([{ number: 99, title: 'x', state: 'open', labels: [] }], badClassify),
+    /must return an array/,
+  );
+});
+
 test('every PROPOSE_META lane is in the allowed set', () => {
   for (const cls of PROPOSE_CLASSES) {
     assert.ok(ALLOWED_LANES.has(PROPOSE_META[cls].inference_lane));


### PR DESCRIPTION
Refs #2990

Phase-1 child of Epic #2981 (zero-cost ticket governance drift sweeper). Adds the
propose-only review queue, the safe complement to #2989's `--fix` auto-remediation.

## What
- `scripts/global/governance-drift-propose.js` — read-only queue for the AMBIGUOUS classes:
  - **D1** unlabeled issue · **D2** in-progress with no role · **D6** dormant/deferred Epic past EPIC_REVIEW · **D7** stalled cross-team hand-off
- Each proposal emits `class`, `rationale`, `suggested_action`, `verdict_required` (manager|consultant), and `inference_lane` (free/fleet — premium prohibited).
- **No mutation path** — the module never writes issue state; `mutates:false` on every proposal. Disjoint from #2989's safe auto-fix set.
- Wired as `--propose` in the sweep CLI. Zero LLM tokens.

## Tests
9 `node:test` cases green (`tests/governance-drift-propose.spec.js`): per-class proposal shape,
no-mutation guarantee, premium-lane-never, classifyIssue reuse, empty-queue, and a fail-closed
guard on a non-array `classify` return. Lint clean; readability 475.

## Baton evidence (all on #2990)
- EDD (GOV-009) + MANAGER_HANDOFF + COLLABORATOR_HANDOFF + ADMIN_HANDOFF + CONSULTANT_CLOSEOUT.
- Cross-family: gemini-2.5-flash@google-ai-studio (Google, $0) — rigorous consultant ACCEPT,
  min(G1..G10)=10, no defects; preflight finding (classify-return validation) fixed root-cause in-cycle.

merge-evidence-deferred-final: #2990
