### PR TITLE
fix(signing): antigravity claude-sonnet alias seed Nova to Aria #3102

### DIFF
--- a/.changes/unreleased/3102.md
+++ b/.changes/unreleased/3102.md
@@ -1,0 +1,2 @@
+### Fixed
+- Antigravity signer-alias for `claude-sonnet` now derives the team-distinctive seed `Aria` (alias `Aria Mason`) instead of the global default seed `Nova`. Restores Team-first attribution (Apollo/Aria/Axel/Aiden A-name family) per the harness Team-then-Role-then-Model naming convention. (#3102, Epic #3095)

--- a/inventory/team-model-signatures.json
+++ b/inventory/team-model-signatures.json
@@ -116,7 +116,7 @@
     {
       "team": "antigravity",
       "modelPattern": "claude-sonnet",
-      "aliasSeed": "Nova"
+      "aliasSeed": "Aria"
     },
     {
       "team": "antigravity",

--- a/tests/baton-artifact-cross-runtime.spec.js
+++ b/tests/baton-artifact-cross-runtime.spec.js
@@ -77,7 +77,7 @@ const { validate: signerFidelityValidate } = require('../scripts/global/megalint
 const REGISTRY = JSON.parse(fs.readFileSync(path.join(__dirname, '../inventory/team-model-signatures.json'), 'utf8'));
 const AG_FIXTURE = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/antigravity-baton.json'), 'utf8'));
 
-test('antigravity registry derives Nova Mason for claude-sonnet role=manager', () => {
+test('antigravity registry derives Aria Mason for claude-sonnet role=manager', () => {
   const team = AG_FIXTURE.team;
   const model = AG_FIXTURE.model;
   const role = AG_FIXTURE.role;

--- a/tests/fixtures/antigravity-baton.json
+++ b/tests/fixtures/antigravity-baton.json
@@ -3,9 +3,9 @@
   "model": "claude-sonnet-4-6",
   "substrate": "google",
   "role": "manager",
-  "expectedAlias": "Nova Mason",
+  "expectedAlias": "Aria Mason",
   "MANAGER_HANDOFF": {
-    "Signed-by": "Nova Mason",
+    "Signed-by": "Aria Mason",
     "Team&Model": "antigravity:claude-sonnet-4-6@google",
     "Role": "manager",
     "scope": "antigravity governance parity — Phase-2 hooks and HAMR substrate",


### PR DESCRIPTION
Refs #3102
Refs #3095
merge-evidence-deferred-final: #3102

## Summary
Corrects the antigravity claude-sonnet signer-alias seed from the global default `Nova` to the team-distinctive `Aria` (Team-then-Role-then-Model convention; A-name family Apollo/Aria/Axel/Aiden). Remediates #3102 AC1 and unblocks the #3107 fixture. Touches the registry, the coupled baton fixture, the cross-runtime spec assertion, and a changelog fragment.

## Evidence
- agent-signature.js derives `Aria Mason` (was `Nova Mason`)
- signer-registry-check.js: 0 errors, no collision; global defaultAliasSeed unchanged (`Nova`)
- npx playwright test tests/baton-artifact-cross-runtime.spec.js: 11 passed
- npm run lint: 545 files, all within the 100-line cap
- Cross-family review (qwen2.5-coder:7b on fleet, non-Anthropic): ACCEPT, no findings

## Baton artifacts (on #3102)
- MANAGER_HANDOFF: posted
- COLLABORATOR_HANDOFF: posted
- ADMIN_HANDOFF: posted
- CONSULTANT_CLOSEOUT: deferred-final, posted after required checks are green and merge completes
