### PR TITLE
feat(governance): cross-team worktree preflight (#3035)

### DIFF
--- a/scripts/global/cross-team-worktree-preflight.js
+++ b/scripts/global/cross-team-worktree-preflight.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+'use strict';
+// Cross-team one-ticket worktree preflight (#3035 C7 AC1).
+const { readJson } = require('./atomic-json-store');
+const { active, DEFAULT_PATH } = require('./cross-team-lease-registry');
+
+const ticket = Number(process.argv[2]);
+const team = String(process.argv[3] || '').toLowerCase();
+if (!ticket || !team) {
+  process.stderr.write('usage: cross-team-worktree-preflight.js <ticket> <team>\n');
+  process.exit(2);
+}
+const registry = readJson(process.env.CROSS_TEAM_LEASE_PATH || DEFAULT_PATH, () => ({ version: 1, leases: [] }));
+const hit = active(registry).find(l => l.ticket === ticket);
+if (hit && hit.team !== team) {
+  process.stderr.write(`cross-team worktree collision: #${ticket} leased by ${hit.team}, not ${team}\n`);
+  process.exit(1);
+}
+process.stdout.write(`cross-team-worktree-preflight: OK (#${ticket} ${team})\n`);

--- a/scripts/worktree-agent-init.sh
+++ b/scripts/worktree-agent-init.sh
@@ -36,6 +36,11 @@ create_task_worktree() {
   local ticket_num worktree_dir
   ticket_num="$(echo "$task_branch" | grep -oP '(?<=/)[0-9]+(?=-)' | head -1)"
   [[ -n "$ticket_num" ]] || die "cannot parse ticket number from task branch '$task_branch'"
+  if [[ -n "${HAMR_TEAM:-}${MEGINGJORD_TEAM:-}" ]]; then
+    local pusher_team="${HAMR_TEAM:-$MEGINGJORD_TEAM}"
+    node "$(dirname "$0")/global/cross-team-worktree-preflight.js" "$ticket_num" "$pusher_team" \
+      || die "cross-team worktree collision on #${ticket_num}"
+  fi
   worktree_dir="$HOME/devenv-ops-${ticket_num}"
   [[ -e "$worktree_dir" ]] && die "worktree dir already exists: $worktree_dir (remove it first)"
   git worktree add "$worktree_dir" -b "$task_branch"


### PR DESCRIPTION
## Summary
## COLLABORATOR_HANDOFF
scope: C7 cross-team-worktree-preflight + worktree-agent-init hook (requires #3033).
cross_family_reviewer: qwen2.5-coder:7b@127.0.0.1:11434
cross_family_rating: 94/100
cross_family_findings: ACCEPT — preflight blocks conflicting worktrees; stacks on #3033 until merged.
reviewer_family: Qwen

Refs #3035
Closes #3035
Refs #3021

## Test plan
- [x] Unit specs on branch
- [ ] CI quality-gates

Signed-by: Cursor Collaborator
Team&Model: cursor:composer-2.5-fast@cursor-ide

Made with [Cursor](https://cursor.com)