### PR TITLE
fix(scripts): honor composed test_strategy in test-evidence

### DIFF
--- a/.changes/unreleased/3278.md
+++ b/.changes/unreleased/3278.md
@@ -1,0 +1,11 @@
+fix(scripts): honor composed test_strategy (<primary>+stress-test) in test-evidence
+
+`test-evidence-validator.validate()` is now composition-aware: for a
+`<primary>+stress-test` strategy it runs the `<primary>` checker (the stress half
+remains enforced by the separate `stress-evidence` gate), and malformed
+compositions return `unknown-strategy` — aligning the validator with the
+methodology-matrix contract (Epic #1875) that "the validator parses `+`-separated
+strategy lists." The `test-evidence` workflow's `test_strategy` capture regex now
+includes `+` so the composed value is no longer silently truncated. A bare
+`stress-test` (no primary checker) now degrades to `unknown-strategy` instead of
+throwing. (#3278)

--- a/.github/workflows/test-evidence.yml
+++ b/.github/workflows/test-evidence.yml
@@ -45,7 +45,7 @@ jobs:
               issue_number: issueNumber, per_page: 100,
             });
             const trail = comments.map(c => c.body || '').join('\n');
-            const stratMatch = trail.match(/test_strategy:\s*([a-z-]+)/i);
+            const stratMatch = trail.match(/test_strategy:\s*([a-z+-]+)/i); // [a-z+-]+ keeps composed '<primary>+stress-test' intact (#3278)
             const test_strategy = stratMatch ? stratMatch[1].toLowerCase() : 'none';
             const { data: prFilesData } = await github.rest.pulls.listFiles({
               owner: context.repo.owner, repo: context.repo.repo,

--- a/scripts/global/test-evidence-validator.js
+++ b/scripts/global/test-evidence-validator.js
@@ -68,11 +68,19 @@ const CHECKERS = {
 };
 
 function validate(ctx = {}) {
-  const strategy = ctx.test_strategy || 'none';
-  if (!ALLOWED_STRATEGIES.includes(strategy)) {
-    return fail('unknown-strategy', `'${strategy}' not in matrix enum; see instructions/test-methodology-matrix.instructions.md`);
+  const raw = ctx.test_strategy || 'none';
+  // Composed strategy (#3278): '<primary>+stress-test' per the matrix (Epic #1875). The primary
+  // checker runs here; the stress half is enforced by the separate stress-evidence gate. Honor the
+  // matrix contract rather than rejecting the composed form or relying on the workflow truncating it.
+  const parts = raw.split('+').map((s) => s.trim());
+  const primary = parts[0];
+  const composedValid = parts.length === 1 || (parts.length === 2 && parts[1] === 'stress-test');
+  // CHECKERS lacks a bare 'stress-test' key (it is only ever a SECOND strategy), so gating on the
+  // checker's existence both rejects unknown strategies and avoids a crash on a standalone stress-test.
+  if (!composedValid || !CHECKERS[primary]) {
+    return fail('unknown-strategy', `'${raw}' not in matrix enum; see instructions/test-methodology-matrix.instructions.md`);
   }
-  return CHECKERS[strategy](ctx);
+  return CHECKERS[primary](ctx);
 }
 
 if (require.main === module) {

--- a/tests/test-evidence-validator.spec.js
+++ b/tests/test-evidence-validator.spec.js
@@ -185,3 +185,64 @@ test.describe('test-evidence-validator #3276 — pytest evidence for tdd-pyramid
     expect(/tdd-pyramid/.test(surfaceRow || '')).toBe(true);
   });
 });
+
+test.describe('test-evidence-validator #3278 — composed test_strategy (<primary>+stress-test)', () => {
+  const fs = require('node:fs');
+  const base = { comments: [], lane: 'lane:code-change' };
+
+  // AC1/AC3: composed strategy runs the PRIMARY checker; stress half is enforced by stress-evidence.yml.
+  test('AC3: tdd-pyramid+stress-test passes when primary JS spec present', () => {
+    const r = validate({ ...base, test_strategy: 'tdd-pyramid+stress-test', pr_files: ['tests/x.spec.js'] });
+    expect(r.ok).toBe(true);
+    expect(r.reason).toBe('evidence-present');
+  });
+
+  test('AC3: eval-harness+stress-test passes when tests/eval/** present', () => {
+    const r = validate({ ...base, test_strategy: 'eval-harness+stress-test', pr_files: ['tests/eval/x.json'] });
+    expect(r.ok).toBe(true);
+  });
+
+  // AC1: the PRIMARY checker is still enforced under composition (no false positive).
+  test('AC3: composed strategy with no primary evidence fails the primary checker', () => {
+    const r = validate({ ...base, test_strategy: 'tdd-pyramid+stress-test', pr_files: ['scripts/foo.js'] });
+    expect(r.ok).toBe(false);
+    expect(r.violations[0].rule).toBe('missing-spec-file');
+  });
+
+  // AC1: malformed compositions are rejected as unknown-strategy.
+  test('AC3: non-stress-test second part is unknown-strategy', () => {
+    const r = validate({ ...base, test_strategy: 'tdd-pyramid+golden-file', pr_files: ['tests/x.spec.js'] });
+    expect(r.ok).toBe(false);
+    expect(r.violations[0].rule).toBe('unknown-strategy');
+  });
+
+  test('AC3: three-part composition is unknown-strategy', () => {
+    const r = validate({ ...base, test_strategy: 'tdd-pyramid+stress-test+foo', pr_files: ['tests/x.spec.js'] });
+    expect(r.ok).toBe(false);
+    expect(r.violations[0].rule).toBe('unknown-strategy');
+  });
+
+  // AC1 (G6): bare stress-test has no primary checker — degrade gracefully, do not crash.
+  test('AC3: bare stress-test degrades to unknown-strategy without throwing', () => {
+    let r;
+    expect(() => { r = validate({ ...base, test_strategy: 'stress-test', pr_files: ['tests/stress-x.spec.js'] }); }).not.toThrow();
+    expect(r.ok).toBe(false);
+    expect(r.violations[0].rule).toBe('unknown-strategy');
+  });
+
+  // AC1: single-strategy path is unchanged (regression).
+  test('AC3: single-strategy path unchanged', () => {
+    expect(validate({ ...base, test_strategy: 'tdd-pyramid', pr_files: ['tests/x.spec.js'] }).ok).toBe(true);
+    expect(validate({ ...base, test_strategy: 'golden-file', pr_files: ['tests/fixtures/x.json'] }).ok).toBe(true);
+    expect(validate({ ...base, test_strategy: 'fuzz-testing', pr_files: [] }).violations[0].rule).toBe('unknown-strategy');
+  });
+
+  // AC4: the workflow test_strategy capture must include '+' so composed strategies are not truncated.
+  test('AC4: test-evidence.yml test_strategy capture includes + (no accidental truncation)', () => {
+    const wf = fs.readFileSync(path.resolve(__dirname, '../.github/workflows/test-evidence.yml'), 'utf8');
+    const line = wf.split('\n').find((l) => l.includes('test_strategy:') && l.includes('match('));
+    expect(line).toBeTruthy();
+    // the character class for the test_strategy capture must contain a literal '+'
+    expect(/\[a-z[^\]]*\+/.test(line)).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #3278

merge-evidence-deferred-final: #3278

## Summary

Aligns the `test-evidence` validator with the methodology-matrix contract (Epic #1875: "the validator parses `+`-separated strategy lists"). Surfaced as a Tier-2 anneal during #3276's Consultant review; **cross-model-verified** as a latent doc/code contract gap (not the originally-framed active false-PASS/FAIL — see the ticket's Cross-Model Verification comment).

- **Validator** (`scripts/global/test-evidence-validator.js`): `validate()` is now composition-aware — for `<primary>+stress-test` it runs the `<primary>` checker (the stress half stays enforced by the separate `stress-evidence` gate); malformed compositions return `unknown-strategy`. Gating dispatch on `CHECKERS[primary]` also makes a bare `stress-test` degrade to `unknown-strategy` instead of throwing (G6).
- **Workflow** (`.github/workflows/test-evidence.yml`): the `test_strategy` capture regex now includes `+` (`[a-z+-]+`) so the composed value is no longer silently truncated — removing the accidental-truncation fragility.
- **Tests** (`tests/test-evidence-validator.spec.js`): +8 fixtures (AC1–AC4) incl. a doclint asserting the workflow regex includes `+`; 23 prior fixtures stay green (31 passed).

## Verification

- Cross-model verification: 4-rater non-Anthropic panel — VERIFIED (latent contract gap), `fix_warranted` 4/4.
- Implementation preflight: **ACCEPT 9/10** (cerebras-gpt-oss-120b + qwen3-32b@groq), hallucination_risk low.
- `npx playwright test tests/test-evidence-validator.spec.js` → 31 passed. `npm run lint` → 625 files, all ≤100 lines.
- Stress half unchanged: `stress-evidence.yml` → `stress-evidence-check.js` L13 still splits on `+`.

## Baton artifacts (on #3278)

MANAGER_HANDOFF, EDD, COLLABORATOR_HANDOFF (per-AC PASS + cross-family preflight) posted; ADMIN_HANDOFF to follow; CONSULTANT_CLOSEOUT deferred-final (Consultant closes #3278 after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
