### PR TITLE
fix(tests): add missing describe/it require from node:test #3023

### DIFF
--- a/tests/hooks/test_pretool_guard_fleet_curl.spec.js
+++ b/tests/hooks/test_pretool_guard_fleet_curl.spec.js
@@ -5,6 +5,7 @@
  * tests/**‌/‌*.spec.js pattern required by test-evidence-validator.js.
  */
 'use strict';
+const { describe, it } = require('node:test');
 const { execSync } = require('child_process');
 const path = require('path');
 


### PR DESCRIPTION
## Summary
Fix test suite regression: add missing `node:test` require to spec shim.

**Change**: One line added to `tests/hooks/test_pretool_guard_fleet_curl.spec.js`
```js
const { describe, it } = require('node:test');
```

**Root Cause**: Post-merge regression from #3018 or #3017. The tdd-pyramid pattern requires this import; other .spec.js files have it correctly.

**Evidence**: 
- npm test was exiting with code 1
- ReferenceError: describe is not defined at line 18
- Verified pattern in 6+ other .spec.js files all have the import
- After fix: file validates correct pattern

**Merge Evidence**: Refs #3023

---

## Baton Artifacts

### MANAGER_HANDOFF
scope: Add missing node:test require to test spec
lane: lane:code-change
test_strategy: tdd-pyramid
acceptance:
- AC1: const { describe, it } = require('node:test') added at line 8
- AC2: npm test passes without ReferenceError  
- AC3: CI gates pass

Signed-by: Curtis Franks
Team&Model: copilot:claude-haiku-4.5@anthropic
Role: manager

### COLLABORATOR_HANDOFF
Ticket: #3023
Status: in-progress
Change: 1 line added to test spec file (node:test import)
Verification:
- File diff reviewed: correct placement after 'use strict'
- Import matches pattern in other .spec.js files
- Syntax validated: valid JavaScript require statement
cross_family_rating: 95/100
cross_family_reviewer: fleet-qwen-7b
cross_family_findings: Clean one-line fix, import pattern correct, no regressions anticipated.
test_strategy: tdd-pyramid

Signed-by: Curtis Franks
Team&Model: copilot:claude-haiku-4.5@anthropic
Role: collaborator
