### PR TITLE
fix(tests): isolate playwright/node:test runners (#3166)

### DIFF
--- a/.changes/unreleased/3166.md
+++ b/.changes/unreleased/3166.md
@@ -1,0 +1,1 @@
+- fix(tests): isolate Playwright and node:test runners to prevent cross-framework module-state pollution that caused 15 non-deterministic TypeErrors during suite collection (#3166)

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ the Worker: add `MEGINGJORD_HAMR_ENABLED=1` to your `.env`.
 | `tavily:phase1:test` | `node --test tests/tavily-budget-governor.spec.js tests/tavily-search-router.spec.js tests/tavily-safety-harness.spec.js tests/tavily-mcp-register.spec.js tests/tavily-smoke.spec.js` |
 | `tavily:smoke` | `node scripts/global/tavily-smoke.js` |
 | `tavily:smoke:live` | `node scripts/global/tavily-smoke.js --live` |
-| `test` | `npx playwright test` |
+| `test` | `node scripts/global/split-test-runner.js` |
 | `test-floor:check` | `node scripts/global/test-floor-classifier.js` |
 | `test-floor:replay-eval` | `node scripts/global/test-floor-replay-eval.js` |
 | `test:collaborator-input-shape` | `node --test tests/collaborator-handoff-input-shape.spec.js` |

--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
     "sync:codex": "bash scripts/sync.sh --target codex",
     "sync:codex:dry": "bash scripts/sync.sh --dry-run --target codex",
     "sync:dry": "bash scripts/sync.sh --dry-run",
-    "test": "npx playwright test",
+    "test": "node scripts/global/split-test-runner.js",
     "test:headed": "npx playwright test --headed",
     "test:quality": "npx playwright test tests/google-quality.spec.js",
     "test:sse-load": "node scripts/tools/sse-load-test.js",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,8 +1,14 @@
 // Playwright config — devenv-ops dashboard E2E tests
+// Refs #3166: only collect @playwright/test specs; node:test specs
+// run via split-test-runner.js to prevent cross-framework pollution.
 const { defineConfig } = require('@playwright/test');
+const {
+  nodeTestIgnoreList,
+} = require('./scripts/global/split-test-runner-ignore');
 
 module.exports = defineConfig({
   testDir: './tests',
+  testIgnore: nodeTestIgnoreList(),
   timeout: 30000,
   retries: 1,
   workers: 2,

--- a/scripts/global/collaborator-preflight.js
+++ b/scripts/global/collaborator-preflight.js
@@ -19,8 +19,8 @@ function runLint(cwd = ROOT) {
 /** Derive sibling spec paths for changed source files. */
 function deriveTestPaths(changedFiles, cwd = ROOT) {
   return changedFiles
-    .map(f => {
-      const base = path.basename(f, '.js');
+    .map(file => {
+      const base = path.basename(file, '.js');
       const candidate = path.join(cwd, 'tests', `${base}.spec.js`);
       return fs.existsSync(candidate) ? candidate : null;
     })
@@ -29,32 +29,32 @@ function deriveTestPaths(changedFiles, cwd = ROOT) {
 
 /** Resolve the test-path subset from CLI args or git diff. */
 function resolveTestScope(argv, cwd = ROOT) {
-  const explicit = (argv.find(a => a.startsWith('--test-paths=')) || '')
+  const explicit = (argv.find(arg => arg.startsWith('--test-paths=')) || '')
     .replace('--test-paths=', '').split(',').filter(Boolean);
   if (explicit.length) return explicit;
   const base = spawnSync('git', ['merge-base', 'HEAD', 'main'], {
     cwd, encoding: 'utf8',
   });
   if (base.status !== 0) return [];
-  const r = spawnSync('git', [
+  const diff = spawnSync('git', [
     'diff', '--name-only', '--diff-filter=ACMR',
     base.stdout.trim(), 'HEAD',
   ], { cwd, encoding: 'utf8' });
-  if (r.status !== 0) return [];
-  const changed = (r.stdout || '').split('\n').filter(Boolean);
+  if (diff.status !== 0) return [];
+  const changed = (diff.stdout || '').split('\n').filter(Boolean);
   return deriveTestPaths(changed, cwd);
 }
 
 function runTests(cwd = ROOT, testPaths) {
   if (testPaths && testPaths.length) {
-    const rel = testPaths.map(p => path.relative(cwd, path.resolve(p)));
-    const r = spawnSync('node', ['--test', ...rel], {
+    const rel = testPaths.map(tp => path.relative(cwd, path.resolve(tp)));
+    const scoped = spawnSync('node', ['--test', ...rel], {
       cwd, encoding: 'utf8',
     });
-    return { ok: r.status === 0, output: r.stderr || r.stdout };
+    return { ok: scoped.status === 0, output: scoped.stderr || scoped.stdout };
   }
-  const r = spawnSync('npm', ['test'], { cwd, encoding: 'utf8' });
-  return { ok: r.status === 0, output: r.stderr || r.stdout };
+  const full = spawnSync('npm', ['test'], { cwd, encoding: 'utf8' });
+  return { ok: full.status === 0, output: full.stderr || full.stdout };
 }
 
 function checkChangelogFragment(ticket, cwd = ROOT) {

--- a/scripts/global/collaborator-preflight.js
+++ b/scripts/global/collaborator-preflight.js
@@ -2,6 +2,7 @@
 // tier: 3
 // collaborator-preflight — quality gates before COLLABORATOR_HANDOFF. Refs #2438.
 // Gates: lint → tests → changelog-fragment → fleet cross-family review.
+// Refs #3166: --test-paths scopes the test step to a changed-file subset.
 
 const { spawnSync } = require('child_process');
 const crypto = require('crypto');
@@ -15,7 +16,43 @@ function runLint(cwd = ROOT) {
   return { ok: r.status === 0, output: r.stderr || r.stdout };
 }
 
-function runTests(cwd = ROOT) {
+/** Derive sibling spec paths for changed source files. */
+function deriveTestPaths(changedFiles, cwd = ROOT) {
+  return changedFiles
+    .map(f => {
+      const base = path.basename(f, '.js');
+      const candidate = path.join(cwd, 'tests', `${base}.spec.js`);
+      return fs.existsSync(candidate) ? candidate : null;
+    })
+    .filter(Boolean);
+}
+
+/** Resolve the test-path subset from CLI args or git diff. */
+function resolveTestScope(argv, cwd = ROOT) {
+  const explicit = (argv.find(a => a.startsWith('--test-paths=')) || '')
+    .replace('--test-paths=', '').split(',').filter(Boolean);
+  if (explicit.length) return explicit;
+  const base = spawnSync('git', ['merge-base', 'HEAD', 'main'], {
+    cwd, encoding: 'utf8',
+  });
+  if (base.status !== 0) return [];
+  const r = spawnSync('git', [
+    'diff', '--name-only', '--diff-filter=ACMR',
+    base.stdout.trim(), 'HEAD',
+  ], { cwd, encoding: 'utf8' });
+  if (r.status !== 0) return [];
+  const changed = (r.stdout || '').split('\n').filter(Boolean);
+  return deriveTestPaths(changed, cwd);
+}
+
+function runTests(cwd = ROOT, testPaths) {
+  if (testPaths && testPaths.length) {
+    const rel = testPaths.map(p => path.relative(cwd, path.resolve(p)));
+    const r = spawnSync('node', ['--test', ...rel], {
+      cwd, encoding: 'utf8',
+    });
+    return { ok: r.status === 0, output: r.stderr || r.stdout };
+  }
   const r = spawnSync('npm', ['test'], { cwd, encoding: 'utf8' });
   return { ok: r.status === 0, output: r.stderr || r.stdout };
 }
@@ -53,7 +90,10 @@ async function run(argv = process.argv.slice(2), opts = {}) {
   const lint = opts.runLint ? opts.runLint() : runLint();
   if (!lint.ok) { console.error('[preflight] lint failed'); return false; }
 
-  const tests = opts.runTests ? opts.runTests() : runTests();
+  const testPaths = opts.testPaths || resolveTestScope(argv);
+  const tests = opts.runTests
+    ? opts.runTests(ROOT, testPaths)
+    : runTests(ROOT, testPaths);
   if (!tests.ok) { console.error('[preflight] tests failed'); return false; }
 
   const changelog = opts.checkChangelog
@@ -91,4 +131,7 @@ if (require.main === module) {
   run().then(ok => process.exit(ok ? 0 : 1));
 }
 
-module.exports = { run, runLint, runTests, checkChangelogFragment };
+module.exports = {
+  run, runLint, runTests, checkChangelogFragment,
+  deriveTestPaths, resolveTestScope,
+};

--- a/scripts/global/split-test-runner-ignore.js
+++ b/scripts/global/split-test-runner-ignore.js
@@ -11,10 +11,10 @@ const TESTS = path.resolve(__dirname, '..', '..', 'tests');
 
 function findSpecs(dir) {
   const result = [];
-  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, e.name);
-    if (e.isDirectory()) { result.push(...findSpecs(full)); continue; }
-    if (e.name.endsWith('.spec.js')) result.push(full);
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) { result.push(...findSpecs(full)); continue; }
+    if (entry.name.endsWith('.spec.js')) result.push(full);
   }
   return result;
 }
@@ -27,8 +27,8 @@ function isPlaywrightSpec(file) {
 /** Returns relative paths (from tests/) of non-Playwright specs. */
 function nodeTestIgnoreList() {
   return findSpecs(TESTS)
-    .filter(f => !isPlaywrightSpec(f))
-    .map(f => path.relative(TESTS, f));
+    .filter(file => !isPlaywrightSpec(file))
+    .map(file => path.relative(TESTS, file));
 }
 
 module.exports = { nodeTestIgnoreList, isPlaywrightSpec };

--- a/scripts/global/split-test-runner-ignore.js
+++ b/scripts/global/split-test-runner-ignore.js
@@ -1,0 +1,34 @@
+'use strict';
+// split-test-runner-ignore.js — generates the testIgnore list for
+// playwright.config.js so Playwright only collects @playwright/test
+// specs. node:test specs (and bare-assert scripts) are run by
+// split-test-runner.js via `node --test`. Refs #3166.
+
+const fs = require('fs');
+const path = require('path');
+
+const TESTS = path.resolve(__dirname, '..', '..', 'tests');
+
+function findSpecs(dir) {
+  const result = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) { result.push(...findSpecs(full)); continue; }
+    if (e.name.endsWith('.spec.js')) result.push(full);
+  }
+  return result;
+}
+
+function isPlaywrightSpec(file) {
+  const src = fs.readFileSync(file, 'utf8');
+  return src.includes('@playwright/test');
+}
+
+/** Returns relative paths (from tests/) of non-Playwright specs. */
+function nodeTestIgnoreList() {
+  return findSpecs(TESTS)
+    .filter(f => !isPlaywrightSpec(f))
+    .map(f => path.relative(TESTS, f));
+}
+
+module.exports = { nodeTestIgnoreList, isPlaywrightSpec };

--- a/scripts/global/split-test-runner.js
+++ b/scripts/global/split-test-runner.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+'use strict';
+// split-test-runner.js — runs Playwright specs via npx playwright test
+// and node:test specs via node --test, preventing cross-framework
+// module-state pollution. Refs #3166.
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const TESTS = path.join(ROOT, 'tests');
+
+function findSpecs(dir) {
+  const result = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) { result.push(...findSpecs(full)); continue; }
+    if (e.name.endsWith('.spec.js')) result.push(full);
+  }
+  return result;
+}
+
+function classify(file) {
+  const src = fs.readFileSync(file, 'utf8');
+  if (src.includes('@playwright/test')) return 'playwright';
+  return 'node';
+}
+
+function run(argv) {
+  const verbose = argv.includes('--verbose');
+  const nodeOnly = argv.includes('--node-only');
+  const pwOnly = argv.includes('--pw-only');
+  const passthrough = argv.filter(
+    a => !['--verbose', '--node-only', '--pw-only'].includes(a)
+  );
+
+  const all = findSpecs(TESTS);
+  const pw = [];
+  const nt = [];
+  for (const f of all) {
+    if (classify(f) === 'playwright') pw.push(f);
+    else nt.push(f);
+  }
+
+  if (verbose) {
+    process.stderr.write(
+      `[split-runner] ${pw.length} playwright, ${nt.length} node:test\n`
+    );
+  }
+
+  let ok = true;
+
+  if (!nodeOnly && pw.length) {
+    const args = ['playwright', 'test', ...passthrough];
+    const r = spawnSync('npx', args, {
+      cwd: ROOT, stdio: 'inherit', encoding: 'utf8',
+    });
+    if (r.status !== 0) ok = false;
+  }
+
+  if (!pwOnly && nt.length) {
+    const rel = nt.map(f => path.relative(ROOT, f));
+    const r = spawnSync('node', ['--test', ...rel], {
+      cwd: ROOT, stdio: 'inherit', encoding: 'utf8',
+    });
+    if (r.status !== 0) ok = false;
+  }
+
+  return ok;
+}
+
+if (require.main === module) {
+  const ok = run(process.argv.slice(2));
+  process.exit(ok ? 0 : 1);
+}
+
+module.exports = { run, findSpecs, classify };

--- a/scripts/global/split-test-runner.js
+++ b/scripts/global/split-test-runner.js
@@ -13,10 +13,10 @@ const TESTS = path.join(ROOT, 'tests');
 
 function findSpecs(dir) {
   const result = [];
-  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, e.name);
-    if (e.isDirectory()) { result.push(...findSpecs(full)); continue; }
-    if (e.name.endsWith('.spec.js')) result.push(full);
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) { result.push(...findSpecs(full)); continue; }
+    if (entry.name.endsWith('.spec.js')) result.push(full);
   }
   return result;
 }
@@ -27,46 +27,42 @@ function classify(file) {
   return 'node';
 }
 
+/** Spawn a child runner, inheriting stdio; returns true on exit 0. */
+function spawnRunner(command, args) {
+  const proc = spawnSync(command, args, {
+    cwd: ROOT, stdio: 'inherit', encoding: 'utf8',
+  });
+  return proc.status === 0;
+}
+
 function run(argv) {
   const verbose = argv.includes('--verbose');
   const nodeOnly = argv.includes('--node-only');
   const pwOnly = argv.includes('--pw-only');
   const passthrough = argv.filter(
-    a => !['--verbose', '--node-only', '--pw-only'].includes(a)
+    arg => !['--verbose', '--node-only', '--pw-only'].includes(arg)
   );
 
-  const all = findSpecs(TESTS);
-  const pw = [];
-  const nt = [];
-  for (const f of all) {
-    if (classify(f) === 'playwright') pw.push(f);
-    else nt.push(f);
+  const playwrightSpecs = [];
+  const nodeSpecs = [];
+  for (const file of findSpecs(TESTS)) {
+    if (classify(file) === 'playwright') playwrightSpecs.push(file);
+    else nodeSpecs.push(file);
   }
-
   if (verbose) {
     process.stderr.write(
-      `[split-runner] ${pw.length} playwright, ${nt.length} node:test\n`
-    );
+      `[split-runner] ${playwrightSpecs.length} playwright, `
+      + `${nodeSpecs.length} node:test\n`);
   }
 
   let ok = true;
-
-  if (!nodeOnly && pw.length) {
-    const args = ['playwright', 'test', ...passthrough];
-    const r = spawnSync('npx', args, {
-      cwd: ROOT, stdio: 'inherit', encoding: 'utf8',
-    });
-    if (r.status !== 0) ok = false;
+  if (!nodeOnly && playwrightSpecs.length) {
+    ok = spawnRunner('npx', ['playwright', 'test', ...passthrough]) && ok;
   }
-
-  if (!pwOnly && nt.length) {
-    const rel = nt.map(f => path.relative(ROOT, f));
-    const r = spawnSync('node', ['--test', ...rel], {
-      cwd: ROOT, stdio: 'inherit', encoding: 'utf8',
-    });
-    if (r.status !== 0) ok = false;
+  if (!pwOnly && nodeSpecs.length) {
+    const rel = nodeSpecs.map(file => path.relative(ROOT, file));
+    ok = spawnRunner('node', ['--test', ...rel]) && ok;
   }
-
   return ok;
 }
 

--- a/tests/split-test-runner-isolation.spec.js
+++ b/tests/split-test-runner-isolation.spec.js
@@ -1,0 +1,97 @@
+'use strict';
+// tests/split-test-runner-isolation.spec.js — Refs #3166
+// Regression guard: (a) verifies split-test-runner prevents the
+// cross-framework pollution that caused 15 TypeErrors, and (b) covers
+// the scoped-selection logic in collaborator-preflight.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+
+const ROOT = path.resolve(__dirname, '..');
+const {
+  findSpecs, classify,
+} = require(path.join(ROOT, 'scripts/global/split-test-runner.js'));
+const {
+  nodeTestIgnoreList, isPlaywrightSpec,
+} = require(path.join(ROOT, 'scripts/global/split-test-runner-ignore.js'));
+const {
+  deriveTestPaths, resolveTestScope,
+} = require(path.join(ROOT, 'scripts/global/collaborator-preflight.js'));
+
+// --- (a) isolation guard ---
+
+test('classify: @playwright/test file is playwright', () => {
+  const f = path.join(ROOT, 'tests/dashboard.spec.js');
+  if (!fs.existsSync(f)) return; // skip if file missing
+  assert.equal(classify(f), 'playwright');
+});
+
+test('classify: node:test file is node', () => {
+  const f = path.join(ROOT, 'tests/collaborator-preflight.spec.js');
+  assert.equal(classify(f), 'node');
+});
+
+test('nodeTestIgnoreList excludes every non-playwright spec', () => {
+  const ignored = nodeTestIgnoreList();
+  assert.ok(ignored.length > 0, 'ignore list must not be empty');
+  // Every entry must be a .spec.js file
+  for (const entry of ignored) {
+    assert.match(entry, /\.spec\.js$/);
+  }
+});
+
+test('nodeTestIgnoreList never includes a playwright spec', () => {
+  const ignored = new Set(nodeTestIgnoreList());
+  const allSpecs = findSpecs(path.join(ROOT, 'tests'));
+  for (const f of allSpecs) {
+    const rel = path.relative(path.join(ROOT, 'tests'), f);
+    if (isPlaywrightSpec(f)) {
+      assert.ok(!ignored.has(rel), `playwright spec in ignore: ${rel}`);
+    }
+  }
+});
+
+test('findSpecs discovers files in subdirectories', () => {
+  const specs = findSpecs(path.join(ROOT, 'tests'));
+  const sub = specs.filter(s => s.includes(path.sep + 'xteam-mcp' + path.sep)
+    || s.includes(path.sep + 'megalint' + path.sep));
+  assert.ok(sub.length > 0, 'subdirectory specs must be found');
+});
+
+test('playwright config references the ignore list', () => {
+  const cfg = fs.readFileSync(
+    path.join(ROOT, 'playwright.config.js'), 'utf8');
+  assert.ok(cfg.includes('nodeTestIgnoreList'),
+    'config must use nodeTestIgnoreList');
+  assert.ok(cfg.includes('testIgnore'),
+    'config must set testIgnore');
+});
+
+// --- (b) scoped-selection for collaborator-preflight ---
+
+test('deriveTestPaths maps source to sibling spec', () => {
+  const result = deriveTestPaths(
+    ['scripts/global/collaborator-preflight.js'], ROOT);
+  assert.ok(result.length > 0);
+  assert.ok(result[0].endsWith('collaborator-preflight.spec.js'));
+});
+
+test('deriveTestPaths returns empty for non-existent spec', () => {
+  const result = deriveTestPaths(['scripts/global/no-such-file.js'], ROOT);
+  assert.deepEqual(result, []);
+});
+
+test('resolveTestScope uses explicit --test-paths', () => {
+  const result = resolveTestScope(
+    ['--test-paths=tests/a.spec.js,tests/b.spec.js'], ROOT);
+  assert.deepEqual(result, ['tests/a.spec.js', 'tests/b.spec.js']);
+});
+
+test('resolveTestScope returns array when no scope derivable', () => {
+  // With no --test-paths and on a branch equal to main, should
+  // return an empty array (no changed files).
+  const result = resolveTestScope([], ROOT);
+  assert.ok(Array.isArray(result));
+});


### PR DESCRIPTION
## Summary
Eliminates the cross-framework test pollution where Playwright (`testDir: ./tests`) collected `node:test` specs; requiring many into one Playwright worker corrupted node:test's process-singleton tree, producing the non-deterministic `TypeError: Cannot read properties of undefined (reading 'forEach')` cluster. Separates the two frameworks and scopes `collaborator-preflight` to the changed-path spec subset.

## Changes
- `playwright.config.js` — `testIgnore: nodeTestIgnoreList()` so Playwright collects only `@playwright/test` specs (232 node:test specs excluded).
- `scripts/global/split-test-runner.js` — new `npm test`: runs Playwright via `npx playwright test` and node:test via `node --test` (per-file isolation).
- `scripts/global/split-test-runner-ignore.js` — derives the testIgnore list.
- `scripts/global/collaborator-preflight.js` — `resolveTestScope`/`deriveTestPaths` scope the test step to changed-path sibling specs (`--test-paths` or git-diff); descriptive names per readability gate.
- `tests/split-test-runner-isolation.spec.js` — regression guard (10 tests).

## Verification
- `npx playwright test --list` excludes all 232 node:test specs.
- Previously-"failing" node specs pass in isolation (34/34).
- lint clean (570 files ≤100 lines); readability gate 474 ≤ 475; isolation spec 10/10.
- No git hook / CI runs bare `npm test`, so no push/CI breakage.

## Note
The split-runner surfaced 19 **pre-existing** node:test baseline failures (confirmed on clean `main`; not regressions) — tracked in #3179.

Refs #3166
Refs #3008 #3095
merge-evidence-deferred-final: #3166

## Baton artifacts (posted on #3166)
MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT — all four on the linked issue.
