### PR TITLE
feat(hooks): baton-role tool allowlist in pretool_guard (#2919)

### DIFF
--- a/.changes/unreleased/2919.md
+++ b/.changes/unreleased/2919.md
@@ -1,0 +1,7 @@
+### Added
+- `config/role-tool-allowlist.json`: per-role operation capability matrix defining allowed/denied tool operations (`git_push`, `pr_merge`, `deploy`, `git_branch_create`) per baton phase (manager/collaborator/admin/consultant). Closes Gap G-16. Refs #2919, OWASP ASI02/ASI06, EU AI Act Art.15.
+- `hooks/scripts/role_tool_allowlist_enforcer.py`: Python enforcement module imported by `pretool_guard.py`; detects operations via regex, reads `current_phase` from governance state, and returns allow/deny decisions per role allowlist. Fail-open: enforcer errors never block the hook.
+- `tests/role-tool-allowlist.spec.js`: unit tests for `role_tool_allowlist_enforcer` (unknown phase fails open, manager blocks push, collaborator blocks merge/deploy, admin blocks branch-create, admin permits push) and integration tests confirming `pretool_guard.py` propagates the deny.
+
+### Changed
+- `hooks/scripts/pretool_guard.py`: added `_check_role_tool_allowlist()` gate at the top of `check_terminal()` — before other terminal-command checks, the active baton phase is consulted for role-scoped operation restrictions (#2919).

--- a/config/role-tool-allowlist.json
+++ b/config/role-tool-allowlist.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 1,
+  "description": "Role-scoped tool allowlists for dynamic least-privilege per-tool enforcement. Enforced at runtime by hooks/scripts/role_tool_allowlist_enforcer.py via pretool_guard. Closes Gap G-16. Refs #2919 (ASI02, ASI06, EU Art.15).",
+  "operationSchema": {
+    "git_push": "Allow git push to remote (any branch)",
+    "pr_merge": "Allow gh pr merge commands",
+    "deploy": "Allow npm run deploy / deployment commands",
+    "git_branch_create": "Allow git checkout -b / git switch -c (new branch creation)"
+  },
+  "roles": {
+    "manager": {
+      "git_push": false,
+      "pr_merge": false,
+      "deploy": false,
+      "git_branch_create": true
+    },
+    "collaborator": {
+      "git_push": false,
+      "pr_merge": false,
+      "deploy": false,
+      "git_branch_create": true
+    },
+    "admin": {
+      "git_push": true,
+      "pr_merge": true,
+      "deploy": true,
+      "git_branch_create": false
+    },
+    "consultant": {
+      "git_push": false,
+      "pr_merge": false,
+      "deploy": false,
+      "git_branch_create": false
+    }
+  }
+}

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -254,7 +254,24 @@ def _read_body_file(path: str, cwd: str) -> str:
     except Exception:
         return ""
 
+def _check_role_tool_allowlist(joined: str, state: dict) -> int | None:
+    """#2919: enforce role-scoped tool allowlist based on active baton phase (G-16)."""
+    try:
+        from role_tool_allowlist_enforcer import check_command as _rtl_check
+        result = _rtl_check(joined, state.get("current_phase"))
+        if result is not None:
+            allowed, reason = result
+            if not allowed:
+                return emit("deny", reason)
+    except Exception:
+        pass  # G6: enforcer failure is never a blocker
+    return None
+
+
 def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
+    role_result = _check_role_tool_allowlist(joined, state)
+    if role_result is not None:
+        return role_result
     flags, ops = state.get("flags", {}), state.get("admin_ops", {})
     repo_type = state.get("repo_type", "generic")
     # #2967: one-ticket-per-worktree — refuse a baton artifact for a second,

--- a/hooks/scripts/role_tool_allowlist_enforcer.py
+++ b/hooks/scripts/role_tool_allowlist_enforcer.py
@@ -1,0 +1,82 @@
+"""#2919 — Role-scoped tool allowlist enforcer (G-16, OWASP ASI02/ASI06).
+
+Provides baton-phase capability checks for pretool_guard.py: reads
+current_phase from governance state and checks terminal commands against
+the per-role allowlist in config/role-tool-allowlist.json.
+
+Fail-open design: any load or detection error returns None so the enforcer
+never bricks the hook on a misconfigured environment.
+"""
+import json
+import re
+from pathlib import Path
+
+_CONFIG_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "config" / "role-tool-allowlist.json"
+)
+_KNOWN_ROLES = ("manager", "collaborator", "admin", "consultant")
+
+_GIT_PUSH_RE = re.compile(r"(?:^|[\s;|&])git\s+push\b")
+_PR_MERGE_RE = re.compile(r"(?:^|[\s;|&])gh\s+pr\s+merge\b")
+_DEPLOY_RE = re.compile(
+    r"(?:^|[\s;|&])npm\s+run\s+deploy(?:[:\w-]*)?\b"
+    r"|(?:^|[\s;|&])npx\s+vsce\s+publish\b"
+    r"|(?:^|[\s;|&])gh\s+release\s+create\b"
+)
+_BRANCH_CREATE_RE = re.compile(
+    r"(?:^|[\s;|&])git\s+(?:checkout\s+-b|switch\s+-c)\s+\S"
+)
+
+_OPERATION_PATTERNS = {
+    "git_push": _GIT_PUSH_RE,
+    "pr_merge": _PR_MERGE_RE,
+    "deploy": _DEPLOY_RE,
+    "git_branch_create": _BRANCH_CREATE_RE,
+}
+
+
+def _load_allowlist() -> dict:
+    """Load role allowlist config. Returns empty dict on error (fail-open)."""
+    try:
+        with open(_CONFIG_PATH, "r", encoding="utf-8") as f:
+            return json.load(f).get("roles", {})
+    except Exception:
+        return {}
+
+
+def infer_operations(command: str) -> list[str]:
+    """Return list of operation names detected in command."""
+    ops = []
+    for op, pattern in _OPERATION_PATTERNS.items():
+        if pattern.search(command):
+            ops.append(op)
+    return ops
+
+
+def check_command(command: str, phase: str | None) -> tuple[bool, str] | None:
+    """Check command against the allowlist for the active baton phase.
+
+    Returns (False, reason) for the first denied operation, or None if
+    all operations are permitted (or phase is unknown — fail-open).
+    """
+    try:
+        if not phase or phase not in _KNOWN_ROLES:
+            return None
+        operations = infer_operations(command)
+        if not operations:
+            return None
+        allowlist = _load_allowlist()
+        if not allowlist:
+            return None
+        role_caps = allowlist.get(phase, {})
+        for op in operations:
+            if op in role_caps and not role_caps[op]:
+                return False, (
+                    f"Role '{phase}' blocks '{op}' (#2919, G-16, ASI02). "
+                    f"Advance the baton to the appropriate phase before "
+                    f"attempting this operation."
+                )
+    except Exception:
+        pass  # Fail-open: detection errors never block
+    return None

