### PR TITLE
feat(megalint): cross-team response fidelity hard blocking (#2912)

### DIFF
--- a/.changes/unreleased/2912.md
+++ b/.changes/unreleased/2912.md
@@ -1,0 +1,4 @@
+### Changed
+- `scripts/global/megalint/cross-team-response-fidelity.js` promoted from advisory to hard-blocking per #2912: all violation severities changed from `advisory` to `hard` (soak complete, soak_counter: 1). Catches TEAM_RESPONSE signed by wrong team (source team impersonating target team), missing `from:` field, invalid signing block, and alias-derivation drift.
+- `.github/workflows/baton-gates.yml` new `cross-team-response-fidelity` job wired as a hard-blocking CI gate: fetches issue comments and calls `validate()`; `setFailed` on any non-advisory violation.
+- `scripts/global/megalint/manager-handoff.js` new `checkTargetTeamSignOff` function added: if MANAGER_HANDOFF contains `target_team_sign_off: pending`, merge is blocked with a `hard` violation (TEAM_QUESTION sign-off gate, #2912 AC2).

--- a/.github/workflows/baton-gates.yml
+++ b/.github/workflows/baton-gates.yml
@@ -208,3 +208,29 @@ jobs:
             const result = validate({ labels, prBody: body, prFiles: files.map(f => f.filename) });
             if (!result.ok) core.setFailed(`changelog-fragment: ${result.reason}`);
             else console.log(`changelog-fragment ok: ${result.reason}`);
+
+  cross-team-response-fidelity:
+    name: cross-team-response-fidelity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            // #2912: hard-blocking gate (promoted from advisory after soak completion).
+            const body = context.payload.pull_request.body || '';
+            const refsMatch = body.match(/Refs\s+#(\d+)/i);
+            if (!refsMatch) { console.log('No Refs #N; skipping cross-team-response-fidelity.'); return; }
+            const linkedIssue = parseInt(refsMatch[1]);
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: linkedIssue, per_page: 100,
+            });
+            const { validate } = require('./scripts/global/megalint/cross-team-response-fidelity.js');
+            const result = validate({ comments });
+            if (!result.ok) {
+              const blocking = (result.violations || [])
+                .filter(v => v.severity !== 'advisory')
+                .map(v => `${v.rule}${v.detail ? ': ' + v.detail : ''}`).join('; ');
+              if (blocking) core.setFailed(`cross-team-response-fidelity violations in #${linkedIssue}: ${blocking}`);
+            }

--- a/scripts/global/megalint/cross-team-response-fidelity.js
+++ b/scripts/global/megalint/cross-team-response-fidelity.js
@@ -6,6 +6,8 @@
 // either fabricated or correctly-derived target-team aliases.
 //
 // Filed under Tier-2 anneal #2370 in response to that drift class.
+// #2912: promoted from advisory to hard-blocking after soak completion.
+// soak_counter: 1 (soak complete)
 
 const { extractArtifactFields, parseTeamModel, expectedAliasFor } = require('./signer-registry-check.js');
 
@@ -23,7 +25,7 @@ function extractFromField(body) {
 function checkSignerTeamMismatch(parsed, fromTeam, signedBy) {
   if (parsed.team === fromTeam) return null;
   return {
-    rule: 'team-response-signer-team-mismatch', severity: 'advisory',
+    rule: 'team-response-signer-team-mismatch', severity: 'hard',
     detail: `TEAM_RESPONSE 'from: ${fromTeam}' signed by operator on team '${parsed.team}' ` +
       `(alias '${signedBy}', model '${parsed.model}'). The response must be authored by ` +
       'the target team, not the source team using a target-team alias.',
@@ -35,7 +37,7 @@ function checkAliasDerivation(parsed, role, signedBy) {
   if (!expected || !signedBy) return null;
   if (signedBy.trim().toLowerCase() === expected.toLowerCase()) return null;
   return {
-    rule: 'signer-alias-non-derived', severity: 'advisory',
+    rule: 'signer-alias-non-derived', severity: 'hard',
     detail: `TEAM_RESPONSE signer alias '${signedBy}' does not match registry-derived ` +
       `'${expected}' for (${parsed.team}, ${parsed.model}, ${role}).`,
   };
@@ -44,13 +46,13 @@ function checkAliasDerivation(parsed, role, signedBy) {
 function checkTeamResponse(body) {
   const violations = [];
   const fromTeam = extractFromField(body);
-  if (!fromTeam) return [{ rule: 'missing-from-field', severity: 'advisory',
+  if (!fromTeam) return [{ rule: 'missing-from-field', severity: 'hard',
     detail: 'TEAM_RESPONSE missing `from:` target-team field' }];
   const fields = extractArtifactFields(body);
-  if (!fields.signedBy || !fields.teamModel || !fields.role) return [{ rule: 'missing-signing-block', severity: 'advisory',
+  if (!fields.signedBy || !fields.teamModel || !fields.role) return [{ rule: 'missing-signing-block', severity: 'hard',
     detail: 'TEAM_RESPONSE missing Signed-by/Team&Model/Role signing block' }];
   const parsed = parseTeamModel(fields.teamModel);
-  if (!parsed) return [{ rule: 'invalid-team-model', severity: 'advisory',
+  if (!parsed) return [{ rule: 'invalid-team-model', severity: 'hard',
     detail: `TEAM_RESPONSE Team&Model value '${fields.teamModel}' did not parse as team:model@substrate` }];
   const mismatch = checkSignerTeamMismatch(parsed, fromTeam, fields.signedBy);
   if (mismatch) violations.push(mismatch);

--- a/scripts/global/megalint/manager-handoff.js
+++ b/scripts/global/megalint/manager-handoff.js
@@ -103,6 +103,20 @@ function checkCrypto(body) {
   }));
 }
 
+// #2912: block merge when a TEAM_QUESTION sign-off is still pending.
+function checkTargetTeamSignOff(body) {
+  const val = extractField(body, 'target_team_sign_off');
+  if (!val) return [];
+  if (/^pending$/i.test(val.trim())) {
+    return [{
+      rule: 'target-team-sign-off-pending',
+      detail: 'MANAGER_HANDOFF target_team_sign_off is "pending". Resolve the TEAM_QUESTION sign-off before merging.',
+      severity: 'hard',
+    }];
+  }
+  return [];
+}
+
 function checkPhaseOneFields(body, labels) {
   if (!(labels || []).includes(PHASE_ONE_LABEL)) return [];
   const violations = [];
@@ -135,6 +149,7 @@ function validate(input) {
     ...checkLaneConsistency(handoff.body, input.lane),
     ...checkLaneTrivialDiffSize(handoff.body, input.diffLines, TRIVIAL_DIFF_THRESHOLD),
     ...checkPhaseOneFields(handoff.body, input.labels),
+    ...checkTargetTeamSignOff(handoff.body),
     ...checkCrypto(handoff.body),
     ...wtGate.checkManager(handoff.body, input),
   ];
@@ -143,5 +158,5 @@ function validate(input) {
 
 module.exports = {
   validate, findManagerHandoff, extractField, REQUIRED_FIELDS,
-  checkLaneTrivialDiffSize, TRIVIAL_DIFF_THRESHOLD,
+  checkLaneTrivialDiffSize, TRIVIAL_DIFF_THRESHOLD, checkTargetTeamSignOff,
 };

--- a/tests/megalint-cross-team-response-fidelity.spec.js
+++ b/tests/megalint-cross-team-response-fidelity.spec.js
@@ -100,12 +100,23 @@ test('Q5 case-insensitive alias comparison: lowercase signedBy does not false-po
     `case-insensitive compare expected; got ${JSON.stringify(r.violations)}`);
 });
 
-test('Q7 every emitted violation carries severity field for advisory-mode-soak', () => {
+test('Q7 every emitted violation carries severity:hard after promotion from advisory (#2912)', () => {
   const r = validator.validate({ comments: [teamResponse({
     fromTeam: 'claude-code', signedBy: 'Apollo Vale', teamModel: 'antigravity:gemini-2.0-pro@google', role: 'consultant',
   })]});
   for (const v of r.violations) {
-    assert.ok(v.severity, `violation ${v.rule} missing severity field for advisory-mode gating`);
+    assert.strictEqual(v.severity, 'hard',
+      `violation ${v.rule} must be severity:hard after #2912 promotion (got: ${v.severity})`);
   }
+});
+
+test('#2912 regression: TEAM_RESPONSE from wrong team produces hard-blocking violation (not advisory)', () => {
+  const r = validator.validate({ comments: [teamResponse({
+    fromTeam: 'codex', signedBy: 'Apollo Vale', teamModel: 'antigravity:gemini-2.0-pro@google', role: 'consultant',
+  })]});
+  assert.strictEqual(r.ok, false);
+  const mismatch = r.violations.find(v => v.rule === 'team-response-signer-team-mismatch');
+  assert.ok(mismatch, 'expected team-response-signer-team-mismatch violation');
+  assert.strictEqual(mismatch.severity, 'hard', 'team-response-signer-team-mismatch must be hard-blocking');
 });
 

--- a/tests/megalint/manager-handoff.spec.js
+++ b/tests/megalint/manager-handoff.spec.js
@@ -98,3 +98,24 @@ test('phase-1: accepts non-bulleted conditional field lines', () => {
   const r = V.validate({ comments: [{ body }], labels: ['phase-gate:phase-1'] });
   expect(r.ok).toBe(true);
 });
+
+// #2912: TEAM_QUESTION sign-off gate
+test('#2912: target_team_sign_off:pending blocks merge with hard violation', () => {
+  const body = `${fullHandoff}\ntarget_team_sign_off: pending`;
+  const r = V.validate({ comments: [{ body }] });
+  expect(r.ok).toBe(false);
+  const v = r.violations.find(x => x.rule === 'target-team-sign-off-pending');
+  expect(v).toBeTruthy();
+  expect(v.severity).toBe('hard');
+});
+
+test('#2912: target_team_sign_off:n/a does not block merge', () => {
+  const body = `${fullHandoff}\ntarget_team_sign_off: n/a`;
+  const r = V.validate({ comments: [{ body }] });
+  expect(r.violations.some(v => v.rule === 'target-team-sign-off-pending')).toBe(false);
+});
+
+test('#2912: absent target_team_sign_off field does not block merge', () => {
+  const r = V.validate({ comments: [{ body: fullHandoff }] });
+  expect(r.violations.some(v => v.rule === 'target-team-sign-off-pending')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- Promote `cross-team-response-fidelity` violations to `hard` severity (soak complete).
- Add `cross-team-response-fidelity` job to `baton-gates.yml`.
- Block merge when `target_team_sign_off: pending` in MANAGER_HANDOFF.

## Test plan
- [x] `node --test tests/megalint-cross-team-response-fidelity.spec.js` (13/13)
- [x] `npm run lint`

Refs #2912
merge-evidence-deferred-final: #2912

Made with [Cursor](https://cursor.com)