### PR TITLE
docs: residual P2 doc-debt remediation (#3271)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,13 @@ signal or core-identity → resident).
 - Deploy: `npm run deploy:apply` deploys the two script-mirror runtimes (Copilot `~/.copilot` + Codex `~/.codex`); `npm run deploy:claude:apply` deploys the Claude Code runtime (`~/.claude`). Run both for full coverage. (Per #2950: `deploy:apply` previously targeted Copilot only, silently drifting Codex; it now targets `both`.)
 - Lint: `npm run lint` — all files must be ≤ 100 lines
 
+## Governance mechanisms — key references
+
+Two machine-guaranteed governance mechanisms underpin the baton workflow; consult these when authoring artifacts or adding a governed link:
+
+- **Governance chains** (no link may depend on operator discretion; every link is auto-emitted or fail-closed) — `docs/howto/governance-chains.md` (Epic #2709).
+- **Baton-artifact builders** (PR body, CHANGELOG fragment, commit trailers, and the six comment artifacts are built deterministically with derived signers — the default path, env-flag rollback) — `docs/howto/baton-builders.md` (Epic #2037).
+
 ## Concurrent session safety
 
 - Do not share this checkout with Copilot or Codex while Claude Code is active.

--- a/docs/howto/baton-builders.md
+++ b/docs/howto/baton-builders.md
@@ -1,0 +1,71 @@
+# Baton-artifact builders: programmatic generation of the baton trail
+
+The harness **builds** baton artifacts from structured input rather than asking the
+operator to hand-author them. Every recurring format defect — signer invention,
+`Refs`-ordering, PR-title length, prose collisions, fragment naming — is encoded as
+data the builder enforces, not prose the operator must remember (Epic #2037).
+
+Builders are **pure and deterministic**: identical structured input yields
+byte-identical output on any runtime (no `Date`/random/env reads in the build path),
+which the cross-runtime invariant test (#2674) asserts. The signer is always
+**derived** via `agent-signature` — never hand-typed — killing the signer-invention
+defect class.
+
+## The builders
+
+| Builder | Produces | Module |
+|---|---|---|
+| Comment artifacts | the six baton COMMENT artifacts (MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT, TEAM_QUESTION, TEAM_RESPONSE) | `scripts/global/baton-artifact-builder.js` (`buildArtifact`) |
+| Comment CLI | a ready-to-post comment from flags | `scripts/global/baton-comment-build.js` (`buildBatonComment`) |
+| Non-comment artifacts | PR body, CHANGELOG fragment, commit trailers | `scripts/global/baton-pr-builders.js` (`buildPrBody`, `buildChangelogFragment`, `buildCommitTrailers`) |
+| Default/rollback state | whether builders are the default path | `scripts/global/baton-builder-mode.js` (`isBuilderDefault`) |
+
+## How to invoke
+
+Build and post a comment artifact:
+
+```
+node scripts/global/baton-comment-build.js \
+  --artifact COLLABORATOR_HANDOFF --role collaborator \
+  --team-model claude-code:opus@local --ticket 3271 \
+  --summary "..." --related-tickets "#2708"
+```
+
+`baton-comment-build.js` fails loud on unrecognized flags (#2693), so stale callers
+surface an error instead of silently dropping a field. Known flags: `--artifact`,
+`--role`, `--team-model`, `--ticket`, `--fields-json`, `--summary`,
+`--related-tickets`, `--overlap-decision`.
+
+From a module (PR body + CHANGELOG fragment + trailers):
+
+```js
+const { buildPrBody, buildChangelogFragment, buildCommitTrailers } =
+  require('./scripts/global/baton-pr-builders');
+// PR title subject is capped at 60 chars (pr-title.yml ^.{1,60}$);
+// Refs ordering and the Closes/Fixes/Resolves auto-close form are enforced.
+```
+
+## Builder-as-default and rollback
+
+The builders are the **default** artifact path (PROMOTED in #2692: 17/17 = 1.00
+byte-identical over the mined corpus). The env flag `MEGINGJORD_BATON_BUILDER_DEFAULT`
+is now the **rollback switch** — set it falsy (`0`/`false`/`off`/`no`) to fall back
+to the legacy hand/template path. A rollback is a one-env-var change, not a code
+revert (G6). Promotion was **replay-eval-gated, not calendar-gated** — see
+[baton-builder-promotion.md](baton-builder-promotion.md).
+
+## The irreducible-3 free-text slots
+
+Most artifacts render fully from schema. Three cases genuinely need exactly one LLM
+free-text slot each (they require judgment/synthesis no schema can render). The
+slot contract names, per case, the structured fields and the single free-text slot,
+and `scripts/global/baton-slot-contract.js` asserts only the named slot is free-text.
+See [irreducible-slot-contract.md](irreducible-slot-contract.md).
+
+## See also
+
+- [baton-builder-promotion.md](baton-builder-promotion.md) — the replay-eval promotion gate
+- [irreducible-slot-contract.md](irreducible-slot-contract.md) — the 3 free-text slots
+- [baton-workflow.md](baton-workflow.md) — the baton lifecycle the artifacts move through
+- `instructions/role-baton-routing.instructions.md` — artifact schemas + gate entry conditions
+- `instructions/team-model-signing.instructions.md` — signer/alias derivation

--- a/docs/howto/merge-time-doc-governance.md
+++ b/docs/howto/merge-time-doc-governance.md
@@ -12,7 +12,7 @@ Every change merged to `main` documents itself across four parallel surfaces. Th
 |---|---|---|---|
 | 1 | GitHub Issues | Every merge has `Closes #N` + complete baton trail on the issue | `closeout-schema` workflow, `baton-gates` |
 | 2 | Release notes | Each `lane:code-change` PR ships `.changes/unreleased/<N>.md` | `changelog-fragment-presence` validator (#2157 / C5) |
-| 3 | Project docs | README, design docs, dev guide — updated per area-label coverage matrix | `doc-coverage` advisory (#2155 / C2) + Tech-Writer sub-phase (#2154 / C1) |
+| 3 | Project docs | README, design docs, dev guide — updated per area-label coverage matrix | `doc-coverage` **hard block** (#2712, lane-derived #3016) + Tech-Writer sub-phase (#2154 / C1) |
 | 4 | Wikis | `wiki/code/`, `wiki/wisdom/project/`, `wiki/work-log/` — updated when scoped | `wiki-lint-gate` workflow (#2156 / C3) |
 
 ## 3. The pre-merge gates
@@ -21,7 +21,7 @@ Every change merged to `main` documents itself across four parallel surfaces. Th
 |---|---|---|---|
 | Issues | `baton-gates` CI | Missing handoff or role-mismatch | Post the missing baton artifact in canonical format |
 | Release notes | `changelog-fragment-presence` | No `.changes/unreleased/<N>.md` and no `[skip-changelog]` | Add `.changes/unreleased/<N>.md` or marker |
-| Project docs | `doc-coverage` advisory | Missing `doc-coverage:` block in COLLABORATOR_HANDOFF | Add block declaring UPDATED/N-A per surface |
+| Project docs | `doc-coverage` **hard block** | Missing `doc-coverage:` block in COLLABORATOR_HANDOFF (on a gated lane) | Add block declaring UPDATED/N-A per surface |
 | Wikis | `wiki-lint-gate` advisory | wiki:lint reports issues | Currently advisory; promoted to required after baseline cleanup |
 
 ## 4. The Tech-Writer sub-phase
@@ -35,7 +35,9 @@ doc-coverage:
   N/A: design docs — internal-only validator; no public surface change
 ```
 
-The advisory validator parses the block. Missing block on `lane:code-change` emits a warning but does not block merge in first ship. Promotion to blocking happens after Epic #2148 close.
+The validator (`scripts/global/megalint/doc-coverage.js`) parses the block. The gate is now a **hard block** (#2712; the old `DOC_COVERAGE_GATE_ADVISORY` escape hatch was removed). The lane is **derived from the issue labels** (#3016), so a builder-produced handoff is gated correctly. A missing or incomplete block on a gated lane **fails the merge**.
+
+Lanes that skip the gate: `lane:docs-research` and `lane:config-only` (no required project-doc surface). The #3121 diff-verification check — declared `UPDATED` surfaces must actually appear in the PR diff — ships advisory-first and promotes per the replay-eval-gated model.
 
 ## 5. The doc-coverage matrix
 


### PR DESCRIPTION
Refs #3271
Refs Epic #2708
merge-evidence-deferred-final: #3271

[skip-changelog] — documentation-only remediation (no runtime/user-facing behavior change).

## Summary

Drains the residual P2 documentation gaps for doc-debt Epic #2708 (resumed from dormant; its resume trigger — doc-coverage gate going blocking via #2707/#3016 — has fired):

- **create** `docs/howto/baton-builders.md` — general howto for the programmatic baton-artifact builders (Child-E gap).
- **refresh** `docs/howto/merge-time-doc-governance.md` — doc-coverage gate is now a hard block (#2712), lane derived from labels (#3016), `lane:docs-research`/`config-only` skip (Child-F: refresh, not a duplicate file).
- **add** governance-chains + baton-builders references to `CLAUDE.md` (Child-C gap).

Proposed Child-D (`docs/howto/governance-chains.md`) already existed and is current — no action. A separate `doc-coverage-enforcement.md` was intentionally NOT created; its content already lives in `merge-time-doc-governance.md`, and #2708 non-goals forbid duplicating accurate docs.

## Baton trail (on #3271)
- MANAGER_HANDOFF — scope/AC/lane:docs-research/test_strategy:drift-lint/overlap_decision
- COLLABORATOR_HANDOFF — per-AC PASS + doc-coverage block + drift-lint evidence
- ADMIN_HANDOFF — branch/commit/signer-independence PASS/sync-verification N/A

## Test strategy
drift-lint — refreshed prose verified against live validator source (`doc-coverage.js`: advisory escape hatch removed, `LANE_SKIP`, lane-key form #3016). `npm run lint` green (620 files ≤100 lines).