### PR TITLE
fix(hooks): worktree push-gate commit-step resolution

### DIFF
--- a/.changes/unreleased/3168.md
+++ b/.changes/unreleased/3168.md
@@ -1,0 +1,1 @@
+- fix(hooks): resolve the Admin push-gate commit-step from the pushed branch's worktree, not only the session/main cwd, so a committed worktree branch pushes without hand-editing hook state; emit pattern_id worktree-push-gate-commit-desync for observability (#3168)

--- a/docs/howto/pre-push-gates.md
+++ b/docs/howto/pre-push-gates.md
@@ -72,6 +72,28 @@ Companion: `scripts/global/gate-failure-tier1.js` auto-emits the Tier-1 incident
 operator-caused gate failure, so self-anneal escalation no longer depends on the
 operator remembering to log it (the gap behind #2703).
 
+## Push-gate commit-step worktree fallback (#3168)
+
+`pretool_guard.py` blocks a `git push` until the Admin commit step is recorded. The flag
+is keyed on the **session cwd**, which is typically the main checkout. When governed work
+lives in a **linked worktree** but the session cwd is the main checkout (stuck on `main`
+with no ticket commits), the recorded flag is unreachable and the gate would falsely block
+the push — the recurring "Push blocked: commit step first" desync.
+
+`hooks/scripts/worktree_push_gate.py` resolves the worktree the push actually targets and
+accepts the commit step there:
+
+- `resolve_push_cwd` picks the push directory: an explicit `git -C <path>` wins, then a
+  leading `cd <path> &&`, otherwise the session cwd.
+- `commit_step_satisfied` accepts the push when the session state recorded the commit, OR
+  the resolved worktree's state recorded it, OR the branch has a **real commit ahead of
+  base** (`origin/main`/`main`) — a cwd-independent signal that fails closed on any git
+  error so the session-state check still governs.
+
+When the push is allowed via the worktree fallback rather than the in-session flag, the
+guard emits a Tier-1 `incidents.jsonl` event with `pattern_id:
+worktree-push-gate-commit-desync` for observability — the fallback is visible, never silent.
+
 ## Fleet-review hard-gate (Epic #2192)
 
 The fleet/cross-family red-team review was promoted from an opt-in tool to a hard gate.

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -226,6 +226,21 @@ def _emit_fleet_bypass_incident(cwd: str) -> None:
     except Exception:
         pass  # telemetry failure must not affect the hook decision
 
+def _emit_worktree_push_desync(cwd: str) -> None:
+    """Append a Tier-1 incident when a push is allowed via the worktree fallback
+    rather than the session commit flag (#3168 AC3). Never raises.
+    """
+    try:
+        path = os.path.join(os.path.expanduser("~"), ".megingjord", "incidents.jsonl")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        event = {"version": 3, "service": "pretool-guard-worktree-push",
+                 "env": "local", "event": "governance.worktree-push-commit-desync",
+                 "pattern_id": "worktree-push-gate-commit-desync", "severity": "low", "cwd": cwd}
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event) + "\n")
+    except Exception:
+        pass  # telemetry failure must not affect the hook decision
+
 def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
     flags, ops = state.get("flags", {}), state.get("admin_ops", {})
     repo_type = state.get("repo_type", "generic")
@@ -284,7 +299,18 @@ def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
             if merged_pr:
                 return emit("deny", f"Push blocked: branch '{branch}' was already merged via PR #{merged_pr}. Check out a new branch from main.")
         if not ops.get("commit"):
-            return emit("deny", "Push blocked: commit step first (Admin sequencing).")
+            # #3168: the session cwd is often the main checkout (on `main`, no ticket
+            # commits) while the work lives in a linked worktree. Resolve the pushed
+            # branch's worktree and accept the commit step there (worktree state OR a
+            # real commit ahead of base) rather than falsely blocking the push.
+            from worktree_push_gate import commit_step_satisfied
+            from state_store import load_state
+            satisfied, used_worktree = commit_step_satisfied(
+                joined, cwd, ops.get("commit"), load_state)
+            if not satisfied:
+                return emit("deny", "Push blocked: commit step first (Admin sequencing).")
+            if used_worktree:
+                _emit_worktree_push_desync(cwd)
     if RE_PR_MERGE.search(joined):
         override = require_bypass_exception(joined, state, cwd)
         if override:

