### PR TITLE
feat(governance): issue-only closeout evidence schema

### DIFF
--- a/.changes/unreleased/2266.md
+++ b/.changes/unreleased/2266.md
@@ -1,0 +1,7 @@
+### Issue-only closeout evidence schema for `lane:no-code-remediation` (#2266)
+
+`consultant-closeout` now enforces a positive evidence schema on no-code-remediation
+closeouts: the CONSULTANT_CLOSEOUT must explicitly declare `N/A` for the PR, merge, CI,
+and deploy surfaces it skips (previously these were only silently exempted by surrounding
+validators). Gated strictly on the `lane:no-code-remediation` label, so code-change
+closeouts are unaffected; `NO_CODE_EVIDENCE_SCHEMA_ADVISORY=1` is the rollback.

--- a/docs/howto/no-code-remediation-workflow.md
+++ b/docs/howto/no-code-remediation-workflow.md
@@ -35,6 +35,25 @@ Use explicit reduced markers:
 - `COLLABORATOR_HANDOFF: N/A - no-code remediation lane`
 - `ADMIN_HANDOFF: N/A - no-code remediation lane`
 
+### Issue-only closeout evidence schema (#2266)
+
+For a `lane:no-code-remediation` ticket the CONSULTANT_CLOSEOUT MUST **explicitly
+declare `N/A`** for every delivery surface the lane skips, so "no evidence existed"
+is never confused with "evidence was silently omitted". All four are required
+(validator: `scripts/global/megalint/consultant-closeout.js#checkIssueOnlyEvidenceSchema`,
+enforced only when the `lane:no-code-remediation` label is present — code-change
+closeouts are unaffected):
+
+- `PR: N/A - <reason>`            (aliases: `pull-request`, `pr-evidence`)
+- `merge-evidence: N/A - <reason>` (alias: `merge`)
+- `CI: N/A - <reason>`            (aliases: `ci-checks`, `checks`)
+- `sync-verification: N/A - <reason>` (aliases: `deploy`, `deploy-runtime-impact`)
+
+The verdict / rubric / `mid_flight_flaws` requirements above still apply in full —
+the schema **adds** the N/A surface declarations, it does not relax the terminal-close
+bar. Rollback: `NO_CODE_EVIDENCE_SCHEMA_ADVISORY=1` demotes the surface checks to
+advisory (never silent).
+
 ## Common False Positives
 
 - Stale advisory label appears on a merged closed ticket.

--- a/scripts/global/megalint/consultant-closeout.js
+++ b/scripts/global/megalint/consultant-closeout.js
@@ -164,6 +164,47 @@ function checkCrossFamilyVerdict(body) {
   return [];
 }
 
