### PR TITLE
feat(hooks): add antigravity hook-parity target #3104

### DIFF
--- a/.changes/unreleased/3104.md
+++ b/.changes/unreleased/3104.md
@@ -1,0 +1,2 @@
+### Added
+- `hook-parity-check.js` now recognizes an `antigravity` deploy target and accepts a `--target <runtime>` filter, so a per-runtime parity check (e.g. `--target antigravity`) validates only that runtime — a not-yet-deployed target takes the G5 opt-out pass. No-target runs are unchanged for copilot/codex/cursor. (#3104, Epic #3095)

--- a/scripts/global/hook-parity-check.js
+++ b/scripts/global/hook-parity-check.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // hook-parity-check (#1824) — three-way diff to discriminate branch-stale from runtime-drift.
 // Closes #1824. Composes with the stress-test prompt as a Step-0 pre-check.
+// #3104 (Epic #3095): antigravity deploy target + `--target <runtime>` filter.
 'use strict';
 
 const fs = require('node:fs');
@@ -13,6 +14,8 @@ const HOOK_DIR = path.join(REPO_ROOT, 'hooks', 'scripts');
 const COPILOT_DEPLOY = path.join(os.homedir(), '.copilot', 'hooks', 'scripts');
 const CODEX_DEPLOY = path.join(os.homedir(), '.codex', 'devenv-ops', 'hooks');
 const CURSOR_DEPLOY = path.join(os.homedir(), '.cursor', 'hooks', 'scripts');
+const ANTIGRAVITY_DEPLOY = path.join(os.homedir(), '.gemini', 'antigravity', 'hooks', 'scripts');
+const DEPLOY_TARGETS = { copilot: COPILOT_DEPLOY, codex: CODEX_DEPLOY, cursor: CURSOR_DEPLOY, antigravity: ANTIGRAVITY_DEPLOY };
 
 const TRACKED = ['stop_checks.py', 'stop_reminder.py', 'manager_ticket_gate.py',
   'userprompt_gate.py', 'pretool_guard.py', 'tool_activity.py',
@@ -25,15 +28,22 @@ function gitShow(rev, file) {
   catch { return null; }
 }
 
-function diagnose(scriptName) {
+// With `target`, parity is checked against only that runtime's deployed copy (an unknown
+// or not-yet-deployed target takes the G5 opt-out path). Without it, the deployed reference
+// is the first runtime that has the script.
+function deployedFor(scriptName, target) {
+  if (target) {
+    const dir = DEPLOY_TARGETS[target];
+    return dir ? read(path.join(dir, scriptName)) : null;
+  }
+  return Object.values(DEPLOY_TARGETS).map((d) => read(path.join(d, scriptName))).find((c) => c != null) || null;
+}
+
+function diagnose(scriptName, target) {
   const branch = read(path.join(HOOK_DIR, scriptName));
   const main = gitShow('origin/main', `hooks/scripts/${scriptName}`);
-  const copilot = read(path.join(COPILOT_DEPLOY, scriptName));
-  const codex = read(path.join(CODEX_DEPLOY, scriptName));
-  const cursor = read(path.join(CURSOR_DEPLOY, scriptName));
-  const deployed = copilot || codex || cursor;
-  const deployState = (copilot === null && codex === null && cursor === null) ? 'not-deployed' : 'deployed';
-  if (deployState === 'not-deployed') {
+  const deployed = deployedFor(scriptName, target);
+  if (deployed === null) {
     return { script: scriptName, diagnosis: 'not-deployed', recommend: 'opt-out path: G5 portability respected; no action needed' };
   }
   const branchMatchMain = branch === main;
@@ -46,26 +56,32 @@ function diagnose(scriptName) {
   return { script: scriptName, diagnosis: 'branch-and-runtime-diverged', recommend: 'manual reconciliation; file incident ticket' };
 }
 
-function run() {
-  const results = TRACKED.map(diagnose);
+function run(target) {
+  const results = TRACKED.map((s) => diagnose(s, target));
   const byDiag = {};
   for (const r of results) { (byDiag[r.diagnosis] = byDiag[r.diagnosis] || []).push(r.script); }
-  const realDrift = results.some(r => r.diagnosis === 'branch-and-runtime-diverged');
-  const runtimeStale = results.some(r => r.diagnosis === 'runtime-stale');
+  const realDrift = results.some((r) => r.diagnosis === 'branch-and-runtime-diverged');
+  const runtimeStale = results.some((r) => r.diagnosis === 'runtime-stale');
   const exitCode = realDrift ? 2 : (runtimeStale ? 1 : 0);
   return { results, byDiagnosis: byDiag, exitCode };
+}
+
+function parseTarget(argv) {
+  const i = argv.findIndex((a) => a === '--target' || a.startsWith('--target='));
+  if (i === -1) return null;
+  return argv[i].includes('=') ? argv[i].split('=')[1] : (argv[i + 1] || null);
 }
 
 if (require.main === module) {
   // Refresh origin/main reference for accurate comparison.
   try { execFileSync('git', ['fetch', 'origin', 'main', '-q'], { cwd: REPO_ROOT, stdio: 'ignore' }); } catch { /* offline ok */ }
-  const out = run();
+  const out = run(parseTarget(process.argv));
   if (process.argv.includes('--json')) {
     process.stdout.write(JSON.stringify(out, null, 2) + '\n');
   } else {
     for (const r of out.results) {
       const sym = r.diagnosis === 'ok' ? '✓' : (r.diagnosis === 'branch-stale' ? '↻' : '✗');
-      process.stdout.write(`${sym} ${r.script.padEnd(28)} ${r.diagnosis}${r.recommend ? '  → ' + r.recommend : ''}\n`);
+      process.stdout.write(`${sym} ${r.script.padEnd(28)} ${r.diagnosis}${r.recommend ? '  -> ' + r.recommend : ''}\n`);
     }
     if (out.exitCode === 1) process.stderr.write('\nrun npm run deploy:both:apply to sync runtime\n');
     if (out.exitCode === 2) process.stderr.write('\nREAL DRIFT detected — file an incident ticket\n');
@@ -73,4 +89,4 @@ if (require.main === module) {
   process.exit(out.exitCode);
 }
 
-module.exports = { run, diagnose, TRACKED, HOOK_DIR, COPILOT_DEPLOY, CODEX_DEPLOY, CURSOR_DEPLOY };
+module.exports = { run, diagnose, deployedFor, TRACKED, HOOK_DIR, COPILOT_DEPLOY, CODEX_DEPLOY, CURSOR_DEPLOY, ANTIGRAVITY_DEPLOY, DEPLOY_TARGETS };

--- a/tests/hook-parity-check.spec.js
+++ b/tests/hook-parity-check.spec.js
@@ -37,7 +37,7 @@ function withStubs(stubs, fn) {
   }
 }
 
-function buildStubs({ branch, main, copilot, codex }, scriptName = 'stop_checks.py') {
+function buildStubs({ branch, main, copilot, codex, cursor, antigravity }, scriptName = 'stop_checks.py') {
   const REPO = path.resolve(__dirname, '..');
   const home = os.homedir();
   return {
@@ -45,6 +45,8 @@ function buildStubs({ branch, main, copilot, codex }, scriptName = 'stop_checks.
       [path.join(REPO, 'hooks', 'scripts', scriptName)]: branch,
       [path.join(home, '.copilot', 'hooks', 'scripts', scriptName)]: copilot,
       [path.join(home, '.codex', 'devenv-ops', 'hooks', scriptName)]: codex,
+      [path.join(home, '.cursor', 'hooks', 'scripts', scriptName)]: cursor,
+      [path.join(home, '.gemini', 'antigravity', 'hooks', 'scripts', scriptName)]: antigravity,
     },
     gitShow: { [`origin/main:hooks/scripts/${scriptName}`]: main },
   };
@@ -86,8 +88,8 @@ test('branch-and-runtime-diverged when all three differ', () => {
   });
 });
 
-test('not-deployed when both copilot and codex absent', () => {
-  const stubs = buildStubs({ branch: 'A', main: 'A', copilot: null, codex: null });
+test('not-deployed when all runtime targets absent', () => {
+  const stubs = buildStubs({ branch: 'A', main: 'A', copilot: null, codex: null, cursor: null, antigravity: null });
   withStubs(stubs, (mod) => {
     const r = mod.diagnose('stop_checks.py');
     assert.equal(r.diagnosis, 'not-deployed');
@@ -119,4 +121,28 @@ test('TRACKED constant covers expected hook scripts', () => {
   assert.ok(mod.TRACKED.includes('stop_checks.py'));
   assert.ok(mod.TRACKED.includes('repo_detection.py'));
   assert.ok(mod.TRACKED.includes('userprompt_gate.py'));
+});
+
+test('target antigravity: not-deployed opt-out when antigravity absent (#3104)', () => {
+  const stubs = buildStubs({ branch: 'A', main: 'A', copilot: 'A', codex: 'A', antigravity: null });
+  withStubs(stubs, (mod) => {
+    const r = mod.diagnose('stop_checks.py', 'antigravity');
+    assert.equal(r.diagnosis, 'not-deployed');
+    assert.match(r.recommend, /G5|opt-out/i);
+  });
+});
+
+test('target antigravity: ok when antigravity deployed matches branch+main (#3104)', () => {
+  const stubs = buildStubs({ branch: 'A', main: 'A', copilot: null, codex: null, antigravity: 'A' });
+  withStubs(stubs, (mod) => {
+    const r = mod.diagnose('stop_checks.py', 'antigravity');
+    assert.equal(r.diagnosis, 'ok');
+  });
+});
+
+test('DEPLOY_TARGETS exposes antigravity target (#3104)', () => {
+  delete require.cache[modulePath];
+  const mod = require(modulePath);
+  assert.ok(Object.keys(mod.DEPLOY_TARGETS).includes('antigravity'));
+  assert.equal(typeof mod.deployedFor, 'function');
 });


### PR DESCRIPTION
Refs #3104
Refs #3095
merge-evidence-deferred-final: #3104

## Summary
Adds an `antigravity` deploy target and a `--target <runtime>` filter to scripts/global/hook-parity-check.js (AC3), so a per-runtime parity check validates only that runtime — a not-yet-deployed target takes the G5 opt-out pass. No-target runs are unchanged for copilot/codex/cursor (AC4). AC1/AC2 already shipped via merged PR #3115.

## Evidence
- node --test tests/hook-parity-check.spec.js: 11/11 pass (3 antigravity cases added, full stub isolation)
- hook-parity-check.js --target antigravity and --target=antigravity: exit 0; no-target: exit 0
- lint: within the 100-line cap
- Cross-family (qwen2.5-coder:7b, non-Anthropic): ACCEPT, G1 9 / G4 8 / G6 7, no findings

## Baton artifacts (on #3104)
- MANAGER_HANDOFF / COLLABORATOR_HANDOFF / ADMIN_HANDOFF / CONSULTANT_CLOSEOUT posted
