### PR TITLE
feat(governance): atomic coordination primitives (#3033)

### DIFF
--- a/.changes/unreleased/3033.md
+++ b/.changes/unreleased/3033.md
@@ -1,0 +1,11 @@
+### Added
+
+- **`scripts/global/atomic-json-store.js`** (#3033 C5 AC1): shared tmp+rename writes and directory lock for JSON stores.
+- **`hooks/scripts/atomic_io.py`**: Python atomic JSON write for hook state.
+- **`scripts/global/cross-team-lease-gate.js`** (#2916 / C5 AC2): pre-push lease check on guarded paths.
+
+### Changed
+
+- **`cross-team-lease-registry.js`**: atomic `mutateRegistry` for read-modify-write; `cross-team-lease.js` CLI uses it.
+- **`hooks/scripts/state_store.py`**: atomic save via `atomic_io.atomic_write_json`.
+- **`lefthook.yml`**: `cross-team-lease-gate` pre-push step.

--- a/hooks/scripts/atomic_io.py
+++ b/hooks/scripts/atomic_io.py
@@ -1,0 +1,41 @@
+"""Atomic JSON file helpers (#3033 C5 AC1)."""
+from __future__ import annotations
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
+
+
+def atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f"{path.name}.tmp.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+def with_json_lock(path: Path, fn: Callable[[dict[str, Any]], Any], default: Callable[[], dict[str, Any]]) -> Any:
+    lock = path.with_suffix(path.suffix + ".lock")
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        lock.mkdir(exist_ok=False)
+    except FileExistsError:
+        raise RuntimeError(f"atomic_io: lock held for {path}") from None
+    try:
+        data = default()
+        if path.exists():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                data = default()
+        out = fn(data)
+        atomic_write_json(path, data)
+        return out
+    finally:
+        lock.rmdir()

--- a/hooks/scripts/state_store.py
+++ b/hooks/scripts/state_store.py
@@ -70,8 +70,8 @@ def load_state(cwd: str) -> dict[str, Any]:
 def save_state(state: dict[str, Any]) -> None:
     cwd = str(state.get("cwd") or os.getcwd())
     path = state_path(cwd)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    from atomic_io import atomic_write_json
+    atomic_write_json(path, state)
 
 
 def ensure_state(cwd: str) -> dict[str, Any]:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -42,6 +42,8 @@ pre-push:
     # #2878: merged-branch-guard — block pushes to already-merged branches.
     merged-branch-guard:
       run: python3 hooks/scripts/merged-branch-guard.py
+    cross-team-lease-gate:
+      run: node scripts/global/cross-team-lease-gate.js
     # #2907: collaborator-self-check hard gate — exits 1 when COLLABORATOR_SELF_CHECK_INPUT
     # is provided and runChecks fails. Without env var the gate passes (CI gate enforces
     # server-side). Bypass: COLLABORATOR_SELF_CHECK_SKIP=1 (emits advisory warning).

--- a/scripts/global/atomic-json-store.js
+++ b/scripts/global/atomic-json-store.js
@@ -1,0 +1,58 @@
+'use strict';
+// Shared atomic JSON read/write + directory lock (#3033 C5 AC1).
+const fs = require('fs');
+const path = require('path');
+
+const TMP = '.tmp';
+const LOCK = '.lock';
+const WAIT_MS = 2;
+const STALE_MS = 5000;
+const LOCK_TIMEOUT_MS = Number(process.env.ATOMIC_LOCK_TIMEOUT_MS || 3000);
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function readJson(file, fallback = () => ({})) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); }
+  catch { return typeof fallback === 'function' ? fallback() : fallback; }
+}
+
+function writeJsonAtomic(data, file) {
+  const dir = path.dirname(file);
+  fs.mkdirSync(dir, { recursive: true });
+  const tmp = `${file}${TMP}.${process.pid}.${Date.now()}`;
+  fs.writeFileSync(tmp, `${JSON.stringify(data, null, 2)}\n`);
+  fs.renameSync(tmp, file);
+}
+
+function withFileLock(file, fn, opts = {}) {
+  const lock = file + LOCK;
+  const deadline = Date.now() + (opts.timeoutMs || LOCK_TIMEOUT_MS);
+  while (true) {
+    try { fs.mkdirSync(lock); break; }
+    catch (e) {
+      if (e.code !== 'EEXIST') throw e;
+      if (Date.now() > deadline) {
+        throw new Error(`atomic-json-store: lock timeout on ${file}`);
+      }
+      try {
+        if (Date.now() - fs.statSync(lock).mtimeMs > STALE_MS) fs.rmSync(lock, { recursive: true, force: true });
+      } catch {}
+      sleep(WAIT_MS);
+    }
+  }
+  try { return fn(); }
+  finally { fs.rmSync(lock, { recursive: true, force: true }); }
+}
+
+function mutateJson(file, mutator, fallback) {
+  return withFileLock(file, () => {
+    const data = readJson(file, fallback);
+    const out = mutator(data);
+    writeJsonAtomic(data, file);
+    return out;
+  });
+}
+
+module.exports = { readJson, writeJsonAtomic, withFileLock, mutateJson };

