### PR TITLE
docs(taxonomy): Diataxis taxonomy + entry-point dedup + tutorial

### DIFF
--- a/.changes/unreleased/3131.md
+++ b/.changes/unreleased/3131.md
@@ -1,0 +1,7 @@
+### Added
+- `docs/diataxis-taxonomy.md` (#3131): the harness documentation taxonomy — Diátaxis (Tutorial/How-to/Reference/Explanation) × audience × surface, the `area:*` → required-quadrants table, and the canonical roles of the entry-point docs. Closes Epic #3124 D8.
+- `docs/howto/getting-started.md` (#3131): an operator getting-started **tutorial** (the previously-empty learning-oriented quadrant) — a first-session walkthrough (model, ticket-first, worktree, baton artifacts, $0 review lane, PR→merge).
+- `config/doc-coverage-matrix.yml` (#3131): a non-breaking `diataxis:` annotation block mapping each `area:*` to its required quadrants (advisory; the doc-coverage validator reads only `surfaces:`).
+
+### Changed
+- `docs/decisions.md`, `docs/DECISIONS.md`, `ARCHITECTURE.md`, `docs/ARCHITECTURE.md` (#3131): added canonical-role disambiguation headers + cross-links. The pairs are genuinely distinct (decisions *log* vs ADR *index*; root *overview* vs docs *detail*), so they are disambiguated rather than deleted — resolving the case-variant / split-brain drift without content loss.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,9 @@
 # Megingjord Harness Architecture
 
+> **Canonical role (Epic #3124 D8):** the architecture *overview* (GitHub root entry surface). For
+> the detailed, arc42-structured reference see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). Taxonomy:
+> [`docs/diataxis-taxonomy.md`](docs/diataxis-taxonomy.md).
+
 Megingjord is a **governance-first AI agent harness** providing cross-runtime
 compliance, skills propagation, and local operational safety for developer AI
 workflows across GitHub Copilot, Claude Code, and Codex.

--- a/config/doc-coverage-matrix.yml
+++ b/config/doc-coverage-matrix.yml
@@ -93,3 +93,16 @@ surfaces:
       - WIKI.md
     suggested:
       - docs/howto/contribute-to-wiki.md
+
+# Diátaxis quadrant requirements per area (Epic #3124 D8). Advisory annotation — the doc-coverage
+# validator (doc-coverage.js) reads only `surfaces:`, so this key is non-breaking. Authored schema
+# for future tooling; human reference is docs/diataxis-taxonomy.md.
+diataxis:
+  area:hooks: [how-to, reference]
+  area:scripts: [how-to, reference]
+  area:instructions: [reference, explanation]
+  area:agents: [reference, explanation]
+  area:dashboard: [tutorial, how-to]
+  area:knowledge: [explanation, reference]
+  area:governance: [explanation, reference]
+  area:infra: [how-to, reference]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,9 @@
 # Megingjord — Architecture
 
+> **Canonical role (Epic #3124 D8):** the detailed architecture *reference* (docs-tree depth,
+> arc42-structured). For the short root overview see [`../ARCHITECTURE.md`](../ARCHITECTURE.md).
+> Taxonomy: [`diataxis-taxonomy.md`](diataxis-taxonomy.md).
+
 Navigation hub for architecture documentation, structured after arc42 sections.
 
 ## Document map

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,9 @@
 # Architecture Decision Records — Index
 
+> **Canonical role (Epic #3124 D8):** the ADR *index* — distinct from
+> [`decisions.md`](decisions.md) (the chronological decisions *log*). See
+> [`diataxis-taxonomy.md`](diataxis-taxonomy.md).
+
 ADRs document significant architecture and process decisions for Megingjord.
 Canonical store: [`research/adr/`](../research/adr/).
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,5 +1,9 @@
 # Decisions Log
 
+> **Canonical role (Epic #3124 D8):** the chronological decisions *log* — distinct from
+> [`DECISIONS.md`](DECISIONS.md) (the ADR *index*). The case-variant filenames are intentional but
+> serve different purposes; see [`diataxis-taxonomy.md`](diataxis-taxonomy.md).
+
 This file is the canonical, portable-by-default record of architectural
 decisions made in this repo. It is the **fallback decisional surface** for
 operators without GitHub Discussions access (air-gapped, offline-during-

--- a/docs/diataxis-taxonomy.md
+++ b/docs/diataxis-taxonomy.md
@@ -1,0 +1,52 @@
+# Documentation Taxonomy — Diátaxis × Audience × Surface (Epic #3124 D8)
+
+The harness organizes documentation on three axes so every doc has an obvious home and authors know
+where new content goes. The cardinal rule (Diátaxis): **do not mix types in one doc** — mixing is the
+top cause of confusing documentation.
+
+## Axis 1 — Diátaxis type (by user need)
+
+| Quadrant | Orientation | Answers | Example here |
+|---|---|---|---|
+| Tutorial | learning | "teach me, step by step" | `docs/howto/getting-started.md` |
+| How-to | task | "help me do X" | `docs/howto/*.md` |
+| Reference | information | "tell me the facts" | `docs/architecture-*.md`, `config/*` |
+| Explanation | understanding | "why is it so" | `ARCHITECTURE.md`, ADRs |
+
+## Axis 2 — Audience
+
+end-user / operator · developer / contributor · AI-agent (reads the *compiled* wiki plane, not raw
+docs — see Epic #3124 D1) · public / evaluator.
+
+## Axis 3 — Surface
+
+repo-markdown (source of truth) → projected to web/dashboard, the GitHub profile, and the AI index.
+Single-source + projection: author once, render many.
+
+## area:* → required Diátaxis quadrants (machine-readable in `config/doc-coverage-matrix.yml`)
+
+| area label | required quadrants |
+|---|---|
+| area:hooks | How-to + Reference |
+| area:scripts | How-to + Reference |
+| area:instructions | Reference + Explanation |
+| area:agents | Reference + Explanation |
+| area:dashboard | Tutorial + How-to |
+| area:knowledge | Explanation + Reference |
+| area:governance | Explanation + Reference |
+| area:infra | How-to + Reference |
+
+## Canonical entry-point docs (disambiguation)
+
+These pairs are distinct by purpose — each is canonical for its role; they cross-link rather than
+duplicate:
+
+- `docs/DECISIONS.md` — canonical **ADR index** (decision records).
+- `docs/decisions.md` — canonical **chronological decisions log** (running notes).
+- `ARCHITECTURE.md` (repo root) — canonical **architecture overview** (GitHub entry surface).
+- `docs/ARCHITECTURE.md` — canonical **detailed architecture reference** (docs-tree depth).
+
+## Scope note
+
+This taxonomy is the organizing schema; it does not rewrite existing docs. Deferred (not in #3131):
+a full arc42/C4 restructure and an `llms.txt` discovery index.

--- a/docs/howto/getting-started.md
+++ b/docs/howto/getting-started.md
@@ -1,0 +1,49 @@
+# Getting Started — operator first session (Tutorial)
+
+A short, ordered walkthrough for an AI operator's first governed session in this harness. This is a
+**tutorial** (learning-oriented, per `docs/diataxis-taxonomy.md`) — follow it top to bottom once; for
+specific tasks afterward, use the how-to guides in `docs/howto/`.
+
+## 1. Understand the model
+
+The GitHub issue **is** the baton. You (the AI operator) run all four roles in sequence —
+Manager → Collaborator → Admin → Consultant — one at a time. The human is the **client** (design
+direction + UAT only). See `governance/README.md` for the four invariants.
+
+## 2. Start from a ticket
+
+Every change needs a GitHub issue first. Never code before a Manager scope comment exists on the
+ticket. Branch naming: `feat/<issue#>-slug` or `fix/<issue#>-slug`.
+
+## 3. Work in a dedicated worktree (never the main checkout)
+
+The main checkout is canonical/read-only during sessions. Create an isolated worktree:
+
+```bash
+git worktree add ~/devenv-ops-<N> -b feat/<N>-slug
+cd ~/devenv-ops-<N>
+```
+
+`node_modules` auto-links from the main checkout (per #1378).
+
+## 4. Post the baton artifacts on the ticket
+
+Before opening a PR, post all four on the linked issue: `MANAGER_HANDOFF`, `COLLABORATOR_HANDOFF`,
+`ADMIN_HANDOFF`, `CONSULTANT_CLOSEOUT`. Build them with
+`node scripts/global/baton-comment-build.js` so signing fields are correct.
+
+## 5. Prefer the $0 review lane
+
+Cross-family review runs on the free fleet/free-cloud lanes — never a paid provider by default
+(goal G3). The optimal fleet rater is selected by quality > cost > speed (Epic #3126).
+
+## 6. Open the PR, wait for green, merge
+
+PR body carries `Refs #N` + a merge-evidence line. Wait for all required checks green before merge;
+then the Consultant closes the issue after `CONSULTANT_CLOSEOUT`.
+
+## Next
+
+- How-to guides: `docs/howto/`
+- Architecture overview: `ARCHITECTURE.md`
+- The taxonomy behind these docs: `docs/diataxis-taxonomy.md`


### PR DESCRIPTION
Refs #3131

## Summary
Closes Epic #3124 D8 (doc taxonomy): adds `docs/diataxis-taxonomy.md` (Diátaxis × audience × surface + `area:*` → required-quadrants table + canonical entry-point roles), a non-breaking `diataxis:` annotation in `config/doc-coverage-matrix.yml`, and `docs/howto/getting-started.md` (the previously-empty operator **tutorial** quadrant). Disambiguates the four entry-point docs (`decisions.md`/`DECISIONS.md`, root/`docs` `ARCHITECTURE.md`) with canonical-role headers + cross-links — they are genuinely distinct, so disambiguated rather than deleted (no content lost).

## Evidence
- markdownlint 0 errors on all 6 docs; YAML parses (9 surfaces intact + 8 diátaxis areas); `doc-coverage.js` still loads (annotation is non-breaking)
- Docs + config only — no code, no behavior change, $0
- Cross-family design consensus: qwen3:32b 95/100 ACCEPT first round ($0 Tailscale fleet, non-Anthropic Qwen)

## Baton
Full set on #3131: COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT (+ EDD).

Phase-1 child C5 (final) of Epic #3124; design source #3125 (closed).

merge-evidence-deferred-final: #3131

🤖 Generated with [Claude Code](https://claude.com/claude-code)
