### PR TITLE
fix(governance): Auto-mode baton-progression parity (#2957)

### DIFF
--- a/.changes/unreleased/2957.md
+++ b/.changes/unreleased/2957.md
@@ -1,0 +1,8 @@
+- **Governance — Auto-mode baton-progression parity (#2957):** Added a route-invariant
+  baton-progression continuity guardrail (`scripts/global/baton-progression-parity.js`),
+  wired into the `pre-pr-gate`. It denies (fail-fast) when the baton artifact chain on a
+  linked issue skips a role or is posted out of order, complementing the existing
+  presence-only completeness check. Enforcement reads no model/route signal, so Copilot
+  Auto-mode receives identical discipline to frontier routing; a progression gap emits a
+  Tier-2 incident (`pattern_id: auto-mode-baton-progression-gap`). Documented an Auto-mode
+  implementation-time checklist in `instructions/programmatic-governance.instructions.md`.

--- a/instructions/programmatic-governance.instructions.md
+++ b/instructions/programmatic-governance.instructions.md
@@ -56,6 +56,36 @@ Per Epic #1612 replay-eval-gated promotion model:
   scans `instructions/*.md` for MUST/SHALL/REQUIRED statements; emits
   inventory of statements lacking corresponding programmatic validator.
 
+## Auto-mode governance parity (#2957)
+
+Auto model selection (Copilot Auto-mode routed to lower-capability models) MUST NOT
+reduce governance discipline relative to frontier routing. The enforcement principle is
+**route-invariance**: governance gates read no model/route/auto-mode signal, so the
+decision is identical regardless of which model is driving the baton. A gate that relaxes
+on a routing hint is the exact bug class this rule forbids.
+
+- `scripts/global/baton-progression-parity.js` (wired into `pre-pr-gate.js`) enforces
+  baton-progression **continuity**: the artifacts present on the linked issue must form a
+  contiguous, time-ordered prefix of MANAGER → COLLABORATOR → ADMIN → CONSULTANT. A
+  skipped role or out-of-order post is denied (fail-fast) before a privileged push/merge.
+  This is the programmatic backstop for the instructional "post all four artifacts, in
+  order, before the PR" contract — which a less-capable model cannot be trusted to honor
+  on prose alone.
+
+### Auto-mode implementation-time checklist (Copilot runtime)
+
+When executing under Auto-mode, before any privileged admin action (push, `gh pr merge`):
+
+1. Confirm the linked issue carries the prior baton artifacts **in role order** — do not
+   post a later-stage artifact before its predecessors exist and predate it.
+2. Do not present a preflight/gate fallback in a way that looks like a bypass — when a
+   gate blocks, treat the block as redirect guidance, fix the cause, and re-run. Never
+   route around it.
+3. **Tier-2 emission rule**: when a progression gap or bypass-looking attempt is observed
+   during implementation, an `auto-mode-baton-progression-gap` incident is emitted to
+   `~/.megingjord/incidents.jsonl` for the recurrence detector. Emission is observability,
+   never a substitute for fixing the gap.
+
 ## Phase 2 (deferred to standalone tickets)
 
 The 8 detached siblings from Epic #1894 remain as P2 backlog work:

--- a/scripts/global/baton-progression-parity.js
+++ b/scripts/global/baton-progression-parity.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+'use strict';
+// Baton-progression continuity guardrail (#2957).
+//
+// Enforces that the baton artifacts present on a linked issue form a CONTIGUOUS,
+// monotonically time-ordered prefix of:
+//   MANAGER_HANDOFF -> COLLABORATOR_HANDOFF -> ADMIN_HANDOFF -> CONSULTANT_CLOSEOUT
+//
+// This complements pre-pr-gate's checkBatonCompleteness (#1896), which only checks
+// artifact PRESENCE. The #2940 incident showed Copilot Auto-mode "proceeding without
+// explicit baton artifact continuity at each step" — i.e. a present artifact set that
+// skips a role or posts artifacts out of order. That is what this module denies.
+//
+// Route-invariance is the core anti-drift property (#2957: "Auto model selection must
+// not reduce governance discipline"). No model/route/auto-mode signal is read by the
+// decision functions, so Copilot Auto-mode receives IDENTICAL enforcement to frontier
+// routing. The evaluate() wrapper makes that invariant explicit and testable.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const STAGE_ORDER = [
+  'MANAGER_HANDOFF',
+  'COLLABORATOR_HANDOFF',
+  'ADMIN_HANDOFF',
+  'CONSULTANT_CLOSEOUT',
+];
+const INCIDENT_PATTERN_ID = 'auto-mode-baton-progression-gap';
+const SUMMARY_MAX_LEN = 200; // _summary cap for the schema-v3 incident record
+
+// Latest createdAt (epoch ms) per baton stage present in the comment list.
+// Tolerant of malformed input: non-array, null comments, non-string bodies, and
+// unparseable timestamps are skipped rather than thrown (G6 resilience).
+function latestTimestampsByStage(comments) {
+  const timestamps = {};
+  const list = Array.isArray(comments) ? comments : [];
+  for (const comment of list) {
+    const body = comment && typeof comment.body === 'string' ? comment.body : '';
+    if (!body) continue;
+    const createdAt = comment && comment.createdAt ? Date.parse(comment.createdAt) : NaN;
+    if (!Number.isFinite(createdAt)) continue;
+    for (const stage of STAGE_ORDER) {
+      if (body.includes(stage)) {
+        if (timestamps[stage] === undefined || createdAt > timestamps[stage]) {
+          timestamps[stage] = createdAt;
+        }
+      }
+    }
+  }
+  return timestamps;
+}
+
+// Returns a violation { rule, detail } when the present artifacts are NOT a
+// contiguous, time-ordered prefix of STAGE_ORDER; otherwise null. Model-agnostic.
+function checkBatonProgression(comments) {
+  const timestamps = latestTimestampsByStage(comments);
+  const present = STAGE_ORDER.map((stage) => timestamps[stage] !== undefined);
+  const lastPresentIndex = present.lastIndexOf(true);
+  if (lastPresentIndex < 0) return null; // no artifacts yet — nothing to order
+
+  // Contiguity: every earlier stage must be present (no skipped step).
+  for (let i = 0; i < lastPresentIndex; i++) {
+    if (!present[i]) {
+      return {
+        rule: 'baton-progression-gap',
+        detail:
+          `${STAGE_ORDER[lastPresentIndex]} present but earlier ${STAGE_ORDER[i]} is ` +
+          'missing — baton continuity skipped a step before a privileged action.',
+      };
+    }
+  }
+  // Monotonic ordering: no present stage may predate the stage before it.
+  for (let i = 1; i <= lastPresentIndex; i++) {
+    if (timestamps[STAGE_ORDER[i]] < timestamps[STAGE_ORDER[i - 1]]) {
+      return {
+        rule: 'baton-progression-out-of-order',
+        detail:
+          `${STAGE_ORDER[i]} is timestamped before ${STAGE_ORDER[i - 1]} — baton ` +
+          'artifacts were posted out of role order.',
+      };
+    }
+  }
+  return null;
+}
+
+// Route-invariant evaluation entrypoint. `context` may carry a model/route/auto-mode
+// hint from the runtime; it is intentionally IGNORED so governance discipline is
+// identical regardless of routing. Do not branch on context here — that is the bug
+// class #2957 exists to prevent.
+function evaluate(comments, context) {
+  void context; // deliberately unused — see route-invariance contract above
+  return checkBatonProgression(comments);
+}
+
+// Append a Tier-2 incident capturing the progression gap for the anneal detector.
+// Emission failure is swallowed (returns false) — observability must never block a
+// gate (G6/G8).
+function emitProgressionIncident(violation, opts = {}) {
+  const file =
+    opts.incidentsPath || path.join(os.homedir(), '.megingjord', 'incidents.jsonl');
+  const record = {
+    ts: opts.now ? new Date(opts.now).toISOString() : new Date().toISOString(),
+    version: 3,
+    service: 'baton-progression-parity',
+    env: 'local',
+    event: 'kill-switch-trip',
+    pattern_id: INCIDENT_PATTERN_ID,
+    rule: violation.rule,
+    _summary: String(violation.detail || '').slice(0, SUMMARY_MAX_LEN),
+  };
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.appendFileSync(file, JSON.stringify(record) + '\n');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  checkBatonProgression,
+  evaluate,
+  latestTimestampsByStage,
+  emitProgressionIncident,
+  STAGE_ORDER,
+  INCIDENT_PATTERN_ID,
+};

--- a/scripts/global/pre-pr-gate.js
+++ b/scripts/global/pre-pr-gate.js
@@ -6,6 +6,8 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 
+const { checkBatonProgression, emitProgressionIncident } = require('./baton-progression-parity.js');
+
 const ARTIFACTS = ['MANAGER_HANDOFF', 'COLLABORATOR_HANDOFF', 'ADMIN_HANDOFF', 'CONSULTANT_CLOSEOUT'];
 
 const gh = args => { try { return execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }); } catch (e) { return e.stdout?.toString('utf8') || ''; } };
