### PR TITLE
fix(review): default cross-family reviews to 7b (#3167)

### DIFF
--- a/.changes/unreleased/3167.md
+++ b/.changes/unreleased/3167.md
@@ -1,0 +1,1 @@
+- fix(review): default routine cross-family reviews to qwen2.5-coder:7b (32b high-stakes opt-in); expose dispatchRedTeam response text to fix the raw-object consumer crash; surface fleet-unreachable as a visible non-pass instead of a fabricated rating or Anthropic self-review (#3167)

--- a/config/red-team-model-matrix.yml
+++ b/config/red-team-model-matrix.yml
@@ -33,8 +33,8 @@ models:
     cost: medium
     throughput_rph: 12
     stakes_threshold: high
-    default_for_stakes: ["high", "medium"]
-    notes: "Preferred for high-stakes and medium-stakes reviews. ~3-5 min/call."
+    default_for_stakes: ["high"]
+    notes: "High-stakes opt-in only (#3167). Cold-loads slowly (~3-5 min/call, p99 907s) and times out on routine reviews; routine work uses 7b."
 
   - id: "qwen2.5-coder:7b"
     family: "qwen"
@@ -51,8 +51,8 @@ models:
     cost: low
     throughput_rph: 60
     stakes_threshold: low
-    default_for_stakes: ["low"]
-    notes: "Fast fallback. Use when 32b unavailable or stakes=low. ~30-60 sec."
+    default_for_stakes: ["low", "medium"]
+    notes: "Routine default for low + medium stakes (#3167). Reliable fast path, ~30-60 sec. 32b reserved for high-stakes opt-in."
 
   - id: "qwen3:32b"
     family: "qwen"
@@ -78,16 +78,16 @@ models:
 #   1. Filter to models where blocked != true
 #   2. Filter to models where cross_family_ok == true (always required)
 #   3. If opts.model explicitly set, use that model (bypasses matrix)
-#   4. If taskContext.stakes == 'high' or 'medium':
-#        select first model where 'high' or 'medium' in default_for_stakes
-#   5. If taskContext.stakes == 'low' or unset:
-#        select first model where 'low' in default_for_stakes
+#   4. If taskContext.stakes == 'high':
+#        select first model where 'high' in default_for_stakes (32b opt-in)
+#   5. If taskContext.stakes == 'medium', 'low', or unset (routine):
+#        select first model where that stakes value in default_for_stakes (7b)
 #   6. Verify availability != 'untested'; warn if 'conditional'
 #   7. Return { modelId, rationale, warningIfConditional }
 
 selection_defaults:
   stakes_when_unset: "low"
-  fallback_chain: ["qwen2.5-coder:32b", "qwen2.5-coder:7b"]
+  fallback_chain: ["qwen2.5-coder:7b", "qwen2.5-coder:32b"]
 
 # Canonical fleet transport path (#2929, Epic #2926 C3) — implemented in
 # scripts/global/fleet-backend-select.js (selectFleetBackend + dispatchFleet),

--- a/scripts/global/collaborator-preflight.js
+++ b/scripts/global/collaborator-preflight.js
@@ -62,24 +62,46 @@ function checkChangelogFragment(ticket, cwd = ROOT) {
   return { ok: fs.existsSync(p), path: p };
 }
 
+// #3167: a reviewer from the authoring (Anthropic) family can never be labelled
+// cross-family — that would defeat the whole invariant.
+const ANTHROPIC_FAMILY_RE = /claude|anthropic|opus|sonnet|haiku/i;
+
+// #3167: pure interpretation of a dispatchRedTeam result into cross-family fields.
+// Exported for direct unit testing of the degraded / non-cross-family paths.
+function interpretReview(result) {
+  const stats = result.hamrStats || {};
+  const reviewerModel = result.modelUsed || 'qwen2.5-coder:7b';
+  // AC2: a degraded dispatch (fleet AND free-cloud unreachable) is a VISIBLE non-pass
+  // — never a fabricated rating that reads as a pass — and an Anthropic reviewer is
+  // rejected rather than mislabelled cross-family.
+  const nonCrossFamily = ANTHROPIC_FAMILY_RE.test(reviewerModel);
+  if (stats.ok === false || stats.degraded === true || nonCrossFamily) {
+    const reason = nonCrossFamily
+      ? `rejected-non-cross-family-reviewer:${reviewerModel}`
+      : (stats.degraded_reason || 'fleet-unreachable');
+    return {
+      reviewer: `${reviewerModel}@unavailable`, rating: null, available: false,
+      findings: `cross-family review UNAVAILABLE (${reason})`,
+    };
+  }
+  // AC3: read the response TEXT, never .match/.slice on the raw object.
+  const text = result.text || '';
+  const host = stats.substituted ? 'free-cloud' : '100.91.113.16:11434';
+  const rating = parseInt(text.match(/rating[:\s]+(\d+)/i)?.[1] || '70', 10);
+  return {
+    reviewer: `${reviewerModel}@${host}`, rating, available: true,
+    findings: (result.findings || []).map(finding => finding.detail || finding.raw || finding)
+      .join('; ') || text.slice(0, 200) || 'none',
+  };
+}
+
 async function runFleetReview(content, ticket) {
   const { dispatchRedTeam } = require('./fleet-red-team-dispatch.js');
   const result = await dispatchRedTeam({
     artifactType: 'collaborator-handoff', content,
     taskContext: { ticket },
   });
-  const rating = parseInt(
-    (result.raw || '').match(/rating[:\s]+(\d+)/i)?.[1] || '70', 10);
-  // #2646: when the fleet was unreachable and the review failed over to the $0
-  // free-cloud tier, surface that substituted reviewer (not the fleet host).
-  const host = result.hamrStats?.substituted ? 'free-cloud'
-    : result.hamrStats?.ok ? '100.91.113.16:11434' : 'unavailable';
-  return {
-    reviewer: `${result.modelUsed || 'qwen2.5-coder:7b'}@${host}`,
-    rating,
-    findings: (result.findings || []).map(f => f.detail || f).join('; ')
-      || (result.raw || '').slice(0, 200) || 'none',
-  };
+  return interpretReview(result);
 }
 
 async function run(argv = process.argv.slice(2), opts = {}) {
@@ -115,9 +137,13 @@ async function run(argv = process.argv.slice(2), opts = {}) {
   const receipt = crypto.createHash('sha256')
     .update(`${review.reviewer}|${review.rating}|${review.findings}|${ticket}`)
     .digest('hex').slice(0, 16);
+  // #3167 AC2: surface an unreachable review as a VISIBLE non-pass, not a number.
+  const ratingLine = review.available === false
+    ? 'UNAVAILABLE (fleet + free-cloud unreachable — visible non-pass)'
+    : `${review.rating}/100`;
   console.log('\n=== COLLABORATOR_HANDOFF cross-family fields ===');
   console.log(`cross_family_reviewer: ${review.reviewer}`);
-  console.log(`cross_family_rating: ${review.rating}/100`);
+  console.log(`cross_family_rating: ${ratingLine}`);
   console.log(`cross_family_findings: ${review.findings}`);
   console.log(`cross_family_receipt: ${receipt}`);
   return true;
@@ -133,5 +159,5 @@ if (require.main === module) {
 
 module.exports = {
   run, runLint, runTests, checkChangelogFragment,
-  deriveTestPaths, resolveTestScope,
+  deriveTestPaths, resolveTestScope, interpretReview, runFleetReview,
 };

--- a/scripts/global/fleet-red-team-dispatch.js
+++ b/scripts/global/fleet-red-team-dispatch.js
@@ -12,7 +12,8 @@ const { wrapProviderCall } = require('./hamr-provider-wrapper');
 const { residentModels } = require('./fleet-resident');
 
 const DEFAULT_HOST = 'http://100.91.113.16:11434';
-const DEFAULT_MODEL = 'qwen2.5-coder:32b';
+// #3167: routine reviews default to the fast 7b; 32b is high-stakes opt-in only.
+const DEFAULT_MODEL = 'qwen2.5-coder:7b';
 const TIER = 'fleet-local';
 const RETRY_DELAYS_MS = [1000, 4000];
 const DEFAULT_TIMEOUT_POLICY = path.join(__dirname, '..', '..', 'config', 'timeout-policy.json');
@@ -218,7 +219,10 @@ async function dispatchRedTeam({
       fallbackModel: activeModel, elapsed, error: envelope.meta?.error ?? envelope.error });
   }
   const { findings, warning } = parseFindings(envelope.value);
-  return { findings, raw: envelope.value, modelUsed: activeModel,
+  // #3167: expose the response TEXT so consumers stop calling .match/.slice on
+  // `raw` (the Ollama response object) — the raw.slice-is-not-a-function crash.
+  const text = (envelope.value && envelope.value.response) || '';
+  return { findings, raw: envelope.value, text, modelUsed: activeModel,
     hamrStats: { ok: true, elapsed, sticky: envelope.sticky, warning,
       modelRationale: resolved.rationale,
       stakesSource } };

--- a/scripts/global/review-dispatch-failover.js
+++ b/scripts/global/review-dispatch-failover.js
@@ -43,14 +43,15 @@ async function freeCloudReviewFailover(prompt, opts = {}) {
     safeRecord(record, { lane: 'free-cloud', model: reviewer, provider: result.provider,
       latencyMs: elapsed, outcome: 'review-failover', taskClass: 'review' });
     const { findings } = parse({ response: result.content });
-    return { findings, raw: result.content, modelUsed: reviewer,
+    // #3167: `text` is the uniform response-text contract across dispatch paths.
+    return { findings, raw: result.content, text: result.content, modelUsed: reviewer,
       hamrStats: { ok: true, substituted: true, substituted_reviewer: reviewer,
         substitution_reason: 'fleet-unreachable', tier: 'free-cloud', elapsed } };
   }
   const degradedReason = classifyDegradation(result);
   safeRecord(record, { lane: 'free-cloud', model: 'none', provider: 'none', latencyMs: elapsed,
     outcome: `degraded:${degradedReason}`, taskClass: 'review' });
-  return { findings: [], raw: null, modelUsed: opts.fallbackModel || 'fleet-unreachable',
+  return { findings: [], raw: null, text: '', modelUsed: opts.fallbackModel || 'fleet-unreachable',
     hamrStats: { ok: false, degraded: true, degraded_reason: degradedReason,
       suggested_tier: 'free-cloud', elapsed } };
 }
@@ -62,7 +63,7 @@ async function onFleetUnavailable(opts = {}) {
     deps: { parseFindings: opts.parseFindings, ...(opts.deps || {}) }, fallbackModel: opts.fallbackModel,
   });
   if (failover.hamrStats.ok) return failover;
-  return { findings: [], raw: null, modelUsed: opts.fallbackModel,
+  return { findings: [], raw: null, text: '', modelUsed: opts.fallbackModel,
     hamrStats: { ok: false, elapsed: opts.elapsed, error: opts.error, degraded: true,
       degraded_reason: failover.hamrStats.degraded_reason, suggested_tier: 'free-cloud' } };
 }

--- a/tests/cross-family-7b-default.spec.js
+++ b/tests/cross-family-7b-default.spec.js
@@ -1,0 +1,89 @@
+'use strict';
+// tests/cross-family-7b-default.spec.js — Refs #3167
+// AC1: routine (low/medium) → 7b, high → 32b (opt-in), fallback prefers 7b.
+// AC2: degraded dispatch / Anthropic reviewer → visible non-pass (no fabricated rating).
+// AC3: consumer reads result.text, never .match/.slice on the raw response object.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const { selectModel, loadMatrix } = require(
+  path.join(__dirname, '..', 'scripts/global/fleet-red-team-dispatch.js'));
+const { interpretReview } = require(
+  path.join(__dirname, '..', 'scripts/global/collaborator-preflight.js'));
+
+const MATRIX = path.join(__dirname, '..', 'config', 'red-team-model-matrix.yml');
+const pick = (stakes) => selectModel({ stakes }, { matrixPath: MATRIX, residentModels: [] }).modelId;
+
+// --- AC1: stakes → model routing ---
+
+test('AC1: medium (routine) routes to 7b, not the slow 32b', () => {
+  assert.match(pick('medium'), /7b/);
+});
+
+test('AC1: low (routine) routes to 7b', () => {
+  assert.match(pick('low'), /7b/);
+});
+
+test('AC1: high stakes opt-in routes to 32b', () => {
+  assert.match(pick('high'), /32b/);
+});
+
+test('AC1: fallback_chain prefers 7b first', () => {
+  assert.match(loadMatrix(MATRIX).fallbackChain[0], /7b/);
+});
+
+// --- AC2: degraded / non-cross-family → visible non-pass ---
+
+test('AC2: fully-degraded dispatch yields available:false with null rating', () => {
+  const review = interpretReview({
+    findings: [], raw: null, text: '',
+    modelUsed: 'qwen2.5-coder:7b',
+    hamrStats: { ok: false, degraded: true, degraded_reason: 'free-cloud-exhausted' },
+  });
+  assert.equal(review.available, false);
+  assert.equal(review.rating, null);
+  assert.match(review.findings, /UNAVAILABLE/);
+  assert.match(review.findings, /free-cloud-exhausted/);
+});
+
+test('AC2: an Anthropic reviewer is rejected, never labelled cross-family', () => {
+  const review = interpretReview({
+    findings: [], text: 'rating: 95', modelUsed: 'claude-opus-4-8',
+    hamrStats: { ok: true },
+  });
+  assert.equal(review.available, false);
+  assert.match(review.findings, /rejected-non-cross-family-reviewer/);
+});
+
+test('AC2: free-cloud substitution stays available and is labelled visibly', () => {
+  const review = interpretReview({
+    findings: [], text: 'rating: 80', modelUsed: 'free-cloud:groq',
+    hamrStats: { ok: true, substituted: true },
+  });
+  assert.equal(review.available, true);
+  assert.match(review.reviewer, /free-cloud/);
+});
+
+// --- AC3: text consumed, no crash on object-shaped raw ---
+
+test('AC3: interpretReview reads result.text and never crashes on object raw', () => {
+  const review = interpretReview({
+    raw: { response: 'rating: 88 ignore-this-object', model: 'x' }, // object, not string
+    text: 'rating: 88 the verdict text',
+    findings: [{ raw: 'finding one' }], modelUsed: 'qwen2.5-coder:7b',
+    hamrStats: { ok: true },
+  });
+  assert.equal(review.available, true);
+  assert.equal(review.rating, 88);
+  assert.match(review.findings, /finding one/);
+});
+
+test('AC3: missing text falls back to a default rating without throwing', () => {
+  const review = interpretReview({
+    findings: [], modelUsed: 'qwen2.5-coder:7b', hamrStats: { ok: true },
+  });
+  assert.equal(review.available, true);
+  assert.equal(typeof review.rating, 'number');
+});


### PR DESCRIPTION
## Summary
Routine cross-family (red-team) reviews now default to `qwen2.5-coder:7b` instead of the slow-cold-loading `qwen2.5-coder:32b` (which timed out, ~p99 907s). 32b becomes a high-stakes opt-in. Also fixes the `dispatchRedTeam` consumer crash (`result.raw` is the Ollama response **object**, but `collaborator-preflight` called `.match`/`.slice` on it) and makes a fleet-unreachable review a **visible non-pass** rather than a fabricated rating or an Anthropic self-review labelled cross-family.

## Changes
- `config/red-team-model-matrix.yml` — 32b `default_for_stakes: [high]`; 7b `[low, medium]`; `fallback_chain` 7b-first.
- `scripts/global/fleet-red-team-dispatch.js` — `DEFAULT_MODEL = qwen2.5-coder:7b`; return a uniform `text` field.
- `scripts/global/review-dispatch-failover.js` — `text` on the free-cloud + degraded envelopes.
- `scripts/global/collaborator-preflight.js` — new pure `interpretReview()`: reads `result.text`, returns a visible non-pass for degraded/Anthropic reviewers (no fabricated rating).
- `tests/cross-family-7b-default.spec.js` — 9 tests (AC1/AC2/AC3).

## Verification
- cross-family-7b-default 9/9; fleet-red-team-dispatch 19/19; review-dispatch-failover 6/6 (pw); collaborator-preflight 5/5.
- lint clean (570 files ≤100); readability 474 ≤ 475 (no new single-letter vars; `interpretReview` extracted as a pure exported fn).

Refs #3167
Refs #3008 #3095
merge-evidence-deferred-final: #3167

## Baton artifacts (on #3167)
MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT — all four on the linked issue. EDD posted.
