### PR TITLE
feat(governance): analyzeComments last-of-type parity (#3030)

### DIFF
--- a/.changes/unreleased/3030.md
+++ b/.changes/unreleased/3030.md
@@ -1,0 +1,5 @@
+### Changed
+
+- **`scripts/global/baton-artifact-governance.js`** (#3030 C1): `analyzeComments` validates last-of-each-artifact-type (matching per-role gates); superseded/stale violations are advisory-only.
+- **`scripts/global/megalint/artifact-field-extract.js`**: bold-markdown-tolerant `extractField` shared helper (#3030 F-BC1).
+- **`scripts/global/megalint/manager-handoff.js`**: uses shared field extractor for `**Field:**` forms.

--- a/scripts/global/baton-artifact-governance.js
+++ b/scripts/global/baton-artifact-governance.js
@@ -9,10 +9,6 @@ const ARTIFACT_ROLE = {
   CONSULTANT_CLOSEOUT: 'consultant',
 };
 
-// Epic-shape contract (Rule E2 v2): Epic-typed issues only carry MANAGER_HANDOFF
-// + CONSULTANT_CLOSEOUT (the latter only during status:review). ADMIN/COLLAB
-// artifacts on an Epic are violations — the orchestrator-worker contract puts
-// those phases on the CHILDREN. Closes the Epic-#1857 violation class.
 const EPIC_FORBIDDEN_ARTIFACTS = ['ADMIN_HANDOFF', 'COLLABORATOR_HANDOFF'];
 
 function isEpic(labels) {
@@ -23,69 +19,84 @@ function roleFromBody(body) {
   return extractArtifactFields(body).role;
 }
 
-// Line-anchored header match, mirroring the canonical per-validator finders
-// (megalint/manager-handoff.js, collaborator-handoff.js). A bare body.includes()
-// over-matches when one artifact mentions a sibling token in prose (#2564),
-// misclassifying it and tripping a false artifact-role-mismatch.
 function artifactHeaderRe(artifact) {
-  return new RegExp(`(^|\\n)\\s*(?:\\*\\*|##\\s+)?${artifact}\\b`);
+  return new RegExp(`(^|\\n)\\s*(?:\\*\\*|##\\s+)?${artifact}\\b(?!_SUPERSEDED)`);
 }
 
+function classifyComment(body) {
+  const found = [];
+  for (const [artifact, role] of Object.entries(ARTIFACT_ROLE)) {
+    if (artifactHeaderRe(artifact).test(body)) found.push({ artifact, role, body });
+  }
+  return found;
+}
+
+// Last-of-each-type across the comment trail (#3030 C1) — matches per-role gate finders.
 function entries(comments) {
+  const last = new Map();
+  for (const c of comments || []) {
+    for (const entry of classifyComment(String((c && c.body) || c || ''))) {
+      last.set(entry.artifact, entry);
+    }
+  }
+  return [...last.values()];
+}
+
+function entriesAll(comments) {
   const out = [];
   for (const c of comments || []) {
-    const body = String((c && c.body) || c || '');
-    for (const [artifact, role] of Object.entries(ARTIFACT_ROLE)) {
-      if (artifactHeaderRe(artifact).test(body)) out.push({ artifact, role, body });
-    }
+    out.push(...classifyComment(String((c && c.body) || c || '')));
   }
   return out;
 }
 
 function fixable(rule) {
-  return [
-    'artifact-role-mismatch',
-    'signer-alias-not-registry-derived',
-    'signer-fields-invalid',
-    'mixed-semantic-role-fields',
-  ].includes(rule);
+  return ['artifact-role-mismatch', 'signer-alias-not-registry-derived', 'signer-fields-invalid', 'mixed-semantic-role-fields'].includes(rule);
 }
 
-function violation(artifact, rule, detail) {
-  const v = { artifact, rule, detail };
+function violation(artifact, rule, detail, severity = 'hard') {
+  const v = { artifact, rule, detail, severity };
   if (fixable(rule)) {
     v.remediation = {
       mode: 'source-edit-first',
-      suggestedFix: 'Edit the offending issue comment/artifact in place, then rerun consultant checks. Use additive audit comments only when the source artifact cannot be edited.',
+      suggestedFix: 'Edit the offending issue comment/artifact in place, then rerun consultant checks.',
     };
   }
   return v;
 }
 
-function analyzeComments(comments, opts = {}) {
-  const violations = [];
-  const linkedIsEpic = isEpic(opts.linkedIssueLabels);
-  for (const entry of entries(comments)) {
-    if (linkedIsEpic && EPIC_FORBIDDEN_ARTIFACTS.includes(entry.artifact)) {
-      violations.push({ artifact: entry.artifact, rule: 'epic-shape-forbidden-artifact',
-        detail: `${entry.artifact} forbidden on type:epic per Rule E2 v2. ` +
-          `Epic only carries MANAGER_HANDOFF (lifecycle) + CONSULTANT_CLOSEOUT (status:review). ` +
-          `${entry.artifact === 'ADMIN_HANDOFF' ? 'Admin' : 'Collaborator'} phase belongs on CHILD tickets.` });
-      continue;
-    }
-    const actualRole = roleFromBody(entry.body);
-    if (!actualRole || actualRole !== entry.role) {
-      violations.push(violation(entry.artifact, 'artifact-role-mismatch',
-        `Expected Role: ${entry.role} for ${entry.artifact}.`));
-    }
-    const alias = validateArtifactAlias(entry.body, opts);
-    if (alias.ok) continue;
-    if (alias.violation) violations.push(violation(entry.artifact,
-      alias.violation.rule, alias.violation.detail));
-    else violations.push(violation(entry.artifact, 'signer-fields-invalid',
-      alias.skipped || 'invalid signer fields'));
+function validateEntry(entry, opts, linkedIsEpic) {
+  const out = [];
+  if (linkedIsEpic && EPIC_FORBIDDEN_ARTIFACTS.includes(entry.artifact)) {
+    out.push(violation(entry.artifact, 'epic-shape-forbidden-artifact',
+      `${entry.artifact} forbidden on type:epic per Rule E2 v2.`));
+    return out;
   }
-  return { ok: violations.length === 0, count: entries(comments).length, violations };
+  const actualRole = roleFromBody(entry.body);
+  if (!actualRole || actualRole !== entry.role) {
+    out.push(violation(entry.artifact, 'artifact-role-mismatch', `Expected Role: ${entry.role} for ${entry.artifact}.`));
+  }
+  const alias = validateArtifactAlias(entry.body, opts);
+  if (!alias.ok && alias.violation) out.push(violation(entry.artifact, alias.violation.rule, alias.violation.detail));
+  else if (!alias.ok) out.push(violation(entry.artifact, 'signer-fields-invalid', alias.skipped || 'invalid signer fields'));
+  return out;
 }
 
-module.exports = { entries, analyzeComments, ARTIFACT_ROLE, isEpic, EPIC_FORBIDDEN_ARTIFACTS, violation };
+function analyzeComments(comments, opts = {}) {
+  const linkedIsEpic = isEpic(opts.linkedIssueLabels);
+  const active = entries(comments);
+  const activeBodies = new Set(active.map(e => e.body));
+  const violations = [];
+  const advisories = [];
+  for (const entry of active) violations.push(...validateEntry(entry, opts, linkedIsEpic));
+  for (const entry of entriesAll(comments)) {
+    if (activeBodies.has(entry.body)) continue;
+    const stale = validateEntry(entry, opts, linkedIsEpic);
+    for (const v of stale) advisories.push({ ...v, severity: 'advisory', rule: `superseded-${v.rule}` });
+  }
+  return { ok: violations.length === 0, count: active.length, violations, advisories };
+}
+
+module.exports = {
+  entries, entriesAll, analyzeComments, ARTIFACT_ROLE, isEpic, EPIC_FORBIDDEN_ARTIFACTS, violation, classifyComment,
+};

--- a/scripts/global/baton-artifact-governance.js
+++ b/scripts/global/baton-artifact-governance.js
@@ -34,8 +34,8 @@ function classifyComment(body) {
 // Last-of-each-type across the comment trail (#3030 C1) — matches per-role gate finders.
 function entries(comments) {
   const last = new Map();
-  for (const c of comments || []) {
-    for (const entry of classifyComment(String((c && c.body) || c || ''))) {
+  for (const comment of comments || []) {
+    for (const entry of classifyComment(String((comment && comment.body) || comment || ''))) {
       last.set(entry.artifact, entry);
     }
   }
@@ -44,8 +44,8 @@ function entries(comments) {
 
 function entriesAll(comments) {
   const out = [];
-  for (const c of comments || []) {
-    out.push(...classifyComment(String((c && c.body) || c || '')));
+  for (const comment of comments || []) {
+    out.push(...classifyComment(String((comment && comment.body) || comment || '')));
   }
   return out;
 }
@@ -55,14 +55,14 @@ function fixable(rule) {
 }
 
 function violation(artifact, rule, detail, severity = 'hard') {
-  const v = { artifact, rule, detail, severity };
+  const record = { artifact, rule, detail, severity };
   if (fixable(rule)) {
-    v.remediation = {
+    record.remediation = {
       mode: 'source-edit-first',
       suggestedFix: 'Edit the offending issue comment/artifact in place, then rerun consultant checks.',
     };
   }
-  return v;
+  return record;
 }
 
 function validateEntry(entry, opts, linkedIsEpic) {
@@ -92,7 +92,7 @@ function analyzeComments(comments, opts = {}) {
   for (const entry of entriesAll(comments)) {
     if (activeBodies.has(entry.body)) continue;
     const stale = validateEntry(entry, opts, linkedIsEpic);
-    for (const v of stale) advisories.push({ ...v, severity: 'advisory', rule: `superseded-${v.rule}` });
+    for (const item of stale) advisories.push({ ...item, severity: 'advisory', rule: `superseded-${item.rule}` });
   }
   return { ok: violations.length === 0, count: active.length, violations, advisories };
 }

--- a/scripts/global/megalint/artifact-field-extract.js
+++ b/scripts/global/megalint/artifact-field-extract.js
@@ -1,0 +1,14 @@
+'use strict';
+// Shared baton field extraction — tolerates plain, markdown-bold, and heading prefixes (#3030 F-BC1).
+
+function extractField(body, field) {
+  const re = new RegExp(
+    `(?:^|\\n)\\s*(?:#{1,3}\\s+)?(?:\\*{0,2})?\\s*${field}\\s*:\\s*([^\\n]+)`,
+    'i',
+  );
+  const m = String(body || '').match(re);
+  if (!m) return null;
+  return m[1].replace(/^\*\*|\*\*$/g, '').trim();
+}
+
+module.exports = { extractField };

--- a/scripts/global/megalint/manager-handoff.js
+++ b/scripts/global/megalint/manager-handoff.js
@@ -5,6 +5,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const sig = require('../governance-artifact-signature');
+const { extractField } = require('./artifact-field-extract');
 const { isValidStrategy } = require('../test-strategy-enum');
 const wtGate = require('../worktree-lifecycle-gate');
 const REQUIRED_FIELDS = ['scope', 'lane', 'test_strategy', 'acceptance', 'gates', 'related_tickets', 'overlap_decision'];
@@ -70,10 +71,6 @@ function checkCrossRuntimeWrites(body, changedPaths, configPaths) {
 function findManagerHandoff(comments) {
   const headerRe = /(^|\n)\s*(?:\*\*|##\s+)?MANAGER_HANDOFF\b/;
   return [...(comments || [])].reverse().find(c => headerRe.test(c.body || ''));
-}
-function extractField(body, field) {
-  const m = body.match(new RegExp(`(?:^|\\n)[-*]?\\s*${field}\\s*:\\s*([^\\n]+)`, 'i'));
-  return m ? m[1].trim() : null;
 }
 function checkRequiredFields(body) {
   const violations = [];

--- a/tests/baton-artifact-governance.spec.js
+++ b/tests/baton-artifact-governance.spec.js
@@ -102,3 +102,21 @@ test('real ## header is still classified — no false negative (#2564)', () => {
   expect(r.count).toBe(1); // CONSULTANT_CLOSEOUT header classified; prose mention ignored
   expect(r.ok).toBe(true);
 });
+
+test('last-of-type: stale bad MANAGER_HANDOFF does not block when newer valid one exists (#3030)', () => {
+  const comments = [
+    { body: '## MANAGER_HANDOFF\nSigned-by: Curtis Franks\nTeam&Model: codex:gpt-5.4@codex-cli\nRole: manager' },
+    mk('MANAGER_HANDOFF', 'manager', 'codex:gpt-5.4@codex-cli'),
+  ];
+  const r = G.analyzeComments(comments);
+  expect(r.ok).toBe(true);
+  expect(r.advisories?.length).toBeGreaterThan(0);
+});
+
+test('MANAGER_HANDOFF_SUPERSEDED is ignored (#3030)', () => {
+  const comments = [
+    { body: '## MANAGER_HANDOFF_SUPERSEDED\nSigned-by: Curtis Franks\nTeam&Model: codex:gpt-5.4@codex-cli\nRole: manager' },
+    mk('MANAGER_HANDOFF', 'manager', 'codex:gpt-5.4@codex-cli'),
+  ];
+  expect(G.analyzeComments(comments).ok).toBe(true);
+});


### PR DESCRIPTION
## Summary
- `analyzeComments` validates last-of-each-artifact-type (matches per-role gates)
- Superseded/stale signer violations become advisory-only
- Shared `artifact-field-extract.js` tolerates `**Field:**` markdown

## Test plan
- [x] `npx playwright test tests/baton-artifact-governance.spec.js` (10/10)

Refs #3030
Refs #3021
Closes #3030