--- a/scripts/global/cross-team-lease-gate.js
+++ b/scripts/global/cross-team-lease-gate.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+'use strict';
+// Pre-push cross-team lease gate (#2916 / #3033 C5 AC2).
+const { execFileSync } = require('child_process');
+const path = require('path');
+const { readJson } = require('./atomic-json-store');
+const { active, DEFAULT_PATH } = require('./cross-team-lease-registry');
+
+const LEASE_PATH = process.env.CROSS_TEAM_LEASE_PATH || DEFAULT_PATH;
+const GUARDED = ['scripts/global/', 'hooks/scripts/', 'inventory/', 'config/'];
+
+function stagedFiles() {
+  const out = execFileSync('git', ['diff', '--cached', '--name-only'], { encoding: 'utf8' });
+  return out.split('\n').map(s => s.trim()).filter(Boolean);
+}
+
+function touchesGuarded(files) {
+  return files.some(f => GUARDED.some(p => f.startsWith(p) || f.includes(`/${p}`)));
+}
+
+function ticketFromBranch(branch) {
+  const m = String(branch || '').match(/(?:feat|fix)\/(\d+)/);
+  return m ? Number(m[1]) : null;
+}
+
+function main() {
+  if (process.env.MEGINGJORD_IT_OPS === '1' || process.env.CROSS_TEAM_LEASE_SKIP === '1') {
+    process.stdout.write('cross-team-lease-gate: skipped (env bypass)\n');
+    return 0;
+  }
+  const files = stagedFiles();
+  if (!touchesGuarded(files)) return 0;
+  const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf8' }).trim();
+  const ticket = ticketFromBranch(branch);
+  if (!ticket) {
+    process.stderr.write('cross-team-lease-gate: guarded paths staged but branch has no ticket id\n');
+    return 1;
+  }
+  const team = (process.env.HAMR_TEAM || process.env.MEGINGJORD_TEAM || '').toLowerCase();
+  const registry = readJson(LEASE_PATH, () => ({ version: 1, leases: [] }));
+  const hit = active(registry).find(l => l.ticket === ticket);
+  if (!hit) {
+    process.stderr.write(`cross-team-lease-gate: no active lease for #${ticket} on guarded paths\n`);
+    return 1;
+  }
+  if (team && hit.team !== team) {
+    process.stderr.write(`cross-team-lease-gate: lease team=${hit.team} != pusher team=${team}\n`);
+    return 1;
+  }
+  process.stdout.write(`cross-team-lease-gate: OK (#${ticket} leased by ${hit.team})\n`);
+  return 0;
+}
+
+if (require.main === module) process.exit(main());
+module.exports = { touchesGuarded, ticketFromBranch, main };

--- a/scripts/global/cross-team-lease-registry.js
+++ b/scripts/global/cross-team-lease-registry.js
@@ -3,6 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { readJson, writeJsonAtomic, mutateJson } = require('./atomic-json-store');
 
 const DEFAULT_PATH = path.join(process.cwd(), '.dashboard', 'cross-team-leases.json');
 const TTL_HOURS = 24;
@@ -19,11 +20,13 @@ function listArg(value) {
 }
 function read(file = DEFAULT_PATH) {
   if (!fs.existsSync(file)) return empty();
-  return JSON.parse(fs.readFileSync(file, 'utf8'));
+  return readJson(file, empty);
 }
 function write(registry, file = DEFAULT_PATH) {
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, `${JSON.stringify(registry, null, 2)}\n`);
+  writeJsonAtomic(registry, file);
+}
+function mutateRegistry(file, mutator) {
+  return mutateJson(file, mutator, empty);
 }
 function active(registry, at = now()) {
   return registry.leases.filter(l => l.status === 'active' && l.expires_at > at);
@@ -84,5 +87,5 @@ function commentBlock(event, lease) {
   ];
   return rows.join('\n');
 }
