### PR TITLE
feat(hamr): add Antigravity HAMR substrate to hamr_check #3106

### DIFF
--- a/.changes/unreleased/3106-antigravity-hamr.md
+++ b/.changes/unreleased/3106-antigravity-hamr.md
@@ -1,0 +1,3 @@
+### Added
+- Add `antigravity` runtime to `hooks/scripts/hamr_activation_check.py` HAMR candidate paths (Refs #3106, Epic #3095)
+- Extend `hooks/scripts/runtime_paths.py` `state_root()` and `runtime_hook_paths()` to support `antigravity` runtime

--- a/hooks/scripts/hamr_activation_check.py
+++ b/hooks/scripts/hamr_activation_check.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""SessionStart hook: warn when HAMR activation is absent, stale, or disabled."""
+"""SessionStart hook: warn when HAMR activation is absent, stale, or disabled.
+
+Runtime support: claude, copilot, codex, cursor, antigravity.
+"""
 from __future__ import annotations
 
 import json
@@ -21,9 +24,10 @@ def candidate_paths() -> list[Path]:
         "copilot": home / ".copilot" / "hamr-config.json",
         "codex": home / ".codex" / "devenv-ops" / "hamr-config.json",
         "cursor": home / ".cursor" / "hamr-config.json",
+        "antigravity": home / ".gemini" / "antigravity" / "hamr-config.json",
     }
     runtime = (os.getenv("DEVENT_OPS_RUNTIME") or os.getenv("HAMR_TEAM") or "copilot").lower()
-    order = [runtime, "copilot", "claude", "codex", "cursor"]
+    order = [runtime, "copilot", "claude", "codex", "cursor", "antigravity"]
     return [paths[name] for name in dict.fromkeys(order) if name in paths]
 
 

--- a/hooks/scripts/runtime_paths.py
+++ b/hooks/scripts/runtime_paths.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Shared runtime path helpers for Copilot/Codex hook parity."""
+"""Shared runtime path helpers for Copilot/Codex/Antigravity hook parity."""
 from __future__ import annotations
 
 import os
@@ -38,7 +38,12 @@ def repo_scope_candidates() -> list[Path]:
 
 
 def state_root() -> Path:
-    return codex_managed_root() / "state" if runtime_name() == "codex" else copilot_home() / "hooks" / "state"
+    rt = runtime_name()
+    if rt == "codex":
+        return codex_managed_root() / "state"
+    if rt == "antigravity":
+        return Path.home() / ".gemini" / "antigravity" / "state"
+    return copilot_home() / "hooks" / "state"
 
 
 def script_candidates(name: str) -> list[Path]:
@@ -55,4 +60,7 @@ def wiki_candidates() -> list[Path]:
 
 
 def runtime_hook_paths() -> tuple[str, ...]:
+    if runtime_name() == "antigravity":
+        ag = str(Path.home() / ".gemini" / "antigravity" / "hooks" / "scripts")
+        return (ag, str(copilot_home() / "hooks" / "scripts"))
     return (str(codex_managed_root() / "hooks"), str(copilot_home() / "hooks" / "scripts"))


### PR DESCRIPTION
Closes #3106. Epic #3095.
test_strategy: manual-verify

before/after summary:
before: DEVENT_OPS_RUNTIME=antigravity → candidate_paths() returns copilot fallback; state_root() returns copilot hooks/state
after: DEVENT_OPS_RUNTIME=antigravity → candidate_paths() first path = ~/.gemini/antigravity/hamr-config.json; state_root() returns ~/.gemini/antigravity/state

Refs #3106

Signed-by: Nova Harper
Team&Model: antigravity:claude-sonnet-4-6@google
Role: collaborator