### PR TITLE
fix(governance): scope pre-push drift block to the pusher's Epic

### DIFF
--- a/.changes/unreleased/3099.md
+++ b/.changes/unreleased/3099.md
@@ -1,0 +1,2 @@
+### Changed
+- Pre-push epic-drift gate now scopes its BLOCK to the pushed branch's ticket + its parent Epic (the pusher's responsibility), reporting all other board-wide drift as advisory instead of hard-failing every unrelated push (#3099). New pure helpers `ticketFromBranch`/`resolveRelevantEpics`/`partitionFindings` in `lint-epic-drift.js`; `pre-push-gates.js` wires them with a fail-safe (unparseable branch → block-all). Also cleared the pre-existing board drift the gate had been over-blocking on (#2248/#3008 progress-update backfill, #2632 native sub-issue links).

--- a/scripts/global/lint-epic-drift.js
+++ b/scripts/global/lint-epic-drift.js
@@ -84,6 +84,49 @@ function lintEpicDrift(owner, repo) {
   return findings;
 }
 
+// ── pre-push scoping (#3099): block on the pusher's own Epic(s); advise the rest ──
+// The whole board is still scanned + reported; only the BLOCK is scoped to the branch
+// ticket + its parent Epic, so unrelated board hygiene stops taxing every push.
+
+const BRANCH_TICKET_RE = /^(?:feat|fix|hotfix|chore|skill)\/(\d+)-/;
+
+/** Parse the ticket number from a branch name; null when it doesn't match. */
+function ticketFromBranch(branch) {
+  const match = BRANCH_TICKET_RE.exec(String(branch || '').trim());
+  return match ? Number(match[1]) : null;
+}
+
+/** Resolve a ticket's parent Epic number via GraphQL (null on absence/error). */
+function resolveParentEpic(ticket, owner, repo, ghFn = gh) {
+  if (!ticket) return null;
+  try {
+    const query = `{repository(owner:"${owner}",name:"${repo}"){issue(number:${ticket}){parent{number}}}}`;
+    const parsed = JSON.parse(ghFn(['api', 'graphql', '-f', `query=${query}`]));
+    return parsed?.data?.repository?.issue?.parent?.number ?? null;
+  } catch { return null; }
+}
+
+/** The set of Epic numbers a push is responsible for: the branch ticket + its parent.
+ *  Returns null when the branch ticket can't be parsed → caller blocks on ALL (fail-safe). */
+function resolveRelevantEpics(branch, owner, repo, ghFn = gh) {
+  const ticket = ticketFromBranch(branch);
+  if (!ticket) return null;
+  const relevant = new Set([ticket]);
+  const parent = resolveParentEpic(ticket, owner, repo, ghFn);
+  if (parent) relevant.add(parent);
+  return relevant;
+}
+
+/** Split findings into blocking (drift on a relevant Epic) vs advisory (the rest).
+ *  relevantSet === null (unparseable branch) → fail-safe: everything blocks. */
+function partitionFindings(findings, relevantSet) {
+  const all = findings || [];
+  if (!relevantSet) return { blocking: all, advisory: [] };
+  const blocking = all.filter((finding) => relevantSet.has(finding.epic));
+  const advisory = all.filter((finding) => !relevantSet.has(finding.epic));
+  return { blocking, advisory };
+}
+
 if (require.main === module) {
   try {
     const raw = gh(['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner']);
@@ -94,4 +137,7 @@ if (require.main === module) {
   } catch (err) { console.error('Error:', err.message); process.exit(1); }
 }
 
-module.exports = { lintEpicDrift, QUERY, childProgressComplete };
+module.exports = {
+  lintEpicDrift, QUERY, childProgressComplete,
+  ticketFromBranch, resolveParentEpic, resolveRelevantEpics, partitionFindings,
+};

--- a/scripts/global/pre-push-gates.js
+++ b/scripts/global/pre-push-gates.js
@@ -44,13 +44,23 @@ function run(argv = process.argv.slice(2), env = process.env) {
     } catch {}
   } else {
     try {
-      const { lintEpicDrift } = require('./lint-epic-drift.js');
-      const raw = require('child_process').execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], { encoding: 'utf8' }).trim();
+      const cp = require('child_process');
+      const { lintEpicDrift, resolveRelevantEpics, partitionFindings } = require('./lint-epic-drift.js');
+      const raw = cp.execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], { encoding: 'utf8' }).trim();
       const [owner, repo] = raw.split('/');
       const findings = lintEpicDrift(owner, repo);
