### PR TITLE
docs(governance): document antigravity and cursor sandbox launchers #3103

### DIFF
--- a/.changes/unreleased/3103.md
+++ b/.changes/unreleased/3103.md
@@ -1,0 +1,2 @@
+### Changed
+- Sandbox worktree governance now documents the `sandbox/antigravity` and `sandbox/cursor` launcher branches and records per-runtime governance-injection models (Antigravity: User Rules + Knowledge Items, no `@`-import; Cursor: `.cursor/rules/*.mdc`; Claude Code: `@`-imports in `CLAUDE.md`). (#3103, Epic #3095)

--- a/instructions/sandbox-worktree-governance.instructions.md
+++ b/instructions/sandbox-worktree-governance.instructions.md
@@ -1,6 +1,6 @@
 ---
 name: Sandbox Worktree Governance
-description: Governance controls for multi-agent sandbox worktrees used by Copilot, Claude Code, and Codex.
+description: Governance controls for multi-agent sandbox worktrees used by Copilot, Claude Code, Codex, Cursor, and Antigravity.
 applyTo: "**"
 ---
 
@@ -8,9 +8,10 @@ applyTo: "**"
 
 ## Operating Model
 
-- `sandbox/copilot`, `sandbox/codex`, and `sandbox/claude-code` are launcher branches.
+- `sandbox/copilot`, `sandbox/codex`, `sandbox/claude-code`, `sandbox/cursor`, and `sandbox/antigravity` are launcher branches.
 - Launcher branches are not delivery branches.
 - Delivery work must happen on ticket-linked task branches (`feat/<issue#>-<slug>`, `fix/<issue#>-<slug>`, `hotfix/<issue#>-<slug>`).
+- Per-runtime governance injection differs: Antigravity uses the User Rules system-prompt block plus Knowledge Items (KI) — the `@`-import mechanism is not supported; Cursor uses `.cursor/rules/*.mdc`; Claude Code uses `@`-imports in `CLAUDE.md`.
 
 ## Required Session Start
 
@@ -24,7 +25,7 @@ Before starting implementation in any sandbox worktree:
 
 Preferred command:
 
-- `bash scripts/worktree-session-start.sh <copilot|codex|claude-code> feat/<issue#>-<slug>`
+- `bash scripts/worktree-session-start.sh <copilot|codex|claude-code|cursor|antigravity> feat/<issue#>-<slug>`
 
 Lease command:
 


### PR DESCRIPTION
Refs #3103
Refs #3095
merge-evidence-deferred-final: #3103

## Summary
Documents the `sandbox/antigravity` launcher (AC2) plus the missing `sandbox/cursor` launcher in instructions/sandbox-worktree-governance.instructions.md, with per-runtime governance-injection notes (Antigravity User Rules + KI; Cursor `.cursor/rules`; Claude Code `@`-imports). AC1/AC3/AC4/AC5 already shipped via merged PR #3114.

## Evidence
- node scripts/global/cross-team-contract-check.js: passed
- docs-lint: clean; lint: 566 files within the 100-line cap
- Cross-family review (qwen2.5-coder:7b on fleet, non-Anthropic): ACCEPT, no findings

## Baton artifacts (on #3103)
- MANAGER_HANDOFF: posted
- COLLABORATOR_HANDOFF: posted
- ADMIN_HANDOFF: posted
- CONSULTANT_CLOSEOUT: posted (deferred-final)
