### PR TITLE
fix(hooks): block canonical-main tracked-file writes via absolute path

### DIFF
--- a/.changes/unreleased/2945.md
+++ b/.changes/unreleased/2945.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `canonical_main_enforcer`: extend canonical-main write guard to block absolute-path writes regardless of session CWD. Adds `main_checkout_root()` helper and updates `pretool_guard.py` enforcement logic. Closes the gap where VS Code Copilot tool calls with absolute `filePath` bypassed `is_main_checkout(cwd)`. (#2945)

--- a/hooks/scripts/canonical_main_enforcer.py
+++ b/hooks/scripts/canonical_main_enforcer.py
@@ -17,6 +17,11 @@ import subprocess
 from pathlib import Path
 
 
+def main_checkout_root() -> str:
+    """Return the canonical main checkout path as a string."""
+    return str(Path.home() / "devenv-ops")
+
+
 def is_main_checkout(cwd: str) -> bool:
     """Return True if cwd is the canonical main checkout path.
 

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -8,7 +8,7 @@ from admin_patterns import (  # noqa: E501
     DANGEROUS_CMD_RE, RE_GH_ISSUE_CLOSE, RE_GH_RELEASE_CREATE, RE_GIT_COMMIT,
     RE_GIT_PUSH, RE_GIT_TAG, RE_PR_CHECKS, RE_PR_CREATE, RE_PR_MERGE,
     RE_RELEASE_INTEGRITY, RE_VSCE_PUBLISH, SECRET_FILE_RE, iter_paths, iter_strings)
-from canonical_main_enforcer import is_main_checkout, evaluate_path
+from canonical_main_enforcer import is_main_checkout, evaluate_path, main_checkout_root
 from blast_radius_cap import ENV_BYPASS, check_caps, emit_cap_incident, load_caps
 from governance_state import ensure_state, save_state
 from baton_handoff_checks import linked_issue_has_authoritative_manager_handoff
@@ -400,13 +400,24 @@ def main() -> int:
                     "Raw file writes to /memories/ are a governance injection vector (G-07, #2903).")
         if active_ticket_is_no_code_lane(state, cwd):
             return emit("deny", "File edit blocked: lane:no-code-remediation is issue-only. Re-route ticket to lane:code-change.")
-        if is_main_checkout(cwd):
-            for path_val in iter_paths(payload.get("tool_input", {})):
-                if not (path_val.startswith("/") or path_val.startswith("./") or "/" in path_val):
+        # Canonical-main write guard: block writes whether cwd is main checkout
+        # OR target path is an absolute path inside canonical-main (Refs #2945).
+        _main_rt = main_checkout_root()
+        for path_val in iter_paths(payload.get("tool_input", {})):
+            if is_main_checkout(cwd):
+                check_root = cwd
+            elif path_val.startswith("/"):
+                try:
+                    Path(os.path.normpath(path_val)).relative_to(
+                        os.path.normpath(_main_rt))
+                except ValueError:
                     continue
-                allowed, reason = evaluate_path(path_val, cwd)
-                if not allowed:
-                    return emit("deny", f"Canonical-main read-only (#2107): {reason}")
+                check_root = _main_rt  # absolute path targets canonical-main
+            else:
+                continue
+            allowed, reason = evaluate_path(path_val, check_root)
+            if not allowed:
+                return emit("deny", f"Canonical-main read-only (#2107): {reason}")
         if not state.get("active_ticket"):
             from worktree_ticket import resolve_ticket_from_paths, any_path_in_governed_repo
             edit_paths = list(iter_paths(payload.get("tool_input", {})))

--- a/tests/canonical-main-enforcer.spec.js
+++ b/tests/canonical-main-enforcer.spec.js
@@ -113,3 +113,13 @@ test('evaluate_path ALLOWS system tmp path', () => {
   expect(out).toMatch(/True/);
   expect(out).toMatch(/outside main-checkout repo/);
 });
+
+// Refs #2945: main_checkout_root() returns canonical path string
+test('main_checkout_root returns home/devenv-ops string', () => {
+  const expected = path.join(os.homedir(), 'devenv-ops');
+  const driver = `import sys; sys.path.insert(0, '${path.dirname(ENFORCER)}'); ` +
+    `from canonical_main_enforcer import main_checkout_root; print(main_checkout_root())`;
+  const result = spawnSync('python3', ['-c', driver], { encoding: 'utf8' });
+  expect(result.status).toBe(0);
+  expect(result.stdout.trim()).toBe(expected);
+});


### PR DESCRIPTION
## Summary

Closes the canonical-main read-only enforcement gap where a write-tool call targeting a tracked file inside `~/devenv-ops` via an **absolute path** bypassed the guard whenever the session CWD was not canonical-main (e.g. VS Code tool calls from a worktree). Root Cause A of the Auto-model early-termination incident.

This PR supersedes #2955 (closed): same branch + diff, re-opened after a clean single-team **claude-code re-baton** so all four baton artifacts predate the PR (the prior PR was blocked at `admin-gate` by cross-team Copilot Auto-mode signer drift — `Quill`/`Quinn` vs registry `Soren`). Resolution matches the merged precedent #2946 (PR #3196); **no admin-merge-bypass**. Copilot's origin contribution (session `701dab5a`) is credited in the COLLABORATOR_HANDOFF.

## Root Cause

`is_main_checkout(cwd)` only checked the session CWD. When a write tool dispatches an absolute `filePath`, the hook-payload `cwd` is not the canonical-main path, so the guard was never entered even though the target was inside canonical-main.

## Changes

- `hooks/scripts/canonical_main_enforcer.py`: add `main_checkout_root()` helper.
- `hooks/scripts/pretool_guard.py`: also check absolute target paths against canonical-main root regardless of CWD; CWD-based path preserved. Rebased onto current `main` — coexists with the #2967 one-ticket guard.

## Test Evidence

- `npm run lint` — all files within 100-line limit.
- `canonical-main-enforcer.spec.js` + `stress-canonical-main-enforcer.spec.js` — 25 passed; p99 54ms.
- `main_checkout_root` unit test added (claude-code).
- Cross-family fleet review (G3 $0): qwen2.5-coder:7b — ACCEPT, receipt `23f2f46577378106`.

## Baton artifacts (on issue #2945)

- COLLABORATOR_HANDOFF — Orla Harper (claude-code)
- ADMIN_HANDOFF — Orla Reyes (claude-code), commit e2f37d98
- CONSULTANT_CLOSEOUT — Orla Vale (claude-code), verdict approve_for_merge

merge-evidence-deferred-final: #2945

Refs #2945
