### PR TITLE
feat(governance): promote doc-coverage diff-miss to blocking

### DIFF
--- a/.changes/unreleased/3122.md
+++ b/.changes/unreleased/3122.md
@@ -1,0 +1,13 @@
+### Governance — doc-coverage diff-membership check promoted to blocking (#3122)
+
+The `doc-coverage-updated-not-in-diff` check (wired advisory-first in #3121) is now
+**blocking**, gated on a replay-eval calibration rather than a calendar: a surface declared
+`UPDATED`/`DONE` that no file in the PR diff covers fails the gate once
+`npm run doc-coverage:replay-eval` precision reaches the 0.85 floor against
+`tests/fixtures/doc-coverage-diff-corpus.json`, and auto-reverts to advisory below it.
+Rollback via `DOC_COVERAGE_DIFF_BLOCKING_DISABLED=1`.
+
+Also wires the previously-dead `#2716` `structuralCheck` into the live doc-coverage caller
+as a second, always-advisory `doc-coverage-surface-substandard` signal (stub / header-less
+declared surfaces), and removes the never-reached `checkRuntimePaths` + `RUNTIME_DOC_ROOTS`
+from the module (the phantom-completion class Epic #2707 surfaced).

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ the Worker: add `MEGINGJORD_HAMR_ENABLED=1` to your `.env`.
 | `deps:render` | `node scripts/global/dep-graph-render.js` |
 | `deps:review` | `node scripts/global/dep-proposals-review.js` |
 | `dispatch:progress:test` | `node --test tests/dispatch-progress.spec.js tests/cascade-observability.spec.js` |
+| `doc-coverage:replay-eval` | `node scripts/global/megalint/doc-coverage-diff-replay-eval.js` |
+| `doc-coverage:replay-eval:test` | `node --test tests/doc-coverage-diff-replay-eval.spec.js tests/doc-coverage-diff-wiring.spec.js tests/doc-coverage-diff-stress.spec.js` |
 | `doc-graph` | `node scripts/global/doc-graph-builder.js` |
 | `doc-plane:lint` | `node scripts/global/doc-plane-boundary-lint.js` |
 | `docs:anchors` | `node scripts/global/docs-anchors.js` |

--- a/docs/howto/merge-time-doc-governance.md
+++ b/docs/howto/merge-time-doc-governance.md
@@ -37,7 +37,7 @@ doc-coverage:
 
 The validator (`scripts/global/megalint/doc-coverage.js`) parses the block. The gate is now a **hard block** (#2712; the old `DOC_COVERAGE_GATE_ADVISORY` escape hatch was removed). The lane is **derived from the issue labels** (#3016), so a builder-produced handoff is gated correctly. A missing or incomplete block on a gated lane **fails the merge**.
 
-Lanes that skip the gate: `lane:docs-research` and `lane:config-only` (no required project-doc surface). The #3121 diff-verification check — declared `UPDATED` surfaces must actually appear in the PR diff — ships advisory-first and promotes per the replay-eval-gated model.
+Lanes that skip the gate: `lane:docs-research` and `lane:config-only` (no required project-doc surface). The #3121 diff-verification check — declared `UPDATED` surfaces must actually appear in the PR diff — is **blocking** as of #3122: the `doc-coverage-updated-not-in-diff` violation is promoted from advisory to error once `npm run doc-coverage:replay-eval` precision reaches the 0.85 floor against `tests/fixtures/doc-coverage-diff-corpus.json`, auto-reverting to advisory below it. Rollback: `DOC_COVERAGE_DIFF_BLOCKING_DISABLED=1`. A second, always-advisory `doc-coverage-surface-substandard` signal (the now-wired #2716 `structuralCheck`) flags a declared file surface that is in the diff but a stub / header-less.
 
 ## 5. The doc-coverage matrix
 

--- a/package.json
+++ b/package.json
@@ -335,7 +335,9 @@
     "hamr:evidence-diag": "node -e \"const d=require('./scripts/global/governance-evidence-diag');console.log(JSON.stringify(d.diagnoseEvidence(process.argv[1],[])))\"",
     "hamr:offload-kpi": "node scripts/global/hamr-offload-kpi.js",
     "hamr:offload-kpi:test": "npx playwright test tests/hamr-offload-kpi.spec.js tests/hamr-epic-parity.spec.js",
-    "hamr:epic-3008:test": "npx playwright test tests/hamr-tool-policy.spec.js tests/governance-evidence-bridge.spec.js tests/hamr-offload-kpi.spec.js tests/cascade-context-integration.spec.js tests/hamr-epic-parity.spec.js"
+    "hamr:epic-3008:test": "npx playwright test tests/hamr-tool-policy.spec.js tests/governance-evidence-bridge.spec.js tests/hamr-offload-kpi.spec.js tests/cascade-context-integration.spec.js tests/hamr-epic-parity.spec.js",
+    "doc-coverage:replay-eval": "node scripts/global/megalint/doc-coverage-diff-replay-eval.js",
+    "doc-coverage:replay-eval:test": "node --test tests/doc-coverage-diff-replay-eval.spec.js tests/doc-coverage-diff-wiring.spec.js tests/doc-coverage-diff-stress.spec.js"
   },
   "keywords": [
     "devops",

--- a/scripts/global/megalint/doc-coverage-diff-replay-eval.js
+++ b/scripts/global/megalint/doc-coverage-diff-replay-eval.js
@@ -1,0 +1,92 @@
+'use strict';
+// Refs #3122 (Epic #2707) — replay-eval calibration gating the doc-coverage
+// diff-membership advisory→blocking promotion. Mirrors the test-floor replay-eval
+// model (#3105/#3068): the `doc-coverage-updated-not-in-diff` check may flip from
+// advisory to blocking ONLY when its precision over a LABELED corpus reaches the
+// floor; below it (or via the env kill-switch) it auto-reverts to advisory.
+// Replay-eval-gated, never calendar-gated (#1771/#1827).
+
+const fs = require('fs');
+const path = require('path');
+const { verifyDeclaredSurfaces } = require('./doc-coverage-diff-verify');
+
+// Promotion threshold: blocking only at precision ≥ this floor against the corpus.
+const PROMOTION_PRECISION = 0.85;
+const DEFAULT_CORPUS = path.join(__dirname, '..', '..', '..', 'tests', 'fixtures', 'doc-coverage-diff-corpus.json');
+// G6 rollback: force advisory regardless of corpus precision.
+const DISABLE_ENV = 'DOC_COVERAGE_DIFF_BLOCKING_DISABLED';
+
+// "Positive" = the diff-membership check flags a violation: a surface declared
+// UPDATED/DONE that no changed file in the diff covers.
+function flagsViolation(declared, changedFiles) {
+  // Defensive: a malformed corpus row must degrade, never throw (G6).
+  const surfaces = (Array.isArray(declared) ? declared : []).filter((s) => typeof s === 'string');
+  const files = (Array.isArray(changedFiles) ? changedFiles : []).filter((f) => typeof f === 'string');
+  const result = verifyDeclaredSurfaces(surfaces, null, { changedFiles: files, structural: false });
+  return result.violations.length > 0;
+}
+
+/**
+ * Replay the diff-membership check over a labeled corpus and score precision/recall.
+ * Each item: { declared: string[], paths: string[], expectedInDiff: boolean }.
+ * expectedInDiff === false means the declared surface SHOULD be flagged (a true gap).
+ * @returns {{n,truePos,falsePos,trueNeg,falseNeg,precision,recall,promotionEligible}}
+ */
+function replayEval(corpus) {
+  const c = { truePos: 0, falsePos: 0, trueNeg: 0, falseNeg: 0 };
+  for (const raw of corpus || []) {
+    const item = raw || {};
+    const predictedGap = flagsViolation(item.declared, item.paths);
+    const actualGap = item.expectedInDiff === false;
+    if (predictedGap && actualGap) c.truePos += 1;
+    else if (predictedGap && !actualGap) c.falsePos += 1;
+    else if (!predictedGap && !actualGap) c.trueNeg += 1;
+    else c.falseNeg += 1;
+  }
+  const precisionDenom = c.truePos + c.falsePos;
+  const recallDenom = c.truePos + c.falseNeg;
+  const precision = precisionDenom ? c.truePos / precisionDenom : 1;
+  const recall = recallDenom ? c.truePos / recallDenom : 1;
+  return { n: (corpus || []).length, ...c,
+    precision: Number(precision.toFixed(4)), recall: Number(recall.toFixed(4)),
+    promotionEligible: precision >= PROMOTION_PRECISION };
+}
+
+function loadCorpus(file = DEFAULT_CORPUS) { return JSON.parse(fs.readFileSync(file, 'utf8')); }
+
+// Live promotion decision consumed by the doc-coverage gate. Computed from the
+// committed corpus each process (so it AUTO-REVOKES the instant corpus precision
+// regresses below the floor); env kill-switch forces advisory; missing/unreadable
+// corpus fails SAFE to advisory.
+let _cache;
+function isBlockingPromoted(opts = {}) {
+  if (process.env[DISABLE_ENV] === '1') return false;
+  if (opts.corpus) return replayEval(opts.corpus).promotionEligible;
+  if (_cache === undefined) {
+    try { _cache = replayEval(loadCorpus(opts.corpusFile)).promotionEligible; }
+    catch (_) { _cache = false; }
+  }
+  return _cache;
+}
+
+// Severity the doc-coverage gate should attach to a diff-membership violation.
+function diffSeverity(opts = {}) { return isBlockingPromoted(opts) ? 'error' : 'advisory'; }
+
+// Test seam: drop the cached promotion decision so a fresh env/corpus is re-read.
+function _resetCache() { _cache = undefined; }
+
+function runCli(argv) {
+  const file = (argv.find((a) => a.startsWith('--corpus=')) || '').split('=')[1] || DEFAULT_CORPUS;
+  const result = replayEval(loadCorpus(file));
+  if (argv.includes('--json')) { process.stdout.write(JSON.stringify(result, null, 2) + '\n'); return 0; }
+  process.stdout.write(`doc-coverage diff replay-eval over ${result.n} cases: precision=${result.precision} recall=${result.recall}\n`);
+  process.stdout.write(result.promotionEligible
+    ? `✓ promotion-eligible (precision >= ${PROMOTION_PRECISION}) — diff-membership check BLOCKS\n`
+    : `⚠ not promotion-eligible (precision < ${PROMOTION_PRECISION}) — stays advisory\n`);
+  return 0;
+}
+
+if (require.main === module) { process.exit(runCli(process.argv.slice(2))); }
+
+module.exports = { PROMOTION_PRECISION, DEFAULT_CORPUS, DISABLE_ENV, flagsViolation,
+  replayEval, loadCorpus, isBlockingPromoted, diffSeverity, runCli, _resetCache };

--- a/scripts/global/megalint/doc-coverage-diff-verify.js
+++ b/scripts/global/megalint/doc-coverage-diff-verify.js
@@ -2,18 +2,15 @@
 // Refs #2716 — diff-based surface verification for doc-coverage gate
 // Verifies declared DONE/UPDATED surfaces were actually modified in the PR diff.
 // Execution contexts: local-pre-push, CI, shallow-clone, multi-runtime, doc-only.
+// #3122: removed the never-wired checkRuntimePaths + RUNTIME_DOC_ROOTS (no caller in
+// the issue/PR gate context ever supplied a `runtime`) — the phantom-completion class
+// Epic #2707 surfaced. structuralCheck stays and is now wired by the doc-coverage gate.
 
 const { spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const GIT_DIFF_TIMEOUT_MS = 10000;
 const MIN_DOC_BYTES = 300;
-
-const RUNTIME_DOC_ROOTS = {
-  copilot: ['docs/', 'wiki/', 'instructions/', '.github/copilot-instructions.md'],
-  codex: ['docs/', '.codex/', 'AGENTS.md'],
-  'claude-code': ['docs/', '.claude/', 'CLAUDE.md'],
-};
 
 function isShallowClone(cwd) {
   try { return fs.existsSync(path.join(cwd || process.cwd(), '.git', 'shallow')); }
@@ -38,16 +35,6 @@ function structuralCheck(filePath, cwd) {
   } catch (e) { return { ok: false, reason: e.message }; }
 }
 
-function checkRuntimePaths(violations, declared, runtime) {
-  if (!runtime || !RUNTIME_DOC_ROOTS[runtime]) return;
-  const roots = RUNTIME_DOC_ROOTS[runtime];
-  for (const surface of declared) {
-    if (!roots.some(root => surface.startsWith(root) || surface === root.replace(/\/$/, '')))
-      violations.push({ rule: 'doc-diff-runtime-path-mismatch', severity: 'warning',
-        surface, detail: `not under expected ${runtime} doc roots: ${roots.join(', ')}` });
-  }
-}
-
 // A changed file "covers" a surface when it equals the surface (root file) or sits
 // under it (directory surface). The `/`-boundary guard prevents `docs` matching
 // `docs-other.md` — the unanchored startsWith would over-match. #3121 hardening.
@@ -59,7 +46,7 @@ function surfaceTouched(surface, changed) {
 // #3121: accept a pre-fetched changed-file set (opts.changedFiles) so the check runs in
 // the PR-API-driven CI context (filenames already in hand, no git base / spawn needed).
 function verifyDeclaredSurfaces(declared, base, opts = {}) {
-  const { cwd, runtime, shallow: forceShallow, changedFiles, structural = true } = opts;
+  const { cwd, shallow: forceShallow, changedFiles, structural = true } = opts;
   const shallow = forceShallow !== undefined ? forceShallow : isShallowClone(cwd);
   const violations = [];
   if (shallow && structural) {
@@ -83,10 +70,9 @@ function verifyDeclaredSurfaces(declared, base, opts = {}) {
       violations.push({ rule: 'doc-diff-not-changed', severity: 'error',
         surface, detail: `declared DONE but not in diff${base ? ` vs ${base}` : ''}` });
   }
-  checkRuntimePaths(violations, declared, runtime);
   return { ok: violations.filter(viol => viol.severity === 'error').length === 0,
     violations, mode: 'diff-verify' };
 }
 
 module.exports = { verifyDeclaredSurfaces, structuralCheck, getChangedFiles,
-  isShallowClone, surfaceTouched, RUNTIME_DOC_ROOTS };
+  isShallowClone, surfaceTouched };

--- a/scripts/global/megalint/doc-coverage.js
+++ b/scripts/global/megalint/doc-coverage.js
@@ -3,7 +3,9 @@
 // DOC_COVERAGE_GATE_ADVISORY removed — this gate is now a hard block (#2712)
 const { loadMatrix, parseYamlSurfaces, surfacesForLabels,
   valueViolation } = require('./doc-coverage-helpers');
-const { verifyDeclaredSurfaces } = require('./doc-coverage-diff-verify');
+const { verifyDeclaredSurfaces, structuralCheck,
+  surfaceTouched } = require('./doc-coverage-diff-verify');
+const { diffSeverity } = require('./doc-coverage-diff-replay-eval');
 
 const LANE_SKIP = new Set(['lane:docs-research', 'lane:config-only']);
 
@@ -28,12 +30,13 @@ function findSurfaceValue(block, surface) {
 }
 
 // #3121 (Epic #2707): verify that surfaces declared UPDATED/DONE actually appear in the
-// PR diff. Delegates to the (previously-unwired) #2716 module — single source of truth —
-// running diff-membership only (structural:false) and advisory-first: a declared-but-absent
-// surface is the gaming hole the #3095 handback surfaced, but a hard block would break
-// in-flight PRs, so the check ships advisory and promotes per the replay-eval-gated model.
-// Skipped entirely when prFiles is unavailable (local pre-push / no PR context).
-function diffVerifyViolations(block, requiredSurfaces, prFiles) {
+// PR diff. Delegates to the #2716 module — single source of truth — running diff-membership
+// (structural:false) for the primary signal. #3122: that signal's severity is now PROMOTED
+// from advisory→blocking by the replay-eval gate (`diffSeverity`) once corpus precision
+// reaches the floor, auto-revoking below it. A SECOND, always-advisory structural signal
+// (the now-wired #2716 `structuralCheck`) flags a declared file surface that exists but is
+// a stub / header-less. Skipped entirely when prFiles is unavailable (local pre-push).
+function diffVerifyViolations(block, requiredSurfaces, prFiles, cwd) {
   if (!Array.isArray(prFiles)) return [];
   const declaredUpdated = requiredSurfaces.filter((surface) => {
     const value = findSurfaceValue(block, surface);
@@ -42,12 +45,29 @@ function diffVerifyViolations(block, requiredSurfaces, prFiles) {
   if (!declaredUpdated.length) return [];
   const result = verifyDeclaredSurfaces(declaredUpdated, null,
     { changedFiles: prFiles, structural: false });
-  return result.violations.map((viol) => ({
-    rule: 'doc-coverage-updated-not-in-diff', severity: 'advisory',
+  const severity = diffSeverity(); // AC1: replay-eval-gated advisory→blocking, auto-revoke
+  const diffViol = result.violations.map((viol) => ({
+    rule: 'doc-coverage-updated-not-in-diff', severity,
     detail: `surface "${viol.surface}" declared UPDATED but no matching file is in the PR diff` }));
+  // Structural advisory runs ONLY on surfaces actually in the diff — a not-in-diff surface
+  // is already covered by the diff-membership violation; re-flagging it file-not-found is noise.
+  const changed = new Set(prFiles);
+  const touched = declaredUpdated.filter((surface) => surfaceTouched(surface, changed));
+  return diffViol.concat(structuralAdvisories(touched, cwd));
 }
 
-function checkBlock(body, labels, matrix, changeType, prFiles) {
+// AC2: the previously-dead structuralCheck, now wired as a second advisory. Only file
+// surfaces (have an extension) are checked — directory surfaces have no single doc body.
+function structuralAdvisories(surfaces, cwd) {
+  return surfaces.flatMap((surface) => {
+    if (!/\.\w+$/.test(surface)) return [];
+    const sc = structuralCheck(surface, cwd);
+    return sc.ok ? [] : [{ rule: 'doc-coverage-surface-substandard', severity: 'advisory',
+      detail: `surface "${surface}" declared UPDATED but ${sc.reason}` }];
+  });
+}
+
+function checkBlock(body, labels, matrix, changeType, prFiles, cwd) {
   const expected = surfacesForLabels(labels, matrix, changeType);
   if (!expected.required.length) return [];
   const block = parseDocBlock(body);
@@ -60,7 +80,7 @@ function checkBlock(body, labels, matrix, changeType, prFiles) {
     const violation = valueViolation(surface, value);
     return violation ? [violation] : [];
   });
-  return violations.concat(diffVerifyViolations(block, expected.required, prFiles));
+  return violations.concat(diffVerifyViolations(block, expected.required, prFiles, cwd));
 }
 
 function validate(input) {
@@ -80,13 +100,14 @@ function validate(input) {
   const handoff = (input.comments || []).slice().reverse()
     .find(c => /(^|\n)\s*(?:##\s*)?COLLABORATOR_HANDOFF\b/i.test(c.body || ''));
   const body = handoff ? handoff.body : (input.body || '');
-  const violations = checkBlock(body, input.labels, matrix, changeType, input.prFiles);
-  // Advisory violations (the diff-verification check, advisory-first) surface but do not block.
+  const violations = checkBlock(body, input.labels, matrix, changeType, input.prFiles, input.cwd);
+  // Advisory violations surface but do not block; the diff-membership check blocks only
+  // once #3122's replay-eval gate has promoted it (severity becomes 'error').
   return { ok: violations.every((v) => v.severity === 'advisory'), violations };
 }
 
 module.exports = { validate, loadMatrix, parseYamlSurfaces, surfacesForLabels,
-  parseDocBlock, checkBlock, diffVerifyViolations };
+  parseDocBlock, checkBlock, diffVerifyViolations, structuralAdvisories };
 
 if (require.main === module) {
   const { readFileSync } = require('fs');

--- a/tests/doc-coverage-diff-replay-eval.spec.js
+++ b/tests/doc-coverage-diff-replay-eval.spec.js
@@ -1,0 +1,70 @@
+'use strict';
+// Refs #3122 — unit (tdd-pyramid) for the doc-coverage diff-membership replay-eval
+// promotion gate: scoring, the precision floor, auto-revoke, and the env kill-switch.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const reval = require('../scripts/global/megalint/doc-coverage-diff-replay-eval');
+
+const CORPUS = path.join(__dirname, 'fixtures', 'doc-coverage-diff-corpus.json');
+
+test('replayEval over the committed corpus is promotion-eligible (precision >= 0.85)', () => {
+  const result = reval.replayEval(reval.loadCorpus(CORPUS));
+  assert.ok(result.n >= 10, 'corpus should carry a meaningful number of labeled cases');
+  assert.ok(result.precision >= reval.PROMOTION_PRECISION,
+    `precision ${result.precision} should meet the floor`);
+  assert.strictEqual(result.promotionEligible, true);
+});
+
+test('replayEval scores a known TP and TN correctly', () => {
+  const result = reval.replayEval([
+    { declared: ['docs/x.md'], paths: ['scripts/foo.js'], expectedInDiff: false }, // TP (gap flagged)
+    { declared: ['docs/x.md'], paths: ['docs/x.md'], expectedInDiff: true },        // TN (no gap)
+  ]);
+  assert.strictEqual(result.truePos, 1);
+  assert.strictEqual(result.trueNeg, 1);
+  assert.strictEqual(result.precision, 1);
+});
+
+test('precision below the floor → NOT promotion-eligible (auto-revoke)', () => {
+  // A false positive = the check flags a gap (declared surface absent from the diff)
+  // but the label says there is none (expectedInDiff: true). 1 TP + 4 FP → precision 0.2.
+  const falsePos = (i) => ({ declared: [`docs/fp${i}.md`], paths: ['unrelated.js'],
+    expectedInDiff: true });
+  const corpus = [
+    { declared: ['docs/real.md'], paths: ['unrelated.js'], expectedInDiff: false }, // TP
+    falsePos(1), falsePos(2), falsePos(3), falsePos(4),
+  ];
+  const r = reval.replayEval(corpus);
+  assert.strictEqual(r.truePos, 1);
+  assert.strictEqual(r.falsePos, 4);
+  assert.ok(r.precision < reval.PROMOTION_PRECISION, `precision ${r.precision} should be below floor`);
+  assert.strictEqual(r.promotionEligible, false);
+});
+
+test('diffSeverity is blocking (error) on an eligible corpus, advisory below floor', () => {
+  reval._resetCache();
+  const eligible = reval.loadCorpus(CORPUS);
+  assert.strictEqual(reval.diffSeverity({ corpus: eligible }), 'error');
+  // all false positives → precision 0 → advisory
+  const ineligible = [
+    { declared: ['docs/x.md'], paths: ['unrelated.js'], expectedInDiff: true },
+    { declared: ['docs/y.md'], paths: ['unrelated.js'], expectedInDiff: true },
+  ];
+  assert.strictEqual(reval.diffSeverity({ corpus: ineligible }), 'advisory');
+});
+
+test('env kill-switch forces advisory even on an eligible corpus (G6 rollback)', () => {
+  const eligible = reval.loadCorpus(CORPUS);
+  process.env[reval.DISABLE_ENV] = '1';
+  try {
+    assert.strictEqual(reval.isBlockingPromoted({ corpus: eligible }), false);
+    assert.strictEqual(reval.diffSeverity({ corpus: eligible }), 'advisory');
+  } finally { delete process.env[reval.DISABLE_ENV]; reval._resetCache(); }
+});
+
+test('missing/unreadable corpus fails SAFE to advisory', () => {
+  reval._resetCache();
+  assert.strictEqual(reval.isBlockingPromoted({ corpusFile: '/no/such/corpus.json' }), false);
+  reval._resetCache();
+});

--- a/tests/doc-coverage-diff-stress.spec.js
+++ b/tests/doc-coverage-diff-stress.spec.js
@@ -1,0 +1,59 @@
+'use strict';
+// Refs #3122 — stress-test for the doc-coverage diff-membership replay-eval gate.
+// Per the test-methodology matrix, a stress spec asserts (G6) a fault-injection /
+// chaos path AND (G7) a p99 latency budget. The diff-verify module carries a perf
+// budget (GIT_DIFF_TIMEOUT), so the floor classifier requires stress alongside the
+// tdd-pyramid primary.
+const test = require('node:test');
+const assert = require('node:assert');
+const reval = require('../scripts/global/megalint/doc-coverage-diff-replay-eval');
+
+// G6 — fault injection: malformed/adversarial corpus entries must degrade, never throw.
+test('chaos: malformed corpus entries do not crash replayEval', () => {
+  const garbage = [
+    null,
+    {},
+    { declared: null, paths: null, expectedInDiff: true },
+    { declared: ['docs/x.md'], paths: 'not-an-array', expectedInDiff: false },
+    { declared: 'not-an-array', paths: ['docs/x.md'] },
+    { declared: ['docs/x.md'], paths: ['docs/x.md'], expectedInDiff: 'maybe' },
+    { declared: [42, {}, null], paths: [undefined, 'docs/x.md'] },
+  ];
+  let result;
+  assert.doesNotThrow(() => { result = reval.replayEval(garbage); });
+  assert.strictEqual(result.n, garbage.length);
+  assert.ok(result.precision >= 0 && result.precision <= 1);
+});
+
+test('chaos: undefined/empty corpus is treated as no cases (precision defaults to 1)', () => {
+  for (const input of [undefined, null, []]) {
+    const r = reval.replayEval(input);
+    assert.strictEqual(r.n, 0);
+    assert.strictEqual(r.promotionEligible, true); // vacuous floor, but isBlockingPromoted gates on a real corpus
+  }
+});
+
+test('chaos: isBlockingPromoted fails safe to advisory on an unreadable corpus path', () => {
+  reval._resetCache();
+  assert.strictEqual(reval.isBlockingPromoted({ corpusFile: '/definitely/not/here.json' }), false);
+  reval._resetCache();
+});
+
+// G7 — p99 latency budget: scoring a large corpus must stay well under budget.
+test('perf: replayEval p99 over a 500-case corpus stays under the latency budget', () => {
+  const big = Array.from({ length: 500 }, (_v, i) => ({
+    declared: [`docs/file${i}.md`],
+    paths: i % 2 === 0 ? [`docs/file${i}.md`] : ['scripts/unrelated.js'],
+    expectedInDiff: i % 2 === 0,
+  }));
+  const P99_BUDGET_MS = 250;
+  const samples = [];
+  for (let run = 0; run < 30; run += 1) {
+    const t0 = process.hrtime.bigint();
+    reval.replayEval(big);
+    samples.push(Number(process.hrtime.bigint() - t0) / 1e6);
+  }
+  samples.sort((a, b) => a - b);
+  const p99 = samples[Math.min(samples.length - 1, Math.ceil(0.99 * samples.length) - 1)];
+  assert.ok(p99 < P99_BUDGET_MS, `p99 ${p99.toFixed(1)}ms should be < ${P99_BUDGET_MS}ms`);
+});

--- a/tests/doc-coverage-diff-verify.spec.js
+++ b/tests/doc-coverage-diff-verify.spec.js
@@ -1,17 +1,22 @@
-// tests/doc-coverage-diff-verify.spec.js — #3121, Epic #2707 keystone.
-// Strategy: tdd-pyramid. Wires the previously-unwired #2716 diff-verify module into the
-// live doc-coverage gate (advisory-first), reusing it rather than reimplementing. Covers
-// the #2716 module extension, the doc-coverage delegation, and the collaborator-handoff
-// threading — the full chain that turns dead code into a live advisory gate.
+// tests/doc-coverage-diff-verify.spec.js — #3121 keystone, #3122 promotion.
+// Strategy: tdd-pyramid. Wires the #2716 diff-verify module into the live doc-coverage
+// gate. #3121 shipped it advisory-first; #3122 PROMOTES the diff-membership check to
+// blocking (severity error) once replay-eval precision reaches the floor, with the
+// DOC_COVERAGE_DIFF_BLOCKING_DISABLED env kill-switch reverting it to advisory.
 'use strict';
 
 const { test, expect } = require('@playwright/test');
 const dc = require('../scripts/global/megalint/doc-coverage');
 const diffVerify = require('../scripts/global/megalint/doc-coverage-diff-verify');
+const reval = require('../scripts/global/megalint/doc-coverage-diff-replay-eval');
 const collab = require('../scripts/global/megalint/collaborator-handoff');
 
 const MATRIX = { 'area:test': { required: ['docs/x.md'], suggested: [] } };
 const updatedBlock = '## COLLABORATOR_HANDOFF\ndoc-coverage:\n  docs/x.md: UPDATED — change\n';
+// A real, healthy in-repo doc surface so the wired structuralCheck (AC2) stays quiet.
+const REAL = 'CHANGELOG.md';
+const realMatrix = { 'area:test': { required: [REAL], suggested: [] } };
+const realBlock = `## COLLABORATOR_HANDOFF\ndoc-coverage:\n  ${REAL}: UPDATED — change\n`;
 
 // ── #2716 module: surfaceTouched boundary correctness ──
 
@@ -36,17 +41,27 @@ test('verifyDeclaredSurfaces uses opts.changedFiles without a git base, structur
   expect(hit.violations).toEqual([]);
 });
 
-// ── doc-coverage delegation: diffVerifyViolations ──
+// ── doc-coverage delegation: diffVerifyViolations (#3122 blocking) ──
 
-test('diffVerifyViolations flags a declared-UPDATED surface absent from the diff (advisory)', () => {
+test('diffVerifyViolations BLOCKS a declared-UPDATED surface absent from the diff (#3122)', () => {
+  reval._resetCache();
   const block = { 'docs/x.md': 'UPDATED — y' };
   const violations = dc.diffVerifyViolations(block, ['docs/x.md'], ['scripts/foo.js']);
-  expect(violations).toHaveLength(1);
-  expect(violations[0]).toMatchObject({ rule: 'doc-coverage-updated-not-in-diff', severity: 'advisory' });
+  expect(violations).toHaveLength(1); // not-in-diff surface: structural check is skipped
+  expect(violations[0]).toMatchObject({ rule: 'doc-coverage-updated-not-in-diff', severity: 'error' });
+});
+
+test('diffVerifyViolations kill-switch: absent surface stays advisory when blocking disabled', () => {
+  reval._resetCache();
+  process.env[reval.DISABLE_ENV] = '1';
+  try {
+    const violations = dc.diffVerifyViolations({ 'docs/x.md': 'UPDATED' }, ['docs/x.md'], ['scripts/foo.js']);
+    expect(violations[0]).toMatchObject({ rule: 'doc-coverage-updated-not-in-diff', severity: 'advisory' });
+  } finally { delete process.env[reval.DISABLE_ENV]; reval._resetCache(); }
 });
 
 test('diffVerifyViolations passes when the UPDATED surface is in the diff', () => {
-  expect(dc.diffVerifyViolations({ 'docs/x.md': 'UPDATED' }, ['docs/x.md'], ['docs/x.md'])).toEqual([]);
+  expect(dc.diffVerifyViolations({ [REAL]: 'UPDATED' }, [REAL], [REAL])).toEqual([]);
 });
 
 test('diffVerifyViolations exempts N/A declarations', () => {
@@ -60,27 +75,39 @@ test('diffVerifyViolations skips gracefully when prFiles is unavailable (local v
 
 // ── checkBlock integration (synthetic matrix) ──
 
-test('checkBlock: UPDATED surface not in diff yields an advisory diff-miss', () => {
+test('checkBlock: UPDATED surface not in diff yields a blocking diff-miss (#3122)', () => {
+  reval._resetCache();
   const violations = dc.checkBlock(updatedBlock, ['area:test'], MATRIX, null, ['scripts/foo.js']);
   expect(violations).toHaveLength(1);
-  expect(violations[0]).toMatchObject({ rule: 'doc-coverage-updated-not-in-diff', severity: 'advisory' });
+  expect(violations[0]).toMatchObject({ rule: 'doc-coverage-updated-not-in-diff', severity: 'error' });
 });
 
 test('checkBlock: UPDATED surface in diff yields no violation', () => {
-  expect(dc.checkBlock(updatedBlock, ['area:test'], MATRIX, null, ['docs/x.md'])).toEqual([]);
+  expect(dc.checkBlock(realBlock, ['area:test'], realMatrix, null, [REAL])).toEqual([]);
 });
 
 test('checkBlock: no prFiles (local) skips diff-verification entirely', () => {
   expect(dc.checkBlock(updatedBlock, ['area:test'], MATRIX, null, undefined)).toEqual([]);
 });
 
-// ── validate ok-logic: advisory does not block; errors still do ──
+// ── validate ok-logic: promoted diff-miss blocks; kill-switch reverts to advisory ──
 
-test('validate: an advisory-only diff-miss keeps ok true (does not block)', () => {
+test('validate: a promoted diff-miss BLOCKS (ok false) (#3122)', () => {
+  reval._resetCache();
   const result = dc.validate({ labels: ['area:test'], body: updatedBlock, prFiles: ['scripts/foo.js'], matrix: MATRIX });
   expect(result.violations).toHaveLength(1);
-  expect(result.violations[0].severity).toBe('advisory');
-  expect(result.ok).toBe(true);
+  expect(result.violations[0].severity).toBe('error');
+  expect(result.ok).toBe(false);
+});
+
+test('validate: kill-switch reverts diff-miss to advisory, ok true', () => {
+  reval._resetCache();
+  process.env[reval.DISABLE_ENV] = '1';
+  try {
+    const result = dc.validate({ labels: ['area:test'], body: updatedBlock, prFiles: ['scripts/foo.js'], matrix: MATRIX });
+    expect(result.violations[0].severity).toBe('advisory');
+    expect(result.ok).toBe(true);
+  } finally { delete process.env[reval.DISABLE_ENV]; reval._resetCache(); }
 });
 
 test('validate: a missing required surface (error) still blocks', () => {
@@ -89,9 +116,10 @@ test('validate: a missing required surface (error) still blocks', () => {
   expect(result.violations.some((v) => v.severity === 'error')).toBe(true);
 });
 
-// ── collaborator-handoff threading: the live gate path stays non-blocking on advisory ──
+// ── collaborator-handoff threading: the live gate path now blocks on a diff-miss ──
 
-test('collaborator-handoff: prFiles diff-miss is advisory, gate stays ok', () => {
+test('collaborator-handoff: prFiles diff-miss BLOCKS the gate (#3122)', () => {
+  reval._resetCache();
   const handoff = [
     '## COLLABORATOR_HANDOFF',
     'Signed-by: Orla Harper',
@@ -102,14 +130,16 @@ test('collaborator-handoff: prFiles diff-miss is advisory, gate stays ok', () =>
     'cross_family_reviewer: qwen:32b@fleet',
     'cross_family_findings: ok',
     'doc-coverage:',
-    '  docs/howto/example.md: UPDATED — declared but not in diff',
+    '  README.md: UPDATED — declared but not in diff',
+    '  .changes/unreleased/: N/A out-of-scope',
+    '  docs/howto/: N/A out-of-scope',
   ].join('\n');
   const result = collab.validate({
     labels: ['lane:code-change', 'area:scripts'],
     comments: [{ body: handoff, user: { login: 'tester' } }],
     prFiles: ['scripts/only-this-changed.js'],
   });
-  // any doc-coverage-updated-not-in-diff violation must be advisory (non-blocking)
   const diffMiss = (result.violations || []).filter((v) => v.rule === 'doc-coverage-updated-not-in-diff');
-  diffMiss.forEach((v) => expect(v.severity).toBe('advisory'));
+  expect(diffMiss.length).toBeGreaterThan(0);
+  diffMiss.forEach((v) => expect(v.severity).toBe('error'));
 });

--- a/tests/doc-coverage-diff-wiring.spec.js
+++ b/tests/doc-coverage-diff-wiring.spec.js
@@ -1,0 +1,59 @@
+'use strict';
+// Refs #3122 — proves the gate wiring: AC1 the diff-membership violation is BLOCKING
+// (severity error) once the replay-eval gate promotes it, and AC2 the now-wired
+// structuralCheck advisory fires through the doc-coverage caller (checkBlock).
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const docCoverage = require('../scripts/global/megalint/doc-coverage');
+const reval = require('../scripts/global/megalint/doc-coverage-diff-replay-eval');
+
+test('AC1: diff-membership violation is blocking (error) once promoted', () => {
+  reval._resetCache(); // default committed corpus is promotion-eligible
+  const violations = docCoverage.diffVerifyViolations(
+    { 'docs/x.md': 'UPDATED — note' }, ['docs/x.md'], ['scripts/other.js'], os.tmpdir());
+  const diff = violations.find((v) => v.rule === 'doc-coverage-updated-not-in-diff');
+  assert.ok(diff, 'a diff-membership violation should be emitted for the absent surface');
+  assert.strictEqual(diff.severity, 'error', 'promoted check must block');
+});
+
+test('AC1 rollback: env kill-switch keeps the diff violation advisory', () => {
+  reval._resetCache();
+  process.env[reval.DISABLE_ENV] = '1';
+  try {
+    const violations = docCoverage.diffVerifyViolations(
+      { 'docs/x.md': 'UPDATED — note' }, ['docs/x.md'], ['scripts/other.js'], os.tmpdir());
+    const diff = violations.find((v) => v.rule === 'doc-coverage-updated-not-in-diff');
+    assert.strictEqual(diff.severity, 'advisory');
+  } finally { delete process.env[reval.DISABLE_ENV]; reval._resetCache(); }
+});
+
+test('AC2: structuralCheck is invoked through checkBlock and flags a stub surface (advisory)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doccov-'));
+  fs.mkdirSync(path.join(dir, 'docs'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'docs', 'stub.md'), 'tiny'); // <300 bytes, no headers
+  const matrix = { 'area:governance': { required: ['docs/stub.md'], suggested: [] } };
+  const body = 'doc-coverage:\n  docs/stub.md: UPDATED — wired\n';
+  const violations = docCoverage.checkBlock(
+    body, ['area:governance'], matrix, null, ['docs/stub.md'], dir);
+  const sub = violations.find((v) => v.rule === 'doc-coverage-surface-substandard');
+  assert.ok(sub, 'structuralCheck advisory should fire for the stub surface');
+  assert.strictEqual(sub.severity, 'advisory');
+  assert.match(sub.detail, /too-short|no-section-headers/);
+});
+
+test('AC2: a healthy declared surface produces no structural advisory', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doccov-'));
+  fs.mkdirSync(path.join(dir, 'docs'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'docs', 'good.md'),
+    '# Heading\n\n' + 'x'.repeat(400) + '\n');
+  const advisories = docCoverage.structuralAdvisories(['docs/good.md'], dir);
+  assert.strictEqual(advisories.length, 0);
+});
+
+test('AC2: directory surfaces are skipped by the structural advisory (no false positive)', () => {
+  const advisories = docCoverage.structuralAdvisories(['docs/howto/'], os.tmpdir());
+  assert.strictEqual(advisories.length, 0);
+});

--- a/tests/fixtures/doc-coverage-diff-corpus.json
+++ b/tests/fixtures/doc-coverage-diff-corpus.json
@@ -1,0 +1,14 @@
+[
+  { "label": "declared file present in diff → no gap", "declared": ["docs/howto/x.md"], "paths": ["docs/howto/x.md"], "expectedInDiff": true },
+  { "label": "declared file absent from diff → gap", "declared": ["docs/howto/x.md"], "paths": ["scripts/global/foo.js"], "expectedInDiff": false },
+  { "label": "README declared, changed alongside code → no gap", "declared": ["README.md"], "paths": ["README.md", "src/a.js"], "expectedInDiff": true },
+  { "label": "two declared docs both in diff → no gap", "declared": ["docs/a.md", "docs/b.md"], "paths": ["docs/a.md", "docs/b.md"], "expectedInDiff": true },
+  { "label": "wiki surface declared, unrelated diff → gap", "declared": ["wiki/wisdom/global/concepts/p.md"], "paths": ["other.md"], "expectedInDiff": false },
+  { "label": "directory surface covered by nested change → no gap", "declared": ["docs/howto/"], "paths": ["docs/howto/install.md"], "expectedInDiff": true },
+  { "label": "declared but empty diff → gap", "declared": ["docs/x.md"], "paths": [], "expectedInDiff": false },
+  { "label": "prefix-collision guard: docs declared, docs-other changed → gap", "declared": ["docs/x.md"], "paths": ["docs-other.md"], "expectedInDiff": false },
+  { "label": "changelog fragment declared and present → no gap", "declared": [".changes/unreleased/3122.md"], "paths": [".changes/unreleased/3122.md"], "expectedInDiff": true },
+  { "label": "instructions surface declared, present → no gap", "declared": ["instructions/release-docs-hygiene.instructions.md"], "paths": ["instructions/release-docs-hygiene.instructions.md"], "expectedInDiff": true },
+  { "label": "two declared, one missing → gap", "declared": ["docs/a.md", "docs/b.md"], "paths": ["docs/a.md"], "expectedInDiff": false },
+  { "label": "root file declared and present → no gap", "declared": ["CHANGELOG.md"], "paths": ["CHANGELOG.md"], "expectedInDiff": true }
+]


### PR DESCRIPTION
Refs #3122
Closes #3122

## Summary

Promotes the doc-coverage **diff-membership** check (`doc-coverage-updated-not-in-diff`,
wired advisory-first in #3121) to **blocking**, gated on a replay-eval calibration rather
than a calendar (the established #3105/#3068 model). Also resolves the residual unwired
parts of the #2716 module per goal-lens (Epic #2707 phantom-completion class).

### AC1 — replay-eval-gated advisory→blocking promotion
- New `scripts/global/megalint/doc-coverage-diff-replay-eval.js` scores the check against
  the labeled corpus `tests/fixtures/doc-coverage-diff-corpus.json` (12 cases, precision 1.0).
- `diffSeverity()` promotes the violation to `error` only at precision ≥ 0.85, **auto-reverts**
  to advisory below the floor, and honors the `DOC_COVERAGE_DIFF_BLOCKING_DISABLED=1` rollback.
- New npm script `doc-coverage:replay-eval`.

### AC2 — wire-or-remove the dead #2716 surfaces
- **Wired**: `structuralCheck` now runs through the live doc-coverage caller (on in-diff
  surfaces only) as an always-advisory `doc-coverage-surface-substandard` stub/header check.
- **Removed**: `checkRuntimePaths` + `RUNTIME_DOC_ROOTS` (never reachable — the issue/PR gate
  context supplies no `runtime`).

## Test evidence
- `tests/doc-coverage-diff-replay-eval.spec.js` (6), `tests/doc-coverage-diff-wiring.spec.js` (5),
  `tests/doc-coverage-diff-stress.spec.js` (4: fault-injection + p99 budget) — `node --test` 15 pass.
- `tests/doc-coverage-diff-verify.spec.js` rewritten to the blocking contract — 15 pass (playwright).
- Regression: `tests/collaborator-handoff-*.spec.js` 29 pass; `npm run lint` clean; `test-floor:check` meets floor.

## Baton artifacts
MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, and CONSULTANT_CLOSEOUT are posted on #3122.
Merge evidence: `Closes #3122` (auto-close on merge; Consultant posts CONSULTANT_CLOSEOUT).

test_strategy: tdd-pyramid+stress-test
