### PR TITLE
feat(memory): compile-doc + doc-plane boundary lint

### DIFF
--- a/.changes/unreleased/3129.md
+++ b/.changes/unreleased/3129.md
@@ -1,0 +1,3 @@
+### Added
+- `npm run wiki:compile-doc` (`scripts/wiki/compile-doc.js`, #3129): deterministically compiles a human doc into a SPARSE agent-plane wiki entry (H1 title + lead paragraph + heading outline) with provenance frontmatter (`source_path`, `source_sha256`, `content_hash`). No LLM in v1 (semantic distillation deferred to the fleet lane). Implements Epic #3124 D1/D3 — agents read the compiled entry, not the raw doc.
+- `npm run doc-plane:lint` (`scripts/global/doc-plane-boundary-lint.js`, #3129): advisory two-plane boundary lint — flags (a) a compiled entry whose `source_sha256` no longer matches its live source (STALE → recompile) and (b) a `docs/**` path `@`-imported into `CLAUDE.md`/`instructions/` (resident raw-doc preload). `--strict` opts into a non-zero exit.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ the Worker: add `MEGINGJORD_HAMR_ENABLED=1` to your `.env`.
 | `deps:review` | `node scripts/global/dep-proposals-review.js` |
 | `dispatch:progress:test` | `node --test tests/dispatch-progress.spec.js tests/cascade-observability.spec.js` |
 | `doc-graph` | `node scripts/global/doc-graph-builder.js` |
+| `doc-plane:lint` | `node scripts/global/doc-plane-boundary-lint.js` |
 | `docs:anchors` | `node scripts/global/docs-anchors.js` |
 | `docs:compile` | `node scripts/docs-compile.js` |
 | `docs:exec` | `node scripts/global/docs-exec.js` |
@@ -416,6 +417,7 @@ the Worker: add `MEGINGJORD_HAMR_ENABLED=1` to your `.env`.
 | `validate:triage` | `node scripts/validate-plugin-triage.js` |
 | `wiki:anneal` | `node scripts/wiki/anneal.js` |
 | `wiki:auto-update` | `node scripts/wiki/auto-update-pipeline.js` |
+| `wiki:compile-doc` | `node scripts/wiki/compile-doc.js` |
 | `wiki:drift` | `node scripts/wiki/drift-detector.js` |
 | `wiki:health` | `node scripts/wiki/wiki-health-detector.js` |
 | `wiki:ingest` | `node scripts/wiki/ingest.js` |

--- a/package.json
+++ b/package.json
@@ -185,6 +185,8 @@
     "resident:budget": "node scripts/global/resident-budget.js",
     "memory:route": "node scripts/global/memory-write-router.js",
     "memory:dedup": "node scripts/global/memory-dedup-lint.js",
+    "wiki:compile-doc": "node scripts/wiki/compile-doc.js",
+    "doc-plane:lint": "node scripts/global/doc-plane-boundary-lint.js",
     "lint:js": "eslint -c lint-configs/eslint.config.devenv.js --max-warnings 9999 dashboard/js scripts/global scripts/wiki",
     "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules/**' '!scripts/xteam-mcp/node_modules/**' '!.claude/**' '!research/**' '!wiki/wisdom/global/sources/**' '!wiki/wisdom/global/syntheses/**' '!raw/**' '!.dashboard/**' '!CHANGELOG-archive.md' '!tickets/**' '!planning/**' '!generated/**' '!tests/fixtures/governance/golden/**' '!tests/fixtures/changelog-fragments-invalid/**' '!wiki/work-log/**' '!wiki/code/**'",
     "lint:py": "ruff check --config lint-configs/ruff.devenv.toml hooks/scripts/",

--- a/scripts/global/doc-plane-boundary-lint.js
+++ b/scripts/global/doc-plane-boundary-lint.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+'use strict';
+// doc-plane-boundary-lint.js (#3129, Epic #3124 D1): enforce the two-plane boundary. (a) FRESHNESS —
+// a compiled wiki entry's source_sha256 must match its live source doc (else STALE -> recompile).
+// (b) RESIDENT-PRELOAD guard — flag a docs/** path @-imported into CLAUDE.md / instructions/ (agents
+// read compiled entries, never raw docs in resident context). Deterministic, local, $0. Advisory;
+// --strict opts into a non-zero exit.
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const root = path.resolve(__dirname, '..', '..');
+
+/** sha256 hex of text. @param {string} text @returns {string} hex digest. */
+function sha256Hex(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+/** Compiled entries whose source_sha256 no longer matches the live source doc.
+ * @param {string} dir compiled-entry directory. @returns {string[]} stale descriptions. */
+function staleEntries(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const stale = [];
+  for (const name of fs.readdirSync(dir)) {
+    if (!name.endsWith('.md')) continue;
+    const text = fs.readFileSync(path.join(dir, name), 'utf8');
+    const sourceMatch = text.match(/source_path:\s*"?([^"\n]+)"?/);
+    const shaMatch = text.match(/source_sha256:\s*([0-9a-f]{64})/);
+    if (!sourceMatch || !shaMatch) continue;
+    const sourcePath = path.join(root, sourceMatch[1].trim());
+    if (
+      fs.existsSync(sourcePath) &&
+      sha256Hex(fs.readFileSync(sourcePath, 'utf8')) !== shaMatch[1]
+    ) {
+      stale.push(`${name} stale vs ${sourceMatch[1].trim()}`);
+    }
+  }
+  return stale;
+}
+
+/** Resident files (CLAUDE.md + instructions/*.md) that @-import a docs/** path. @returns {string[]} hits. */
+function residentDocPreloads() {
+  const files = [path.join(root, 'CLAUDE.md')];
+  const instructionsDir = path.join(root, 'instructions');
+  if (fs.existsSync(instructionsDir)) {
+    for (const name of fs.readdirSync(instructionsDir))
+      if (name.endsWith('.md')) files.push(path.join(instructionsDir, name));
+  }
+  const hits = [];
+  for (const file of files.filter((candidate) => fs.existsSync(candidate))) {
+    for (const line of fs.readFileSync(file, 'utf8').split('\n')) {
+      if (/^@docs\//.test(line.trim())) hits.push(`${path.relative(root, file)}: ${line.trim()}`);
+    }
+  }
+  return hits;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const dirIndex = argv.indexOf('--dir');
+  const dir = dirIndex !== -1 ? argv[dirIndex + 1] : path.join(root, 'wiki/code/concepts');
+  const stale = staleEntries(dir);
+  const preloads = residentDocPreloads();
+  process.stdout.write(
+    `doc-plane-boundary-lint: ${stale.length} stale entr(ies), ${preloads.length} resident doc-preload(s)\n`
+  );
+  for (const item of stale) process.stdout.write(`  STALE: ${item}\n`);
+  for (const item of preloads) process.stdout.write(`  PRELOAD: ${item}\n`);
+  if (argv.includes('--strict') && (stale.length || preloads.length)) process.exit(1);
+}
+
+if (require.main === module) main();
+module.exports = { staleEntries, residentDocPreloads, sha256Hex };

--- a/scripts/wiki/compile-doc.js
+++ b/scripts/wiki/compile-doc.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+'use strict';
+// compile-doc.js (#3129, Epic #3124 D1+D3): deterministically compile a human doc into a SPARSE agent
+// wiki entry (H1 title + lead paragraph + heading outline) carrying provenance frontmatter
+// (source_path, source_sha256, content_hash). No LLM in v1 — the semantic-distillation step is
+// fleet-lane and DEFERRED. Local, $0. Agents read this compiled entry, never the raw human doc.
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const OUTLINE_HEADING_RE = /^#{2,4}\s+(.+)$/;
+const CONTENT_TRUST = 0.9;
+
+/** sha256 hex of text. @param {string} text @returns {string} hex digest. */
+function sha256Hex(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+/** Compile a doc's text into a sparse compiled-entry record.
+ * @param {string} sourcePath repo-relative source path. @param {string} text doc contents. @returns {object} */
+/** Render the compiled-entry markdown body (frontmatter + sparse content).
+ * @param {object} meta {sourcePath, sourceSha, contentHash, title, lead, outline}. @returns {string} */
+function renderBody(meta) {
+  const frontmatter = [
+    '---',
+    'type: code',
+    'sub_layer: semantic',
+    `source_path: "${meta.sourcePath}"`,
+    `source_sha256: ${meta.sourceSha}`,
+    `content_hash: ${meta.contentHash}`,
+    `content_trust_score: ${CONTENT_TRUST}`,
+    '---',
+  ];
+  const content = [
+    '',
+    `# ${meta.title}`,
+    '',
+    `> Compiled sparse entry of \`${meta.sourcePath}\` (agent plane — read this, not the raw doc).`,
+    '',
+    meta.lead || '_(no lead paragraph)_',
+    '',
+    '## Outline',
+    ...meta.outline.map((heading) => `- ${heading}`),
+    '',
+  ];
+  return [...frontmatter, ...content].join('\n');
+}
+
+function compileDoc(sourcePath, text) {
+  const lines = text.split('\n');
+  const titleLine = lines.find((line) => line.startsWith('# ')) || `# ${path.basename(sourcePath)}`;
+  const title = titleLine.replace(/^#\s+/, '').trim();
+  const lead = (lines.find((line) => line.trim() && !line.startsWith('#')) || '').trim();
+  const outline = lines
+    .map((line) => line.match(OUTLINE_HEADING_RE))
+    .filter(Boolean)
+    .map((match) => match[1].trim());
+  const sourceSha = sha256Hex(text);
+  const contentHash = sha256Hex(`${title}|${lead}|${outline.join('|')}`);
+  const body = renderBody({ sourcePath, sourceSha, contentHash, title, lead, outline });
+  return { title, sourcePath, sourceSha, contentHash, outline, body };
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const docIndex = argv.indexOf('--doc');
+  const docPath = docIndex !== -1 ? argv[docIndex + 1] : null;
+  if (!docPath || !fs.existsSync(docPath)) {
+    process.stdout.write('usage: compile-doc.js --doc <path> [--out <file>]\n');
+    process.exit(docPath ? 1 : 0);
+  }
+  const record = compileDoc(docPath, fs.readFileSync(docPath, 'utf8'));
+  const outIndex = argv.indexOf('--out');
+  if (outIndex !== -1 && argv[outIndex + 1]) fs.writeFileSync(argv[outIndex + 1], record.body);
+  else process.stdout.write(record.body);
+}
+
+if (require.main === module) main();
+module.exports = { compileDoc, sha256Hex };

--- a/tests/doc-compile-boundary.spec.js
+++ b/tests/doc-compile-boundary.spec.js
@@ -1,0 +1,46 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { compileDoc } = require('../scripts/wiki/compile-doc.js');
+const {
+  staleEntries,
+  residentDocPreloads,
+  sha256Hex,
+} = require('../scripts/global/doc-plane-boundary-lint.js');
+
+test('compileDoc emits a sparse entry with provenance + outline', () => {
+  const text = '# My Doc\n\nLead paragraph here.\n\n## Section A\nbody\n\n## Section B\nmore\n';
+  const record = compileDoc('docs/howto/my-doc.md', text);
+  assert.equal(record.title, 'My Doc');
+  assert.deepEqual(record.outline, ['Section A', 'Section B']);
+  assert.match(record.body, /source_path: "docs\/howto\/my-doc.md"/);
+  assert.match(record.body, /source_sha256: [0-9a-f]{64}/);
+  assert.match(record.body, /content_hash: [0-9a-f]{64}/);
+  assert.match(record.body, /read this, not the raw doc/);
+});
+
+test('compileDoc is deterministic (same input -> same hash)', () => {
+  const text = '# T\n\nlead\n\n## H\n';
+  assert.equal(compileDoc('a.md', text).contentHash, compileDoc('a.md', text).contentHash);
+});
+
+test('staleEntries flags a compiled entry whose source changed', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'compiled-'));
+  const srcRel = 'tmp-src.md';
+  const compiled = `---\nsource_path: "${srcRel}"\nsource_sha256: ${sha256Hex('OLD CONTENT')}\n---\n# x\n`;
+  fs.writeFileSync(path.join(dir, 'entry.md'), compiled);
+  // create the live source with DIFFERENT content at repo root
+  const root = path.resolve(__dirname, '..');
+  fs.writeFileSync(path.join(root, srcRel), 'NEW CONTENT');
+  const stale = staleEntries(dir);
+  fs.unlinkSync(path.join(root, srcRel));
+  fs.rmSync(dir, { recursive: true, force: true });
+  assert.equal(stale.length, 1, 'one stale entry flagged');
+});
+
+test('residentDocPreloads returns an array (no docs/** preload in resident set)', () => {
+  assert.ok(Array.isArray(residentDocPreloads()));
+});


### PR DESCRIPTION
Refs #3129

## Summary
Implements Epic #3124 D1+D3: `scripts/wiki/compile-doc.js` deterministically compiles a human doc into a SPARSE agent-plane wiki entry (title + lead + outline) with provenance frontmatter (`source_path`/`source_sha256`/`content_hash`); no LLM in v1 (semantic distillation deferred to the fleet lane). `scripts/global/doc-plane-boundary-lint.js` is an advisory two-plane boundary lint (stale-vs-source freshness + `docs/**` resident-preload guard). `npm run wiki:compile-doc` / `doc-plane:lint`.

## Evidence
- 4/4 spec tests green; eslint 0 errors; readability ≤475; prettier clean
- Deterministic, local, $0 — no LLM, no network, no embeddings
- Cross-family design consensus: qwen3:32b 97/100 ACCEPT first round ($0 Tailscale fleet, non-Anthropic Qwen)

## Baton
Full set on #3129: COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT (+ EDD).

Phase-1 child C3 of Epic #3124; design source #3125 (closed).

merge-evidence-deferred-final: #3129

🤖 Generated with [Claude Code](https://claude.com/claude-code)
