### PR TITLE
feat(memory): deterministic tool-output pruning clipper

### DIFF
--- a/.changes/unreleased/3141.md
+++ b/.changes/unreleased/3141.md
@@ -1,0 +1,2 @@
+### Added
+- `scripts/global/output-clipper.js` + `npm run output:clip` (#3141, Epic #3137 T3): `clip(text, opts)` deterministically bounds verbose tool outputs (grep/gh dumps) before they enter the context window — keeps head + tail + lines matching an optional pattern, elides the bulk with a `[... N lines elided ...]` marker. **Lossless under budget** (no-op), idempotent, graceful on non-string input. Reduces tokens on **both** the paid and fleet lanes. Deterministic, local, $0.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ the Worker: add `MEGINGJORD_HAMR_ENABLED=1` to your `.env`.
 | `memory:read-route` | `node scripts/global/read-router.js` |
 | `memory:route` | `node scripts/global/memory-write-router.js` |
 | `merge-evidence:snapshot` | `node scripts/global/merge-evidence-snapshot.js` |
+| `output:clip` | `node scripts/global/output-clipper.js` |
 | `prefix:cache-report` | `node scripts/global/prefix-cache.js` |
 | `prepare` | `bash scripts/install-git-hooks.sh` |
 | `quality:parity` | `node scripts/global/quality-parity-report.js --json` |

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "lint:coverage-metric": "node scripts/global/lint-coverage-metric.js",
     "lint:decisions": "node scripts/global/decisions-md-validator.js",
     "prefix:cache-report": "node scripts/global/prefix-cache.js",
+    "output:clip": "node scripts/global/output-clipper.js",
     "resident:budget": "node scripts/global/resident-budget.js",
     "instructions:split-classify": "node scripts/global/instructions-split-classifier.js",
     "memory:route": "node scripts/global/memory-write-router.js",

--- a/scripts/global/output-clipper.js
+++ b/scripts/global/output-clipper.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+'use strict';
+// output-clipper.js (#3141, Epic #3137 T3): deterministically bound verbose tool outputs (grep/gh
+// dumps) before they enter the context window — keep head + tail + matched lines, elide the bulk.
+// Lossless under budget (no-op); idempotent; graceful on non-string. Reduces tokens on BOTH lanes.
+// Deterministic, local, $0 — no LLM, no network.
+
+const DEFAULT_HEAD = 20;
+const DEFAULT_TAIL = 10;
+const DEFAULT_MAX_LINES = 60;
+
+/** Indices to keep: head + tail (+ lines matching matchRe).
+ * @param {string[]} lines all lines. @param {number} head @param {number} tail @param {RegExp|null} matchRe @returns {Set<number>} */
+function keptIndices(lines, head, tail, matchRe) {
+  const kept = new Set();
+  for (let i = 0; i < head && i < lines.length; i += 1) kept.add(i);
+  for (let i = Math.max(0, lines.length - tail); i < lines.length; i += 1) kept.add(i);
+  if (matchRe)
+    lines.forEach((line, idx) => {
+      if (matchRe.test(line)) kept.add(idx);
+    });
+  return kept;
+}
+
+/** Clip text to head + tail (+ matched lines), eliding the middle when over the line budget.
+ * @param {string} text input. @param {object} [opts] {maxLines, head, tail, match}. @returns {string} */
+function clip(text, opts = {}) {
+  if (typeof text !== 'string') return text;
+  const lines = text.split('\n');
+  const maxLines = opts.maxLines || DEFAULT_MAX_LINES;
+  if (lines.length <= maxLines) return text; // lossless under budget
+  const matchRe = opts.match ? new RegExp(opts.match, 'i') : null;
+  const kept = keptIndices(lines, opts.head || DEFAULT_HEAD, opts.tail || DEFAULT_TAIL, matchRe);
+  const out = [];
+  let elided = 0;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (kept.has(i)) {
+      if (elided) {
+        out.push(`[... ${elided} line(s) elided ...]`);
+        elided = 0;
+      }
+      out.push(lines[i]);
+    } else {
+      elided += 1;
+    }
+  }
+  if (elided) out.push(`[... ${elided} line(s) elided ...]`);
+  return out.join('\n');
+}
+
+function main() {
+  const text = require('fs').readFileSync(0, 'utf8');
+  process.stdout.write(clip(text));
+}
+
+if (require.main === module) main();
+module.exports = { clip };

--- a/tests/output-clipper.spec.js
+++ b/tests/output-clipper.spec.js
@@ -1,0 +1,37 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { clip } = require('../scripts/global/output-clipper.js');
+
+test('clip is a no-op under the line budget (lossless)', () => {
+  const text = 'a\nb\nc';
+  assert.equal(clip(text, { maxLines: 60 }), text);
+});
+
+test('clip keeps head + tail and elides the middle when over budget', () => {
+  const text = Array.from({ length: 200 }, (_, i) => `line${i}`).join('\n');
+  const out = clip(text, { maxLines: 60, head: 5, tail: 5 });
+  assert.ok(out.includes('line0'), 'keeps head');
+  assert.ok(out.includes('line199'), 'keeps tail');
+  assert.ok(out.includes('elided'), 'marks elision');
+  assert.ok(out.split('\n').length < 200, 'fewer lines than input');
+});
+
+test('clip keeps lines matching the match pattern', () => {
+  const text = Array.from({ length: 200 }, (_, i) =>
+    i === 100 ? 'IMPORTANT MATCH' : `line${i}`
+  ).join('\n');
+  const out = clip(text, { maxLines: 30, head: 2, tail: 2, match: 'IMPORTANT' });
+  assert.ok(out.includes('IMPORTANT MATCH'), 'keeps matched line');
+});
+
+test('clip is idempotent once under budget', () => {
+  const text = Array.from({ length: 200 }, (_, i) => `line${i}`).join('\n');
+  const once = clip(text, { maxLines: 60 });
+  assert.equal(clip(once, { maxLines: 60 }), once);
+});
+
+test('clip returns non-string input unchanged (graceful)', () => {
+  assert.equal(clip(null), null);
+  assert.deepEqual(clip(42), 42);
+});


### PR DESCRIPTION
Refs #3141

## Summary
Epic #3137 T3: `scripts/global/output-clipper.js` — `clip(text, opts)` deterministically bounds verbose tool outputs (grep/gh dumps) before they enter the window: keep head + tail + lines matching an optional pattern, elide the bulk with a `[... N lines elided ...]` marker. **Lossless under budget** (no-op), idempotent, graceful on non-string. Reduces tokens on **both** lanes. `npm run output:clip` (stdin filter).

## Evidence
- 5/5 spec tests green; eslint 0 errors; readability ≤475; prettier clean
- Deterministic, local, $0 — no network, no LLM
- **3-stage cross-model review** (qwen3:32b, $0 fleet, non-Anthropic): collaborator-self **PASS 98**, admin **PASS 95**, consultant-workflow **PASS 95**

## Baton
Full set on #3141: COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT (+ EDD).

Phase-1 child C3 of Epic #3137; design source #3138 (closed).

merge-evidence-deferred-final: #3141

🤖 Generated with [Claude Code](https://claude.com/claude-code)