@@ -49,8 +51,13 @@ function check(opts = {}) {
   if (predate) violations.push(predate);
   const closes = checkClosesKeyword(opts.prBodyDraft, leadTicket);
   if (closes) violations.push(closes);
+  // #2957: route-invariant baton-progression continuity (skipped-step / out-of-order)
+  // on top of the presence-only completeness check above.
+  const progression = checkBatonProgression(comments);
+  if (progression) violations.push(progression);
 
   const isTestEnv = opts.skipDrift || (typeof global.test === 'function') || process.env.NODE_ENV === 'test';
+  if (progression && !isTestEnv) emitProgressionIncident(progression);
   if (isTestEnv) {
     // skip drift checks in unit test runner
   } else if (process.env.SKIP_DRIFT_LINT === 'true') {

--- a/tests/baton-progression-parity.spec.js
+++ b/tests/baton-progression-parity.spec.js
@@ -1,0 +1,134 @@
+'use strict';
+// Unit tests for the baton-progression continuity guardrail (#2957).
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  checkBatonProgression,
+  evaluate,
+  emitProgressionIncident,
+  STAGE_ORDER,
+  INCIDENT_PATTERN_ID,
+} = require('../scripts/global/baton-progression-parity.js');
+
+// Build a comment fixture: each entry [STAGE, secondsOffset] -> {body, createdAt}.
+const base = Date.parse('2026-06-22T00:00:00Z');
+const mk = (entries) =>
+  entries.map(([stage, offsetSec]) => ({
+    body: `## ${stage}\nbody text`,
+    createdAt: new Date(base + offsetSec * 1000).toISOString(),
+  }));
+
+test('ordered full chain passes', () => {
+  const c = mk([
+    ['MANAGER_HANDOFF', 0],
+    ['COLLABORATOR_HANDOFF', 10],
+    ['ADMIN_HANDOFF', 20],
+    ['CONSULTANT_CLOSEOUT', 30],
+  ]);
+  assert.equal(checkBatonProgression(c), null);
+});
+
+test('ordered partial prefix (manager + collaborator) passes', () => {
+  const c = mk([
+    ['MANAGER_HANDOFF', 0],
+    ['COLLABORATOR_HANDOFF', 10],
+  ]);
+  assert.equal(checkBatonProgression(c), null);
+});
+
+test('no artifacts yet passes (nothing to order)', () => {
+  assert.equal(checkBatonProgression([{ body: 'random note', createdAt: new Date(base).toISOString() }]), null);
+  assert.equal(checkBatonProgression([]), null);
+});
+
+test('skipped step (admin present, collaborator absent) is denied', () => {
+  const c = mk([
+    ['MANAGER_HANDOFF', 0],
+    ['ADMIN_HANDOFF', 20],
+  ]);
+  const v = checkBatonProgression(c);
+  assert.ok(v, 'expected a violation');
+  assert.equal(v.rule, 'baton-progression-gap');
+});
+
+test('skipped manager (collaborator present, manager absent) is denied', () => {
+  const c = mk([['COLLABORATOR_HANDOFF', 10]]);
+  const v = checkBatonProgression(c);
+  assert.equal(v.rule, 'baton-progression-gap');
+});
+
+test('out-of-order (collaborator predates manager) is denied', () => {
+  const c = mk([
+    ['MANAGER_HANDOFF', 50],
+    ['COLLABORATOR_HANDOFF', 10],
+  ]);
+  const v = checkBatonProgression(c);
+  assert.equal(v.rule, 'baton-progression-out-of-order');
+});
+
+test('latest artifact of a stage wins (re-posted manager handoff)', () => {
+  const c = [
+    { body: 'MANAGER_HANDOFF v1', createdAt: new Date(base + 100 * 1000).toISOString() },
+    { body: 'MANAGER_HANDOFF v2', createdAt: new Date(base + 0).toISOString() },
+    { body: 'COLLABORATOR_HANDOFF', createdAt: new Date(base + 50 * 1000).toISOString() },
+  ];
+  // latest MANAGER is at +100s, COLLAB at +50s -> collab predates latest manager -> denied
+  const v = checkBatonProgression(c);
+  assert.equal(v.rule, 'baton-progression-out-of-order');
+});
+
+// AC2: route-invariance — the decision MUST NOT depend on any model/route/auto-mode hint.
+test('parity: evaluate() ignores route/model/auto-mode context', () => {
+  const fixtures = [
+    mk([['MANAGER_HANDOFF', 0], ['COLLABORATOR_HANDOFF', 10], ['ADMIN_HANDOFF', 20]]),
+    mk([['MANAGER_HANDOFF', 0], ['ADMIN_HANDOFF', 20]]),
+    mk([['MANAGER_HANDOFF', 50], ['COLLABORATOR_HANDOFF', 10]]),
+    [],
+  ];
+  const contexts = [
+    { route: 'auto', model: 'qwen', autoMode: true },
+    { route: 'frontier', model: 'claude-opus', autoMode: false },
+    { route: 'fleet', model: 'gpt-5.3-codex' },
+    undefined,
+  ];
+  for (const f of fixtures) {
+    const truth = checkBatonProgression(f);
+    for (const ctx of contexts) {
+      assert.deepEqual(
+        evaluate(f, ctx),
+        truth,
+        `route/model context must not change the decision (ctx=${JSON.stringify(ctx)})`,
+      );
+    }
+  }
+});
+
+test('emitProgressionIncident writes a v3 record and is swallow-safe', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bpp-'));
+  const incidentsPath = path.join(dir, 'incidents.jsonl');
+  const ok = emitProgressionIncident({ rule: 'baton-progression-gap', detail: 'x' }, { incidentsPath, now: base });
+  assert.equal(ok, true);
+  const line = JSON.parse(fs.readFileSync(incidentsPath, 'utf8').trim());
+  assert.equal(line.pattern_id, INCIDENT_PATTERN_ID);
+  assert.equal(line.version, 3);
+  assert.equal(line.rule, 'baton-progression-gap');
+
+  // unwritable path (parent is a regular file -> ENOTDIR) returns false, never throws
+  const blocker = path.join(dir, 'blocker');
+  fs.writeFileSync(blocker, 'x');
+  const bad = emitProgressionIncident({ rule: 'r', detail: 'd' }, { incidentsPath: path.join(blocker, 'nested', 'x.jsonl') });
+  assert.equal(bad, false);
+});
+
+test('STAGE_ORDER is the canonical four-role chain', () => {
+  assert.deepEqual(STAGE_ORDER, [
+    'MANAGER_HANDOFF',
+    'COLLABORATOR_HANDOFF',
+    'ADMIN_HANDOFF',
+    'CONSULTANT_CLOSEOUT',
+  ]);
+});

