### PR TITLE
feat(antigravity): update parity matrix and document waivers

### DIFF
--- a/inventory/orchestrator-governance-parity.json
+++ b/inventory/orchestrator-governance-parity.json
@@ -160,6 +160,9 @@
       },
       "cursor": {
         "note": "cross-runtime read; inherits copilot tiers (#3086)"
+      },
+      "antigravity": {
+        "note": "cross-runtime read; inherits copilot tiers (#3109)"
       }
     },
     "dependencies": [
@@ -176,12 +179,20 @@
         "type": "cross-runtime-read",
         "status": "expected",
         "impact": "claude-code inherits copilot wiki health"
+      },
+      {
+        "from": "antigravity",
+        "to": "copilot",
+        "type": "cross-runtime-read",
+        "status": "expected",
+        "impact": "antigravity inherits copilot wiki health (#3109)"
       }
     ],
     "parityGaps": [
       "claude-code has no dedicated wiki home \u2014 reads Copilot runtime by design",
       "codex wiki missing sources/ and syntheses/ (ingest-only artifacts; expected)",
-      "cursor has no dedicated wiki home \u2014 reads Copilot runtime by design (#3086, mirror claude-code)"
+      "cursor has no dedicated wiki home \u2014 reads Copilot runtime by design (#3086, mirror claude-code)",
+      "antigravity has no dedicated wiki home \u2014 reads Copilot runtime by design (#3109, mirror claude-code)"
     ]
   }
 }

--- a/scripts/global/wiki-parity-check.js
+++ b/scripts/global/wiki-parity-check.js
@@ -12,12 +12,14 @@ const WIKI_PATHS = {
   copilot: path.join(HOME, '.copilot', 'wiki'),
   codex: path.join(HOME, '.codex', 'devenv-ops', 'wiki'),
   'claude-code': path.join(HOME, '.copilot', 'wiki'),
+  antigravity: path.join(HOME, '.copilot', 'wiki'),
 };
 
 const SEARCH_SCRIPTS = {
   copilot: path.join(HOME, '.copilot', 'scripts', 'wiki-search.js'),
   codex: path.join(HOME, '.codex', 'devenv-ops', 'scripts', 'wiki-search.js'),
   'claude-code': null,
+  antigravity: null,
 };
 
 const SUBDIR_TIERS = {
@@ -59,7 +61,7 @@ function checkRuntime(findings, rt, digestManifest, runtimeTiers) {
     add(findings, `wiki-${rt}-search-missing`, 'medium', `${rt} wiki-search.js missing.`,
       `Expected: ${searchScript}`, rt === 'copilot' ? 'npm run deploy:apply' : 'npm run deploy:codex:apply');
   }
-  if (rt === 'claude-code') {
+  if (rt === 'claude-code' || rt === 'antigravity') {
     add(findings, `wiki-${rt}-depends-on-copilot`, 'low',
       `${rt} wiki read-only; depends_on copilot.wiki.`, `wikiPath: ${wikiPath} (cross-runtime)`, 'Expected design; no action required');
     return;
@@ -80,8 +82,9 @@ function run(options = {}) {
   const dependencies = [];
   if (digestManifest || runtimeTiers) {
     dependencies.push({ from: 'claude-code', to: 'copilot', type: 'cross-runtime-read', status: 'expected' });
+    dependencies.push({ from: 'antigravity', to: 'copilot', type: 'cross-runtime-read', status: 'expected' });
   }
-  for (const rt of ['copilot', 'codex', 'claude-code']) checkRuntime(findings, rt, digestManifest, runtimeTiers);
+  for (const rt of ['copilot', 'codex', 'claude-code', 'antigravity']) checkRuntime(findings, rt, digestManifest, runtimeTiers);
   return {
     ok: findings.filter(f => f.severity === 'high').length === 0,
     surface: 'wiki_docs_memory',

--- a/tests/wiki-parity-check.spec.js
+++ b/tests/wiki-parity-check.spec.js
@@ -27,11 +27,13 @@ test('run() with runtimeTiers validates tier compliance', () => {
   assert.ok(typeof result.ok === 'boolean', 'tier validation works');
 });
 
-test('claude-code depends_on copilot edge emitted', () => {
+test('claude-code and antigravity depends_on copilot edge emitted', () => {
   const result = run({ digestManifest: {} });
   const dep = result.dependencies.find(d => d.from === 'claude-code' && d.to === 'copilot');
   assert.ok(dep, 'cross-runtime dependency found');
   assert.equal(dep.type, 'cross-runtime-read');
+  const depAnti = result.dependencies.find(d => d.from === 'antigravity' && d.to === 'copilot');
+  assert.ok(depAnti, 'antigravity cross-runtime dependency found');
 });
 
 test('SUBDIR_TIERS models required/optional/ingest-only', () => {


### PR DESCRIPTION
Refs #3109
Closes #3109

This PR updates the parity matrix in `inventory/orchestrator-governance-parity.json` to include the `antigravity` profile with all waivers and wikiDocsParity. It also updates the `wiki-parity-check` scripts and tests to properly validate the `antigravity` target.