--- a/hooks/scripts/worktree_push_gate.py
+++ b/hooks/scripts/worktree_push_gate.py
@@ -1,0 +1,69 @@
+"""#3168 — resolve the worktree a push targets so the Admin commit-step gate
+reads commit state from the pushed branch's worktree, not only the session
+(main-checkout) cwd.
+
+The push gate keys admin_ops on the SESSION cwd. When governed work lives in a
+linked worktree but the session cwd is the main checkout (stuck on `main` with no
+ticket commits), the recorded commit flag is unreachable and the gate falsely
+blocks the push. These helpers locate the worktree the push acts on and confirm
+the commit step ran there — preferring a REAL commit ahead of base, which is a
+stronger signal than the in-session flag.
+"""
+import re
+import subprocess
+
+_DASH_C_RE = re.compile(r"git\s+-C\s+(\S+)")
+_CD_RE = re.compile(r"cd\s+(\S+)\s*&&")
+
+
+def resolve_push_cwd(joined, cwd):
+    """The directory the push acts on: an explicit `git -C <path>` wins, then a
+    leading `cd <path> &&`, otherwise the session cwd.
+    """
+    dash_c = _DASH_C_RE.search(joined or "")
+    if dash_c:
+        return dash_c.group(1)
+    chdir = _CD_RE.search(joined or "")
+    if chdir:
+        return chdir.group(1)
+    return cwd
+
+
+def branch_has_commit_ahead(push_cwd, bases=("origin/main", "main")):
+    """True when the worktree branch has at least one commit not on its base —
+    a cwd-independent signal the Admin commit step actually produced a commit.
+    Fails closed (False) on any git error so the session-state check still governs.
+    """
+    for base in bases:
+        try:
+            result = subprocess.run(
+                ["git", "-C", push_cwd, "rev-list", "--count", f"{base}..HEAD"],
+                check=False, capture_output=True, text=True, timeout=5)
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            return False
+        if result.returncode == 0:
+            try:
+                return int((result.stdout or "0").strip() or "0") > 0
+            except ValueError:
+                return False
+    return False
+
+
+def commit_step_satisfied(joined, cwd, session_committed, load_state):
+    """Decide whether the Admin commit-step is satisfied for a push.
+
+    Returns (satisfied, used_worktree_fallback). Satisfied when: the session state
+    recorded the commit, OR the pushed branch's worktree state recorded it, OR the
+    branch has a real commit ahead of base. The fallback flag drives the
+    worktree-push-gate-commit-desync observability signal (AC3).
+    """
+    if session_committed:
+        return True, False
+    push_cwd = resolve_push_cwd(joined, cwd)
+    if push_cwd != cwd:
+        worktree_state = load_state(push_cwd)
+        if (worktree_state.get("admin_ops") or {}).get("commit"):
+            return True, True
+    if branch_has_commit_ahead(push_cwd):
+        return True, True
+    return False, False

