### PR TITLE
fix(scripts): accept pytest specs for tdd-pyramid Python hooks

### DIFF
--- a/.changes/unreleased/3276.md
+++ b/.changes/unreleased/3276.md
@@ -1,0 +1,9 @@
+fix(scripts): test-evidence validator accepts pytest specs for tdd-pyramid Python hooks
+
+The `test-evidence` `tdd-pyramid` / `tdd-trophy` checkers now accept a Python pytest
+spec (`tests/**/test_*.py` / `*_test.py`) as valid evidence when the PR diff also
+changes Python source — resolving the false-negative where a matrix-mandated pytest
+spec for a `hooks/scripts/*.py` change was flagged `missing-spec-file`. The JS/TS
+evidence path is unchanged; the Python accept emits a distinct `python-pytest-evidence`
+reason for attributability. The methodology-matrix evidence table is reconciled to list
+pytest for Python surfaces, with a doclint fixture enforcing doc/code agreement. (#3276)

--- a/instructions/test-methodology-matrix.instructions.md
+++ b/instructions/test-methodology-matrix.instructions.md
@@ -47,7 +47,7 @@ A surface does NOT require `stress-test` when ALL of:
 
 | Strategy | Required evidence in PR or issue trail |
 |---|---|
-| `tdd-pyramid` | New/modified `tests/**/*.spec.{js,ts}` file in PR diff; `npm test` green |
+| `tdd-pyramid` | New/modified `tests/**/*.spec.{js,ts}` (JS/TS) OR `tests/**/test_*.py` / `*_test.py` (pytest, when the diff also changes Python source) in PR diff; `npm test` / `pytest` green |
 | `tdd-trophy` | Same as pyramid + at least one integration-flavored fixture |
 | `contract-test` | Schema assertion in trail OR `tests/**/contract.spec.*` in PR |
 | `golden-file` | `tests/fixtures/**` referenced in PR OR fixture diff inline |

--- a/scripts/global/test-evidence-validator.js
+++ b/scripts/global/test-evidence-validator.js
@@ -15,10 +15,32 @@ function anyFile(prFiles, patterns) {
   return (prFiles || []).some(f => patterns.some(p => p.test(f)));
 }
 
+// JS/TS spec (original, unchanged) and Python pytest spec (#3276): tests/**/test_*.py or *_test.py.
+const JS_SPEC_RE = /^tests\/.+\.(spec|test)\.(js|ts)$/;
+const PY_SPEC_RE = /^tests\/(?:.+\/)?(?:test_[^/]+|[^/]+_test)\.py$/;
+
+// "Python surface present" predicate (#3276): a *.py path in the diff that is NOT itself a
+// pytest spec. Gates Python evidence on real Python source change so a stray test file in a
+// pure-JS diff cannot satisfy the gate (no false positive). Path-pattern only — intentionally
+// not git-status-aware and POSIX forward-slash (matches `gh pr view --json files`).
+function hasPythonSource(prFiles) {
+  return (prFiles || []).some(f => /\.py$/.test(f) && !PY_SPEC_RE.test(f));
+}
+
+// tdd-pyramid / tdd-trophy: accept a JS/TS spec (unchanged), OR a Python pytest spec when the
+// diff also changes Python source. Distinct `python-pytest-evidence` reason for G8 attributability.
+function pyramidCheck(ctx) {
+  if (anyFile(ctx.pr_files, [JS_SPEC_RE])) return ok();
+  if ((ctx.pr_files || []).some(f => PY_SPEC_RE.test(f)) && hasPythonSource(ctx.pr_files)) {
+    return ok('python-pytest-evidence');
+  }
+  return fail('missing-spec-file',
+    'tdd-pyramid requires tests/**/*.spec.{js,ts}, or tests/**/test_*.py|*_test.py with a Python source file in the diff');
+}
+
 const CHECKERS = {
-  'tdd-pyramid': (ctx) => anyFile(ctx.pr_files, [/^tests\/.+\.(spec|test)\.(js|ts)$/])
-    ? ok() : fail('missing-spec-file', 'TDD strategy requires tests/**/*.spec.{js,ts}'),
-  'tdd-trophy': (ctx) => CHECKERS['tdd-pyramid'](ctx),
+  'tdd-pyramid': (ctx) => pyramidCheck(ctx),
+  'tdd-trophy': (ctx) => pyramidCheck(ctx),
   'contract-test': (ctx) => anyFile(ctx.pr_files,
     [/^cloudflare\/.*(test|spec)\.(ts|js)$/, /^tests\/.*contract.*\.(spec|test)\.(js|ts)$/])
     ? ok() : fail('missing-contract-test', 'contract-test requires cloudflare/**/test.ts or tests/**contract*.spec.*'),

--- a/tests/test-evidence-validator.spec.js
+++ b/tests/test-evidence-validator.spec.js
@@ -97,3 +97,91 @@ test.describe('test-evidence-validator (#1214)', () => {
     expect(ALLOWED_STRATEGIES).toContain('none');
   });
 });
