### PR TITLE
feat(megalint): consultant rubric vs verdict consistency (#2908)

### DIFF
--- a/.changes/unreleased/2908.md
+++ b/.changes/unreleased/2908.md
@@ -1,0 +1,1 @@
+- Consultant rubric internal consistency: block approve_for_merge when min(G1..G9) < 7 (#2908).

--- a/scripts/global/megalint/consultant-closeout.js
+++ b/scripts/global/megalint/consultant-closeout.js
@@ -8,6 +8,7 @@ const { enforceTier3Emission } = require(path.join(__dirname, 'goal-failure-emis
 const { fleetCloseoutParity } = require(path.join(__dirname, '..', 'governance-bundle.js'));
 const wtGate = require('../worktree-lifecycle-gate');
 const { checkMemoryNoteRecurrence } = require(path.join(__dirname, '..', 'closeout-recurrence-guard.js'));
+const { checkRubricVerdictConsistency } = require('./consultant-rubric-consistency.js');
 
 // #2094 AC-4: parity for a fleet-authored CLOSEOUT. Same standard as non-fleet
 // — a CLOSEOUT that cites a governance-bundle-hash must trace to a hash-valid,
@@ -155,6 +156,7 @@ function validate(input) {
   const violations = [
     ...checkSignerFields(body),
     ...checkEvidenceFields(body),
+    ...checkRubricVerdictConsistency(body),
     ...checkRequiredFlawFields(body),
     ...checkCrypto(body),
     ...checkTier3Emission(body, input),
@@ -175,4 +177,5 @@ module.exports = {
   checkFleetBundleProvenance,
   checkRequiredFlawFields,
   checkMemoryNoteRecurrence,
+  checkRubricVerdictConsistency,
 };

--- a/scripts/global/megalint/consultant-rubric-consistency.js
+++ b/scripts/global/megalint/consultant-rubric-consistency.js
@@ -1,0 +1,35 @@
+'use strict';
+// #2908 — G1–G9 rubric vs verdict internal consistency (Gap G-04).
+
+const APPROVE_RE = /\bverdict:\s*approve_for_merge\b/i;
+const REJECT_RE = /\bverdict:\s*reject(?:_for_\w+)?\b/i;
+const FLOOR = 7;
+
+function parseGScores(body) {
+  const text = String(body || '');
+  const scores = [];
+  for (let i = 1; i <= 9; i++) {
+    const m = text.match(new RegExp(`\\bG${i}\\s*[=:]\\s*([0-9]+(?:\\.[0-9]+)?)`, 'i'));
+    if (!m) return null;
+    scores.push(Number(m[1]));
+  }
+  return scores;
+}
+
+function checkRubricVerdictConsistency(body) {
+  const scores = parseGScores(body);
+  if (!scores) return [];
+  const min = Math.min(...scores);
+  const violations = [];
+  if (APPROVE_RE.test(body) && min < FLOOR) {
+    violations.push({ rule: 'rubric-floor-violation',
+      detail: `min(G1..G9)=${min} < ${FLOOR} but verdict is approve_for_merge` });
+  }
+  if (REJECT_RE.test(body) && min >= FLOOR) {
+    violations.push({ rule: 'rubric-verdict-contradiction',
+      detail: `min(G1..G9)=${min} >= ${FLOOR} but verdict is reject` });
+  }
+  return violations;
+}
+
+module.exports = { checkRubricVerdictConsistency, parseGScores, FLOOR };

--- a/tests/consultant-rubric-consistency.spec.js
+++ b/tests/consultant-rubric-consistency.spec.js
@@ -1,0 +1,32 @@
+'use strict';
+const { test, expect } = require('@playwright/test');
+const { checkRubricVerdictConsistency, parseGScores, FLOOR } =
+  require('../scripts/global/megalint/consultant-rubric-consistency.js');
+
+const HIGH = 'G1: 8 G2: 8 G3: 8 G4: 8 G5: 8 G6: 8 G7: 8 G8: 8 G9: 8';
+const LOW = 'G1: 2 G2: 8 G3: 8 G4: 8 G5: 8 G6: 8 G7: 8 G8: 8 G9: 8';
+
+test.describe('consultant rubric consistency (#2908)', () => {
+  test('parseGScores reads G1–G9', () => {
+    expect(parseGScores(HIGH)).toHaveLength(9);
+    expect(parseGScores('G1: 8')).toBeNull();
+  });
+
+  test('blocks approve when min < floor', () => {
+    const v = checkRubricVerdictConsistency(`verdict: approve_for_merge\n${LOW}`);
+    expect(v.some(x => x.rule === 'rubric-floor-violation')).toBe(true);
+  });
+
+  test('allows approve when min >= floor', () => {
+    expect(checkRubricVerdictConsistency(`verdict: approve_for_merge\n${HIGH}`)).toHaveLength(0);
+  });
+
+  test('blocks reject when min >= floor', () => {
+    const v = checkRubricVerdictConsistency(`verdict: reject\n${HIGH}`);
+    expect(v.some(x => x.rule === 'rubric-verdict-contradiction')).toBe(true);
+  });
+
+  test('FLOOR is 7', () => {
+    expect(FLOOR).toBe(7);
+  });
+});

--- a/tests/governance-adversarial.spec.js
+++ b/tests/governance-adversarial.spec.js
@@ -172,13 +172,7 @@ verdict: approve_for_merge`;
       `expected missing-rubric; got: ${rules.join(', ')}`);
   });
 
-  test('S09b: [KNOWN-GAP #2908] G-score floor not yet enforced — documents the rubber-stamp gap', () => {
-    // NOT a mutation test (it asserts ABSENCE of a guard, so it passes whether or not a guard
-    // exists). It is a deliberate KNOWN-GAP marker: consultant-closeout.js does not yet enforce a
-    // minimum G-score floor, so a G1=2 + approve_for_merge closeout is not blocked. Child #2908
-    // (consultant rubric internal-consistency validator: G-score vs verdict) will add that floor;
-    // when it lands this assertion flips to fail and forces an explicit update here. Kept OUTSIDE
-    // the mutation-test contract on purpose and named so it cannot be mistaken for a passing guard.
+  test('S09b: G-score floor enforced — low rubric + approve blocked (#2908)', () => {
     const body = `## CONSULTANT_CLOSEOUT
 Signed-by: Orla Vale
 Team&Model: claude-code:claude-sonnet-4-6@anthropic
@@ -187,12 +181,9 @@ verification-timestamp: 2026-06-13T00:00:00Z
 verdict: approve_for_merge
 G1: 2 G2: 8 G3: 8 G4: 8 G5: 8 G6: 8 G7: 8 G8: 8 G9: 8`;
     const result = closeout.validate(makeCloseoutInput(body));
-    // rubric present + verdict present → blocking violations should be empty (gap exists).
-    // When a floor enforcement lands, this test will fail and force an explicit decision.
-    const blocking = (result.violations || []).filter(v => v.severity !== 'advisory');
-    const gap = blocking.filter(v => v.rule.includes('rubric-floor'));
-    assert.strictEqual(gap.length, 0,
-      'G1=2 rubber-stamp gap: no floor enforced yet; update test when floor is implemented');
+    const rules = (result.violations || []).map(v => v.rule);
+    assert.ok(rules.includes('rubric-floor-violation'),
+      `expected rubric-floor-violation; got: ${rules.join(', ')}`);
   });
 
   test('S10: closeout missing verdict is rejected [mutation: removes verdict guard]', () => {


### PR DESCRIPTION
## Summary
- Add `consultant-rubric-consistency.js` — block `approve_for_merge` when min(G1..G9) < 7; block `reject` when min >= 7.
- Wire into `consultant-closeout.js`; close KNOWN-GAP S09b in adversarial suite.

## Test plan
- [x] `npx playwright test tests/consultant-rubric-consistency.spec.js`
- [x] S09b in `tests/governance-adversarial.spec.js`
- [x] `npm run lint`

Refs #2908
merge-evidence-deferred-final: #2908

Made with [Cursor](https://cursor.com)