--- a/tests/role-tool-allowlist.spec.js
+++ b/tests/role-tool-allowlist.spec.js
@@ -1,0 +1,166 @@
+// #2919 — Role-scoped tool allowlist enforcement (G-16, ASI02, ASI06)
+// Tests: per-role operation gates in pretool_guard via role_tool_allowlist_enforcer.
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function runPython(code, env = {}) {
+  return execFileSync('python3', ['-c', code], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+}
+
+// ─── role_tool_allowlist_enforcer unit tests ─────────────────────────────────
+
+test('#2919 enforcer: unknown phase fails open (returns None)', () => {
+  const result = runPython(`
+import sys; sys.path.insert(0, 'hooks/scripts')
+from role_tool_allowlist_enforcer import check_command
+assert check_command('git push origin main', None) is None
+assert check_command('git push origin main', 'unknown') is None
+print('OK')
+`);
+  expect(result.trim()).toBe('OK');
+});
+
+test('#2919 enforcer: manager phase denies git push', () => {
+  const result = runPython(`
+import sys; sys.path.insert(0, 'hooks/scripts')
+from role_tool_allowlist_enforcer import check_command
+res = check_command('git push origin feat/2919-role-tool-allowlist', 'manager')
+assert res is not None and res[0] is False, f"Expected deny, got: {res}"
+assert 'manager' in res[1]
+assert 'git_push' in res[1]
+print('OK')
+`);
+  expect(result.trim()).toBe('OK');
+});
+
+test('#2919 enforcer: collaborator phase denies gh pr merge', () => {
+  const result = runPython(`
+import sys; sys.path.insert(0, 'hooks/scripts')
+from role_tool_allowlist_enforcer import check_command
+res = check_command('gh pr merge 123 --squash', 'collaborator')
+assert res is not None and res[0] is False, f"Expected deny, got: {res}"
+assert 'collaborator' in res[1]
+assert 'pr_merge' in res[1]
+print('OK')
+`);
+  expect(result.trim()).toBe('OK');
+});
+
+test('#2919 enforcer: collaborator phase denies deploy', () => {
+  const result = runPython(`
+import sys; sys.path.insert(0, 'hooks/scripts')
+from role_tool_allowlist_enforcer import check_command
+res = check_command('npm run deploy:apply', 'collaborator')
+assert res is not None and res[0] is False, f"Expected deny, got: {res}"
+assert 'collaborator' in res[1]
+assert 'deploy' in res[1]
+print('OK')
+`);
+  expect(result.trim()).toBe('OK');
+});
+
+test('#2919 enforcer: admin phase denies branch creation', () => {
+  const result = runPython(`
+import sys; sys.path.insert(0, 'hooks/scripts')
+from role_tool_allowlist_enforcer import check_command
+res = check_command('git checkout -b feat/new-thing', 'admin')
+assert res is not None and res[0] is False, f"Expected deny, got: {res}"
+assert 'admin' in res[1]
+assert 'git_branch_create' in res[1]
+print('OK')
+`);
+  expect(result.trim()).toBe('OK');
+});
+
+test('#2919 enforcer: admin phase permits git push', () => {
+  const result = runPython(`
+import sys; sys.path.insert(0, 'hooks/scripts')
+from role_tool_allowlist_enforcer import check_command
+res = check_command('git push origin feat/2919', 'admin')
+assert res is None, f"Expected permit, got: {res}"
+print('OK')
+`);
+  expect(result.trim()).toBe('OK');
+});
+
+test('#2919 enforcer: collaborator phase permits branch creation', () => {
+  const result = runPython(`
+import sys; sys.path.insert(0, 'hooks/scripts')
+from role_tool_allowlist_enforcer import check_command
+res = check_command('git checkout -b feat/2919-sub', 'collaborator')
+assert res is None, f"Expected permit, got: {res}"
+print('OK')
+`);
+  expect(result.trim()).toBe('OK');
+});
+
+// ─── pretool_guard.py integration tests ──────────────────────────────────────
+
+const MOCK_PREAMBLE = `
+import sys, json
+sys.path.insert(0, 'hooks/scripts')
+import pretool_guard
+from unittest.mock import patch
+import io as _io
+`;
+
+function buildPayload(command) {
+  return JSON.stringify({ tool_name: 'run_in_terminal', tool_input: { command }, cwd: '.' });
+}
+
+function buildMockPatch(phase) {
+  return `{"flags": {}, "admin_ops": {}, "active_ticket": 2919, "current_phase": "${phase}"}`;
+}
+
+test('#2919 pretool_guard: manager phase denies git push via terminal', () => {
+  const payload = buildPayload('git push origin main');
+  const state = buildMockPatch('manager');
+  const result = runPython(`${MOCK_PREAMBLE}
+payload = json.dumps(${payload})
+state = ${state}
+captured = {}
+def cap(decision, reason, extra=None):
+    captured["d"] = decision; captured["r"] = reason; return 0
+with patch("pretool_guard.emit", side_effect=cap), \\
+     patch("sys.stdin", _io.StringIO(payload)), \\
+     patch("pretool_guard.ensure_state", return_value=state), \\
+     patch("state_store.reset_on_branch_change", return_value=state), \\
+     patch("pretool_guard.enforce_blast_radius", return_value=None):
+    pretool_guard.main()
+assert captured.get("d") == "deny", f"Expected deny, got: {captured}"
+assert "manager" in captured.get("r", ""), f"Expected manager in reason: {captured}"
+print("OK: manager blocks git push")
+`);
+  expect(result.trim()).toBe('OK: manager blocks git push');
+});
+
+test('#2919 pretool_guard: admin phase denies git branch create via terminal', () => {
+  const payload = buildPayload('git switch -c feat/new-branch');
+  const state = buildMockPatch('admin');
+  const result = runPython(`${MOCK_PREAMBLE}
+payload = json.dumps(${payload})
+state = ${state}
+captured = {}
+def cap(decision, reason, extra=None):
+    captured["d"] = decision; captured["r"] = reason; return 0
+with patch("pretool_guard.emit", side_effect=cap), \\
+     patch("sys.stdin", _io.StringIO(payload)), \\
+     patch("pretool_guard.ensure_state", return_value=state), \\
+     patch("state_store.reset_on_branch_change", return_value=state), \\
+     patch("pretool_guard.enforce_blast_radius", return_value=None):
+    pretool_guard.main()
+assert captured.get("d") == "deny", f"Expected deny, got: {captured}"
+assert "admin" in captured.get("r", ""), f"Expected admin in reason: {captured}"
+print("OK: admin blocks branch create")
+`);
+  expect(result.trim()).toBe('OK: admin blocks branch create');
+});


### PR DESCRIPTION
## Summary
- Per-role capability matrix in `config/role-tool-allowlist.json`
- `role_tool_allowlist_enforcer.py` gate in `pretool_guard.check_terminal`

## Test plan
- [x] `npx playwright test tests/role-tool-allowlist.spec.js` (9/9)

Refs #2919
Closes #2919
merge-evidence-deferred-final: #2919