### PR TITLE
feat(scripts): add free providers to free-cloud rotation

### DIFF
--- a/.changes/unreleased/3061.md
+++ b/.changes/unreleased/3061.md
@@ -1,0 +1,3 @@
+### Added
+
+- `free-cloud-dispatch`: wired four more free-tier OpenAI-compatible providers into the rotation — Mistral, GitHub Models, NVIDIA NIM, SambaNova — each auto-skipped until its `.env` key is set. Reordered `free-cloud.providers` to prefer high-volume/reliable providers (cerebras, groq) over the rate-limit-prone gemini, improving G6 resilience when a single provider throttles. (#3061)

--- a/scripts/global/free-cloud-dispatch.js
+++ b/scripts/global/free-cloud-dispatch.js
@@ -44,6 +44,35 @@ const PROVIDERS = {
     headers: (k) => ({ 'content-type': 'application/json', authorization: `Bearer ${k}` }),
     parse: (j) => j?.choices?.[0]?.message?.content,
   },
+  // Added #3061: extra free-tier OpenAI-compatible providers (auto-skipped until their key is set).
+  mistral: {
+    envKey: 'MISTRAL_API_KEY',
+    url: () => 'https://api.mistral.ai/v1/chat/completions',
+    body: (prompt) => ({ model: 'mistral-large-latest', messages: [{ role: 'user', content: prompt }] }),
+    headers: (key) => ({ 'content-type': 'application/json', authorization: `Bearer ${key}` }),
+    parse: (json) => json?.choices?.[0]?.message?.content,
+  },
+  'github-models': {
+    envKey: 'GITHUB_MODELS_TOKEN',
+    url: () => 'https://models.github.ai/inference/chat/completions',
+    body: (prompt) => ({ model: 'openai/gpt-4o-mini', messages: [{ role: 'user', content: prompt }] }),
+    headers: (key) => ({ 'content-type': 'application/json', authorization: `Bearer ${key}` }),
+    parse: (json) => json?.choices?.[0]?.message?.content,
+  },
+  nvidia: {
+    envKey: 'NVIDIA_API_KEY',
+    url: () => 'https://integrate.api.nvidia.com/v1/chat/completions',
+    body: (prompt) => ({ model: 'meta/llama-3.3-70b-instruct', messages: [{ role: 'user', content: prompt }] }),
+    headers: (key) => ({ 'content-type': 'application/json', authorization: `Bearer ${key}` }),
+    parse: (json) => json?.choices?.[0]?.message?.content,
+  },
+  sambanova: {
+    envKey: 'SAMBANOVA_API_KEY',
+    url: () => 'https://api.sambanova.ai/v1/chat/completions',
+    body: (prompt) => ({ model: 'Meta-Llama-3.3-70B-Instruct', messages: [{ role: 'user', content: prompt }] }),
+    headers: (key) => ({ 'content-type': 'application/json', authorization: `Bearer ${key}` }),
+    parse: (json) => json?.choices?.[0]?.message?.content,
+  },
 };
 
 /** Ordered free-cloud providers from policy (falls back to all known). @returns {string[]} */

--- a/scripts/global/model-routing-policy.json
+++ b/scripts/global/model-routing-policy.json
@@ -72,7 +72,7 @@
       "costPer1kTokens": 0,
       "endpoint": "openai-compatible",
       "_doc": "#2619: $0 cloud failover used when fleet is UNREACHABLE (availability failure), before any paid tier. Ordered free providers; see skills/openrouter-free-failover.",
-      "providers": ["openrouter-free", "gemini", "groq", "cerebras"]
+      "providers": ["cerebras", "groq", "gemini", "openrouter-free", "mistral", "github-models", "nvidia", "sambanova"]
     },
     "haiku": {
       "id": "balanced-cloud",

--- a/tests/free-cloud-providers-3061.spec.js
+++ b/tests/free-cloud-providers-3061.spec.js
@@ -1,0 +1,43 @@
+'use strict';
+// #3061: extra free-tier providers wired into free-cloud rotation, with graceful key-absent skip.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { PROVIDERS, providerOrder, callProvider, dispatchFreeCloud } = require('../scripts/global/free-cloud-dispatch.js');
+
+const NEW = ['mistral', 'github-models', 'nvidia', 'sambanova'];
+
+describe('#3061 free-cloud provider rotation', () => {
+  test('the 4 new providers are registered with the required shape', () => {
+    for (const name of NEW) {
+      const spec = PROVIDERS[name];
+      assert.ok(spec, `${name} missing from PROVIDERS`);
+      for (const field of ['envKey', 'url', 'body', 'headers', 'parse']) {
+        assert.strictEqual(typeof spec[field], field === 'envKey' ? 'string' : 'function', `${name}.${field}`);
+      }
+      assert.ok(spec.url().startsWith('https://'), `${name} url must be https`);
+    }
+  });
+
+  test('providerOrder includes all new providers and every entry exists in PROVIDERS', () => {
+    const order = providerOrder();
+    assert.ok(NEW.every((n) => order.includes(n)), 'new providers missing from order');
+    assert.ok(order.every((n) => PROVIDERS[n]), 'order has an unknown provider');
+    // reliable/high-volume first: cerebras before gemini (the rate-limited one)
+    assert.ok(order.indexOf('cerebras') < order.indexOf('gemini'), 'cerebras should precede gemini');
+  });
+
+  test('a provider with no key gracefully returns no_key (skip, not throw)', async () => {
+    for (const name of NEW) {
+      const res = await callProvider(name, 'hi', { env: {} });
+      assert.strictEqual(res.ok, false);
+      assert.strictEqual(res.reason, 'no_key', `${name} should skip with no_key`);
+    }
+  });
+
+  test('dispatchFreeCloud skips key-absent providers and reports them in tried[]', async () => {
+    const res = await dispatchFreeCloud('hi', { env: {}, fetchImpl: null });
+    assert.strictEqual(res.ok, false);
+    assert.ok(Array.isArray(res.tried));
+    assert.ok(res.tried.some((t) => t.startsWith('mistral:')), 'mistral should appear in tried');
+  });
+});


### PR DESCRIPTION
Refs #3061
Closes #3061

Adds four free-tier OpenAI-compatible providers (**Mistral, GitHub Models, NVIDIA NIM, SambaNova**) to the `free-cloud-dispatch` rotation, and reorders the policy to prefer reliable/high-volume providers (cerebras, groq) over the rate-limit-prone gemini — a G6 resilience fix after Gemini throttling.

## Evidence
- New providers are **auto-skipped until their `.env` key is set** (existing `no_key` path), so this is inert until keys are pasted.
- Tests: `tests/free-cloud-providers-3061.spec.js` 4/0 pass (registration, order, graceful skip, dispatch tried[]).
- Cross-family review: groq `gpt-oss-120b` (OpenAI open, non-Anthropic) → **92/approve**.
- Baton artifacts (MANAGER/COLLABORATOR/ADMIN/CONSULTANT, signer-independent) on #3061; readability 475; changelog `.changes/unreleased/3061.md`.
- `.env` gained commented declarations for the four keys (gitignored, IT).