+// #2266: positive issue-only closeout evidence schema for `lane:no-code-remediation`.
+// Epic #2258's no-code lane shipped via #2264/#2265/#2268, but the surrounding validators
+// (merge-evidence, admin-handoff, branch-name) only *silently exempt* the issue-only lane.
+// This turns that silent exemption into an EXPLICIT, auditable declaration: a no-code
+// CONSULTANT_CLOSEOUT must positively state `N/A` for each surface it skips (PR, merge,
+// CI, deploy) so "no evidence existed" can never be mistaken for "evidence was omitted".
+// Gated strictly on the authoritative GitHub label (input.labels), never on body text, so
+// a code-change closeout cannot forge the reduced schema (anti-over-accept, #2266 AC5).
+// Non-no-code lanes are a no-op (#2266 AC4). Verdict/rubric/flaw fields stay required for
+// ALL lanes via the universal checks in validate() (#2266 AC3).
+const NO_CODE_REMEDIATION_LANE = 'lane:no-code-remediation';
+const ISSUE_ONLY_NA_SURFACES = Object.freeze([
+  { key: 'pr',     label: 'PR',     re: /(?:^|\n)[ \t]*(?:pr|pull[- ]?request|pr-evidence)[ \t]*:[ \t]*n\/?a\b/i },
+  { key: 'merge',  label: 'merge',  re: /(?:^|\n)[ \t]*merge(?:[- ]?evidence)?[ \t]*:[ \t]*n\/?a\b/i },
+  { key: 'ci',     label: 'CI',     re: /(?:^|\n)[ \t]*(?:ci|ci[- ]?checks|checks)[ \t]*:[ \t]*n\/?a\b/i },
+  { key: 'deploy', label: 'deploy', re: /(?:^|\n)[ \t]*(?:deploy|deploy[- ]?runtime[- ]?impact|sync[- ]?verification)[ \t]*:[ \t]*n\/?a\b/i },
+]);
+
+// checkIssueOnlyEvidenceSchema — #2266 AC1/AC2. Returns one violation per surface whose
+// explicit N/A declaration is missing on a lane:no-code-remediation closeout.
+function checkIssueOnlyEvidenceSchema(body, input) {
+  const labels = (input && input.labels) || [];
+  if (!labels.includes(NO_CODE_REMEDIATION_LANE)) return [];
+  const advisory = process.env.NO_CODE_EVIDENCE_SCHEMA_ADVISORY === '1';
+  const text = typeof body === 'string' ? body : '';
+  return ISSUE_ONLY_NA_SURFACES
+    .filter(surface => !surface.re.test(text))
+    .map(surface => {
+      const violation = {
+        rule: `issue-only-${surface.key}-na-missing`,
+        detail: `lane:no-code-remediation CONSULTANT_CLOSEOUT must explicitly declare `
+          + `\`${surface.label}: N/A\` — issue-only remediation has no ${surface.label} surface, `
+          + `and silent omission is not accepted. See #2266 and `
+          + `docs/howto/no-code-remediation-workflow.md. `
+          + `Rollback: NO_CODE_EVIDENCE_SCHEMA_ADVISORY=1 demotes to advisory.`,
+      };
+      if (advisory) violation.severity = 'advisory';
+      return violation;
+    });
+}
+
 function validate(input) {
   const closeout = findConsultantCloseout(input.comments || []);
   if (!closeout) {
@@ -183,6 +224,7 @@ function validate(input) {
     ...checkCrossFamilyVerdict(body),
     ...checkFleetBundleProvenance(body, input),
     ...checkCrossRuntimeWritesPending(input.comments),
+    ...checkIssueOnlyEvidenceSchema(body, input),
     ...wtGate.checkConsultant(body, input),
   ];
   return { ok: violations.filter(v => v.severity !== 'advisory').length === 0, violations, found: true };
@@ -197,4 +239,5 @@ module.exports = {
   checkMemoryNoteRecurrence,
   checkRubricVerdictConsistency,
   checkCrossRuntimeWritesPending,
+  checkIssueOnlyEvidenceSchema,
 };

--- a/tests/issue-only-closeout-evidence-schema.spec.js
+++ b/tests/issue-only-closeout-evidence-schema.spec.js
@@ -1,0 +1,146 @@
+'use strict';
+// Tests for #2266: positive issue-only closeout evidence schema in consultant-closeout.js.
+// Lane:no-code-remediation closeouts must explicitly declare N/A for PR, merge, CI, deploy.
+// Strategy: tdd-pyramid (scripts/global/megalint validator) per test-methodology-matrix.
+// node:test + node:assert — exercises the real blocking path, no mocks.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  checkIssueOnlyEvidenceSchema,
+  validate,
+} = require('../scripts/global/megalint/consultant-closeout');
+
+const NO_CODE = ['type:task', 'lane:no-code-remediation', 'status:review'];
+const CODE_CHANGE = ['type:task', 'lane:code-change', 'status:review'];
+
+// A closeout body that declares all four issue-only N/A surfaces.
+function issueOnlyBody(overrides = '') {
+  return [
+    'CONSULTANT_CLOSEOUT',
+    'verdict: approve_for_merge',
+    'G1: 8 G2: 8 G3: 8 G4: 8 G5: 8 G6: 8 G7: 8 G8: 8 G9: 8',
+    'verification-timestamp: 2026-06-26T12:00:00Z',
+    'PR: N/A - no-code remediation lane',
+    'merge-evidence: N/A - issue-only',
+    'CI: N/A - no repository diff',
+    'sync-verification: N/A - change does not touch deployed runtime targets',
+    'Signed-by: Orla Vale',
+    'Team&Model: claude-code:claude-opus-4-8@local',
+    'Role: consultant',
+    'anneal_tickets_filed: none',
+    'mid_flight_flaws: none',
+    overrides,
+  ].join('\n');
+}
+
+const makeComments = body => [{ body }];
+
+// ---------------------------------------------------------------------------
+// Unit: checkIssueOnlyEvidenceSchema
+// ---------------------------------------------------------------------------
+
+test('AC1/AC2: no-code lane + all four N/A surfaces declared → no violations', () => {
+  const viols = checkIssueOnlyEvidenceSchema(issueOnlyBody(), { labels: NO_CODE });
+  assert.strictEqual(viols.length, 0, `unexpected: ${viols.map(v => v.rule).join(', ')}`);
+});
+
+test('AC2: no-code lane + missing CI N/A → one blocking violation', () => {
+  const body = issueOnlyBody().replace(/CI: N\/A.*\n/, '');
+  const viols = checkIssueOnlyEvidenceSchema(body, { labels: NO_CODE });
+  const rules = viols.map(v => v.rule);
+  assert.deepStrictEqual(rules, ['issue-only-ci-na-missing']);
+  assert.strictEqual(viols[0].severity, undefined, 'must be hard-blocking by default');
+});
+
+test('AC2: no-code lane + zero N/A surfaces → all four surfaces flagged', () => {
+  const viols = checkIssueOnlyEvidenceSchema('CONSULTANT_CLOSEOUT\nverdict: approve', { labels: NO_CODE });
+  const rules = viols.map(v => v.rule).sort();
+  assert.deepStrictEqual(rules, [
+    'issue-only-ci-na-missing',
+    'issue-only-deploy-na-missing',
+    'issue-only-merge-na-missing',
+    'issue-only-pr-na-missing',
+  ]);
+});
+
+test('AC4: code-change lane → no issue-only requirement even with surfaces absent', () => {
+  const viols = checkIssueOnlyEvidenceSchema('CONSULTANT_CLOSEOUT\nverdict: approve', { labels: CODE_CHANGE });
+  assert.strictEqual(viols.length, 0, 'code-change lane must be untouched');
+});
+
+test('AC5 anti-forgery: label absent but body claims the lane → schema NOT applied', () => {
+  // Detection is gated on the authoritative label, never on body text, so a closeout
+  // that merely writes "lane: no-code-remediation" in prose cannot claim the reduced schema.
+  const body = 'CONSULTANT_CLOSEOUT\nlane: lane:no-code-remediation\nverdict: approve';
+  const viols = checkIssueOnlyEvidenceSchema(body, { labels: CODE_CHANGE });
+  assert.strictEqual(viols.length, 0, 'body-claimed lane must not trigger the reduced schema');
+});
+
+test('alias forms accepted: pull-request / merge / checks / deploy-runtime-impact', () => {
+  const body = [
+    'pull-request: N/A',
+    'merge: N/A',
+    'checks: N/A',
+    'deploy-runtime-impact: N/A',
+  ].join('\n');
+  const viols = checkIssueOnlyEvidenceSchema(body, { labels: NO_CODE });
+  assert.strictEqual(viols.length, 0, `aliases should satisfy: ${viols.map(v => v.rule).join(', ')}`);
+});
+
+test('rollback: NO_CODE_EVIDENCE_SCHEMA_ADVISORY=1 demotes violations to advisory', () => {
+  const prev = process.env.NO_CODE_EVIDENCE_SCHEMA_ADVISORY;
+  process.env.NO_CODE_EVIDENCE_SCHEMA_ADVISORY = '1';
+  try {
+    const viols = checkIssueOnlyEvidenceSchema('CONSULTANT_CLOSEOUT', { labels: NO_CODE });
+    assert.strictEqual(viols.length, 4);
+    for (const v of viols) assert.strictEqual(v.severity, 'advisory');
+  } finally {
+    if (prev === undefined) delete process.env.NO_CODE_EVIDENCE_SCHEMA_ADVISORY;
+    else process.env.NO_CODE_EVIDENCE_SCHEMA_ADVISORY = prev;
+  }
+});
+
+test('non-string body / missing input → no throw, no false pass', () => {
+  assert.doesNotThrow(() => checkIssueOnlyEvidenceSchema(null, { labels: NO_CODE }));
+  assert.strictEqual(checkIssueOnlyEvidenceSchema(null, { labels: NO_CODE }).length, 4);
+  assert.doesNotThrow(() => checkIssueOnlyEvidenceSchema('x', undefined));
+  assert.strictEqual(checkIssueOnlyEvidenceSchema('x', undefined).length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Integration: validate() end-to-end
+// ---------------------------------------------------------------------------
+
+test('AC1: validate() ok:true for complete issue-only closeout on no-code lane', () => {
+  const result = validate({ comments: makeComments(issueOnlyBody()), labels: NO_CODE, lane: 'lane:no-code-remediation' });
+  const hard = (result.violations || []).filter(v => v.severity !== 'advisory');
+  assert.strictEqual(hard.length, 0, `unexpected hard violations: ${hard.map(v => v.rule).join(', ')}`);
+  assert.strictEqual(result.ok, true);
+});
+
+test('AC1: validate() ok:false when no-code closeout omits a surface N/A', () => {
+  const body = issueOnlyBody().replace(/merge-evidence: N\/A.*\n/, '');
+  const result = validate({ comments: makeComments(body), labels: NO_CODE, lane: 'lane:no-code-remediation' });
+  assert.strictEqual(result.ok, false);
+  assert.ok((result.violations || []).some(v => v.rule === 'issue-only-merge-na-missing'));
+});
+
+test('AC3: verdict/rubric/flaw fields still required on the no-code lane', () => {
+  // Drop the flaw fields but keep all four N/A surfaces — universal checks must still fail.
+  const body = issueOnlyBody().replace(/anneal_tickets_filed: none\n/, '').replace(/mid_flight_flaws: none\n?/, '');
+  const result = validate({ comments: makeComments(body), labels: NO_CODE, lane: 'lane:no-code-remediation' });
+  assert.strictEqual(result.ok, false, 'flaw fields remain mandatory in the reduced lane');
+  const rules = (result.violations || []).map(v => v.rule);
+  assert.ok(rules.includes('missing-anneal-tickets-filed') || rules.includes('missing-mid-flight-flaws'));
+});
+
+test('AC4: validate() unaffected for code-change closeout missing N/A surfaces', () => {
+  // Same body minus the N/A lines, but lane is code-change → no issue-only violations.
+  const body = issueOnlyBody()
+    .replace(/PR: N\/A.*\n/, '').replace(/merge-evidence: N\/A.*\n/, '')
+    .replace(/CI: N\/A.*\n/, '').replace(/sync-verification: N\/A.*\n/, '');
+  const result = validate({ comments: makeComments(body), labels: CODE_CHANGE, lane: 'lane:code-change', isEpic: false });
+  const issueOnly = (result.violations || []).filter(v => v.rule.startsWith('issue-only-'));
+  assert.strictEqual(issueOnly.length, 0, 'code-change lane must carry no issue-only violations');
+});

--- a/tests/stress-issue-only-closeout-evidence.spec.js
+++ b/tests/stress-issue-only-closeout-evidence.spec.js
@@ -1,0 +1,66 @@
+'use strict';
+// Stress/adversarial coverage for #2266 issue-only closeout evidence schema.
+// Strategy: stress-test (second strategy alongside tdd-pyramid) per test-methodology-matrix —
+// consultant-closeout parses untrusted issue-comment text (adversarial-input parser).
+// Asserts (1) a fault-injection / adversarial corpus path (G6) and (2) a p99 latency budget (G7).
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { checkIssueOnlyEvidenceSchema } = require('../scripts/global/megalint/consultant-closeout');
+
+const NO_CODE = ['lane:no-code-remediation'];
+const CODE = ['lane:code-change'];
+
+// Non-BMP / control bytes built in-code so no literal control chars live in the source.
+const WEIRD = String.fromCharCode(0xFFFF) + String.fromCharCode(0x200B);
+
+// ---------------------------------------------------------------------------
+// (1) Adversarial / fault-injection corpus — must never throw, never over-accept.
+// ---------------------------------------------------------------------------
+
+const ADVERSARIAL_BODIES = [
+  '',                                                  // empty
+  WEIRD + 'PR: N/A',                                   // non-BMP / zero-width bytes
+  'x_pr: N/A\nx_merge: N/A\nx_ci: N/A\nx_deploy: N/A', // prefix-spoof keys must NOT satisfy
+  'PRN/A merge N/A',                                   // missing colons → not declarations
+  'pr:N/Aevil'.repeat(5000),                           // pathological repetition (ReDoS probe)
+  'PR: NOT-APPLICABLE\nmerge: none\nCI: skip\ndeploy: skip', // near-miss values, not N/A
+  '```\nPR: N/A\nmerge: N/A\nCI: N/A\ndeploy: N/A\n```',     // fenced block (still line-matched)
+  'a'.repeat(200000),                                  // very long single line
+];
+
+test('adversarial corpus: never throws, prefix-spoofed keys never satisfy the schema', () => {
+  for (const body of ADVERSARIAL_BODIES) {
+    assert.doesNotThrow(() => checkIssueOnlyEvidenceSchema(body, { labels: NO_CODE }), `threw on: ${body.slice(0, 24)}`);
+  }
+  // Prefix-spoofed keys (x_pr:) must leave all four surfaces unsatisfied.
+  const spoof = checkIssueOnlyEvidenceSchema('x_pr: N/A\nx_merge: N/A\nx_ci: N/A\nx_deploy: N/A', { labels: NO_CODE });
+  assert.strictEqual(spoof.length, 4, 'prefixed keys must not be accepted as surface declarations');
+  // Near-miss non-N/A values must also be rejected.
+  const nearMiss = checkIssueOnlyEvidenceSchema('PR: NOT-APPLICABLE\nmerge: none\nCI: skip\ndeploy: skip', { labels: NO_CODE });
+  assert.strictEqual(nearMiss.length, 4, 'values other than N/A must not satisfy the schema');
+});
+
+test('adversarial: forged code-change closeout claiming issue-only lane in body is rejected', () => {
+  // The label is authoritative; a body that fabricates the lane gets no reduced schema.
+  const forged = 'CONSULTANT_CLOSEOUT\nlane: lane:no-code-remediation\nPR: N/A (forged)';
+  assert.strictEqual(checkIssueOnlyEvidenceSchema(forged, { labels: CODE }).length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// (2) Perf budget — p99 latency under adversarial load (G7 SLO assertion).
+// ---------------------------------------------------------------------------
+
+test('p99 latency budget: <= 5ms per call across 2000 adversarial iterations', () => {
+  const body = 'pr:N/Aevil'.repeat(2000) + '\nmerge: N/A\nCI: N/A\ndeploy: N/A';
+  const samples = [];
+  for (let i = 0; i < 2000; i++) {
+    const t0 = process.hrtime.bigint();
+    checkIssueOnlyEvidenceSchema(body, { labels: NO_CODE });
+    const t1 = process.hrtime.bigint();
+    samples.push(Number(t1 - t0) / 1e6); // ms
+  }
+  samples.sort((a, b) => a - b);
+  const p99 = samples[Math.floor(samples.length * 0.99)];
+  assert.ok(p99 <= 5, `p99 latency ${p99.toFixed(3)}ms exceeded 5ms budget (ReDoS / pathological-input regression)`);
+});


### PR DESCRIPTION
Refs #2266
merge-evidence-deferred-final: #2266

## Summary

Closes the residual gap in Epic #2258's no-code-remediation lane. The lane's contract, eligibility rules, and docs shipped (#2264 / #2265 / #2268), but the issue-only closeout **evidence schema** was only *silently exempted* by neighbouring validators. This PR makes the exemption an **explicit, auditable declaration**: a `lane:no-code-remediation` CONSULTANT_CLOSEOUT must positively declare `N/A` for the PR, merge, CI, and deploy surfaces it skips.

- New `checkIssueOnlyEvidenceSchema` in `scripts/global/megalint/consultant-closeout.js`, gated strictly on `input.labels` (anti-forgery — a code-change closeout cannot claim the reduced schema).
- Rollback: `NO_CODE_EVIDENCE_SCHEMA_ADVISORY=1`.
- Tests: `tests/issue-only-closeout-evidence-schema.spec.js` (unit) + `tests/stress-issue-only-closeout-evidence.spec.js` (adversarial corpus + p99 latency). 15 pass / 0 fail.
- Docs: `docs/howto/no-code-remediation-workflow.md` + changelog fragment `.changes/unreleased/2266.md`.

## Baton artifacts (full set on #2266)

- MANAGER_HANDOFF: posted on #2266 (scope, lane:code-change, test_strategy tdd-pyramid+stress-test, overlap_decision, worktree_branch).
- COLLABORATOR_HANDOFF: posted on #2266 — per-AC PASS, doc-coverage block, cross_family_rating: 9/10 ACCEPT (qwen2.5-coder:7b@fleet, non-Anthropic cross-family).
- ADMIN_HANDOFF: posted on #2266 — branch/commit, signer-independence PASS, deploy-runtime-impact.
- CONSULTANT_CLOSEOUT: to follow at review (deferred-final flow).

## Drift remediation performed at pickup

- #2266 was `status:queued` against a `status:backlog` Epic (Rule E6 violation) → advanced; Epic #2258 → `status:in-progress`.
- Added native Sub-issue link #2266 → Epic #2258 (was prose `Refs Epic` only).

## Test strategy

tdd-pyramid+stress-test. Stress spec asserts a fault-injection/adversarial path (ReDoS probe, prefix-spoof + near-miss rejection) and a p99 ≤ 5ms latency budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