--- a/tests/stress-baton-progression-parity.spec.js
+++ b/tests/stress-baton-progression-parity.spec.js
@@ -1,0 +1,95 @@
+'use strict';
+// Stress test for the baton-progression guardrail (#2957).
+// Required because this surface (a) parses untrusted input (baton comments from PRs /
+// issue threads) and (b) mutates shared state (appends to incidents.jsonl) — both are
+// stress-applicability triggers per instructions/test-methodology-matrix.instructions.md.
+// Asserts: >=1 fault-injection / chaos path (G6) AND >=1 p99 latency budget (G7).
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  checkBatonProgression,
+  latestTimestampsByStage,
+  emitProgressionIncident,
+} = require('../scripts/global/baton-progression-parity.js');
+
+// ---- G6: fault-injection / adversarial input must never throw ----
+test('chaos: malformed and adversarial comment shapes never throw', () => {
+  const adversarial = [
+    null,
+    undefined,
+    'not-an-array-element',
+    42,
+    {},
+    { body: null, createdAt: null },
+    { body: 12345, createdAt: 'not-a-date' },
+    { body: 'MANAGER_HANDOFF', createdAt: undefined },
+    { body: 'MANAGER_HANDOFF', createdAt: 'garbage' },
+    // artifact name embedded in prose must still be detected by substring (worst case)
+    { body: 'I will not post a COLLABORATOR_HANDOFF yet', createdAt: new Date(0).toISOString() },
+    { body: 'ADMIN_HANDOFF'.repeat(1000), createdAt: new Date(1000).toISOString() },
+  ];
+  const inputs = [adversarial, null, undefined, 'string', 99, {}, [[]]];
+  for (const input of inputs) {
+    assert.doesNotThrow(() => checkBatonProgression(input));
+    assert.doesNotThrow(() => latestTimestampsByStage(input));
+    const result = checkBatonProgression(input);
+    assert.ok(result === null || (result && typeof result.rule === 'string'));
+  }
+});
+
+test('chaos: incident emission to an unwritable path is swallowed', () => {
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bpp-stress-'));
+  const blocker = path.join(dir, 'blocker');
+  fs.writeFileSync(blocker, 'x'); // a regular file as the parent dir -> mkdir ENOTDIR
+  assert.doesNotThrow(() => {
+    const ok = emitProgressionIncident(
+      { rule: 'baton-progression-gap', detail: 'x' },
+      { incidentsPath: path.join(blocker, 'nested', 'incidents.jsonl') },
+    );
+    assert.equal(ok, false);
+  });
+});
+
+test('chaos: determinism under repeated evaluation of the same large input', () => {
+  const big = [];
+  const base = Date.parse('2026-06-22T00:00:00Z');
+  for (let i = 0; i < 4000; i++) {
+    big.push({ body: `noise comment ${i}`, createdAt: new Date(base + i * 1000).toISOString() });
+  }
+  big.push({ body: 'MANAGER_HANDOFF', createdAt: new Date(base + 5000 * 1000).toISOString() });
+  big.push({ body: 'ADMIN_HANDOFF', createdAt: new Date(base + 6000 * 1000).toISOString() });
+  const first = JSON.stringify(checkBatonProgression(big));
+  for (let i = 0; i < 50; i++) {
+    assert.equal(JSON.stringify(checkBatonProgression(big)), first);
+  }
+  // skipped COLLABORATOR -> gap
+  assert.equal(JSON.parse(first).rule, 'baton-progression-gap');
+});
+
+// ---- G7: p99 latency budget ----
+test('p99 latency budget on a large comment set', () => {
+  const base = Date.parse('2026-06-22T00:00:00Z');
+  const comments = [];
+  for (let i = 0; i < 5000; i++) {
+    comments.push({ body: `comment ${i} with some text`, createdAt: new Date(base + i * 1000).toISOString() });
+  }
+  comments.push({ body: 'MANAGER_HANDOFF', createdAt: new Date(base + 6000 * 1000).toISOString() });
+  comments.push({ body: 'COLLABORATOR_HANDOFF', createdAt: new Date(base + 6100 * 1000).toISOString() });
+
+  const N = 200;
+  const samples = [];
+  for (let i = 0; i < N; i++) {
+    const t0 = process.hrtime.bigint();
+    checkBatonProgression(comments);
+    const t1 = process.hrtime.bigint();
+    samples.push(Number(t1 - t0) / 1e6); // ms
+  }
+  samples.sort((a, b) => a - b);
+  const p99 = samples[Math.min(samples.length - 1, Math.floor(samples.length * 0.99))];
+  const BUDGET_MS = 50;
+  assert.ok(p99 < BUDGET_MS, `p99 ${p99.toFixed(2)}ms exceeded budget ${BUDGET_MS}ms`);
+});