--- a/tests/hooks/test_pretool_guard_worktree_push.py
+++ b/tests/hooks/test_pretool_guard_worktree_push.py
@@ -1,0 +1,97 @@
+"""#3168 — worktree-correct Admin push-gate.
+
+A committed worktree branch must push even when the session cwd is the main
+checkout (on `main`, no ticket commits). Unit-tests the resolver + commit-step
+logic and the pretool_guard push decision.
+"""
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "hooks" / "scripts"))
+
+import worktree_push_gate as wpg  # noqa: E402
+
+
+class ResolvePushCwd(unittest.TestCase):
+    def test_dash_c_wins(self):
+        self.assertEqual(
+            wpg.resolve_push_cwd("git -C /home/u/dev-3168 push", "/home/u/main"),
+            "/home/u/dev-3168")
+
+    def test_cd_into_worktree(self):
+        self.assertEqual(
+            wpg.resolve_push_cwd("cd /home/u/dev-3168 && git push", "/home/u/main"),
+            "/home/u/dev-3168")
+
+    def test_defaults_to_cwd(self):
+        self.assertEqual(wpg.resolve_push_cwd("git push", "/home/u/wt"), "/home/u/wt")
+
+
+class BranchHasCommitAhead(unittest.TestCase):
+    def _run(self, returncode, stdout):
+        fake = unittest.mock.MagicMock(returncode=returncode, stdout=stdout)
+        with patch("subprocess.run", return_value=fake):
+            return wpg.branch_has_commit_ahead("/wt")
+
+    def test_commit_present(self):
+        self.assertTrue(self._run(0, "2\n"))
+
+    def test_no_commit(self):
+        self.assertFalse(self._run(0, "0\n"))
+
+    def test_git_error_fails_closed(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            self.assertFalse(wpg.branch_has_commit_ahead("/wt"))
+
+
+class CommitStepSatisfied(unittest.TestCase):
+    def test_session_flag_short_circuits(self):
+        satisfied, used_wt = wpg.commit_step_satisfied("git push", "/wt", True, lambda c: {})
+        self.assertEqual((satisfied, used_wt), (True, False))
+
+    def test_worktree_state_records_commit(self):
+        load = lambda c: {"admin_ops": {"commit": True}}
+        satisfied, used_wt = wpg.commit_step_satisfied(
+            "git -C /wt push", "/main", False, load)
+        self.assertEqual((satisfied, used_wt), (True, True))
+
+    def test_real_ahead_commit_satisfies(self):
+        with patch.object(wpg, "branch_has_commit_ahead", return_value=True):
+            satisfied, used_wt = wpg.commit_step_satisfied(
+                "git -C /wt push", "/main", False, lambda c: {})
+        self.assertEqual((satisfied, used_wt), (True, True))
+
+    def test_nothing_committed_blocks(self):
+        with patch.object(wpg, "branch_has_commit_ahead", return_value=False):
+            satisfied, used_wt = wpg.commit_step_satisfied(
+                "git -C /wt push", "/main", False, lambda c: {})
+        self.assertEqual((satisfied, used_wt), (False, False))
+
+
+class PushGateIntegration(unittest.TestCase):
+    def _decide(self, satisfied):
+        import pretool_guard
+        captured = {}
+        state = {"admin_ops": {"commit": False}, "repo_type": "generic"}
+        with patch("pretool_guard.emit",
+                   side_effect=lambda d, r, e=None: captured.setdefault("d", d)), \
+             patch("pretool_guard.current_branch", return_value="fix/3168-x"), \
+             patch("pretool_guard.check_merged_pr", return_value=None), \
+             patch("worktree_push_gate.commit_step_satisfied",
+                   return_value=(satisfied, satisfied)), \
+             patch("pretool_guard._emit_worktree_push_desync"):
+            pretool_guard.check_terminal("cd /wt && git push", state, "/main")
+        return captured.get("d")
+
+    def test_worktree_commit_allows_push(self):
+        self.assertIsNone(self._decide(True))
+
+    def test_no_commit_denies_push(self):
+        self.assertEqual(self._decide(False), "deny")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #3168
merge-evidence-deferred-final: #3168

Fix the Admin push-gate falsely blocking pushes from linked worktrees when the session cwd is the main checkout. Resolves the pushed branch worktree and accepts the commit-step from worktree state OR a real commit ahead of base; emits pattern_id worktree-push-gate-commit-desync for observability.

Three-stress N/A: tdd-pyramid (pure resolution helpers + git read-only probe). 12 pytest cases green.

---
## MANAGER_HANDOFF

scope: Fix the Admin push-gate (hooks/scripts/pretool_guard.py 'Push blocked: commit step first') reading admin_ops.commit only from state keyed to the SESSION cwd (the main checkout, stuck on main with no ticket commits) while governed work lives in a linked worktree. Resolve the pushed branch's worktree and treat the Admin commit-step as satisfied when the worktree recorded the commit OR the branch has a real commit ahead of base; emit pattern_id worktree-push-gate-commit-desync for observability.
lane: lane:code-change
test_strategy: tdd-pyramid
acceptance:
- AC1 — the push gate resolves commit/admin_ops state from the pushed branch's worktree (git-C <wt> path, cd-into-worktree, or worktree cwd), not only the session/main cwd.
- AC2 — a committed worktree branch pushes cleanly with no hand-editing of hook state.
- AC3 — pytest regression test for the worktree-push path; pattern_id worktree-push-gate-commit-desync emitted to incidents.jsonl for observability.

gates: lint + readability clean; pytest tests/hooks green; hook-parity-check; baton-gates; changelog fragment .changes/unreleased/3168.md; EDD posted
related_tickets: #3095, #3166, #3167, #3169, #3165
overlap_decision: Independent of #3166/#3167 (those were scripts/global + config; this is hooks/scripts Python). New module worktree_push_gate.py + a localized edit to the pretool_guard push gate; no overlap.
goal_lens: G6 Resilience (worktree pushes no longer falsely blocked), G1 (sequencing intent preserved — real commit still required), G8 Observability (desync pattern_id).

Signed-by: Orla Mason
Team&Model: claude-code:opus@anthropic
Role: manager


---
## COLLABORATOR_HANDOFF

ticket: #3168

scope: Push-gate worktree commit-step resolution: new hooks/scripts/worktree_push_gate.py + localized pretool_guard push-gate edit. Resolves the pushed branch worktree and accepts the Admin commit-step from worktree state OR a real commit ahead of base; emits pattern_id worktree-push-gate-commit-desync.
test_strategy: tdd-pyramid
per_ac_verification:
- AC1 — PASS. worktree_push_gate.resolve_push_cwd resolves the push dir (git -C <path> wins, then leading cd <path> &&, else session cwd); commit_step_satisfied reads worktree state via load_state(push_cwd). Tests: ResolvePushCwd (3 cases) + CommitStepSatisfied worktree-state path.
- AC2 — PASS. commit_step_satisfied accepts a committed worktree branch via worktree admin_ops.commit OR branch_has_commit_ahead (real commit vs origin/main|main) with no hand-edit. Tests: CommitStepSatisfied real-commit-ahead path + BranchHasCommitAhead.
- AC3 — PASS. 12 pytest cases in tests/hooks/test_pretool_guard_worktree_push.py (all green); pretool_guard._emit_worktree_push_desync writes pattern_id worktree-push-gate-commit-desync to ~/.megingjord/incidents.jsonl when the worktree fallback is used.

doc_coverage:
  .changes/unreleased/: UPDATED — .changes/unreleased/3168.md fragment describing the worktree push-gate fix
  docs/howto/pre-push-gates.md: UPDATED — new "Push-gate commit-step worktree fallback (#3168)" section documenting resolve_push_cwd + commit_step_satisfied + the desync pattern_id
  docs/howto/hooks.md: N/A — out-of-scope (no general hooks.md exists in repo; this push-gate fix is documented in pre-push-gates.md, the canonical push-gate doc, updated this PR)

cross_family_rating: 70/100
cross_family_reviewer: qwen2.5-coder:7b@100.91.113.16:11434
cross_family_findings: ACCEPT — verdict ACCEPT on the staged diff; fail-closed git-error handling and the real-commit-ahead signal noted as sound. (qwen=Alibaba family != Anthropic author = valid cross-family.)
cross_family_receipt: 485bc769b1c99009
reviewer_family: qwen

Signed-by: Orla Harper
Team&Model: claude-code:opus@anthropic
Role: collaborator

---
## ADMIN_HANDOFF

ticket: #3168

branch: fix/3168-worktree-push-gate
commit: d22c1acd
signer-independence-check: PASS — Collaborator alias Orla Harper != Admin alias Orla Reyes (distinct surnames).
deploy-runtime-impact: Touches deployed hook runtime (hooks/scripts/pretool_guard.py + new worktree_push_gate.py -> ~/.claude, ~/.copilot, ~/.codex). Post-merge: deploy:apply + deploy:claude:apply + hamr:sync-verify (forward direction; NOT sync:claude/sync:codex which are reverse).

Signed-by: Orla Reyes
Team&Model: claude-code:opus@anthropic
Role: admin

---
## CONSULTANT_CLOSEOUT

ticket: #3168

status: review
verdict: approve_for_merge
verification-timestamp: 2026-06-22T01:17:04.314Z
rubric_rating: G1:9 G2:9 G3:9 G4:9 G5:8 G6:9 G7:8 G8:9 G9:8 -> min(G1..G9)=8, rubric 8/10
anneal_tickets_filed: none (frictions captured for #3165 seed catalog: worktree-push-gate-commit-desync confirmed pattern_id)
mid_flight_flaws:
- preflight fleet review hung under npm wrapper (10m), decision=memory-note-only artifact=existing feedback (run fleet step via node + hard timeout). No code/process delta.
- doc-coverage required docs/howto/hooks.md does not exist in repo, decision=no-action-justified rationale=pre-push-gates.md is the canonical push-gate doc and was updated; hooks.md N/A out-of-scope.


Signed-by: Orla Vale
Team&Model: claude-code:opus@anthropic
Role: consultant
