### PR TITLE
feat(governance): promote collaborator self-check to hard gate (#2907)

### DIFF
--- a/.changes/unreleased/2907.md
+++ b/.changes/unreleased/2907.md
@@ -1,0 +1,6 @@
+### Changed
+
+- `collaborator-self-check.js`: promoted from advisory to hard gate (#2907). Added `checkHandoffHasVerification()` to assert that a `COLLABORATOR_HANDOFF` body includes a `Pre-handoff verification` block before advancing to Admin. Added CLI entry point that exits 1 when `runChecks()` returns `ok: false` (bypass: `COLLABORATOR_SELF_CHECK_SKIP=1` emits advisory warning).
+- `megalint/collaborator-handoff.js`: wires `checkHandoffHasVerification` into `validate()` for `lane:code-change`; missing or FAIL verification block is a blocking violation.
+- `lefthook.yml`: added `collaborator-self-check` as a required pre-push step (exits 1 on non-zero; CI workflow enforces server-side when env var absent).
+- `baton-gates.yml`: collaborator-gate now enforces self-check evidence via `validate()` (explicit comment added referencing #2907).

--- a/.github/workflows/baton-gates.yml
+++ b/.github/workflows/baton-gates.yml
@@ -53,6 +53,7 @@ jobs:
             // to bare .body strings false-failed the gate on every PR.
             // #3121: pass the PR file list so doc-coverage can advisory-verify that any
             // surface declared UPDATED actually appears in the diff (wires the #2716 module).
+            // #2907: validate() now enforces Pre-handoff verification block presence (hard gate).
             const { data: prFilesData } = await github.rest.pulls.listFiles({
               owner: context.repo.owner, repo: context.repo.repo,
               pull_number: context.payload.pull_request.number, per_page: 100,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -42,3 +42,8 @@ pre-push:
     # #2878: merged-branch-guard — block pushes to already-merged branches.
     merged-branch-guard:
       run: python3 hooks/scripts/merged-branch-guard.py
+    # #2907: collaborator-self-check hard gate — exits 1 when COLLABORATOR_SELF_CHECK_INPUT
+    # is provided and runChecks fails. Without env var the gate passes (CI gate enforces
+    # server-side). Bypass: COLLABORATOR_SELF_CHECK_SKIP=1 (emits advisory warning).
+    collaborator-self-check:
+      run: node scripts/global/collaborator-self-check.js

--- a/scripts/global/collaborator-self-check.js
+++ b/scripts/global/collaborator-self-check.js
@@ -1,7 +1,10 @@
 'use strict';
-// collaborator-self-check — Epic #1568 AC-2 (#1571). Entry-point that dispatches
-// the 10 deterministic pre-handoff checks defined in collaborator-self-check-rules.js.
-// Caller passes pre-extracted data; helper runs no commands itself (keeps it pure).
+// collaborator-self-check — Epic #1568 AC-2 (#1571), #2907 (hard-gate promotion).
+// Entry-point that dispatches the 10 deterministic pre-handoff checks defined in
+// collaborator-self-check-rules.js. Caller passes pre-extracted data; helper runs
+// no commands itself (keeps it pure).
+// CLI mode: exits 1 when runChecks returns ok=false.
+// Bypass: COLLABORATOR_SELF_CHECK_SKIP=1 (emits advisory warning on stderr).
 
 const Rules = require('./collaborator-self-check-rules.js');
 
@@ -37,4 +40,54 @@ function formatChecks(result) {
   return `Pre-handoff verification (${result.ok ? 'PASS' : 'FAIL'})\n${lines.join('\n')}`;
 }
 
-module.exports = { runChecks, formatChecks, CHECKS, OVERRIDE_LABEL, shouldSkip };
+/**
+ * Check that a COLLABORATOR_HANDOFF body contains a self-check evidence block.
+ * Used by megalint/collaborator-handoff.js to enforce the hard gate (AC3 #2907).
+ * @param {string} handoffBody
+ * @returns {{ ok: boolean, rule: string, detail: string }}
+ */
+function checkHandoffHasVerification(handoffBody) {
+  const body = (typeof handoffBody === 'string') ? handoffBody : '';
+  if (!body) {
+    return { ok: false, rule: 'missing-self-check-verification',
+      detail: 'COLLABORATOR_HANDOFF body is empty or missing' };
+  }
+  if (!/Pre-handoff verification/i.test(body)) {
+    return { ok: false, rule: 'missing-self-check-verification',
+      detail: 'COLLABORATOR_HANDOFF missing "Pre-handoff verification" block — run runChecks() and paste formatChecks() output into handoff' };
+  }
+  if (/Pre-handoff verification.*FAIL/i.test(body)) {
+    return { ok: false, rule: 'self-check-verification-failed',
+      detail: 'COLLABORATOR_HANDOFF "Pre-handoff verification" block shows FAIL — fix failing checks before advancing to Admin' };
+  }
+  return { ok: true, rule: 'self-check-verification',
+    detail: 'Pre-handoff verification block present and not FAIL' };
+}
+
+if (require.main === module) {
+  if (process.env.COLLABORATOR_SELF_CHECK_SKIP === '1') {
+    process.stderr.write('[collaborator-self-check] SKIPPED via COLLABORATOR_SELF_CHECK_SKIP=1 (advisory-only opt-out)\n');
+    process.exit(0);
+  }
+  // CLI mode: read JSON input from COLLABORATOR_SELF_CHECK_INPUT env var.
+  // Without env var the gate passes — CI workflow enforces server-side.
+  const rawInput = process.env.COLLABORATOR_SELF_CHECK_INPUT;
+  if (!rawInput) {
+    process.stderr.write('[collaborator-self-check] No COLLABORATOR_SELF_CHECK_INPUT env var; CI workflow gate handles server-side.\n');
+    process.exit(0);
+  }
+  let input;
+  try { input = JSON.parse(rawInput); } catch (err) {
+    process.stderr.write(`[collaborator-self-check] Invalid JSON in COLLABORATOR_SELF_CHECK_INPUT: ${err.message}\n`);
+    process.exit(1);
+  }
+  const result = runChecks(input);
+  process.stdout.write(formatChecks(result) + '\n');
+  if (!result.ok) {
+    process.stderr.write('[collaborator-self-check] FAIL — resolve failing checks before creating PR\n');
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+module.exports = { runChecks, formatChecks, CHECKS, OVERRIDE_LABEL, shouldSkip, checkHandoffHasVerification };

--- a/scripts/global/megalint/collaborator-handoff.js
+++ b/scripts/global/megalint/collaborator-handoff.js
@@ -11,6 +11,8 @@ const { LIGHTWEIGHT, laneSeverity } = require(path.join(__dirname, '..', 'lane-e
 const docCoverage = require('./doc-coverage.js');
 const wtGate = require('../worktree-lifecycle-gate');
 const { KNOWN_FAMILIES, extractAIFamily } = require('./signer-fidelity.js');
+// #2907: hard-gate promotion — require self-check evidence in COLLABORATOR_HANDOFF.
+const { checkHandoffHasVerification } = require('../collaborator-self-check.js');
 
 // #2562: accept string OR {body} comment elements so a caller passing bare
 // bodies (the baton-gates.yml regression) cannot silently false-fail the gate.
@@ -128,6 +130,9 @@ function validate(input) {
     violations.push(...docCoverageViolations(body, input.labels, input.comments, input.prFiles));
     violations.push(...checkCrossFamily(body));
     violations.push(...wtGate.checkCollaborator(body, { ...input, lane }));
+    // #2907: require self-check evidence block (Pre-handoff verification) in COLLABORATOR_HANDOFF.
+    const selfCheck = checkHandoffHasVerification(body);
+    if (!selfCheck.ok) violations.push({ rule: selfCheck.rule, detail: selfCheck.detail });
   }
   const signer = roleIdentity({ body, author: handoff.user && handoff.user.login });
   const blocking = violations.filter(v => v.severity !== 'advisory');

--- a/tests/collaborator-handoff-cross-family.spec.js
+++ b/tests/collaborator-handoff-cross-family.spec.js
@@ -12,13 +12,17 @@ const validBody = `## COLLABORATOR_HANDOFF
 Signed-by: Soren Harper
 Team&Model: copilot:claude-sonnet-4-6@github
 Role: collaborator
+worktree_branch: feat/2907-test
+worktree_behind_main: 0
 cross_family_reviewer: qwen2.5-coder:7b@fleet-tailscale
 cross_family_rating: 82/100
 cross_family_findings: No major issues found.
 cross_family_receipt: abcdef0123456789
 reviewer_family: qwen
 doc-coverage:
-  N/A: all surfaces — lane test only`;
+  N/A: all surfaces — lane test only
+Pre-handoff verification (PASS)
+- [x] \`branch-name-prefix\` — pass`;
 
 const makeInput = body => ({
   lane: 'lane:code-change',

--- a/tests/collaborator-handoff-doc-coverage.spec.js
+++ b/tests/collaborator-handoff-doc-coverage.spec.js
@@ -4,8 +4,9 @@ const assert = require('node:assert/strict');
 const { validate } = require('../scripts/global/megalint/collaborator-handoff.js');
 const { checkBlock, parseDocBlock, loadMatrix } = require('../scripts/global/megalint/doc-coverage.js');
 
+const VERIFICATION_BLOCK = 'Pre-handoff verification (PASS)\n- [x] `branch-name-prefix` — pass\n';
 const HANDOFF_SIGNED = (extra) =>
-  `## COLLABORATOR_HANDOFF\n${extra}\ncross_family_reviewer: qwen2.5-coder:32b@100.91.113.16:11434\ncross_family_rating: 82/100\ncross_family_findings: none\ncross_family_receipt: 0123456789abcdef\nreviewer_family: Qwen\nSigned-by: Alex Harper\nTeam&Model: copilot:sonnet@anthropic\nRole: collaborator\n`;
+  `## COLLABORATOR_HANDOFF\n${extra}\n${VERIFICATION_BLOCK}worktree_branch: feat/test\nworktree_behind_main: 0\ncross_family_reviewer: qwen2.5-coder:32b@100.91.113.16:11434\ncross_family_rating: 82/100\ncross_family_findings: none\ncross_family_receipt: 0123456789abcdef\nreviewer_family: Qwen\nSigned-by: Alex Harper\nTeam&Model: copilot:sonnet@anthropic\nRole: collaborator\n`;
 
 test('validate: blocking when doc-coverage: block missing on lane:code-change with governance label', () => {
   const matrix = loadMatrix();

--- a/tests/collaborator-self-check.spec.js
+++ b/tests/collaborator-self-check.spec.js
@@ -161,3 +161,32 @@ test('mcpLoadCheck detects MCP via plain MCP marker', () => {
   expect(result.ok).toBe(true);
 });
 
+// #2907: checkHandoffHasVerification — hard gate for Pre-handoff verification block.
+test('checkHandoffHasVerification: passes when PASS block is present', () => {
+  const body = 'COLLABORATOR_HANDOFF\nPre-handoff verification (PASS)\n- [x] `branch-name-prefix` — pass';
+  expect(C.checkHandoffHasVerification(body).ok).toBe(true);
+});
+
+test('checkHandoffHasVerification: fails when block is missing', () => {
+  const result = C.checkHandoffHasVerification('COLLABORATOR_HANDOFF\nsome other content');
+  expect(result.ok).toBe(false);
+  expect(result.rule).toBe('missing-self-check-verification');
+});
+
+test('checkHandoffHasVerification: fails when block shows FAIL', () => {
+  const body = 'Pre-handoff verification (FAIL)\n- [ ] `branch-name-prefix` — fail';
+  const result = C.checkHandoffHasVerification(body);
+  expect(result.ok).toBe(false);
+  expect(result.rule).toBe('self-check-verification-failed');
+});
+
+test('checkHandoffHasVerification: fails on empty/missing body', () => {
+  expect(C.checkHandoffHasVerification('').ok).toBe(false);
+  expect(C.checkHandoffHasVerification(null).ok).toBe(false);
+});
+
+test('checkHandoffHasVerification: passes on SKIPPED block (waiver)', () => {
+  const body = 'Pre-handoff verification: SKIPPED (override-waived)';
+  expect(C.checkHandoffHasVerification(body).ok).toBe(true);
+});
+


### PR DESCRIPTION
## Summary
- Add `collaborator-self-check` as required lefthook pre-push step (exits 1 on failure).
- `checkHandoffHasVerification()` enforces Pre-handoff verification block in COLLABORATOR_HANDOFF via CI.
- CLI entry point with `COLLABORATOR_SELF_CHECK_SKIP=1` advisory bypass.

## Test plan
- [x] `npx playwright test tests/collaborator-self-check.spec.js` (25/25)
- [x] `npm run lint`

Refs #2907
merge-evidence-deferred-final: #2907

Made with [Cursor](https://cursor.com)