-module.exports = { read, write, createLease, refreshLease, expireLeases,
+module.exports = { read, write, mutateRegistry, createLease, refreshLease, expireLeases,
   closeLease, active, commentBlock, DEFAULT_PATH };

--- a/scripts/global/cross-team-lease.js
+++ b/scripts/global/cross-team-lease.js
@@ -31,17 +31,22 @@ async function post(issue, body, opts = {}) {
 async function run(argv = process.argv.slice(2), opts = {}) {
   const args = parse(argv);
   const cmd = args._[0];
-  const registry = leaseRegistry.read(args.file || leaseRegistry.DEFAULT_PATH);
+  const file = args.file || leaseRegistry.DEFAULT_PATH;
   const commands = {
-    create: () => leaseRegistry.createLease(registry, args),
-    refresh: () => leaseRegistry.refreshLease(registry, args.ticket, args.ttl_hours),
-    expire: () => leaseRegistry.expireLeases(registry),
-    close: () => leaseRegistry.closeLease(registry, args.ticket),
-    list: () => leaseRegistry.active(registry),
+    create: (registry) => leaseRegistry.createLease(registry, args),
+    refresh: (registry) => leaseRegistry.refreshLease(registry, args.ticket, args.ttl_hours),
+    expire: (registry) => leaseRegistry.expireLeases(registry),
+    close: (registry) => leaseRegistry.closeLease(registry, args.ticket),
+    list: (registry) => leaseRegistry.active(registry),
   };
   if (!commands[cmd]) throw new Error('usage: create|refresh|expire|close|list');
-  const result = commands[cmd]();
-  if (cmd !== 'list') leaseRegistry.write(registry, args.file || leaseRegistry.DEFAULT_PATH);
+  if (cmd === 'list') {
+    const registry = leaseRegistry.read(file);
+    const result = commands.list(registry);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result;
+  }
+  const result = leaseRegistry.mutateRegistry(file, (registry) => commands[cmd](registry));
   if (args.post_comment && result && !Array.isArray(result)) {
     await post(result.ticket, leaseRegistry.commentBlock(cmd, result), opts);
   }

--- a/tests/atomic-json-store-3033.spec.js
+++ b/tests/atomic-json-store-3033.spec.js
@@ -1,0 +1,22 @@
+'use strict';
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const store = require('../scripts/global/atomic-json-store');
+
+test('writeJsonAtomic + readJson round-trip', () => {
+  const file = path.join(os.tmpdir(), `atomic-${Date.now()}.json`);
+  store.writeJsonAtomic({ ok: true }, file);
+  expect(store.readJson(file)).toEqual({ ok: true });
+  fs.unlinkSync(file);
+});
+
+test('mutateJson serializes concurrent writers', () => {
+  const file = path.join(os.tmpdir(), `atomic-mut-${Date.now()}.json`);
+  store.writeJsonAtomic({ n: 0 }, file);
+  store.mutateJson(file, (d) => { d.n += 1; return d.n; });
+  store.mutateJson(file, (d) => { d.n += 1; return d.n; });
+  expect(store.readJson(file).n).toBe(2);
+  fs.unlinkSync(file);
+});

--- a/tests/cross-team-lease-gate-3033.spec.js
+++ b/tests/cross-team-lease-gate-3033.spec.js
@@ -1,0 +1,13 @@
+'use strict';
+const { test, expect } = require('@playwright/test');
+const gate = require('../scripts/global/cross-team-lease-gate');
+
+test('touchesGuarded detects governance paths', () => {
+  expect(gate.touchesGuarded(['scripts/global/foo.js'])).toBe(true);
+  expect(gate.touchesGuarded(['README.md'])).toBe(false);
+});
+
+test('ticketFromBranch parses feat/N-slug', () => {
+  expect(gate.ticketFromBranch('feat/3033-atomic-primitives')).toBe(3033);
+  expect(gate.ticketFromBranch('main')).toBeNull();
+});


### PR DESCRIPTION
## Summary
- Shared `atomic-json-store.js` + `atomic_io.py` for fail-closed local-process JSON writes
- `cross-team-lease-gate.js` pre-push blocking gate (subsumes #2916)
- Lease registry + state_store wired to atomic mutate/write paths

Refs #3033
Closes #3033
Refs #3021

## Test plan
- [x] `npx playwright test tests/atomic-json-store-3033.spec.js tests/cross-team-lease-gate-3033.spec.js` — 4/4 PASS
- [ ] CI quality-gates

Signed-by: Cursor Collaborator
Team&Model: cursor:composer-2.5-fast@cursor-ide

Made with [Cursor](https://cursor.com)