### PR TITLE
feat(hooks): branch-scoped MANAGER_HANDOFF baton sequencing gate #3204

### DIFF
--- a/.changes/unreleased/3204.md
+++ b/.changes/unreleased/3204.md
@@ -1,0 +1,1 @@
+- Branch-scoped authoritative MANAGER_HANDOFF gate + collaborator-phase first-edit enforcement (#3204, Epic #2891). New `hooks/scripts/baton_handoff_checks.py`; pretool_guard, userprompt_gate, and tool_activity wired. Friction catalog entry `stale-manager-handoff-gate-bypass`.

--- a/.cursor/rules/megingjord.mdc
+++ b/.cursor/rules/megingjord.mdc
@@ -27,5 +27,5 @@ then Throughput, then Observability, then Interoperability, then Maintainability
 - Repo-local governance files may extend or tighten this baseline.
 - Runtime home for Cursor assets (`~/.cursor/`): deploy through the governed `deploy:cursor`
   workflow only; the project `.cursor/rules/megingjord.mdc` is the committed source.
-- Phase 0 (#3084) is registration + this static adapter; runtime hook/HAMR enforcement
-  lands in Phase 1 (#3085).
+- Phase 0 (#3084) is registration + this static adapter; runtime hook/HAMR enforcement ships via `deploy:cursor:apply` (Phase 1 #3085, Phase 2 #3086 — see `docs/howto/cursor-parity-matrix.md`).
+- **Baton before code**: post `MANAGER_HANDOFF` with `worktree_branch:` matching your feat/fix branch before any file edit; hooks enforce authoritative handoff (#3204).

--- a/config/friction-pattern-catalog.json
+++ b/config/friction-pattern-catalog.json
@@ -59,7 +59,12 @@
       "refs": ["#2355", "#3165"]
     },
     {
-      "pattern_id": "test-evidence-tdd-pyramid-no-pytest",
+      "pattern_id": "stale-manager-handoff-gate-bypass",
+      "surface": "hooks/scripts/baton_handoff_checks.py",
+      "description": "Historical MANAGER_HANDOFF without worktree_branch satisfied the #2876 first-edit gate while a session's authoritative handoff was posted after implementation (#2252 class).",
+      "first_seen_teams": ["cursor"],
+      "refs": ["#3204", "#2252", "#2876"]
+    }
       "surface": "scripts/global/test-evidence-validator.js",
       "description": "test-evidence tdd-pyramid checker matches only tests/**/*.{spec,test}.{js,ts}; a python-hooks PR with a pytest test_*.py fails 'missing-spec-file' though the matrix maps hooks/scripts/*.py to tdd-pyramid (pytest).",
       "first_seen_teams": ["claude-code"],

--- a/docs/howto/hooks.md
+++ b/docs/howto/hooks.md
@@ -1,0 +1,32 @@
+# Hooks — operator reference
+
+Governed hook scripts live in `hooks/scripts/` and deploy to runtime homes via
+`npm run deploy:apply` / `npm run deploy:cursor:apply`. See
+[hook-parity-check.md](hook-parity-check.md) for cross-runtime parity verification.
+
+## Baton sequencing (#3204, extends #2876)
+
+On ticket branches (`feat/<N>-*` / `fix/<N>-*`), the first file edit in a session
+requires:
+
+1. **Authoritative `MANAGER_HANDOFF`** on the linked issue — the **latest**
+   handoff must include `worktree_branch:` matching the current branch.
+2. **Collaborator phase** — session state must be `collaborator` (promoted from
+   `ready` after handoff post, or on the next prompt when authoritative handoff
+   exists).
+
+Implementation: `hooks/scripts/baton_handoff_checks.py`, wired from
+`pretool_guard.py`, `userprompt_gate.py`, and `tool_activity.py`.
+
+Stale historical handoffs without `worktree_branch:` no longer satisfy the gate.
+
+## Key scripts
+
+| Script | Role |
+|--------|------|
+| `pretool_guard.py` | Pre-edit and admin sequencing gates |
+| `manager_ticket_gate.py` | Ticket-first on Manager scope |
+| `userprompt_gate.py` | Finish-intent and baton phase promotion |
+| `baton_handoff_checks.py` | Branch-scoped MANAGER_HANDOFF authority |
+
+See [pre-push-gates.md](pre-push-gates.md) for push/merge gate ordering.

--- a/docs/howto/pre-push-gates.md
+++ b/docs/howto/pre-push-gates.md
@@ -49,7 +49,9 @@ To support it, the consultant-closeout check is **deferred to PR-open**:
 
 - **No PR yet, no closeout posted**: `MANAGER_HANDOFF` is still validated, but the
   consultant-closeout check is deferred (a `consultant-closeout deferred to PR-open` line is
-  logged). The push is not blocked for a missing closeout.
+  logged). The push is not blocked for a missing closeout. On ticket branches, the first-edit
+  gate also requires an **authoritative** handoff: latest `MANAGER_HANDOFF` must declare
+  `worktree_branch:` matching HEAD (#3204, `baton_handoff_checks.py`).
 - **A closeout is already posted early**: it is still validated — deferral relaxes the
   ordering, it never silently un-checks a closeout that is present.
 - **The PR exists** (`prBody` resolvable): the consultant-closeout check and

--- a/docs/workflow/learnings.md
+++ b/docs/workflow/learnings.md
@@ -27,3 +27,7 @@ one fact, one home, no duplicated prose. Each line points to its source ticket +
 
 - #3121/#2716 — second phantom class: merged-but-unwired; need a wiring test. See [[workflow-learnings]].
 - #3124/#3127 — drain MEMORY.md to pointers; measure with `npm run resident:budget`. See [[workflow-learnings]].
+
+## 2026-06-23
+
+- #3204/#2252 — stale MANAGER_HANDOFF without `worktree_branch:` bypassed #2876; authoritative latest-handoff gate added. See [[workflow-learnings]].

--- a/hooks/scripts/baton_handoff_checks.py
+++ b/hooks/scripts/baton_handoff_checks.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Branch-scoped MANAGER_HANDOFF authority checks (#3204, extends #2876)."""
+import json
+import re
+import subprocess
+
+RE_BRANCH_ISSUE = re.compile(r"(?:feat|fix|hotfix)/(\d+)-")
+RE_MH_HEADER = re.compile(r"(^|\n)\s*(?:\*\*|##\s+)?MANAGER_HANDOFF\b")
+RE_WT_BRANCH = re.compile(r"(?:^|\n)\s*worktree_branch:\s*(\S+)", re.IGNORECASE)
+
+
+def _branch_and_issue(cwd: str) -> tuple[str, str | None]:
+    branch = subprocess.check_output(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        text=True, stderr=subprocess.DEVNULL, cwd=cwd,
+    ).strip()
+    m = RE_BRANCH_ISSUE.match(branch)
+    return branch, (m.group(1) if m else None)
+
+
+def _issue_comments(issue_num: str, cwd: str) -> list:
+    r = subprocess.run(
+        ["gh", "issue", "view", issue_num, "--json", "comments"],
+        capture_output=True, text=True, cwd=cwd, timeout=20,
+    )
+    return json.loads(r.stdout or "{}").get("comments", [])
+
+
+def latest_manager_handoff_body(comments: list) -> str | None:
+    body = None
+    for c in comments:
+        text = str(c.get("body") or "")
+        if RE_MH_HEADER.search(text):
+            body = text
+    return body
+
+
+def worktree_branch_from_handoff(body: str) -> str | None:
+    m = RE_WT_BRANCH.search(body or "")
+    return m.group(1).strip() if m else None
+
+
+def linked_issue_has_authoritative_manager_handoff(cwd: str) -> bool:
+    """Latest MANAGER_HANDOFF must declare worktree_branch matching HEAD (#3204)."""
+    try:
+        branch, issue = _branch_and_issue(cwd)
+        if not issue:
+            return True
+        mh = latest_manager_handoff_body(_issue_comments(issue, cwd))
+        if not mh:
+            return False
+        wt = worktree_branch_from_handoff(mh)
+        return bool(wt) and wt == branch
+    except Exception:
+        return True

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -10,7 +10,8 @@ from admin_patterns import (  # noqa: E501
     RE_RELEASE_INTEGRITY, RE_VSCE_PUBLISH, SECRET_FILE_RE, iter_paths, iter_strings)
 from canonical_main_enforcer import is_main_checkout, evaluate_path
 from blast_radius_cap import ENV_BYPASS, check_caps, emit_cap_incident, load_caps
-from governance_state import ensure_state
+from governance_state import ensure_state, save_state
+from baton_handoff_checks import linked_issue_has_authoritative_manager_handoff
 from one_ticket_per_worktree import check_one_ticket_per_worktree
 from live_checks import ci_gate_status_stable, linked_issue_has_collab_handoff, linked_issue_has_manager_handoff, linked_issue_has_planning_consensus, check_merged_pr
 from runtime_paths import runtime_hook_paths
@@ -417,9 +418,15 @@ def main() -> int:
             if not derived and gated:
                 return emit("deny","File edit blocked: no active ticket. Manager must reference a ticket (#N) before edits.")
         elif not flags.get("code_touched"):
-            # #2876: first-edit MANAGER_HANDOFF ordering gate — Refs #2871
-            if not linked_issue_has_manager_handoff(cwd):
-                return emit("deny", "File edit blocked: MANAGER_HANDOFF not found on linked issue (#2876). Post Manager scope before first code edit.")
+            # #2876 + #3204: authoritative MANAGER_HANDOFF + collaborator phase
+            if not linked_issue_has_authoritative_manager_handoff(cwd):
+                return emit("deny", "File edit blocked: authoritative MANAGER_HANDOFF with matching worktree_branch required (#3204). Post Manager scope before first code edit.")
+            phase = state.get("current_phase", "manager")
+            if phase == "ready" and linked_issue_has_authoritative_manager_handoff(cwd):
+                state["current_phase"] = "collaborator"
+                save_state(state)
+            elif phase != "collaborator":
+                return emit("deny", "File edit blocked: collaborator baton phase required (#3204). Post MANAGER_HANDOFF, then continue on next prompt.")
             if not linked_issue_has_planning_consensus(cwd):
                 if os.environ.get(CONSENSUS_OVERRIDE_ENV) == "1":
                     _emit_planning_consensus_override_incident(cwd, state.get("active_ticket"))

--- a/hooks/scripts/tool_activity.py
+++ b/hooks/scripts/tool_activity.py
@@ -182,3 +182,5 @@ def mark_tool_activity(state: dict[str, Any], payload: dict[str, Any]) -> None:
                               input_summary=f"{artifact_name} posted on #{ticket}")
             except Exception:
                 pass  # G6: never break activity tracking
+            if artifact_name == "MANAGER_HANDOFF":
+                state["current_phase"] = "ready"

--- a/hooks/scripts/userprompt_gate.py
+++ b/hooks/scripts/userprompt_gate.py
@@ -11,6 +11,7 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from governance_state import ensure_state, save_state
+from baton_handoff_checks import linked_issue_has_authoritative_manager_handoff
 from repo_scope import is_repo_enabled
 from routing_context import build_route_context, run_fleet_cascade
 from semantic_router import classify as semantic_classify
@@ -49,6 +50,10 @@ def main() -> int:
         return 0
 
     state = ensure_state(cwd)
+    if linked_issue_has_authoritative_manager_handoff(cwd):
+        phase = state.get("current_phase", "manager")
+        if phase in ("manager", "ready"):
+            state["current_phase"] = "collaborator"
     # Layer 0: semantic pre-classifier (zero cost, <1ms)
     semantic = semantic_classify(prompt)
     # Layer 1+: keyword classifier (falls through if semantic is unclear)

--- a/tests/baton-sequencing-gate-3204.spec.js
+++ b/tests/baton-sequencing-gate-3204.spec.js
@@ -1,0 +1,12 @@
+'use strict';
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+test('baton handoff authority Python suite passes (#3204)', () => {
+  const root = path.resolve(__dirname, '..');
+  execFileSync('python3', ['-m', 'unittest', 'tests.hooks.test_baton_handoff_checks'], {
+    cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  expect(true).toBe(true);
+});

--- a/tests/hooks/test_baton_handoff_checks.py
+++ b/tests/hooks/test_baton_handoff_checks.py
@@ -1,0 +1,53 @@
+"""Unit tests for branch-scoped MANAGER_HANDOFF authority (#3204)."""
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "hooks" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import baton_handoff_checks as bhc  # noqa: E402
+
+
+def _run(stdout: str):
+    r = MagicMock()
+    r.stdout = stdout
+    r.returncode = 0
+    return r
+
+
+class TestAuthoritativeManagerHandoff(unittest.TestCase):
+    def test_matching_worktree_branch(self):
+        body = '{"comments":[{"body":"## MANAGER_HANDOFF\\nworktree_branch: feat/99-slug"}]}'
+        with patch("subprocess.check_output", return_value="feat/99-slug\n"):
+            with patch("subprocess.run", return_value=_run(body)):
+                self.assertTrue(bhc.linked_issue_has_authoritative_manager_handoff("."))
+
+    def test_stale_without_worktree_branch(self):
+        body = '{"comments":[{"body":"## MANAGER_HANDOFF\\nticket: #99"}]}'
+        with patch("subprocess.check_output", return_value="feat/99-slug\n"):
+            with patch("subprocess.run", return_value=_run(body)):
+                self.assertFalse(bhc.linked_issue_has_authoritative_manager_handoff("."))
+
+    def test_branch_mismatch(self):
+        body = '{"comments":[{"body":"## MANAGER_HANDOFF\\nworktree_branch: feat/99-other"}]}'
+        with patch("subprocess.check_output", return_value="feat/99-slug\n"):
+            with patch("subprocess.run", return_value=_run(body)):
+                self.assertFalse(bhc.linked_issue_has_authoritative_manager_handoff("."))
+
+    def test_latest_wins(self):
+        body = '{"comments":[' \
+               '{"body":"## MANAGER_HANDOFF\\nworktree_branch: feat/99-old"},' \
+               '{"body":"## MANAGER_HANDOFF\\nworktree_branch: feat/99-slug"}]}'
+        with patch("subprocess.check_output", return_value="feat/99-slug\n"):
+            with patch("subprocess.run", return_value=_run(body)):
+                self.assertTrue(bhc.linked_issue_has_authoritative_manager_handoff("."))
+
+    def test_no_ticket_branch_fail_open(self):
+        with patch("subprocess.check_output", return_value="main\n"):
+            self.assertTrue(bhc.linked_issue_has_authoritative_manager_handoff("."))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the stale-`MANAGER_HANDOFF` bypass that allowed implementation before authoritative baton scope (#2252 class). Extends #2876 with branch-scoped handoff verification and collaborator-phase first-edit enforcement — provider-neutral across all runtimes.

Refs #3204
merge-evidence-deferred-final: #3204

## Changes

- `hooks/scripts/baton_handoff_checks.py` — latest MH must declare `worktree_branch:` matching HEAD
- `pretool_guard.py` — authoritative check + collaborator phase gate
- `userprompt_gate.py` — promotes manager/ready → collaborator when authoritative MH verified
- `tool_activity.py` — sets `ready` on MANAGER_HANDOFF post
- Tests, friction catalog, minimal `.mdc` adapter touch
- `docs/howto/hooks.md` — operator reference for baton sequencing

## Test plan

- [x] `npm run lint`
- [x] `python3 -m unittest tests.hooks.test_baton_handoff_checks`
- [x] `npx playwright test tests/baton-sequencing-gate-3204.spec.js`