### PR TITLE
feat: add Antigravity model patterns and Ed25519 signing keys

### DIFF
--- a/.changes/unreleased/3102-antigravity-signing-registry.md
+++ b/.changes/unreleased/3102-antigravity-signing-registry.md
@@ -1,0 +1,3 @@
+### Added
+- Add Antigravity model patterns to signing registry: `gemini→Apollo`, `claude-sonnet→Nova`, `claude-opus→Axel`, `claude-haiku→Aiden` (Refs #3102, Epic #3095)
+- Generate and register Ed25519 public keys for Antigravity team (manager, collaborator, admin, consultant)

--- a/inventory/team-model-signatures.json
+++ b/inventory/team-model-signatures.json
@@ -46,11 +46,6 @@
       "aliasSeed": "Cyrus"
     },
     {
-      "team": "antigravity",
-      "modelPattern": "^gemini-2\\.0-pro$",
-      "aliasSeed": "Apollo"
-    },
-    {
       "team": "codex",
       "modelPattern": "^gpt-5\\.4$",
       "aliasSeed": "Quill"
@@ -112,6 +107,26 @@
       "modelPattern": "phi",
       "aliasSeed": "Fia",
       "devicePattern": "^windows-laptop$"
+    },
+    {
+      "team": "antigravity",
+      "modelPattern": "gemini",
+      "aliasSeed": "Apollo"
+    },
+    {
+      "team": "antigravity",
+      "modelPattern": "claude-sonnet",
+      "aliasSeed": "Nova"
+    },
+    {
+      "team": "antigravity",
+      "modelPattern": "claude-opus",
+      "aliasSeed": "Axel"
+    },
+    {
+      "team": "antigravity",
+      "modelPattern": "claude-haiku",
+      "aliasSeed": "Aiden"
     },
     {
       "team": "*",
@@ -230,6 +245,34 @@
       "role": "consultant",
       "keyId": "openclaw-consultant-v1",
       "publicKey": "-----BEGIN PUBLIC KEY-----\\nMCowBQYDK2VwAyEACCF0/o48aS8deiRJsyFPOAQqXoiyFfhQajo4AnaGaBY=\\n-----END PUBLIC KEY-----\\n"
+    },
+    {
+      "team": "antigravity",
+      "role": "manager",
+      "keyId": "antigravity-manager-v1",
+      "algorithm": "ed25519",
+      "publicKey": "-----BEGIN PUBLIC KEY-----\\nMCowBQYDK2VwAyEAX0OYK3cEeqSPBwpSyFJIQkYJnWXx6bRMrygvJMA12MU=\\n-----END PUBLIC KEY-----\\n"
+    },
+    {
+      "team": "antigravity",
+      "role": "collaborator",
+      "keyId": "antigravity-collaborator-v1",
+      "algorithm": "ed25519",
+      "publicKey": "-----BEGIN PUBLIC KEY-----\\nMCowBQYDK2VwAyEAXdkwDsKfkYBc8DNxWQ9ZVEhwHezfJCTj4UxGt5bJkOw=\\n-----END PUBLIC KEY-----\\n"
+    },
+    {
+      "team": "antigravity",
+      "role": "admin",
+      "keyId": "antigravity-admin-v1",
+      "algorithm": "ed25519",
+      "publicKey": "-----BEGIN PUBLIC KEY-----\\nMCowBQYDK2VwAyEAXJ9EP31PROFuy73IXfR/KLYFb5YOgYhud4NgCoeF49k=\\n-----END PUBLIC KEY-----\\n"
+    },
+    {
+      "team": "antigravity",
+      "role": "consultant",
+      "keyId": "antigravity-consultant-v1",
+      "algorithm": "ed25519",
+      "publicKey": "-----BEGIN PUBLIC KEY-----\\nMCowBQYDK2VwAyEAzDObrABU4g6ftSa0aKcH/W6D2hbxG25vwapcHxw10dU=\\n-----END PUBLIC KEY-----\\n"
     }
   ]
 }


### PR DESCRIPTION
Closes #3102. Epic #3095.
test_strategy: manual-verify

before: antigravity signing registry = 1 entry (gemini-2.0-pro exact to Apollo); cryptoKeys = empty
after: antigravity signing registry = 4 glob patterns (gemini/claude-sonnet/claude-opus/claude-haiku); cryptoKeys = 4 Ed25519 public keys

## Summary
Completes Antigravity signing registry with 4 model patterns and 4 Ed25519 keypairs. Resolves F1 signer-fidelity violation from Claude Code Team red-team review.

## Verification
- agent-signature.js gives Nova Mason for claude-sonnet-4-6@google
- signer-registry-check.js: PASS (0 collisions)
- Consultant closeout: ACCEPT min=8 mean=8.4

Refs #3102

Signed-by: Nova Harper
Team&Model: antigravity:claude-sonnet-4-6@google
Role: collaborator