### PR TITLE
feat(hooks): one-ticket-per-worktree baton guard (#2967)

### DIFF
--- a/.changes/unreleased/2967.md
+++ b/.changes/unreleased/2967.md
@@ -1,0 +1,3 @@
+### Added
+
+- One-ticket-per-worktree pretool guard (`hooks/scripts/one_ticket_per_worktree.py`): refuses to post an Agile baton artifact (MANAGER_HANDOFF / COLLABORATOR_HANDOFF / ADMIN_HANDOFF / CONSULTANT_CLOSEOUT) for a second ticket from a worktree whose active ticket still has an unresolved baton. Provider-neutral across Claude Code / Copilot / Codex / Antigravity; sequential per-ticket iteration, coordination comments, and multi-close batch evidence stay allowed; fails open on ambiguous state; kill-switch `MEGINGJORD_ONE_TICKET_GUARD_OFF=1`. (#2967)

--- a/docs/howto/sandbox-worktree-governance.md
+++ b/docs/howto/sandbox-worktree-governance.md
@@ -28,6 +28,24 @@ Record this evidence at session start:
 - Branch name follows `feat/<N>-...` or `fix/<N>-...`.
 - Ticket linkage exists before edits (`#N`).
 
+## One Ticket Per Worktree (#2967)
+
+A pretool guard (`hooks/scripts/one_ticket_per_worktree.py`) blocks posting an
+Agile baton artifact (MANAGER_HANDOFF / COLLABORATOR_HANDOFF / ADMIN_HANDOFF /
+CONSULTANT_CLOSEOUT) for a **second** ticket from a worktree whose active ticket
+still has an unresolved baton. It is provider-neutral (identical verdict for
+Claude Code / Copilot / Codex / Antigravity, since all post via `gh issue
+comment`).
+
+What stays allowed (false-positive prevention): non-baton coordination comments,
+follow-on `gh issue create`, label edits, multi-close batch sibling evidence
+("resolved as part of batch with #N"), and **sequential** iteration — finish and
+`gh issue close` the active ticket, then start the next.
+
+**Recovery path** if you hit the deny: finish the active ticket
+(`CONSULTANT_CLOSEOUT` + `gh issue close #N`), or run the next ticket from its own
+worktree. Emergency override: `export MEGINGJORD_ONE_TICKET_GUARD_OFF=1`.
+
 ## Stale-Worktree Taxonomy
 
 Use inventory and governance outputs as classification evidence.

--- a/hooks/scripts/one_ticket_per_worktree.py
+++ b/hooks/scripts/one_ticket_per_worktree.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""#2967: one-ticket-per-worktree baton guard.
+
+Deterministic, provider-neutral guard that blocks emitting an Agile baton
+artifact (MANAGER_HANDOFF / COLLABORATOR_HANDOFF / ADMIN_HANDOFF /
+CONSULTANT_CLOSEOUT) for a SECOND ticket from a worktree whose active ticket
+still has an unresolved baton.
+
+Design goals:
+- Provider-neutral: a pure function over (command string, governance state).
+  All four runtimes (Claude Code / Copilot / Codex / Antigravity) shell out to
+  `gh issue comment`, so the same command form yields the same verdict.
+- Low false-positive: ONLY the four baton-artifact headers posted to a specific
+  issue are guarded. Non-baton coordination comments, follow-on `gh issue
+  create`, and label edits are never matched. Sequential per-ticket iteration
+  (close ticket A, then start B) stays allowed, and ambiguous/unparseable state
+  fails OPEN (returns None) rather than emitting a spurious deny.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Optional
+
+# The four Agile baton artifacts this guard scopes to (ticket-body AC2).
+BATON_ARTIFACT_RE = re.compile(
+    r"\b(MANAGER_HANDOFF|COLLABORATOR_HANDOFF|ADMIN_HANDOFF|CONSULTANT_CLOSEOUT)\b"
+)
+# `gh issue comment <N>` — the cross-runtime way every ADK posts an artifact.
+ISSUE_COMMENT_RE = re.compile(r"\bgh\s+issue\s+comment\s+#?(\d+)\b")
+# `--body-file <path>` (or `--body-file=<path>`) whose content holds the artifact.
+BODY_FILE_RE = re.compile(r"--body-file[=\s]+(\S+)")
+# Documented multi-close batch carve-out: sibling brief-evidence is allowed.
+BATCH_MARKER_RE = re.compile(r"resolved as part of batch with #\d+", re.IGNORECASE)
+
+# Operator kill-switch (parity with other guard opt-outs).
+KILL_SWITCH_ENV = "MEGINGJORD_ONE_TICKET_GUARD_OFF"
+
+
+def _artifact_bearing_text(command: str, body_file_reader: Optional[Callable[[str], str]]) -> str:
+    """Return command text plus any --body-file content, for artifact detection.
+
+    Inline `--body "...MANAGER_HANDOFF..."` already lives in the command; a
+    `--body-file <path>` post keeps the artifact in a file, so we read it via the
+    injected reader (which returns '' on any error — never raises).
+    """
+    text = command
+    match = BODY_FILE_RE.search(command)
+    if match and body_file_reader is not None:
+        try:
+            text = text + "\n" + (body_file_reader(match.group(1)) or "")
+        except Exception:
+            pass  # G6: a body-file read failure must never break the guard
+    return text
+
+
+def detect_baton_post(
+    command: str, body_file_reader: Optional[Callable[[str], str]] = None
+) -> Optional[tuple[int, str]]:
+    """Return (target_ticket, artifact_name) if `command` posts a baton artifact
+    to a specific issue, else None.
+
+    None means 'not a one-ticket-guarded action' — the caller allows it.
+    """
+    issue_match = ISSUE_COMMENT_RE.search(command or "")
+    if not issue_match:
+        return None
+    text = _artifact_bearing_text(command, body_file_reader)
+    artifact_match = BATON_ARTIFACT_RE.search(text)
+    if not artifact_match:
+        return None
+    if BATCH_MARKER_RE.search(text):
+        return None  # documented multi-close batch sibling evidence — allowed
+    return int(issue_match.group(1)), artifact_match.group(1)
+
+
+def _active_ticket_unresolved(state: dict[str, Any]) -> bool:
+    """The active ticket counts as an unresolved baton only when it shows recorded
+    baton activity AND has not been closed this session. Requiring activity keeps a
+    stale active_ticket pointer (set but never worked) from blocking — a key
+    false-positive guard.
+    """
+    if state.get("admin_ops", {}).get("issue_close"):
+        return False  # active ticket already closed — sequential iteration is fine
+    roles = state.get("roles", {}) or {}
+    return any(bool(value) for value in roles.values())
+
+
+def check_one_ticket_per_worktree(
+    command: str,
+    state: dict[str, Any],
+    body_file_reader: Optional[Callable[[str], str]] = None,
+    env: Optional[dict[str, str]] = None,
+) -> Optional[str]:
+    """Return a deny-reason string when `command` would post a baton artifact for a
+    second, different, still-unresolved ticket from this worktree; else None.
+
+    Pure and provider-neutral: depends only on the command and governance state.
+    """
+    import os
+    env = env if env is not None else os.environ
+    if env.get(KILL_SWITCH_ENV) == "1":
+        return None
+    post = detect_baton_post(command, body_file_reader)
+    if post is None:
+        return None
+    target, artifact = post
+    active = state.get("active_ticket")
+    if active in (None, "", 0):
+        return None  # no active ticket — this becomes the worktree's ticket
+    try:
+        active_num = int(active)
+    except (TypeError, ValueError):
+        return None  # unparseable active ticket — fail open, never a false deny
+    if active_num == target:
+        return None  # same ticket — allowed
+    if not _active_ticket_unresolved(state):
+        return None  # prior ticket resolved — sequential iteration allowed
+    return (
+        f"One ticket per worktree (#2967): this worktree's active baton is #{active_num}, "
+        f"still unresolved (not closed). Refusing to post {artifact} for #{target}. "
+        f"Finish #{active_num} (CONSULTANT_CLOSEOUT + gh issue close) or use a separate "
+        f"worktree for #{target}."
+    )

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -11,6 +11,7 @@ from admin_patterns import (  # noqa: E501
 from canonical_main_enforcer import is_main_checkout, evaluate_path
 from blast_radius_cap import ENV_BYPASS, check_caps, emit_cap_incident, load_caps
 from governance_state import ensure_state
+from one_ticket_per_worktree import check_one_ticket_per_worktree
 from live_checks import ci_gate_status_stable, linked_issue_has_collab_handoff, linked_issue_has_manager_handoff, linked_issue_has_planning_consensus, check_merged_pr
 from runtime_paths import runtime_hook_paths
 RE_ISSUE_REF = re.compile(r"#\d+")
@@ -241,9 +242,26 @@ def _emit_worktree_push_desync(cwd: str) -> None:
     except Exception:
         pass  # telemetry failure must not affect the hook decision
 
+def _read_body_file(path: str, cwd: str) -> str:
+    """#2967: read a `--body-file` target (cwd-relative or absolute) for baton-artifact
+    detection. Returns '' on any error so the guard never breaks on a missing file.
+    """
+    try:
+        full = path if os.path.isabs(path) else os.path.join(cwd, path)
+        with open(full, "r", encoding="utf-8") as handle:
+            return handle.read()
+    except Exception:
+        return ""
+
 def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
     flags, ops = state.get("flags", {}), state.get("admin_ops", {})
     repo_type = state.get("repo_type", "generic")
+    # #2967: one-ticket-per-worktree — refuse a baton artifact for a second,
+    # still-unresolved ticket from this worktree (provider-neutral, fail-open).
+    one_ticket_deny = check_one_ticket_per_worktree(
+        joined, state, body_file_reader=lambda path: _read_body_file(path, cwd))
+    if one_ticket_deny:
+        return emit("deny", one_ticket_deny)
     no_code_lane = active_ticket_is_no_code_lane(state, cwd)
     if no_code_lane and NO_CODE_ADMIN_RE.search(joined):
         return emit("deny", "No-code remediation lane is issue-only. Admin/implementation commands are blocked; re-route to lane:code-change.")

--- a/tests/hooks/test_one_ticket_per_worktree.py
+++ b/tests/hooks/test_one_ticket_per_worktree.py
@@ -1,0 +1,141 @@
+"""#2967: one-ticket-per-worktree baton guard tests.
+
+Covers the allow/deny matrix, false-positive prevention, the cross-ADK
+compatibility matrix, and the pretool_guard integration (deny path)."""
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOKS_SCRIPTS = REPO_ROOT / "hooks" / "scripts"
+sys.path.insert(0, str(HOOKS_SCRIPTS))
+
+import one_ticket_per_worktree as guard  # noqa: E402
+import pretool_guard  # noqa: E402
+
+
+def _state(active=None, roles=None, closed=False):
+    return {
+        "active_ticket": active,
+        "roles": roles if roles is not None else {},
+        "admin_ops": {"issue_close": True} if closed else {},
+    }
+
+
+# An active ticket that is genuinely mid-baton: has activity, not closed.
+MIDBATON = {"collaborator": True}
+
+
+class DetectBatonPost(unittest.TestCase):
+    def test_detects_inline_artifact(self):
+        cmd = 'gh issue comment 100 --body "## MANAGER_HANDOFF\nscope: x"'
+        self.assertEqual(guard.detect_baton_post(cmd), (100, "MANAGER_HANDOFF"))
+
+    def test_detects_body_file_artifact_via_reader(self):
+        cmd = "gh issue comment 100 --body-file /tmp/ah.md"
+        reader = lambda p: "## ADMIN_HANDOFF\nbranch: x"
+        self.assertEqual(guard.detect_baton_post(cmd, reader), (100, "ADMIN_HANDOFF"))
+
+    def test_non_comment_command_is_not_a_post(self):
+        self.assertIsNone(guard.detect_baton_post("gh issue create --title MANAGER_HANDOFF"))
+
+    def test_coordination_comment_is_not_a_post(self):
+        cmd = 'gh issue comment 100 --body "Epic progress update: child closed"'
+        self.assertIsNone(guard.detect_baton_post(cmd))
+
+    def test_batch_sibling_evidence_is_exempt(self):
+        cmd = ('gh issue comment 100 --body "## CONSULTANT_CLOSEOUT\n'
+               'resolved as part of batch with #99"')
+        self.assertIsNone(guard.detect_baton_post(cmd))
+
+
+class CheckGuard(unittest.TestCase):
+    def test_deny_cross_ticket_while_active_unresolved(self):
+        cmd = 'gh issue comment 200 --body "## COLLABORATOR_HANDOFF"'
+        reason = guard.check_one_ticket_per_worktree(cmd, _state(active=100, roles=MIDBATON), env={})
+        self.assertIsNotNone(reason)
+        self.assertIn("#100", reason)
+        self.assertIn("#200", reason)
+
+    def test_allow_same_ticket(self):
+        cmd = 'gh issue comment 100 --body "## ADMIN_HANDOFF"'
+        self.assertIsNone(
+            guard.check_one_ticket_per_worktree(cmd, _state(active=100, roles=MIDBATON), env={}))
+
+    def test_allow_after_active_ticket_closed(self):
+        cmd = 'gh issue comment 200 --body "## MANAGER_HANDOFF"'
+        self.assertIsNone(
+            guard.check_one_ticket_per_worktree(cmd, _state(active=100, roles=MIDBATON, closed=True), env={}))
+
+    def test_allow_when_active_has_no_baton_activity(self):
+        # active_ticket set but no recorded role activity -> stale pointer, not a block.
+        cmd = 'gh issue comment 200 --body "## MANAGER_HANDOFF"'
+        self.assertIsNone(
+            guard.check_one_ticket_per_worktree(cmd, _state(active=100, roles={}), env={}))
+
+    def test_allow_no_active_ticket(self):
+        cmd = 'gh issue comment 200 --body "## MANAGER_HANDOFF"'
+        self.assertIsNone(
+            guard.check_one_ticket_per_worktree(cmd, _state(active=None, roles=MIDBATON), env={}))
+
+    def test_allow_coordination_comment_cross_ticket(self):
+        cmd = 'gh issue comment 200 --body "see related work"'
+        self.assertIsNone(
+            guard.check_one_ticket_per_worktree(cmd, _state(active=100, roles=MIDBATON), env={}))
+
+    def test_failopen_unparseable_active_ticket(self):
+        cmd = 'gh issue comment 200 --body "## MANAGER_HANDOFF"'
+        self.assertIsNone(
+            guard.check_one_ticket_per_worktree(cmd, _state(active="not-a-number", roles=MIDBATON), env={}))
+
+    def test_kill_switch_disables_guard(self):
+        cmd = 'gh issue comment 200 --body "## MANAGER_HANDOFF"'
+        self.assertIsNone(guard.check_one_ticket_per_worktree(
+            cmd, _state(active=100, roles=MIDBATON), env={"MEGINGJORD_ONE_TICKET_GUARD_OFF": "1"}))
+
+    def test_deny_uses_body_file_content(self):
+        cmd = "gh issue comment 200 --body-file /tmp/cc.md"
+        reader = lambda p: "## CONSULTANT_CLOSEOUT\nverdict: approve"
+        reason = guard.check_one_ticket_per_worktree(
+            cmd, _state(active=100, roles=MIDBATON), body_file_reader=reader, env={})
+        self.assertIsNotNone(reason)
+
+
+class CrossAdkMatrix(unittest.TestCase):
+    """AC2: the verdict is provider-neutral — identical gh command, identical result
+    regardless of which runtime issued it."""
+    RUNTIMES = ["claude-code", "copilot", "codex", "antigravity"]
+
+    def test_same_verdict_across_runtimes(self):
+        cmd = 'gh issue comment 200 --body "## ADMIN_HANDOFF"'
+        state = _state(active=100, roles=MIDBATON)
+        verdicts = {
+            runtime: bool(guard.check_one_ticket_per_worktree(cmd, state, env={}))
+            for runtime in self.RUNTIMES
+        }
+        self.assertEqual(set(verdicts.values()), {True})  # all deny, uniformly
+
+
+class PretoolGuardIntegration(unittest.TestCase):
+    def _run(self, cmd, state):
+        captured = {}
+
+        def fake_emit(decision, reason, extra=None):
+            captured["decision"] = decision
+            captured["reason"] = reason
+            return 0
+
+        with patch("pretool_guard.emit", side_effect=fake_emit):
+            pretool_guard.check_terminal(cmd, state, str(REPO_ROOT))
+        return captured
+
+    def test_check_terminal_denies_cross_ticket_baton(self):
+        cmd = 'gh issue comment 200 --body "## MANAGER_HANDOFF"'
+        out = self._run(cmd, _state(active=100, roles=MIDBATON))
+        self.assertEqual(out.get("decision"), "deny")
+        self.assertIn("One ticket per worktree", out.get("reason", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/one-ticket-per-worktree.spec.js
+++ b/tests/one-ticket-per-worktree.spec.js
@@ -1,0 +1,25 @@
+'use strict';
+// tests/one-ticket-per-worktree.spec.js — tdd-pyramid evidence bridge for #2967.
+// The one-ticket-per-worktree guard is a Python hook (one_ticket_per_worktree.py +
+// pretool_guard.py), so its real assertions live in pytest/unittest
+// (tests/hooks/test_one_ticket_per_worktree.py). The test-evidence gate only
+// recognizes tests/**/*.spec.{js,ts} for tdd-pyramid (known validator gap #2980/#3183),
+// so this spec EXECUTES the Python suite and fails if it fails — genuine evidence,
+// not a stub. Refs #2967, #2980.
+const test = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+test('python one-ticket-per-worktree guard suite passes', () => {
+  const result = spawnSync(
+    'python3',
+    ['-m', 'unittest', 'tests.hooks.test_one_ticket_per_worktree'],
+    { cwd: REPO_ROOT, encoding: 'utf8' },
+  );
+  // unittest writes its summary to stderr; surface it on failure for diagnosis.
+  assert.strictEqual(result.status, 0,
+    `python unittest suite failed (exit ${result.status}):\n${result.stderr || result.stdout}`);
+});


### PR DESCRIPTION
Refs #2967

Adds a deterministic, provider-neutral pretool guard that refuses to post an Agile baton artifact (MANAGER_HANDOFF / COLLABORATOR_HANDOFF / ADMIN_HANDOFF / CONSULTANT_CLOSEOUT) for a **second** ticket from a worktree whose active ticket still has an unresolved baton. Complements the per-ticket worktree isolation shipped in #2946.

## What changed
- **`hooks/scripts/one_ticket_per_worktree.py`** (new) — pure helper: `detect_baton_post()` (reads inline `--body` + `--body-file` content) and `check_one_ticket_per_worktree()` applying the deny logic + carve-outs.
- **`hooks/scripts/pretool_guard.py`** — wires the check into `check_terminal` (first deny check) with a cwd-relative body-file reader.
- **`tests/hooks/test_one_ticket_per_worktree.py`** (new) — 16 cases: allow/deny matrix, false-positive prevention, cross-ADK compatibility matrix, pretool_guard integration.
- **`docs/howto/sandbox-worktree-governance.md`** — guard behavior, recovery path, cross-ADK contract.

## False-positive prevention (key design)
Only the four baton-artifact headers on `gh issue comment <N>` are guarded. Allowed/exempt: non-baton coordination comments, follow-on `gh issue create`, label edits, multi-close batch sibling evidence, sequential per-ticket iteration (close A → start B), unparseable state (fail-open), and the `MEGINGJORD_ONE_TICKET_GUARD_OFF=1` kill-switch. The deny also requires the active ticket to show recorded baton activity AND be unclosed, so a stale pointer never blocks.

## Evidence
- `npm run governance:hooks:test`: 353 tests OK (incl. 16 new; no regressions). `npm run lint:py` (ruff) clean; `npm run lint` clean; markdownlint 0 errors.
- Cross-family review (fleet qwen2.5-coder:7b, G3 zero-cost): 70/100, receipt dd28536a9253a1d0.

## Drift remediation
This ticket carried two duplicate, stalled cross-team (Codex) MANAGER_HANDOFFs from 2026-06-12 that never advanced past Manager. Both deleted; re-authored as a single-team claude-code baton. Scope narrowed from the Codex draft (which also denied cross-ticket close/reopen + label edits — high false-positive risk) to the authoritative ticket-body ACs (the four baton artifacts only).

## Baton artifacts (on #2967)
MANAGER_HANDOFF, EDD, COLLABORATOR_HANDOFF, ADMIN_HANDOFF posted. CONSULTANT_CLOSEOUT to follow (deferred-final).

merge-evidence-deferred-final: #2967

🤖 Generated with [Claude Code](https://claude.com/claude-code)