### PR DESCRIPTION
Refs #2957
merge-evidence-deferred-final: #2957

## Summary

Hardens Auto-mode governance adherence (#2957) by adding a **route-invariant**
baton-progression continuity guardrail. The decision functions read no model/route
signal, so Copilot Auto-mode receives identical discipline to frontier routing
("Auto must not reduce discipline").

`checkBatonProgression` denies (fail-fast) when the baton artifacts on a linked
issue skip a role or are posted out of time-order — the "continuity at each step"
gap the #2940 incident exposed. It complements the existing presence-only
completeness check in `pre-pr-gate`. A progression gap emits a Tier-2 incident
(`pattern_id: auto-mode-baton-progression-gap`) for the anneal detector.

## Changes

- `scripts/global/baton-progression-parity.js` — new route-invariant guardrail + Tier-2 emitter
- `scripts/global/pre-pr-gate.js` — wire the progression check into `check()`
- `tests/baton-progression-parity.spec.js` — tdd-pyramid unit spec (parity invariant incl.)
- `tests/stress-baton-progression-parity.spec.js` — stress (fault-injection G6 + p99 budget G7)
- `instructions/programmatic-governance.instructions.md` — Auto-mode implementation-time checklist
- `.changes/unreleased/2957.md` — changelog fragment

Tests: 14/14 green (`node --test`); lint + readability + megalint clean.

## Baton artifacts (full text on #2957)

- MANAGER_HANDOFF — scope, lane:code-change, overlap_decision boundary vs #3029
- COLLABORATOR_HANDOFF — per-AC PASS, cross-family qwen review, doc-coverage block
- ADMIN_HANDOFF — branch/commit, signer independence (Reyes vs Harper)
- CONSULTANT_CLOSEOUT — approve_for_merge, rubric min 8/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
