### PR TITLE
chore(infra): gitignore .tabignore (Antigravity IDE-indexing config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 __pycache__/
 *.pyc
 
+# Refs #3090 — per-runtime IDE-indexing config (Antigravity TabIgnore); local, never committed
+.tabignore
+
 # Ephemeral hook state (runtime-only)
 hooks/state/
 


### PR DESCRIPTION
Refs #3090
Refs #3083
merge-evidence-deferred-final: #3090

## Summary
Add `.tabignore` to `.gitignore` (config-only). The Antigravity Team's per-runtime IDE-indexing config (TabIgnore engine) was appearing as untracked drift in the canonical main checkout and tripping the stop-hook worktree-drift guard. Ignoring it (vs deleting the stray) is the non-destructive root-cause fix — every team's local copy is preserved, and it never re-registers as drift in any checkout.

Connected to the #3083 dedicated-IDE runtime model (#3088): Antigravity/Cursor operate from their own worktrees; their workspace configs shouldn't pollute canonical main.

## Verification (manual-verify, config-only)
- Before: `git status` lists `.tabignore` (untracked); guard flags worktree-drift.
- After: `git check-ignore .tabignore` returns the path; `git status` lists 0.

Baton (config-only: Manager→Admin→Consultant; COLLABORATOR N/A) on #3090: ADMIN_HANDOFF (Orla Reyes, commit 9f63037c) · CONSULTANT_CLOSEOUT (approve_for_merge, Orla Vale).

test_strategy: manual-verify
