### PR TITLE
fix(scripts): isolate task branch in own worktree dir (#2946)

### DIFF
--- a/.changes/unreleased/2946.md
+++ b/.changes/unreleased/2946.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `worktree-session-start.sh`: the task branch is now created in an isolated worktree directory (`~/devenv-ops-<N>`) via a new `create_task_worktree()` helper, instead of an in-place branch switch of the current checkout. In-place creation stalled the moment a ticket required new tracked files, because the canonical-main checkout is read-only for tracked paths. (#2946)

--- a/docs/howto/sandbox-worktree-governance.md
+++ b/docs/howto/sandbox-worktree-governance.md
@@ -17,6 +17,12 @@ Before implementation, refresh the launcher and move to a ticket branch:
 bash scripts/worktree-session-start.sh <copilot|codex|claude-code> feat/<issue#>-<slug>
 ```
 
+Since #2946 the task branch is created in an **isolated worktree directory**
+(`~/devenv-ops-<issue#>`) rather than switched in place — so after running the
+command, `cd ~/devenv-ops-<issue#>` to implement. This keeps the canonical-main
+checkout untouched (it is read-only for tracked paths) even when a ticket needs
+new tracked files.
+
 Record this evidence at session start:
 - `git worktree list` output.
 - Branch name follows `feat/<N>-...` or `fix/<N>-...`.

--- a/scripts/worktree-agent-init.sh
+++ b/scripts/worktree-agent-init.sh
@@ -24,3 +24,23 @@ copy_env_if_needed() {
   cp "$main_root/.env" "$worktree_root/.env"
   log ".env copy: $main_root/.env → $worktree_root/.env"
 }
+
+# Refs #2946: create the task branch in an ISOLATED worktree directory rather
+# than switching the current (possibly canonical-main) checkout in place. An
+# in-place branch switch stalls the moment a ticket needs new tracked files,
+# because the canonical-main checkout is read-only for tracked paths (#2995).
+# Depends on bootstrap_node_modules / configure_per_worktree_hooks / die from
+# the sourcing worktree-session-start.sh (resolved at call time).
+create_task_worktree() {
+  local agent="$1" task_branch="$2"
+  local ticket_num worktree_dir
+  ticket_num="$(echo "$task_branch" | grep -oP '(?<=/)[0-9]+(?=-)' | head -1)"
+  [[ -n "$ticket_num" ]] || die "cannot parse ticket number from task branch '$task_branch'"
+  worktree_dir="$HOME/devenv-ops-${ticket_num}"
+  [[ -e "$worktree_dir" ]] && die "worktree dir already exists: $worktree_dir (remove it first)"
+  git worktree add "$worktree_dir" -b "$task_branch"
+  bootstrap_node_modules "$worktree_dir"
+  configure_per_worktree_hooks "$worktree_dir"
+  copy_env_if_needed "$agent" "$worktree_dir"
+  log "worktree ready: $worktree_dir ($task_branch) — cd \"$worktree_dir\", implement, open PR with Refs #${ticket_num}"
+}

--- a/scripts/worktree-session-start.sh
+++ b/scripts/worktree-session-start.sh
@@ -93,8 +93,6 @@ if git show-ref --verify --quiet "refs/heads/$task_branch"; then
   warn "task branch already exists locally: $task_branch"
 fi
 
-git switch -c "$task_branch"
-bootstrap_node_modules "$root"
-configure_per_worktree_hooks "$root"
-copy_env_if_needed "$agent" "$root"
-log "ready on task branch: $task_branch"
+# Refs #2946: isolate the task branch in its own worktree dir, not in the
+# current (possibly canonical-main) checkout. Helper lives in worktree-agent-init.sh.
+create_task_worktree "$agent" "$task_branch"

--- a/tests/worktree-bootstrap-1378.spec.js
+++ b/tests/worktree-bootstrap-1378.spec.js
@@ -6,6 +6,7 @@ const { execSync, spawnSync } = require('child_process');
 
 const REPO = path.resolve(__dirname, '..');
 const SESSION_START = path.join(REPO, 'scripts', 'worktree-session-start.sh');
+const AGENT_INIT = path.join(REPO, 'scripts', 'worktree-agent-init.sh');
 const BOOTSTRAP = path.join(REPO, 'scripts', 'worktree-bootstrap-node-modules.sh');
 
 test('#1378 AC1: worktree-session-start.sh includes bootstrap_node_modules function', () => {
@@ -15,13 +16,28 @@ test('#1378 AC1: worktree-session-start.sh includes bootstrap_node_modules funct
   expect(content).toContain('ln -sf');
 });
 
-test('#1378 AC1: bootstrap is called after task-branch creation', () => {
-  const content = fs.readFileSync(SESSION_START, 'utf-8');
-  // Must appear after `git switch -c "$task_branch"`
-  const switchPos = content.indexOf('git switch -c "$task_branch"');
-  const bootstrapCallPos = content.indexOf('bootstrap_node_modules "$root"');
-  expect(switchPos).toBeGreaterThan(0);
-  expect(bootstrapCallPos).toBeGreaterThan(switchPos);
+test('#2946 AC1: task branch is created in an isolated worktree dir, not in-place', () => {
+  const session = fs.readFileSync(SESSION_START, 'utf-8');
+  const init = fs.readFileSync(AGENT_INIT, 'utf-8');
+  // The old in-place `git switch -c "$task_branch"` must be gone.
+  expect(session.includes('git switch -c "$task_branch"')).toBe(false);
+  // worktree-session-start.sh delegates to the extracted helper (AC2).
+  expect(session).toContain('create_task_worktree "$agent" "$task_branch"');
+  // The helper lives in worktree-agent-init.sh and uses an isolated worktree dir.
+  expect(init).toContain('create_task_worktree()');
+  expect(init).toContain('git worktree add "$worktree_dir"');
+  expect(init).toContain('$HOME/devenv-ops-${ticket_num}');
+});
+
+test('#2946 AC3: bootstrap/hooks/env in the helper target the new worktree dir', () => {
+  const init = fs.readFileSync(AGENT_INIT, 'utf-8');
+  // After the isolated worktree-add, init steps must run against $worktree_dir.
+  const addPos = init.indexOf('git worktree add "$worktree_dir"');
+  const bootstrapPos = init.indexOf('bootstrap_node_modules "$worktree_dir"');
+  const hooksPos = init.indexOf('configure_per_worktree_hooks "$worktree_dir"');
+  expect(addPos).toBeGreaterThan(0);
+  expect(bootstrapPos).toBeGreaterThan(addPos);
+  expect(hooksPos).toBeGreaterThan(addPos);
 });
 
 test('#1378 AC1: bootstrap is idempotent (skips if node_modules already exists)', () => {


### PR DESCRIPTION
Refs #2946

`worktree-session-start.sh` created the task branch in the **current** checkout, which stalls the moment a ticket needs new tracked files — the canonical-main checkout is read-only for tracked paths (#2995). This change creates the task branch in an **isolated worktree directory** (`~/devenv-ops-<N>`) instead.

## What changed
- **`scripts/worktree-agent-init.sh`** — new `create_task_worktree()` helper: parses the ticket number, refuses if the dir already exists, creates the isolated worktree with the branch, then runs `bootstrap_node_modules` / `configure_per_worktree_hooks` / `copy_env_if_needed` against the **new** dir.
- **`scripts/worktree-session-start.sh`** — calls the helper instead of an in-place branch switch (stays at 98 lines, under the 100-line cap).
- **`tests/worktree-bootstrap-1378.spec.js`** — asserts the isolated-worktree path + helper extraction + dir-targeting (replaces the old in-place assertion).
- **`docs/howto/sandbox-worktree-governance.md`** — documents the new `cd ~/devenv-ops-<N>` step.

## Evidence
- `npx playwright test tests/worktree-bootstrap-1378.spec.js`: 12/12 green. `npm run lint`: PASS. `bash -n` + `shellcheck --severity=warning`: clean.
- Functional smoke of `create_task_worktree` (throwaway repo): valid branch → isolated dir; dir-exists → refuse; unparseable branch → refuse.
- Cross-family review (fleet qwen2.5-coder:7b, G3 zero-cost): 70/100, receipt 69dd9d093fbc0a7c.

## Drift remediation
This ticket stalled at `status:testing` since 2026-06-11 with stale Copilot Auto-mode baton artifacts (non-registry-derived aliases — the #2945 blocker class) and a now-unappliable PR #2954. Those artifacts were deleted, PR #2954 closed + branch removed, and the work re-authored on current main under a clean single-team claude-code baton (no identity forging, per the #2945 BLOCKER_NOTE).

## Baton artifacts (on #2946)
MANAGER_HANDOFF, EDD, COLLABORATOR_HANDOFF, ADMIN_HANDOFF posted. CONSULTANT_CLOSEOUT to follow (deferred-final).

merge-evidence-deferred-final: #2946

🤖 Generated with [Claude Code](https://claude.com/claude-code)
