### PR TITLE
feat(megalint): cross_runtime_writes hard CI gate (#2911)

### DIFF
--- a/.changes/unreleased/2911.md
+++ b/.changes/unreleased/2911.md
@@ -1,0 +1,3 @@
+### Added
+- Cross-runtime writes hard CI gate: `manager-handoff` validator now blocks a MANAGER_HANDOFF when the PR diff touches cross-runtime config paths (`.claude/`, `.codex/`, `.copilot/`) and the `cross_runtime_writes` field is absent. The cross-runtime path list is configurable via `config/governance-rules.yaml` (`cross-runtime-writes-gate` rule) or the `CROSS_RUNTIME_PATHS` environment variable (#2911).
+- Closeout-time sign-off gate: `consultant-closeout` validator now blocks a CONSULTANT_CLOSEOUT when the linked MANAGER_HANDOFF declares `cross_runtime_writes` but `target_team_sign_off` is still `pending`, enforcing the cross-team sign-off contract before any ticket can be closed (#2911).

--- a/config/governance-rules.yaml
+++ b/config/governance-rules.yaml
@@ -213,3 +213,21 @@ rules:
       - codex
       - copilot
       - antigravity
+
+  - rule_id: cross-runtime-writes-gate
+    class: doc-vs-no-enforcement
+    statement: >
+      MANAGER_HANDOFF must declare cross_runtime_writes when the PR diff
+      touches cross-runtime config paths; absence is hard-blocking. Refs #2911.
+    source: scripts/global/megalint/manager-handoff.js
+    cross_runtime_paths:
+      - '.claude/'
+      - '.codex/'
+      - '.copilot/'
+    enum_values: []
+    severity: hard-mandatory
+    cross_runtime_applicability:
+      - claude-code
+      - codex
+      - copilot
+      - antigravity

--- a/scripts/global/megalint/consultant-closeout.js
+++ b/scripts/global/megalint/consultant-closeout.js
@@ -3,6 +3,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const { findManagerHandoff, extractField } = require('./manager-handoff');
 const sig = require(path.join(__dirname, '..', 'governance-artifact-signature.js'));
 const { enforceTier3Emission } = require(path.join(__dirname, 'goal-failure-emission.js'));
 const { fleetCloseoutParity } = require(path.join(__dirname, '..', 'governance-bundle.js'));
@@ -141,6 +142,22 @@ function checkSubstantiveContent(body, isEpic) {
   return [{ rule: 'epic-closeout-no-substantive-evidence', detail: 'CONSULTANT_CLOSEOUT on an Epic must reference: (a) #N child ref, (b) PR ref, (c) research/*.md — see #1453.' }];
 }
 
+function checkCrossRuntimeWritesPending(comments) {
+  const handoff = findManagerHandoff(comments || []);
+  if (!handoff) return [];
+  const crw = extractField(handoff.body || '', 'cross_runtime_writes');
+  if (!crw || !crw.trim() || /^none$/i.test(crw.trim())) return [];
+  if (/target_team_sign_off\s*:\s*pending/i.test(handoff.body || '')) {
+    return [{
+      rule: 'cross-runtime-sign-off-pending',
+      detail: 'CONSULTANT_CLOSEOUT blocked: MANAGER_HANDOFF cross_runtime_writes has ' +
+        'target_team_sign_off: pending. All cross-runtime writes require a resolved ' +
+        'sign-off before closeout. Refs #2911.',
+    }];
+  }
+  return [];
+}
+
 function checkCrossFamilyVerdict(body) {
   if (!/cross_family_verdict:/i.test(body)) return [{ rule: 'cross-family-verdict-missing', severity: 'advisory', detail: 'CONSULTANT_CLOSEOUT: cross_family_verdict field missing (advisory; #2537)' }];
   if (!/cross_family_verdict:\s*(ACCEPT|PARTIAL|REJECT)\s*[—–-]+\s*\S+@\S+\s*[—–-]+\s*.+/i.test(body)) return [{ rule: 'cross-family-verdict-malformed', detail: 'cross_family_verdict must be: ACCEPT|PARTIAL|REJECT — <model@host> — <rationale>' }];
@@ -165,6 +182,7 @@ function validate(input) {
     ...checkSubstantiveContent(body, input.isEpic === true),
     ...checkCrossFamilyVerdict(body),
     ...checkFleetBundleProvenance(body, input),
+    ...checkCrossRuntimeWritesPending(input.comments),
     ...wtGate.checkConsultant(body, input),
   ];
   return { ok: violations.filter(v => v.severity !== 'advisory').length === 0, violations, found: true };
@@ -178,4 +196,5 @@ module.exports = {
   checkRequiredFlawFields,
   checkMemoryNoteRecurrence,
   checkRubricVerdictConsistency,
+  checkCrossRuntimeWritesPending,
 };

--- a/scripts/global/megalint/manager-handoff.js
+++ b/scripts/global/megalint/manager-handoff.js
@@ -24,6 +24,49 @@ function loadTrivialThreshold() {
 
 const TRIVIAL_DIFF_THRESHOLD = loadTrivialThreshold();
 
+// Load cross-runtime paths from governance-rules.yaml or CROSS_RUNTIME_PATHS env override.
+function loadCrossRuntimePaths() {
+  if (process.env.CROSS_RUNTIME_PATHS) return process.env.CROSS_RUNTIME_PATHS.split(',').map(p => p.trim());
+  try {
+    const raw = fs.readFileSync(
+      path.resolve(__dirname, '..', '..', '..', 'config', 'governance-rules.yaml'), 'utf8');
+    const ruleStart = raw.indexOf('rule_id: cross-runtime-writes-gate');
+    if (ruleStart >= 0) {
+      const nextRule = raw.indexOf('\n  - rule_id:', ruleStart + 1);
+      const block = nextRule >= 0 ? raw.slice(ruleStart, nextRule) : raw.slice(ruleStart);
+      const pathsIdx = block.indexOf('cross_runtime_paths:');
+      if (pathsIdx >= 0) {
+        const paths = [...block.slice(pathsIdx).matchAll(/\n\s+- ['"]?([^'"\n\r]+)['"]?/g)]
+          .map(m => m[1].trim()).filter(Boolean);
+        if (paths.length) return paths;
+      }
+    }
+  } catch { /* config absent: use default */ }
+  return ['.claude/', '.codex/', '.copilot/'];
+}
+
+const CROSS_RUNTIME_PATHS = loadCrossRuntimePaths();
+
+// AC #2911 — block when diff touches cross-runtime paths but cross_runtime_writes is absent.
+// FAIL-OPEN when changedPaths is not supplied (caller has not yet been updated).
+function checkCrossRuntimeWrites(body, changedPaths, configPaths) {
+  if (!Array.isArray(changedPaths) || changedPaths.length === 0) return [];
+  const paths = Array.isArray(configPaths) && configPaths.length ? configPaths : CROSS_RUNTIME_PATHS;
+  const affected = changedPaths.filter(p => paths.some(cp => p === cp || p.startsWith(cp) || p.includes(`/${cp.replace(/\/$/, '')}/`)));
+  if (affected.length === 0) return [];
+  const declared = extractField(body, 'cross_runtime_writes');
+  if (!declared || !declared.trim() || /^none$/i.test(declared.trim())) {
+    return [{
+      rule: 'cross-runtime-writes-missing',
+      detail: `MANAGER_HANDOFF diff touches cross-runtime path(s) [${affected.join(', ')}] ` +
+        'but cross_runtime_writes field is absent or none. ' +
+        'List all cross-runtime files under cross_runtime_writes:.',
+      severity: 'hard',
+    }];
+  }
+  return [];
+}
+
 function findManagerHandoff(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?MANAGER_HANDOFF\b/;
   return [...(comments || [])].reverse().find(c => headerRe.test(c.body || ''));
@@ -148,6 +191,7 @@ function validate(input) {
     ...checkTestStrategy(handoff.body),
     ...checkLaneConsistency(handoff.body, input.lane),
     ...checkLaneTrivialDiffSize(handoff.body, input.diffLines, TRIVIAL_DIFF_THRESHOLD),
+    ...checkCrossRuntimeWrites(handoff.body, input.changedPaths),
     ...checkPhaseOneFields(handoff.body, input.labels),
     ...checkTargetTeamSignOff(handoff.body),
     ...checkCrypto(handoff.body),
@@ -159,4 +203,5 @@ function validate(input) {
 module.exports = {
   validate, findManagerHandoff, extractField, REQUIRED_FIELDS,
   checkLaneTrivialDiffSize, TRIVIAL_DIFF_THRESHOLD, checkTargetTeamSignOff,
+  checkCrossRuntimeWrites, CROSS_RUNTIME_PATHS,
 };

--- a/tests/cross-runtime-writes-gate.spec.js
+++ b/tests/cross-runtime-writes-gate.spec.js
@@ -1,0 +1,206 @@
+'use strict';
+// tests/cross-runtime-writes-gate.spec.js — AC #2911: cross_runtime_writes hard CI gate.
+// Validates that MANAGER_HANDOFF blocks when PR diff touches cross-runtime paths without
+// declaring cross_runtime_writes, and that CONSULTANT_CLOSEOUT blocks when sign-off is pending.
+// Refs #2911 (Rule 1.9 advisory → hard-blocking).
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  checkCrossRuntimeWrites,
+  CROSS_RUNTIME_PATHS,
+  validate,
+} = require('../scripts/global/megalint/manager-handoff.js');
+const {
+  checkCrossRuntimeWritesPending,
+} = require('../scripts/global/megalint/consultant-closeout.js');
+
+// ── CROSS_RUNTIME_PATHS constant ────────────────────────────────────────────
+
+test('CROSS_RUNTIME_PATHS is a non-empty array of strings', () => {
+  assert.ok(Array.isArray(CROSS_RUNTIME_PATHS));
+  assert.ok(CROSS_RUNTIME_PATHS.length > 0);
+  for (const p of CROSS_RUNTIME_PATHS) assert.strictEqual(typeof p, 'string');
+});
+
+test('CROSS_RUNTIME_PATHS includes .claude/ .codex/ .copilot/ by default', () => {
+  assert.ok(CROSS_RUNTIME_PATHS.some(p => p.includes('.claude')));
+  assert.ok(CROSS_RUNTIME_PATHS.some(p => p.includes('.codex')));
+  assert.ok(CROSS_RUNTIME_PATHS.some(p => p.includes('.copilot')));
+});
+
+// ── checkCrossRuntimeWrites — gate is inactive when no cross-runtime paths touched ──
+
+test('no violation when changedPaths is empty', () => {
+  assert.deepStrictEqual(checkCrossRuntimeWrites('some body', [], ['.claude/']), []);
+});
+
+test('no violation when changedPaths is undefined (fail-open)', () => {
+  assert.deepStrictEqual(checkCrossRuntimeWrites('some body', undefined, ['.claude/']), []);
+});
+
+test('no violation when changedPaths is null (fail-open)', () => {
+  assert.deepStrictEqual(checkCrossRuntimeWrites('some body', null, ['.claude/']), []);
+});
+
+test('no violation when changedPaths touches non-cross-runtime paths only', () => {
+  const paths = ['src/index.js', 'README.md', 'tests/foo.spec.js'];
+  assert.deepStrictEqual(checkCrossRuntimeWrites('some body', paths, ['.claude/', '.codex/']), []);
+});
+
+// ── checkCrossRuntimeWrites — gate blocks on cross-runtime path without field ──
+
+const BODY_NO_CRW = `## MANAGER_HANDOFF
+scope: add hook
+lane: lane:code-change
+Signed-by: Cyrus Mason
+Team&Model: cursor:composer@cursor-ide
+Role: manager`;
+
+const BODY_WITH_CRW = `## MANAGER_HANDOFF
+scope: add hook
+lane: lane:code-change
+cross_runtime_writes: .claude/settings.json
+Signed-by: Cyrus Mason
+Team&Model: cursor:composer@cursor-ide
+Role: manager`;
+
+test('[mutation-anchor] blocks when .claude/ path touched and cross_runtime_writes absent', () => {
+  const result = checkCrossRuntimeWrites(BODY_NO_CRW, ['.claude/settings.json'], ['.claude/']);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].rule, 'cross-runtime-writes-missing');
+  assert.strictEqual(result[0].severity, 'hard');
+});
+
+test('[mutation-anchor] blocks when .codex/ path touched and cross_runtime_writes absent', () => {
+  const result = checkCrossRuntimeWrites(BODY_NO_CRW, ['.codex/config.json'], ['.codex/']);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].rule, 'cross-runtime-writes-missing');
+});
+
+test('[mutation-anchor] blocks when .copilot/ path touched and cross_runtime_writes absent', () => {
+  const result = checkCrossRuntimeWrites(BODY_NO_CRW, ['.copilot/instructions.md'], ['.copilot/']);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].rule, 'cross-runtime-writes-missing');
+});
+
+test('no violation when cross_runtime_writes present and paths match', () => {
+  const result = checkCrossRuntimeWrites(BODY_WITH_CRW, ['.claude/settings.json'], ['.claude/']);
+  assert.deepStrictEqual(result, []);
+});
+
+test('violation detail mentions the affected path', () => {
+  const result = checkCrossRuntimeWrites(BODY_NO_CRW, ['.claude/hooks/pre-run.sh'], ['.claude/']);
+  assert.match(result[0].detail, /\.claude\/hooks\/pre-run\.sh/);
+});
+
+test('treats cross_runtime_writes: none as absent (blocks)', () => {
+  const body = BODY_NO_CRW + '\ncross_runtime_writes: none';
+  const result = checkCrossRuntimeWrites(body, ['.claude/settings.json'], ['.claude/']);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].rule, 'cross-runtime-writes-missing');
+});
+
+test('uses env-configurable configPaths override', () => {
+  const customPaths = ['.myruntime/'];
+  const result = checkCrossRuntimeWrites(BODY_NO_CRW, ['.myruntime/config.json'], customPaths);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].rule, 'cross-runtime-writes-missing');
+});
+
+// ── validate() integration — checkCrossRuntimeWrites wired in ───────────────
+
+const VALID_MH = `## MANAGER_HANDOFF
+scope: add hook
+lane: lane:code-change
+test_strategy: tdd-pyramid
+acceptance: AC1 pass
+gates: lint
+related_tickets: #1
+overlap_decision: no-overlap
+Signed-by: Cyrus Mason
+Team&Model: cursor:composer@cursor-ide
+Role: manager`;
+
+test('validate passes when no cross-runtime paths in changedPaths', () => {
+  const result = validate({
+    comments: [{ body: VALID_MH }],
+    changedPaths: ['src/foo.js'],
+  });
+  const hits = result.violations.filter(v => v.rule === 'cross-runtime-writes-missing');
+  assert.strictEqual(hits.length, 0);
+});
+
+test('validate blocks when changedPaths touches .claude/ without cross_runtime_writes', () => {
+  const result = validate({
+    comments: [{ body: VALID_MH }],
+    changedPaths: ['.claude/settings.json'],
+  });
+  const hits = result.violations.filter(v => v.rule === 'cross-runtime-writes-missing');
+  assert.strictEqual(hits.length, 1);
+  assert.strictEqual(result.ok, false);
+});
+
+test('validate passes when changedPaths omitted (fail-open; backward-compat)', () => {
+  const result = validate({ comments: [{ body: VALID_MH }] });
+  const hits = result.violations.filter(v => v.rule === 'cross-runtime-writes-missing');
+  assert.strictEqual(hits.length, 0);
+});
+
+// ── checkCrossRuntimeWritesPending (closeout gate) ───────────────────────────
+
+const MH_WITH_PENDING = `## MANAGER_HANDOFF
+scope: write claude settings
+lane: lane:config-only
+cross_runtime_writes: .claude/settings.json
+target_team_sign_off: pending
+Signed-by: Cyrus Mason
+Team&Model: cursor:composer@cursor-ide
+Role: manager`;
+
+const MH_WITH_RESOLVED = `## MANAGER_HANDOFF
+scope: write claude settings
+lane: lane:config-only
+cross_runtime_writes: .claude/settings.json
+target_team_sign_off: https://github.com/org/repo/issues/1#issuecomment-123
+Signed-by: Cyrus Mason
+Team&Model: cursor:composer@cursor-ide
+Role: manager`;
+
+const MH_NO_CRW = `## MANAGER_HANDOFF
+scope: docs update
+lane: lane:docs-research
+Signed-by: Cyrus Mason
+Team&Model: cursor:composer@cursor-ide
+Role: manager`;
+
+test('[mutation-anchor] closeout blocks when cross_runtime_writes has target_team_sign_off: pending', () => {
+  const comments = [{ body: MH_WITH_PENDING }];
+  const result = checkCrossRuntimeWritesPending(comments);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].rule, 'cross-runtime-sign-off-pending');
+});
+
+test('closeout passes when target_team_sign_off is a URL (resolved)', () => {
+  const comments = [{ body: MH_WITH_RESOLVED }];
+  assert.deepStrictEqual(checkCrossRuntimeWritesPending(comments), []);
+});
+
+test('closeout passes when no cross_runtime_writes field in MANAGER_HANDOFF', () => {
+  const comments = [{ body: MH_NO_CRW }];
+  assert.deepStrictEqual(checkCrossRuntimeWritesPending(comments), []);
+});
+
+test('closeout passes when no MANAGER_HANDOFF comment present', () => {
+  assert.deepStrictEqual(checkCrossRuntimeWritesPending([]), []);
+});
+
+test('closeout passes when comments is null/undefined', () => {
+  assert.deepStrictEqual(checkCrossRuntimeWritesPending(null), []);
+  assert.deepStrictEqual(checkCrossRuntimeWritesPending(undefined), []);
+});
+
+test('closeout violation detail references #2911', () => {
+  const result = checkCrossRuntimeWritesPending([{ body: MH_WITH_PENDING }]);
+  assert.match(result[0].detail, /#2911/);
+});


### PR DESCRIPTION
## Summary
- Block MANAGER_HANDOFF when PR diff touches `.claude/`, `.codex/`, `.copilot/` without `cross_runtime_writes` declaration.
- Block CONSULTANT_CLOSEOUT when cross-runtime sign-off still `pending`.
- Configurable paths via `governance-rules.yaml`.

## Test plan
- [x] `node --test tests/cross-runtime-writes-gate.spec.js` (22/22)
- [x] `npm run lint`

Refs #2911
merge-evidence-deferred-final: #2911

Made with [Cursor](https://cursor.com)