-      if (findings.length) {
-        console.error('❌ pre-push-gates: Ticket Governance Drift Detected:');
-        findings.forEach(f => console.error(`  - [Class ${f.class}] ${f.message}`));
+      // #3099: block only on drift the pusher owns (branch ticket + its parent Epic);
+      // report the rest of the board's drift as advisory rather than failing the push.
+      const branch = cp.execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf8' }).trim();
+      const relevant = resolveRelevantEpics(branch, owner, repo);
+      const { blocking, advisory } = partitionFindings(findings, relevant);
+      if (advisory.length) {
+        console.log('⚠️ pre-push-gates: unrelated board drift (advisory — not blocking this push):');
+        advisory.forEach(f => console.log(`  - [Class ${f.class}] ${f.message}`));
+      }
+      if (blocking.length) {
+        console.error('❌ pre-push-gates: drift on YOUR ticket/Epic — fix before push:');
+        blocking.forEach(f => console.error(`  - [Class ${f.class}] ${f.message}`));
         return 1;
       }
     } catch (e) {

--- a/tests/pre-push-drift-scoping.spec.js
+++ b/tests/pre-push-drift-scoping.spec.js
@@ -1,0 +1,93 @@
+// tests/pre-push-drift-scoping.spec.js — #3099. Scopes the pre-push epic-drift BLOCK
+// to the pusher's own ticket + parent Epic; the rest of the board is advisory.
+// Strategy: tdd-pyramid (pure scoping units) + stress (adversarial branches + large
+// finding sets) — pre-push-gates is a side-effect-bearing gate per the matrix.
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const drift = require('../scripts/global/lint-epic-drift');
+
+// ── ticketFromBranch ──
+
+test('ticketFromBranch parses governed branch prefixes, null otherwise', () => {
+  expect(drift.ticketFromBranch('feat/3098-objective-test-floor')).toBe(3098);
+  expect(drift.ticketFromBranch('fix/12-x')).toBe(12);
+  expect(drift.ticketFromBranch('hotfix/7-y')).toBe(7);
+  expect(drift.ticketFromBranch('chore/100-z')).toBe(100);
+  expect(drift.ticketFromBranch('skill/55-s')).toBe(55);
+  expect(drift.ticketFromBranch('main')).toBeNull();
+  expect(drift.ticketFromBranch('sandbox/cursor')).toBeNull();
+  expect(drift.ticketFromBranch('')).toBeNull();
+});
+
+// ── partitionFindings ──
+
+const FINDINGS = [
+  { epic: 1948, class: 'C', message: 'a' },
+  { epic: 2248, class: 'C', message: 'b' },
+  { epic: 1948, class: 'A', message: 'c' },
+  { epic: 3008, class: 'C', message: 'd' },
+];
+
+test('partitionFindings blocks relevant-epic drift, advises the rest', () => {
+  const { blocking, advisory } = drift.partitionFindings(FINDINGS, new Set([1948, 3098]));
+  expect(blocking.map((f) => f.epic)).toEqual([1948, 1948]);
+  expect(advisory.map((f) => f.epic)).toEqual([2248, 3008]);
+});
+
+test('partitionFindings fail-safe: null relevant set blocks everything', () => {
+  const { blocking, advisory } = drift.partitionFindings(FINDINGS, null);
+  expect(blocking).toHaveLength(4);
+  expect(advisory).toHaveLength(0);
+});
+
+test('partitionFindings handles empty/undefined findings', () => {
+  expect(drift.partitionFindings([], new Set([1])).blocking).toEqual([]);
+  expect(drift.partitionFindings(undefined, new Set([1])).blocking).toEqual([]);
+});
+
+// ── resolveRelevantEpics (with injected gh) ──
+
+test('resolveRelevantEpics returns {ticket, parentEpic} for a child branch', () => {
+  const fakeGh = () => JSON.stringify({ data: { repository: { issue: { parent: { number: 1948 } } } } });
+  expect([...drift.resolveRelevantEpics('feat/3098-x', 'o', 'r', fakeGh)].sort()).toEqual([1948, 3098]);
+});
+
+test('resolveRelevantEpics returns just the ticket when it has no parent', () => {
+  const fakeGh = () => JSON.stringify({ data: { repository: { issue: { parent: null } } } });
+  expect([...drift.resolveRelevantEpics('feat/2891-x', 'o', 'r', fakeGh)]).toEqual([2891]);
+});
+
+test('resolveRelevantEpics returns null for an unparseable branch (→ block-all)', () => {
+  expect(drift.resolveRelevantEpics('main', 'o', 'r', () => '{}')).toBeNull();
+});
+
+test('resolveRelevantEpics survives a gh failure (scopes to the ticket only)', () => {
+  const throwingGh = () => { throw new Error('gh down'); };
+  expect([...drift.resolveRelevantEpics('feat/42-x', 'o', 'r', throwingGh)]).toEqual([42]);
+});
+
+// ── stress: adversarial branches (G6) + p99 over a large board (G7) ──
+
+test('stress: adversarial branch strings never throw, never mis-scope', () => {
+  const hostile = ['feat/$(rm -rf ~)-x', 'feat/-x', 'feat/999999999999999999-x',
+    'feat//x', '../../feat/1-x', 'feat/1\n-x', 'FEAT/1-X', `feat/${'9'.repeat(500)}-x`];
+  for (const branch of hostile) {
+    expect(() => drift.ticketFromBranch(branch)).not.toThrow();
+    expect(() => drift.partitionFindings(FINDINGS, drift.resolveRelevantEpics(branch, 'o', 'r', () => '{}'))).not.toThrow();
+  }
+});
+
+test('stress: partitionFindings over a 5000-finding board stays under a p99 budget', () => {
+  const big = Array.from({ length: 5000 }, (_, index) => ({ epic: index % 50, class: 'C', message: `m${index}` }));
+  const relevant = new Set([7, 13, 42]);
+  const samples = [];
+  for (let iteration = 0; iteration < 50; iteration += 1) {
+    const start = process.hrtime.bigint();
+    drift.partitionFindings(big, relevant);
+    samples.push(Number(process.hrtime.bigint() - start) / 1e6);
+  }
+  samples.sort((first, second) => first - second);
+  const p99 = samples[Math.floor(samples.length * 0.99)];
+  expect(p99, `p99 ${p99.toFixed(2)}ms exceeded 25ms`).toBeLessThan(25);
+});


### PR DESCRIPTION
Refs #3099

merge-evidence-deferred-final: #3099

Fixes the systemic over-block surfaced across #3086 and #3098: `lint-epic-drift` exits 1 on
**any** board-wide drift, so unrelated pre-existing Epic drift hard-failed every push (forcing
two `SKIP_DRIFT_LINT` bypasses this session).

## What ships
- **Scoped block**: `pre-push-gates.js` now blocks only on drift in the pushed branch's ticket +
  its parent Epic (the pusher's responsibility); all other board drift prints as **advisory**.
  New pure helpers `ticketFromBranch` / `resolveParentEpic` / `resolveRelevantEpics` /
  `partitionFindings` in `lint-epic-drift.js`. **Fail-safe**: an unparseable branch → block-all
  (no weaker than before). The whole board is still scanned + reported — only the *block* is scoped.
- **Board hygiene**: cleared the pre-existing drift the gate had been over-blocking on
  (#2248/#3008 progress-update backfill, #2632 native sub-issue links) → `lint-epic-drift` now 0 findings.

## Validated live
This very push showed `⚠️ pre-push-gates: unrelated board drift (advisory — not blocking this push)`
and proceeded **without a bypass**.

## Tests (test_strategy: tdd-pyramid+stress-test)
`tests/pre-push-drift-scoping.spec.js` — 10 tests (scoping units + adversarial-branch fault
injection + p99 budget). Lint clean (525 files); readability 475. Pre-existing baseline red
`lefthook-pre-push.spec.js` is unrelated (lefthook.yml untouched).

## Baton artifacts (full set on #3099)
- MANAGER_HANDOFF / COLLABORATOR_HANDOFF (cross-family Llama-70B 100/100 ACCEPT, receipt 4065ac1db3c2016e) / ADMIN_HANDOFF (branch feat/3099-drift-gate-scoping, commit 74581932, signer-independence PASS) / CONSULTANT_CLOSEOUT (approve_for_merge, rubric 9/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
