### PR TITLE
fix(workflows): repair wiki-auto-update startup_failure

### DIFF
--- a/.changes/unreleased/3064.md
+++ b/.changes/unreleased/3064.md
@@ -1,0 +1,1 @@
+fix(workflows): repair wiki-auto-update startup_failure caused by a duplicate `env:` mapping key on the Stage 1 step, which GitHub rejected so the 11-stage wiki pipeline never ran (Wikis A/B stayed empty). Adds an advisory actionlint workflow to catch the duplicate-key class. (#3064, Epic #3063)

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,35 @@
+# actionlint.yml — Lint GitHub Actions workflow files. Refs #3064 Epic #3063.
+# Catches the class of defect that broke wiki-auto-update.yml: a step with a
+# DUPLICATE `env:` mapping key, which GitHub rejects as a startup_failure but
+# which python yaml.safe_load silently merges. Advisory in first ship (does not
+# block on findings); promotion to required is a follow-on per Epic #3063 C5.
+name: actionlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint-workflows
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run actionlint (advisory)
+        run: |
+          VER=1.7.7
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${VER}/actionlint_${VER}_linux_amd64.tar.gz" \
+            | tar -xz actionlint
+          echo "Running actionlint ${VER} over .github/workflows/"
+          ./actionlint -color .github/workflows/*.yml || {
+            echo "::warning title=actionlint::actionlint reported findings (advisory; see log). Promotion to required tracked by Epic #3063 C5 (#3068)."
+            exit 0
+          }
+          echo "actionlint clean."

--- a/.github/workflows/wiki-auto-update.yml
+++ b/.github/workflows/wiki-auto-update.yml
@@ -45,15 +45,13 @@ jobs:
       - name: Stage 1 - Classify diff
         id: classify
         env:
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           FILES=$(gh pr view "$PR_NUMBER" --json files \
             --jq '.files[].path' | tr '\n' ',')
           echo "changed_files=$FILES" >> "$GITHUB_OUTPUT"
           echo "Classified files: $FILES"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
 
       # -----------------------------------------------------------------------
       # Stage 2 — Invisible-char scan (HIGH-severity aborts)

--- a/tests/fixtures/actionlint/duplicate-env-step.yml
+++ b/tests/fixtures/actionlint/duplicate-env-step.yml
@@ -1,0 +1,18 @@
+# Golden NEGATIVE fixture for #3064 / Epic #3063. NOT a live workflow.
+# Reproduces the exact defect that caused the wiki-auto-update startup_failure:
+# a single step carrying TWO `env:` mapping keys. GitHub's workflow parser
+# rejects duplicate keys (startup_failure); python yaml.safe_load silently
+# merges them. actionlint (the gate added in this PR) flags this. The real fix
+# removed this pattern from .github/workflows/wiki-auto-update.yml.
+name: duplicate-env-fixture
+on: workflow_dispatch
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: step-with-duplicate-env
+        env:
+          FIRST: "1"
+        run: echo "this step has two env: keys — invalid"
+        env:
+          SECOND: "2"


### PR DESCRIPTION
Refs #3064
merge-evidence-deferred-final: #3064

## Summary
Repairs the root-cause `startup_failure` in `.github/workflows/wiki-auto-update.yml`: the `Stage 1 - Classify diff` step had a **duplicate `env:` mapping key** (one before `run:`, one after). GitHub's workflow parser rejects duplicate keys as a startup_failure, so the 11-stage wiki pipeline **never executed** — which is why Wiki A (code) and Wiki B (work-log) have always been empty. Python `yaml.safe_load` silently merges duplicate keys, which is why it appeared to "parse locally."

Fix: merge the two `env:` blocks into one (`GH_TOKEN` + `PR_NUMBER`) before `run:`. Adds an advisory `actionlint.yml` workflow (pinned v1.7.7) to catch this defect class pre-merge (promotion-to-required tracked by #3068).

Phase-1 child of Epic #3063 (Restore continuous auto-update of the Three-Wiki data-stores). Unblocks siblings #3065/#3066/#3067/#3068.

## Verification
- Strict duplicate-mapping-key loader over all `.github/workflows/*.yml`: no duplicate keys; Stage 1 step now has exactly one `env:`.
- Cross-family review: qwen2.5-coder:32b @ fleet (Alibaba) — 100/100 ACCEPT.

## COLLABORATOR_HANDOFF / ADMIN_HANDOFF / CONSULTANT_CLOSEOUT
Full baton artifacts posted on #3064 (signers Orla Harper / Orla Reyes / Orla Vale — signer-independence PASS). CONSULTANT_CLOSEOUT verdict: approve_for_merge, rubric 9/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