+
+test.describe('test-evidence-validator #3276 — pytest evidence for tdd-pyramid Python hooks', () => {
+  const fs = require('node:fs');
+  const base = { comments: [], lane: 'lane:code-change' };
+  const PY_SOURCE = 'hooks/scripts/push_counter.py';
+  const PY_SPEC = 'tests/hooks/test_push_counter.py';
+  const PY_SPEC_ALT = 'tests/hooks/push_counter_test.py';
+  const JS_SPEC = 'tests/push.spec.js';
+
+  // AC1 + AC5: python source + pytest spec → PASS with distinct reason token (G8 attributability).
+  test('AC1/AC5: python source + pytest spec passes via python path with distinct reason', () => {
+    const r = validate({ ...base, test_strategy: 'tdd-pyramid', pr_files: [PY_SOURCE, PY_SPEC] });
+    expect(r.ok).toBe(true);
+    expect(r.reason).toBe('python-pytest-evidence');
+  });
+
+  test('AC1: *_test.py naming also accepted', () => {
+    const r = validate({ ...base, test_strategy: 'tdd-pyramid', pr_files: [PY_SOURCE, PY_SPEC_ALT] });
+    expect(r.ok).toBe(true);
+    expect(r.reason).toBe('python-pytest-evidence');
+  });
+
+  // AC2/AC4(b): python source + no test → FAIL.
+  test('AC2: python source with no test fails', () => {
+    const r = validate({ ...base, test_strategy: 'tdd-pyramid', pr_files: [PY_SOURCE] });
+    expect(r.ok).toBe(false);
+    expect(r.violations[0].rule).toBe('missing-spec-file');
+  });
+
+  // AC2/AC4(e): pytest spec but NO python source → FAIL (no false positive).
+  test('AC2: pytest spec without python source fails (no false positive)', () => {
+    const r = validate({ ...base, test_strategy: 'tdd-pyramid', pr_files: [PY_SPEC, 'scripts/global/foo.js'] });
+    expect(r.ok).toBe(false);
+  });
+
+  // AC4(c): JS regression — JS path unchanged, original reason token preserved.
+  test('AC4: JS source + JS spec still passes with evidence-present reason', () => {
+    const r = validate({ ...base, test_strategy: 'tdd-pyramid', pr_files: ['scripts/global/foo.js', JS_SPEC] });
+    expect(r.ok).toBe(true);
+    expect(r.reason).toBe('evidence-present');
+  });
+
+  // AC4(d): mixed JS+py source + only pytest → PASS.
+  test('AC4: mixed JS+py source with only pytest spec passes', () => {
+    const r = validate({ ...base, test_strategy: 'tdd-pyramid',
+      pr_files: ['scripts/global/foo.js', PY_SOURCE, PY_SPEC] });
+    expect(r.ok).toBe(true);
+  });
+
+  // AC4(g): tdd-trophy delegation locks the same python-pytest acceptance.
+  test('AC4: tdd-trophy delegates to the same python-pytest acceptance', () => {
+    const r = validate({ ...base, test_strategy: 'tdd-trophy', pr_files: [PY_SOURCE, PY_SPEC] });
+    expect(r.ok).toBe(true);
+    expect(r.reason).toBe('python-pytest-evidence');
+  });
+
+  // AC4(f): malformed / edge-case paths never crash; degrade to no-match (G6 resilience).
+  test('AC4: edge-case paths do not crash', () => {
+    const edgeSets = [
+      [],
+      ['noextensionfile'],
+      ['tests/hooks/tést_unicodé.py'],
+      ['hooks/scripts/with space.py', 'tests/hooks/test_x.py'],
+      ['hooks/scripts/deleted_only.py'],
+    ];
+    for (const files of edgeSets) {
+      expect(() => validate({ ...base, test_strategy: 'tdd-pyramid', pr_files: files })).not.toThrow();
+    }
+    // space-in-source + pytest spec is a valid python diff → passes.
+    expect(validate({ ...base, test_strategy: 'tdd-pyramid',
+      pr_files: ['hooks/scripts/with space.py', 'tests/hooks/test_x.py'] }).ok).toBe(true);
+    // empty set fails the python path.
+    expect(validate({ ...base, test_strategy: 'tdd-pyramid', pr_files: [] }).ok).toBe(false);
+  });
+
+  // AC3: doclint — the methodology matrix tdd-pyramid evidence row mentions a pytest artifact.
+  test('AC3: matrix tdd-pyramid evidence row mentions a pytest artifact', () => {
+    const matrix = fs.readFileSync(
+      path.resolve(__dirname, '../instructions/test-methodology-matrix.instructions.md'), 'utf8');
+    const lines = matrix.split('\n');
+    const evidenceRow = lines.find(l => /^\|\s*`tdd-pyramid`\s*\|/.test(l));
+    expect(evidenceRow).toBeTruthy();
+    expect(/test_\*\.py|pytest|_test\.py/i.test(evidenceRow)).toBe(true);
+    // tdd-trophy delegates to the same checker — ensure the python-hook surface still maps to tdd-pyramid.
+    const surfaceRow = lines.find(l => /hooks\/scripts\/\*\.py/.test(l));
+    expect(/tdd-pyramid/.test(surfaceRow || '')).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #3276

merge-evidence-deferred-final: #3276

## Summary

Fixes the `test-evidence` validator false-negative where a Python-hook change declaring the matrix-mandated `tdd-pyramid (pytest)` strategy and shipping a passing `tests/**/test_*.py` was flagged `missing-spec-file` — because the `tdd-pyramid` / `tdd-trophy` checkers only recognized JS/TS specs.

- **Validator** (`scripts/global/test-evidence-validator.js`): `tdd-pyramid`/`tdd-trophy` now accept `tests/**/test_*.py` / `*_test.py` as valid evidence **when the PR diff also contains a Python source file** (deterministic "Python surface present" predicate — no false positives, mixed-diff deterministic). JS/TS path unchanged. Python accept emits a distinct `python-pytest-evidence` reason (G8 attributability).
- **Matrix** (`instructions/test-methodology-matrix.instructions.md`): evidence-artifact row reconciled to list pytest for Python surfaces, removing the internal contradiction with the surface table.
- **Tests** (`tests/test-evidence-validator.spec.js`): +9 fixtures (AC1–AC5) incl. a doclint fixture that machine-enforces the matrix↔code agreement; 14 prior fixtures remain green (23 passed).

## R&P consensus

The research & planning was iterated through a cross-family `$0` consensus panel (G3) to **median 94/100** vs the harness goal lens (groq-llama3.3-70b, mistral-large, cerebras-gpt-oss-120b, groq-qwen3-32b — all non-Anthropic), exceeding the >93 bar. Implementation cross-family preflight: **ACCEPT 9/10** (cerebras-gpt-oss-120b + qwen3-32b@groq), hallucination_risk low.

## Baton artifacts (on #3276)

- MANAGER_HANDOFF — scope/lane/test_strategy/acceptance/gates/related_tickets/overlap_decision/worktree_branch.
- COLLABORATOR_HANDOFF — per-AC PASS, Pre-handoff verification (23 tests green, lint clean), doc-coverage, cross_family preflight.
- ADMIN_HANDOFF — to follow on the issue.
- CONSULTANT_CLOSEOUT — deferred-final; Consultant closes #3276 after merge.

## Verification

- `npx playwright test tests/test-evidence-validator.spec.js` → 23 passed.
- `npm run lint` → 623 files, all ≤100 lines, 0 errors.
- Demonstration (#3275 scenario): `validate({test_strategy:'tdd-pyramid', pr_files:['hooks/scripts/blast_radius.py','tests/hooks/test_push_counter_true_ships.py']})` → `{ok:true, reason:'python-pytest-evidence'}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
