### PR TITLE
feat(governance): baton-fsm conformance corpus + CI gate

### DIFF
--- a/.changes/unreleased/3288.md
+++ b/.changes/unreleased/3288.md
@@ -1,0 +1,8 @@
+### baton-fsm conformance corpus + CI gate (Baton Authority Plane W1b) — #3288
+
+Add the conformance corpus (tests/fixtures/baton-fsm-corpus/, generated from the canonical TRANSITIONS
+table with W-method full coverage plus adversarial fixtures), a conformance runner asserting
+byte-identical JS/WASM verdicts, a deployed-WASM-vs-canonical-source integrity diff (fails on mismatch),
+an agent x runtime matrix (JS plus WASM executed; Py/Go/Rust recorded as pending-toolchain, never
+silently skipped), and an advisory baton-fsm-conformance CI gate (promotes to blocking at replay-eval
+precision of 0.85 or higher).

--- a/.github/workflows/baton-fsm-conformance.yml
+++ b/.github/workflows/baton-fsm-conformance.yml
@@ -1,0 +1,42 @@
+name: Baton FSM Conformance
+# ADVISORY gate — promotion to blocking is gated on replay-eval precision
+# >= 0.85 (auto-revoking, not calendar). Refs #3288, Epic #3284.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/global/baton-fsm/**'
+      - 'tests/fixtures/baton-fsm-corpus/**'
+      - 'tests/baton-fsm-conformance.spec.js'
+      - 'tests/baton-fsm-wasm-integrity.spec.js'
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    name: fsm-conformance-advisory
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+
+      - name: Run conformance tests
+        run: node --test tests/baton-fsm-conformance.spec.js
+
+      - name: Run WASM integrity tests
+        run: node --test tests/baton-fsm-wasm-integrity.spec.js
+
+      - name: Generate conformance matrix
+        run: node scripts/global/baton-fsm/conformance-matrix.js
+
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: baton-fsm-conformance-matrix
+          path: generated/baton-fsm-conformance-matrix.json
+          retention-days: 30

--- a/generated/baton-fsm-conformance-matrix.json
+++ b/generated/baton-fsm-conformance-matrix.json
@@ -1,0 +1,302 @@
+{
+  "generated_at": "2026-06-28T04:39:33.351Z",
+  "schema_version": "1.0.0",
+  "conformance_summary": {
+    "total_cases": 163,
+    "js_wasm_byte_identical": true,
+    "all_passed": true
+  },
+  "agents": [
+    "claude-code",
+    "copilot",
+    "codex",
+    "antigravity",
+    "cursor"
+  ],
+  "runtimes_executed": [
+    "js",
+    "wasm"
+  ],
+  "runtimes_pending": [
+    "python",
+    "go",
+    "rust"
+  ],
+  "cells": [
+    {
+      "agent": "claude-code",
+      "runtime": "js",
+      "status": "executed",
+      "total": 163,
+      "passed": 163,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "pass",
+      "note": "All agents consume the same shared baton-fsm core; JS and WASM verdicts are byte-identical by construction."
+    },
+    {
+      "agent": "claude-code",
+      "runtime": "wasm",
+      "status": "executed",
+      "total": 163,
+      "passed": 163,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "pass",
+      "note": "All agents consume the same shared baton-fsm core; JS and WASM verdicts are byte-identical by construction."
+    },
+    {
+      "agent": "claude-code",
+      "runtime": "python",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Python kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "claude-code",
+      "runtime": "go",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Go kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "claude-code",
+      "runtime": "rust",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Rust kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "copilot",
+      "runtime": "js",
+      "status": "executed",
+      "total": 163,
+      "passed": 163,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "pass",
+      "note": "All agents consume the same shared baton-fsm core; JS and WASM verdicts are byte-identical by construction."
+    },
+    {
+      "agent": "copilot",
+      "runtime": "wasm",
+      "status": "executed",
+      "total": 163,
+      "passed": 163,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "pass",
+      "note": "All agents consume the same shared baton-fsm core; JS and WASM verdicts are byte-identical by construction."
+    },
+    {
+      "agent": "copilot",
+      "runtime": "python",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Python kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "copilot",
+      "runtime": "go",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Go kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "copilot",
+      "runtime": "rust",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Rust kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "codex",
+      "runtime": "js",
+      "status": "executed",
+      "total": 163,
+      "passed": 163,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "pass",
+      "note": "All agents consume the same shared baton-fsm core; JS and WASM verdicts are byte-identical by construction."
+    },
+    {
+      "agent": "codex",
+      "runtime": "wasm",
+      "status": "executed",
+      "total": 163,
+      "passed": 163,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "pass",
+      "note": "All agents consume the same shared baton-fsm core; JS and WASM verdicts are byte-identical by construction."
+    },
+    {
+      "agent": "codex",
+      "runtime": "python",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Python kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "codex",
+      "runtime": "go",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Go kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "codex",
+      "runtime": "rust",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Rust kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "antigravity",
+      "runtime": "js",
+      "status": "executed",
+      "total": 163,
+      "passed": 163,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "pass",
+      "note": "All agents consume the same shared baton-fsm core; JS and WASM verdicts are byte-identical by construction."
+    },
+    {
+      "agent": "antigravity",
+      "runtime": "wasm",
+      "status": "executed",
+      "total": 163,
+      "passed": 163,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "pass",
+      "note": "All agents consume the same shared baton-fsm core; JS and WASM verdicts are byte-identical by construction."
+    },
+    {
+      "agent": "antigravity",
+      "runtime": "python",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Python kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "antigravity",
+      "runtime": "go",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Go kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "antigravity",
+      "runtime": "rust",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Rust kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "cursor",
+      "runtime": "js",
+      "status": "executed",
+      "total": 163,
+      "passed": 163,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "pass",
+      "note": "All agents consume the same shared baton-fsm core; JS and WASM verdicts are byte-identical by construction."
+    },
+    {
+      "agent": "cursor",
+      "runtime": "wasm",
+      "status": "executed",
+      "total": 163,
+      "passed": 163,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "pass",
+      "note": "All agents consume the same shared baton-fsm core; JS and WASM verdicts are byte-identical by construction."
+    },
+    {
+      "agent": "cursor",
+      "runtime": "python",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Python kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "cursor",
+      "runtime": "go",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Go kernel port not yet implemented; toolchain pending."
+    },
+    {
+      "agent": "cursor",
+      "runtime": "rust",
+      "status": "pending-toolchain",
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "mismatches": 0,
+      "verdict": "not-executed",
+      "note": "Rust kernel port not yet implemented; toolchain pending."
+    }
+  ]
+}

--- a/scripts/global/baton-fsm/build-wasm.js
+++ b/scripts/global/baton-fsm/build-wasm.js
@@ -350,4 +350,8 @@ function main() {
   });
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { buildWasm };

--- a/scripts/global/baton-fsm/conformance-matrix.js
+++ b/scripts/global/baton-fsm/conformance-matrix.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// conformance-matrix.js — Agent x runtime conformance matrix producer.
+// Executes JS and WASM locally; records python/go/rust as pending-toolchain.
+// Refs #3288, Epic #3284.
+'use strict';
+
+const { writeFileSync, mkdirSync } = require('node:fs');
+const { join } = require('node:path');
+const { runConformance } = require('./conformance-runner');
+
+const AGENTS = Object.freeze([
+  'claude-code', 'copilot', 'codex', 'antigravity', 'cursor',
+]);
+
+const EXECUTED_RUNTIMES = Object.freeze(['js', 'wasm']);
+
+const PENDING_RUNTIMES = Object.freeze([
+  { name: 'python', note: 'Python kernel port not yet implemented; toolchain pending.' },
+  { name: 'go', note: 'Go kernel port not yet implemented; toolchain pending.' },
+  { name: 'rust', note: 'Rust kernel port not yet implemented; toolchain pending.' },
+]);
+
+const MATRIX_OUTPUT_DIR = join(__dirname, '..', '..', '..', 'generated');
+const MATRIX_FILENAME = 'baton-fsm-conformance-matrix.json';
+
+/**
+ * Build a single agent's executed-runtime cell from the conformance result.
+ */
+function buildExecutedCell(agent, runtime, conformanceResult) {
+  return {
+    agent,
+    runtime,
+    status: 'executed',
+    total: conformanceResult.total,
+    passed: conformanceResult.passed,
+    failed: conformanceResult.failed,
+    mismatches: conformanceResult.mismatches,
+    verdict: conformanceResult.failed === 0 ? 'pass' : 'fail',
+    note: 'All agents consume the same shared baton-fsm core; '
+      + 'JS and WASM verdicts are byte-identical by construction.',
+  };
+}
+
+/**
+ * Build a single agent's pending-runtime cell.
+ */
+function buildPendingCell(agent, pendingRuntime) {
+  return {
+    agent,
+    runtime: pendingRuntime.name,
+    status: 'pending-toolchain',
+    total: 0,
+    passed: 0,
+    failed: 0,
+    mismatches: 0,
+    verdict: 'not-executed',
+    note: pendingRuntime.note,
+  };
+}
+
+/**
+ * Build all matrix cells for every agent across executed and pending runtimes.
+ */
+function buildAllCells(conformanceResult) {
+  const cells = [];
+  for (const agent of AGENTS) {
+    for (const runtime of EXECUTED_RUNTIMES) {
+      cells.push(buildExecutedCell(agent, runtime, conformanceResult));
+    }
+    for (const pendingRuntime of PENDING_RUNTIMES) {
+      cells.push(buildPendingCell(agent, pendingRuntime));
+    }
+  }
+  return cells;
+}
+
+/**
+ * Build the matrix summary and metadata envelope.
+ */
+function buildMatrixEnvelope(conformanceResult, cells) {
+  return {
+    generated_at: new Date().toISOString(),
+    schema_version: '1.0.0',
+    conformance_summary: {
+      total_cases: conformanceResult.total,
+      js_wasm_byte_identical: conformanceResult.mismatches === 0,
+      all_passed: conformanceResult.failed === 0,
+    },
+    agents: AGENTS,
+    runtimes_executed: EXECUTED_RUNTIMES,
+    runtimes_pending: PENDING_RUNTIMES.map(function (entry) { return entry.name; }),
+    cells,
+  };
+}
+
+/**
+ * Produce the full agent x runtime conformance matrix.
+ * Returns the matrix object and writes it to a JSON file.
+ */
+async function produceMatrix(corpusDir) {
+  const conformanceResult = await runConformance(corpusDir);
+  const cells = buildAllCells(conformanceResult);
+  const matrix = buildMatrixEnvelope(conformanceResult, cells);
+  mkdirSync(MATRIX_OUTPUT_DIR, { recursive: true });
+  const outputPath = join(MATRIX_OUTPUT_DIR, MATRIX_FILENAME);
+  writeFileSync(outputPath, JSON.stringify(matrix, null, 2) + '\n');
+  return { matrix, outputPath };
+}
+
+if (require.main === module) {
+  produceMatrix().then(function (result) {
+    console.log('Matrix written to: ' + result.outputPath);
+    console.log(JSON.stringify(result.matrix.conformance_summary, null, 2));
+    const executedCount = result.matrix.cells.filter(
+      function (cell) { return cell.status === 'executed'; }
+    ).length;
+    const pendingCount = result.matrix.cells.filter(
+      function (cell) { return cell.status === 'pending-toolchain'; }
+    ).length;
+    console.log('Executed cells: ' + executedCount +
+      ', Pending-toolchain cells: ' + pendingCount);
+  }).catch(function (err) {
+    console.error('Matrix generation failed:', err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { produceMatrix, AGENTS, EXECUTED_RUNTIMES, PENDING_RUNTIMES };

--- a/scripts/global/baton-fsm/conformance-runner.js
+++ b/scripts/global/baton-fsm/conformance-runner.js
@@ -1,0 +1,191 @@
+// conformance-runner.js — Runs corpus cases through JS and WASM kernels.
+// Asserts byte-identical results between runtimes AND vs expected.
+// Refs #3288, Epic #3284.
+'use strict';
+
+const { readFileSync, readdirSync } = require('node:fs');
+const { join } = require('node:path');
+const { decide, unpack, REASON_ILLEGAL_TRANSITION, REASON_NONE } = require('./kernel');
+const { DECISIONS, EVIDENCE_BIT_NAMES } = require('./transitions');
+
+const DEFAULT_CORPUS_DIR = join(
+  __dirname, '..', '..', '..', 'tests', 'fixtures', 'baton-fsm-corpus'
+);
+
+/**
+ * Load all corpus JSON files from a directory.
+ * Returns a flat array of all test cases with their source category.
+ */
+function loadCorpus(corpusDir) {
+  const files = readdirSync(corpusDir).filter(
+    (fileName) => fileName.endsWith('.json')
+  );
+  const allCases = [];
+  for (const fileName of files) {
+    const category = fileName.replace('.json', '');
+    const filePath = join(corpusDir, fileName);
+    const cases = JSON.parse(readFileSync(filePath, 'utf8'));
+    for (const testCase of cases) {
+      allCases.push({ ...testCase, category });
+    }
+  }
+  return allCases;
+}
+
+/**
+ * Map an expected reason string to its numeric reasonCode.
+ */
+function reasonStringToCode(reasonStr) {
+  if (reasonStr === 'none') return REASON_NONE;
+  if (reasonStr === 'illegal-transition') return REASON_ILLEGAL_TRANSITION;
+  // Look up by evidence bit name
+  for (const [bitIdxStr, bitNameStr] of Object.entries(EVIDENCE_BIT_NAMES)) {
+    if (bitNameStr === reasonStr) return parseInt(bitIdxStr, 10);
+  }
+  return -1;
+}
+
+/**
+ * Check a single test case result against expected values.
+ * Returns null on pass, or an error description string on mismatch.
+ */
+function checkExpected(testCase, unpacked) {
+  const expected = testCase.expected;
+  if (unpacked.decision !== expected.decision) {
+    return 'decision: got ' + unpacked.decision + ' want ' + expected.decision;
+  }
+  if (expected.reason) {
+    const expectedReasonCode = reasonStringToCode(expected.reason);
+    if (unpacked.reasonCode !== expectedReasonCode) {
+      return 'reason: got ' + unpacked.reasonName + '(' + unpacked.reasonCode +
+        ') want ' + expected.reason + '(' + expectedReasonCode + ')';
+    }
+  }
+  if (expected.required_next !== undefined) {
+    if (unpacked.requiredNext !== expected.required_next) {
+      return 'required_next: got ' + unpacked.requiredNext +
+        ' want ' + expected.required_next;
+    }
+  }
+  return null;
+}
+
+/**
+ * Run conformance over a corpus directory using JS kernel only.
+ * Returns {total, passed, failed, failures[]}.
+ */
+function runConformanceJsOnly(corpusDir) {
+  const cases = loadCorpus(corpusDir || DEFAULT_CORPUS_DIR);
+  let passed = 0;
+  let failed = 0;
+  const failures = [];
+
+  for (const testCase of cases) {
+    const jsPacked = decide(testCase.state, testCase.event, testCase.evidence);
+    const jsUnpacked = unpack(jsPacked);
+    const errorMsg = checkExpected(testCase, jsUnpacked);
+    if (errorMsg) {
+      failed++;
+      failures.push({ name: testCase.name, category: testCase.category, error: errorMsg });
+    } else {
+      passed++;
+    }
+  }
+
+  return { total: cases.length, passed, failed, mismatches: 0, failures };
+}
+
+/**
+ * Load the WASM kernel decide function from disk.
+ */
+async function loadWasmDecide() {
+  const wasmPath = join(__dirname, 'kernel.wasm');
+  const wasmBytes = readFileSync(wasmPath);
+  const wasmModule = await WebAssembly.instantiate(wasmBytes, {});
+  return wasmModule.instance.exports.decide;
+}
+
+/**
+ * Evaluate one corpus case against both JS and WASM kernels.
+ * Returns null on pass, or a failure descriptor object.
+ */
+function evaluateCase(testCase, wasmDecide) {
+  const jsPacked = decide(testCase.state, testCase.event, testCase.evidence);
+  const wasmPacked = wasmDecide(testCase.state, testCase.event, testCase.evidence);
+  if (jsPacked !== wasmPacked) {
+    return { mismatch: true, error: 'JS/WASM mismatch: js=' + jsPacked + ' wasm=' + wasmPacked };
+  }
+  const errorMsg = checkExpected(testCase, unpack(jsPacked));
+  if (errorMsg) return { mismatch: false, error: errorMsg };
+  return null;
+}
+
+/**
+ * Run full conformance: JS kernel + WASM kernel, check byte-identity and expected.
+ * Returns {total, passed, failed, mismatches, failures[]}.
+ */
+async function runConformance(corpusDir) {
+  const cases = loadCorpus(corpusDir || DEFAULT_CORPUS_DIR);
+  const wasmDecide = await loadWasmDecide();
+  let passed = 0, failed = 0, mismatches = 0;
+  const failures = [];
+  for (const testCase of cases) {
+    const result = evaluateCase(testCase, wasmDecide);
+    if (result) {
+      failed++;
+      if (result.mismatch) mismatches++;
+      failures.push({ name: testCase.name, category: testCase.category, error: result.error });
+    } else {
+      passed++;
+    }
+  }
+  return { total: cases.length, passed, failed, mismatches, failures };
+}
+
+/**
+ * Build a WASM integrity result object.
+ */
+function integrityResult(pass, reason, committedSize, rebuiltSize) {
+  return { pass, reason, committedSize, rebuiltSize };
+}
+
+/**
+ * Find the offset of the first byte where two buffers differ.
+ */
+function findFirstDiffOffset(bufferA, bufferB) {
+  for (let idx = 0; idx < bufferA.length; idx++) {
+    if (bufferA[idx] !== bufferB[idx]) return idx;
+  }
+  return -1;
+}
+
+/**
+ * Verify deployed WASM integrity: rebuild from transitions and compare byte-for-byte
+ * against the committed kernel.wasm. AC3 deployed-WASM integrity check.
+ */
+async function deployedWasmIntegrity() {
+  const { buildWasm } = require('./build-wasm');
+  const committedPath = join(__dirname, 'kernel.wasm');
+  const committedBytes = readFileSync(committedPath);
+  const rebuiltBytes = buildWasm();
+  const cSize = committedBytes.length;
+  const rSize = rebuiltBytes.length;
+  if (cSize !== rSize) {
+    return integrityResult(false, 'size-mismatch: committed=' + cSize + ' rebuilt=' + rSize, cSize, rSize);
+  }
+  if (!committedBytes.equals(rebuiltBytes)) {
+    const diffAt = findFirstDiffOffset(committedBytes, rebuiltBytes);
+    return integrityResult(false, 'byte-mismatch at offset ' + diffAt, cSize, rSize);
+  }
+  return integrityResult(true, 'byte-identical', cSize, rSize);
+}
+
+if (require.main === module) {
+  (async () => {
+    const result = await runConformance();
+    console.log(JSON.stringify(result, null, 2));
+    if (result.failed !== 0) process.exit(1);
+  })();
+}
+
+module.exports = { runConformance, runConformanceJsOnly, deployedWasmIntegrity, loadCorpus };

--- a/scripts/global/baton-fsm/corpus-generate.js
+++ b/scripts/global/baton-fsm/corpus-generate.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// corpus-generate.js — Derives exhaustive W-method conformance corpus from TRANSITIONS.
+// Generates legal, guarded, and adversarial fixture files. Refs #3288, Epic #3284.
+'use strict';
+
+const { writeFileSync, mkdirSync } = require('node:fs');
+const { join } = require('node:path');
+const {
+  STATES, STATE_NAMES, STATE_COUNT,
+  EVENTS, EVENT_NAMES, EVENT_COUNT,
+  EVIDENCE_BITS, EVIDENCE_BIT_NAMES,
+  DECISIONS,
+  TRANSITIONS, TERMINAL_STATES,
+} = require('./transitions');
+const { decide, unpack, REASON_ILLEGAL_TRANSITION } = require('./kernel');
+
+const CORPUS_DIR = join(__dirname, '..', '..', '..', 'tests', 'fixtures', 'baton-fsm-corpus');
+
+/**
+ * Return an array of individual bit positions present in a mask.
+ */
+function bitPositions(mask) {
+  const positions = [];
+  for (let bitIdx = 0; bitIdx < 16; bitIdx++) {
+    if (mask & (1 << bitIdx)) positions.push(bitIdx);
+  }
+  return positions;
+}
+
+/**
+ * Return the human-readable name for an evidence bit by its position index.
+ */
+function bitName(bitIdx) {
+  return EVIDENCE_BIT_NAMES[bitIdx] || ('bit-' + bitIdx);
+}
+
+/**
+ * Generate legal transition cases (all evidence satisfied, expect ALLOW).
+ */
+function generateLegalCases() {
+  const cases = [];
+  for (const row of TRANSITIONS) {
+    cases.push({
+      name: 'legal_' + STATE_NAMES[row.fromState] + '_' + EVENT_NAMES[row.event],
+      state: row.fromState,
+      event: row.event,
+      evidence: row.requiredMask,
+      expected: {
+        decision: DECISIONS.ALLOW,
+        reason: 'none',
+        required_next: row.toState,
+      },
+    });
+  }
+  return cases;
+}
+
+/**
+ * Generate guard-deny cases: for each transition with requiredMask nonzero,
+ * omit each required bit individually and expect DENY with that bit as reason.
+ */
+function generateGuardDenyCases() {
+  const cases = [];
+  for (const row of TRANSITIONS) {
+    if (row.requiredMask === 0) continue;
+    const bits = bitPositions(row.requiredMask);
+    for (const missingBitIdx of bits) {
+      const maskWithout = row.requiredMask & ~(1 << missingBitIdx);
+      cases.push({
+        name: 'guard_deny_' + STATE_NAMES[row.fromState] + '_' +
+              EVENT_NAMES[row.event] + '_missing_' + bitName(missingBitIdx),
+        state: row.fromState,
+        event: row.event,
+        evidence: maskWithout,
+        expected: {
+          decision: DECISIONS.DENY,
+          reason: bitName(missingBitIdx),
+          required_next: row.toState,
+        },
+      });
+    }
+  }
+  return cases;
+}
+
+/**
+ * Generate illegal-transition cases: every (state, event) pair that has
+ * NO transition row, producing DENY with illegal-transition reason.
+ */
+function generateIllegalCases() {
+  const cases = [];
+  const transitionSet = new Set(
+    TRANSITIONS.map((row) => row.fromState + ':' + row.event)
+  );
+  for (let stateIdx = 0; stateIdx < STATE_COUNT; stateIdx++) {
+    for (let eventIdx = 0; eventIdx < EVENT_COUNT; eventIdx++) {
+      const key = stateIdx + ':' + eventIdx;
+      if (transitionSet.has(key)) continue;
+      cases.push({
+        name: 'illegal_' + STATE_NAMES[stateIdx] + '_' + EVENT_NAMES[eventIdx],
+        state: stateIdx,
+        event: eventIdx,
+        evidence: 0,
+        expected: {
+          decision: DECISIONS.DENY,
+          reason: 'illegal-transition',
+        },
+      });
+    }
+  }
+  return cases;
+}
+
+/**
+ * Compute the OR of all evidence bit values.
+ */
+function computeAllBitsMask() {
+  return Object.values(EVIDENCE_BITS).reduce(
+    function (acc, val) { return acc | val; }, 0
+  );
+}
+
+/**
+ * Generate adversarial cases for force-close and cancel vectors.
+ */
+function adversarialCloseAndCancel(EB) {
+  return [
+    { name: 'adversarial_force_close_no_pr_merged',
+      state: STATES.REVIEW, event: EVENTS.CONSULTANT_CLOSEOUT,
+      evidence: EB.CONSULTANT_CLOSEOUT,
+      expected: { decision: DECISIONS.DENY, reason: 'pr_merged' } },
+    { name: 'adversarial_cancel_no_disposition',
+      state: STATES.IN_PROGRESS, event: EVENTS.CANCEL, evidence: 0,
+      expected: { decision: DECISIONS.DENY, reason: 'disposition_recorded' } },
+  ];
+}
+
+/**
+ * Generate adversarial cases for signer-collision and spoofed-evidence vectors.
+ */
+function adversarialSignerAndSpoofed(EB, allBitsMask) {
+  return [
+    { name: 'adversarial_signer_collision',
+      state: STATES.TESTING, event: EVENTS.ADMIN_HANDOFF,
+      evidence: EB.ADMIN_HANDOFF | EB.CI_GREEN | EB.WORKTREE_MERGE_OK,
+      expected: { decision: DECISIONS.DENY, reason: 'signer_independent' } },
+    { name: 'adversarial_spoofed_terminal_done',
+      state: STATES.DONE, event: EVENTS.PICKUP_MANAGER, evidence: allBitsMask,
+      expected: { decision: DECISIONS.DENY, reason: 'illegal-transition' } },
+    { name: 'adversarial_spoofed_terminal_cancelled',
+      state: STATES.CANCELLED, event: EVENTS.RESUME, evidence: allBitsMask,
+      expected: { decision: DECISIONS.DENY, reason: 'illegal-transition' } },
+  ];
+}
+
+/**
+ * Generate adversarial cases for stale-state and missing-evidence vectors.
+ */
+function adversarialStaleAndMissing(EB) {
+  return [
+    { name: 'adversarial_missing_acs_pass',
+      state: STATES.IN_PROGRESS, event: EVENTS.COLLABORATOR_HANDOFF,
+      evidence: EB.COLLABORATOR_HANDOFF,
+      expected: { decision: DECISIONS.DENY, reason: 'all_acs_pass' } },
+    { name: 'adversarial_stale_merge_partial_evidence',
+      state: STATES.TESTING, event: EVENTS.MERGE,
+      evidence: EB.ADMIN_HANDOFF | EB.CI_GREEN | EB.SIGNER_INDEPENDENT,
+      expected: { decision: DECISIONS.DENY, reason: 'worktree_merge_ok' } },
+    { name: 'adversarial_baton_back_no_reason',
+      state: STATES.TESTING, event: EVENTS.BATON_BACK, evidence: 0,
+      expected: { decision: DECISIONS.DENY, reason: 'baton_back_reason' } },
+  ];
+}
+
+/**
+ * Generate adversarial fixture cases that must always DENY.
+ */
+function generateAdversarialCases() {
+  const EB = EVIDENCE_BITS;
+  const allBitsMask = computeAllBitsMask();
+  return [
+    ...adversarialCloseAndCancel(EB),
+    ...adversarialSignerAndSpoofed(EB, allBitsMask),
+    ...adversarialStaleAndMissing(EB),
+  ];
+}
+
+/**
+ * Generate all corpus categories. Returns an object keyed by category name.
+ */
+function generateCorpus() {
+  return {
+    legal: generateLegalCases(),
+    'guard-deny': generateGuardDenyCases(),
+    illegal: generateIllegalCases(),
+    adversarial: generateAdversarialCases(),
+  };
+}
+
+/**
+ * Write corpus JSON files to the given directory.
+ */
+function writeCorpus(corpusDir) {
+  mkdirSync(corpusDir, { recursive: true });
+  const corpus = generateCorpus();
+  for (const [category, cases] of Object.entries(corpus)) {
+    const filePath = join(corpusDir, category + '.json');
+    writeFileSync(filePath, JSON.stringify(cases, null, 2) + '\n');
+  }
+  const totalCount = Object.values(corpus).reduce(
+    function (sum, arr) { return sum + arr.length; }, 0
+  );
+  return { categories: Object.keys(corpus), totalCount };
+}
+
+if (require.main === module) {
+  const result = writeCorpus(CORPUS_DIR);
+  console.log('Corpus generated: ' + result.totalCount + ' cases across ' +
+    result.categories.join(', '));
+}
+
+module.exports = { generateCorpus, writeCorpus, CORPUS_DIR };

--- a/tests/baton-fsm-conformance.spec.js
+++ b/tests/baton-fsm-conformance.spec.js
@@ -1,0 +1,108 @@
+// baton-fsm-conformance.spec.js — Golden-file conformance tests for the baton FSM.
+// Strategy: golden-file. Asserts JS/WASM byte-identity, W-method completeness,
+// adversarial DENY invariant, and corpus freshness. Refs #3288, Epic #3284.
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync, readdirSync } = require('node:fs');
+const { join } = require('node:path');
+
+const { runConformance, loadCorpus } = require(
+  '../scripts/global/baton-fsm/conformance-runner'
+);
+const { generateCorpus } = require(
+  '../scripts/global/baton-fsm/corpus-generate'
+);
+const {
+  STATES, STATE_COUNT, EVENTS, EVENT_COUNT, TRANSITIONS, DECISIONS,
+} = require('../scripts/global/baton-fsm/transitions');
+
+const CORPUS_DIR = join(__dirname, 'fixtures', 'baton-fsm-corpus');
+
+describe('baton-fsm conformance', function () {
+
+  it('runConformance reports zero failures over the committed corpus', async function () {
+    const result = await runConformance(CORPUS_DIR);
+    assert.equal(result.failed, 0,
+      'Conformance failures: ' + JSON.stringify(result.failures));
+    assert.equal(result.mismatches, 0,
+      'JS/WASM mismatches detected: ' + result.mismatches);
+    assert.ok(result.total > 0, 'Corpus must contain at least one case');
+  });
+
+  it('JS and WASM produce byte-identical packed i32 for every corpus case', async function () {
+    const result = await runConformance(CORPUS_DIR);
+    assert.equal(result.mismatches, 0,
+      'JS/WASM byte-identity violated in ' + result.mismatches + ' cases');
+  });
+
+  it('corpus covers every state in STATES', function () {
+    const cases = loadCorpus(CORPUS_DIR);
+    const coveredStates = new Set(cases.map(function (tc) { return tc.state; }));
+    for (let stateIdx = 0; stateIdx < STATE_COUNT; stateIdx++) {
+      assert.ok(coveredStates.has(stateIdx),
+        'State ' + stateIdx + ' not covered in corpus');
+    }
+  });
+
+  it('corpus covers every event in EVENTS', function () {
+    const cases = loadCorpus(CORPUS_DIR);
+    const coveredEvents = new Set(cases.map(function (tc) { return tc.event; }));
+    for (let eventIdx = 0; eventIdx < EVENT_COUNT; eventIdx++) {
+      assert.ok(coveredEvents.has(eventIdx),
+        'Event ' + eventIdx + ' not covered in corpus');
+    }
+  });
+
+  it('corpus covers every TRANSITIONS row (W-method completeness)', function () {
+    const cases = loadCorpus(CORPUS_DIR);
+    const corpusKeys = new Set(cases.map(
+      function (tc) { return tc.state + ':' + tc.event; }
+    ));
+    for (const row of TRANSITIONS) {
+      const key = row.fromState + ':' + row.event;
+      assert.ok(corpusKeys.has(key),
+        'TRANSITIONS row ' + key + ' not covered in corpus');
+    }
+  });
+
+  it('every adversarial fixture yields DENY (never ALLOW)', function () {
+    const adversarialPath = join(CORPUS_DIR, 'adversarial.json');
+    const adversarialCases = JSON.parse(readFileSync(adversarialPath, 'utf8'));
+    assert.ok(adversarialCases.length > 0, 'Adversarial corpus must not be empty');
+    for (const tc of adversarialCases) {
+      assert.equal(tc.expected.decision, DECISIONS.DENY,
+        'Adversarial case ' + tc.name + ' should expect DENY');
+    }
+  });
+
+  it('committed corpus matches corpus-generate.js output (golden-file)', function () {
+    const generated = generateCorpus();
+    const committedFiles = readdirSync(CORPUS_DIR).filter(
+      function (fileName) { return fileName.endsWith('.json'); }
+    ).sort();
+    const generatedCategories = Object.keys(generated).sort();
+    assert.deepStrictEqual(committedFiles, generatedCategories.map(
+      function (cat) { return cat + '.json'; }
+    ), 'Corpus file names must match generated categories');
+
+    for (const category of generatedCategories) {
+      const committedPath = join(CORPUS_DIR, category + '.json');
+      const committedData = JSON.parse(readFileSync(committedPath, 'utf8'));
+      assert.deepStrictEqual(committedData, generated[category],
+        'Committed corpus for "' + category + '" differs from generator output');
+    }
+  });
+
+  it('corpus contains all 11 states x 12 events coverage (exhaustive pair set)', function () {
+    const cases = loadCorpus(CORPUS_DIR);
+    const coveredPairs = new Set(cases.map(
+      function (tc) { return tc.state + ':' + tc.event; }
+    ));
+    const expectedPairCount = STATE_COUNT * EVENT_COUNT;
+    assert.equal(coveredPairs.size, expectedPairCount,
+      'Expected ' + expectedPairCount + ' unique state:event pairs, got ' +
+      coveredPairs.size);
+  });
+});

--- a/tests/baton-fsm-wasm-integrity.spec.js
+++ b/tests/baton-fsm-wasm-integrity.spec.js
@@ -1,0 +1,62 @@
+// baton-fsm-wasm-integrity.spec.js — Deployed WASM integrity tests.
+// Asserts committed kernel.wasm matches a fresh rebuild (positive)
+// and detects byte-level mutation (negative). Refs #3288, Epic #3284.
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const { deployedWasmIntegrity } = require(
+  '../scripts/global/baton-fsm/conformance-runner'
+);
+
+describe('baton-fsm WASM integrity', function () {
+
+  it('deployedWasmIntegrity passes for committed kernel.wasm', async function () {
+    const result = await deployedWasmIntegrity();
+    assert.equal(result.pass, true,
+      'WASM integrity check failed: ' + result.reason);
+    assert.equal(result.reason, 'byte-identical');
+    assert.ok(result.committedSize > 0, 'Committed WASM must be non-empty');
+    assert.equal(result.committedSize, result.rebuiltSize,
+      'Size mismatch: committed=' + result.committedSize +
+      ' rebuilt=' + result.rebuiltSize);
+  });
+
+  it('detects mutation when a byte is flipped (negative test)', async function () {
+    // Read the committed WASM, flip one byte, write to a temp path,
+    // then call the integrity check with a patched reader.
+    const wasmPath = join(__dirname, '..', 'scripts', 'global', 'baton-fsm', 'kernel.wasm');
+    const originalBytes = readFileSync(wasmPath);
+    assert.ok(originalBytes.length > 20,
+      'WASM file too small to be valid: ' + originalBytes.length + ' bytes');
+
+    // Create a mutated copy by flipping a byte in the data section
+    // (toward the end of the file to avoid corrupting the WASM header)
+    const mutatedBytes = Buffer.from(originalBytes);
+    const flipOffset = mutatedBytes.length - 10;
+    mutatedBytes[flipOffset] = mutatedBytes[flipOffset] ^ 0xFF;
+
+    // Verify the mutated buffer differs from original
+    assert.ok(!originalBytes.equals(mutatedBytes),
+      'Mutation must produce a different buffer');
+
+    // Temporarily replace the committed file, check integrity, restore
+    const { writeFileSync } = require('node:fs');
+    writeFileSync(wasmPath, mutatedBytes);
+    try {
+      const result = await deployedWasmIntegrity();
+      assert.equal(result.pass, false,
+        'Integrity check should FAIL on mutated WASM');
+      assert.ok(
+        result.reason.includes('byte-mismatch') || result.reason.includes('size-mismatch'),
+        'Reason should indicate mismatch, got: ' + result.reason
+      );
+    } finally {
+      // Restore the original WASM file
+      writeFileSync(wasmPath, originalBytes);
+    }
+  });
+});

--- a/tests/fixtures/baton-fsm-corpus/adversarial.json
+++ b/tests/fixtures/baton-fsm-corpus/adversarial.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "adversarial_force_close_no_pr_merged",
+    "state": 6,
+    "event": 5,
+    "evidence": 8,
+    "expected": {
+      "decision": 2,
+      "reason": "pr_merged"
+    }
+  },
+  {
+    "name": "adversarial_cancel_no_disposition",
+    "state": 4,
+    "event": 7,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "disposition_recorded"
+    }
+  },
+  {
+    "name": "adversarial_signer_collision",
+    "state": 5,
+    "event": 4,
+    "evidence": 324,
+    "expected": {
+      "decision": 2,
+      "reason": "signer_independent"
+    }
+  },
+  {
+    "name": "adversarial_spoofed_terminal_done",
+    "state": 7,
+    "event": 0,
+    "evidence": 2047,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "adversarial_spoofed_terminal_cancelled",
+    "state": 8,
+    "event": 11,
+    "evidence": 2047,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "adversarial_missing_acs_pass",
+    "state": 4,
+    "event": 3,
+    "evidence": 2,
+    "expected": {
+      "decision": 2,
+      "reason": "all_acs_pass"
+    }
+  },
+  {
+    "name": "adversarial_stale_merge_partial_evidence",
+    "state": 5,
+    "event": 6,
+    "evidence": 100,
+    "expected": {
+      "decision": 2,
+      "reason": "worktree_merge_ok"
+    }
+  },
+  {
+    "name": "adversarial_baton_back_no_reason",
+    "state": 5,
+    "event": 8,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "baton_back_reason"
+    }
+  }
+]

--- a/tests/fixtures/baton-fsm-corpus/guard-deny.json
+++ b/tests/fixtures/baton-fsm-corpus/guard-deny.json
@@ -1,0 +1,255 @@
+[
+  {
+    "name": "guard_deny_triage_manager_handoff_missing_manager_handoff",
+    "state": 2,
+    "event": 1,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "manager_handoff",
+      "required_next": 3
+    }
+  },
+  {
+    "name": "guard_deny_in-progress_collaborator_handoff_missing_collaborator_handoff",
+    "state": 4,
+    "event": 3,
+    "evidence": 16,
+    "expected": {
+      "decision": 2,
+      "reason": "collaborator_handoff",
+      "required_next": 5
+    }
+  },
+  {
+    "name": "guard_deny_in-progress_collaborator_handoff_missing_all_acs_pass",
+    "state": 4,
+    "event": 3,
+    "evidence": 2,
+    "expected": {
+      "decision": 2,
+      "reason": "all_acs_pass",
+      "required_next": 5
+    }
+  },
+  {
+    "name": "guard_deny_testing_admin_handoff_missing_admin_handoff",
+    "state": 5,
+    "event": 4,
+    "evidence": 352,
+    "expected": {
+      "decision": 2,
+      "reason": "admin_handoff",
+      "required_next": 6
+    }
+  },
+  {
+    "name": "guard_deny_testing_admin_handoff_missing_signer_independent",
+    "state": 5,
+    "event": 4,
+    "evidence": 324,
+    "expected": {
+      "decision": 2,
+      "reason": "signer_independent",
+      "required_next": 6
+    }
+  },
+  {
+    "name": "guard_deny_testing_admin_handoff_missing_ci_green",
+    "state": 5,
+    "event": 4,
+    "evidence": 292,
+    "expected": {
+      "decision": 2,
+      "reason": "ci_green",
+      "required_next": 6
+    }
+  },
+  {
+    "name": "guard_deny_testing_admin_handoff_missing_worktree_merge_ok",
+    "state": 5,
+    "event": 4,
+    "evidence": 100,
+    "expected": {
+      "decision": 2,
+      "reason": "worktree_merge_ok",
+      "required_next": 6
+    }
+  },
+  {
+    "name": "guard_deny_testing_merge_missing_admin_handoff",
+    "state": 5,
+    "event": 6,
+    "evidence": 352,
+    "expected": {
+      "decision": 2,
+      "reason": "admin_handoff",
+      "required_next": 5
+    }
+  },
+  {
+    "name": "guard_deny_testing_merge_missing_signer_independent",
+    "state": 5,
+    "event": 6,
+    "evidence": 324,
+    "expected": {
+      "decision": 2,
+      "reason": "signer_independent",
+      "required_next": 5
+    }
+  },
+  {
+    "name": "guard_deny_testing_merge_missing_ci_green",
+    "state": 5,
+    "event": 6,
+    "evidence": 292,
+    "expected": {
+      "decision": 2,
+      "reason": "ci_green",
+      "required_next": 5
+    }
+  },
+  {
+    "name": "guard_deny_testing_merge_missing_worktree_merge_ok",
+    "state": 5,
+    "event": 6,
+    "evidence": 100,
+    "expected": {
+      "decision": 2,
+      "reason": "worktree_merge_ok",
+      "required_next": 5
+    }
+  },
+  {
+    "name": "guard_deny_review_consultant_closeout_missing_consultant_closeout",
+    "state": 6,
+    "event": 5,
+    "evidence": 128,
+    "expected": {
+      "decision": 2,
+      "reason": "consultant_closeout",
+      "required_next": 7
+    }
+  },
+  {
+    "name": "guard_deny_review_consultant_closeout_missing_pr_merged",
+    "state": 6,
+    "event": 5,
+    "evidence": 8,
+    "expected": {
+      "decision": 2,
+      "reason": "pr_merged",
+      "required_next": 7
+    }
+  },
+  {
+    "name": "guard_deny_testing_baton_back_missing_baton_back_reason",
+    "state": 5,
+    "event": 8,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "baton_back_reason",
+      "required_next": 4
+    }
+  },
+  {
+    "name": "guard_deny_backlog_cancel_missing_disposition_recorded",
+    "state": 0,
+    "event": 7,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "disposition_recorded",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "guard_deny_queued_cancel_missing_disposition_recorded",
+    "state": 1,
+    "event": 7,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "disposition_recorded",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "guard_deny_triage_cancel_missing_disposition_recorded",
+    "state": 2,
+    "event": 7,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "disposition_recorded",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "guard_deny_ready_cancel_missing_disposition_recorded",
+    "state": 3,
+    "event": 7,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "disposition_recorded",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "guard_deny_in-progress_cancel_missing_disposition_recorded",
+    "state": 4,
+    "event": 7,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "disposition_recorded",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "guard_deny_testing_cancel_missing_disposition_recorded",
+    "state": 5,
+    "event": 7,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "disposition_recorded",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "guard_deny_review_cancel_missing_disposition_recorded",
+    "state": 6,
+    "event": 7,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "disposition_recorded",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "guard_deny_dormant_cancel_missing_disposition_recorded",
+    "state": 9,
+    "event": 7,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "disposition_recorded",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "guard_deny_deferred_cancel_missing_disposition_recorded",
+    "state": 10,
+    "event": 7,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "disposition_recorded",
+      "required_next": 8
+    }
+  }
+]

--- a/tests/fixtures/baton-fsm-corpus/illegal.json
+++ b/tests/fixtures/baton-fsm-corpus/illegal.json
@@ -1,0 +1,1102 @@
+[
+  {
+    "name": "illegal_backlog_manager_handoff",
+    "state": 0,
+    "event": 1,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_backlog_pickup_collaborator",
+    "state": 0,
+    "event": 2,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_backlog_collaborator_handoff",
+    "state": 0,
+    "event": 3,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_backlog_admin_handoff",
+    "state": 0,
+    "event": 4,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_backlog_consultant_closeout",
+    "state": 0,
+    "event": 5,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_backlog_merge",
+    "state": 0,
+    "event": 6,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_backlog_baton_back",
+    "state": 0,
+    "event": 8,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_backlog_epic_pause",
+    "state": 0,
+    "event": 9,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_backlog_epic_defer",
+    "state": 0,
+    "event": 10,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_backlog_resume",
+    "state": 0,
+    "event": 11,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_queued_manager_handoff",
+    "state": 1,
+    "event": 1,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_queued_pickup_collaborator",
+    "state": 1,
+    "event": 2,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_queued_collaborator_handoff",
+    "state": 1,
+    "event": 3,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_queued_admin_handoff",
+    "state": 1,
+    "event": 4,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_queued_consultant_closeout",
+    "state": 1,
+    "event": 5,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_queued_merge",
+    "state": 1,
+    "event": 6,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_queued_baton_back",
+    "state": 1,
+    "event": 8,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_queued_epic_pause",
+    "state": 1,
+    "event": 9,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_queued_epic_defer",
+    "state": 1,
+    "event": 10,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_queued_resume",
+    "state": 1,
+    "event": 11,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_triage_pickup_manager",
+    "state": 2,
+    "event": 0,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_triage_pickup_collaborator",
+    "state": 2,
+    "event": 2,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_triage_collaborator_handoff",
+    "state": 2,
+    "event": 3,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_triage_admin_handoff",
+    "state": 2,
+    "event": 4,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_triage_consultant_closeout",
+    "state": 2,
+    "event": 5,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_triage_merge",
+    "state": 2,
+    "event": 6,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_triage_baton_back",
+    "state": 2,
+    "event": 8,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_triage_epic_pause",
+    "state": 2,
+    "event": 9,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_triage_epic_defer",
+    "state": 2,
+    "event": 10,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_triage_resume",
+    "state": 2,
+    "event": 11,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_ready_pickup_manager",
+    "state": 3,
+    "event": 0,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_ready_manager_handoff",
+    "state": 3,
+    "event": 1,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_ready_collaborator_handoff",
+    "state": 3,
+    "event": 3,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_ready_admin_handoff",
+    "state": 3,
+    "event": 4,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_ready_consultant_closeout",
+    "state": 3,
+    "event": 5,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_ready_merge",
+    "state": 3,
+    "event": 6,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_ready_baton_back",
+    "state": 3,
+    "event": 8,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_ready_epic_pause",
+    "state": 3,
+    "event": 9,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_ready_epic_defer",
+    "state": 3,
+    "event": 10,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_ready_resume",
+    "state": 3,
+    "event": 11,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_in-progress_pickup_manager",
+    "state": 4,
+    "event": 0,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_in-progress_manager_handoff",
+    "state": 4,
+    "event": 1,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_in-progress_pickup_collaborator",
+    "state": 4,
+    "event": 2,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_in-progress_admin_handoff",
+    "state": 4,
+    "event": 4,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_in-progress_consultant_closeout",
+    "state": 4,
+    "event": 5,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_in-progress_merge",
+    "state": 4,
+    "event": 6,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_in-progress_baton_back",
+    "state": 4,
+    "event": 8,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_in-progress_resume",
+    "state": 4,
+    "event": 11,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_testing_pickup_manager",
+    "state": 5,
+    "event": 0,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_testing_manager_handoff",
+    "state": 5,
+    "event": 1,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_testing_pickup_collaborator",
+    "state": 5,
+    "event": 2,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_testing_collaborator_handoff",
+    "state": 5,
+    "event": 3,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_testing_consultant_closeout",
+    "state": 5,
+    "event": 5,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_testing_epic_pause",
+    "state": 5,
+    "event": 9,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_testing_epic_defer",
+    "state": 5,
+    "event": 10,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_testing_resume",
+    "state": 5,
+    "event": 11,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_review_pickup_manager",
+    "state": 6,
+    "event": 0,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_review_manager_handoff",
+    "state": 6,
+    "event": 1,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_review_pickup_collaborator",
+    "state": 6,
+    "event": 2,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_review_collaborator_handoff",
+    "state": 6,
+    "event": 3,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_review_admin_handoff",
+    "state": 6,
+    "event": 4,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_review_merge",
+    "state": 6,
+    "event": 6,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_review_baton_back",
+    "state": 6,
+    "event": 8,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_review_epic_pause",
+    "state": 6,
+    "event": 9,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_review_epic_defer",
+    "state": 6,
+    "event": 10,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_review_resume",
+    "state": 6,
+    "event": 11,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_done_pickup_manager",
+    "state": 7,
+    "event": 0,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_done_manager_handoff",
+    "state": 7,
+    "event": 1,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_done_pickup_collaborator",
+    "state": 7,
+    "event": 2,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_done_collaborator_handoff",
+    "state": 7,
+    "event": 3,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_done_admin_handoff",
+    "state": 7,
+    "event": 4,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_done_consultant_closeout",
+    "state": 7,
+    "event": 5,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_done_merge",
+    "state": 7,
+    "event": 6,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_done_cancel",
+    "state": 7,
+    "event": 7,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_done_baton_back",
+    "state": 7,
+    "event": 8,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_done_epic_pause",
+    "state": 7,
+    "event": 9,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_done_epic_defer",
+    "state": 7,
+    "event": 10,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_done_resume",
+    "state": 7,
+    "event": 11,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_cancelled_pickup_manager",
+    "state": 8,
+    "event": 0,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_cancelled_manager_handoff",
+    "state": 8,
+    "event": 1,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_cancelled_pickup_collaborator",
+    "state": 8,
+    "event": 2,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_cancelled_collaborator_handoff",
+    "state": 8,
+    "event": 3,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_cancelled_admin_handoff",
+    "state": 8,
+    "event": 4,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_cancelled_consultant_closeout",
+    "state": 8,
+    "event": 5,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_cancelled_merge",
+    "state": 8,
+    "event": 6,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_cancelled_cancel",
+    "state": 8,
+    "event": 7,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_cancelled_baton_back",
+    "state": 8,
+    "event": 8,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_cancelled_epic_pause",
+    "state": 8,
+    "event": 9,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_cancelled_epic_defer",
+    "state": 8,
+    "event": 10,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_cancelled_resume",
+    "state": 8,
+    "event": 11,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_dormant_pickup_manager",
+    "state": 9,
+    "event": 0,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_dormant_manager_handoff",
+    "state": 9,
+    "event": 1,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_dormant_pickup_collaborator",
+    "state": 9,
+    "event": 2,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_dormant_collaborator_handoff",
+    "state": 9,
+    "event": 3,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_dormant_admin_handoff",
+    "state": 9,
+    "event": 4,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_dormant_consultant_closeout",
+    "state": 9,
+    "event": 5,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_dormant_merge",
+    "state": 9,
+    "event": 6,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_dormant_baton_back",
+    "state": 9,
+    "event": 8,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_dormant_epic_pause",
+    "state": 9,
+    "event": 9,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_dormant_epic_defer",
+    "state": 9,
+    "event": 10,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_deferred_pickup_manager",
+    "state": 10,
+    "event": 0,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_deferred_manager_handoff",
+    "state": 10,
+    "event": 1,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_deferred_pickup_collaborator",
+    "state": 10,
+    "event": 2,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_deferred_collaborator_handoff",
+    "state": 10,
+    "event": 3,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_deferred_admin_handoff",
+    "state": 10,
+    "event": 4,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_deferred_consultant_closeout",
+    "state": 10,
+    "event": 5,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_deferred_merge",
+    "state": 10,
+    "event": 6,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_deferred_baton_back",
+    "state": 10,
+    "event": 8,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_deferred_epic_pause",
+    "state": 10,
+    "event": 9,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  },
+  {
+    "name": "illegal_deferred_epic_defer",
+    "state": 10,
+    "event": 10,
+    "evidence": 0,
+    "expected": {
+      "decision": 2,
+      "reason": "illegal-transition"
+    }
+  }
+]

--- a/tests/fixtures/baton-fsm-corpus/legal.json
+++ b/tests/fixtures/baton-fsm-corpus/legal.json
@@ -1,0 +1,244 @@
+[
+  {
+    "name": "legal_backlog_pickup_manager",
+    "state": 0,
+    "event": 0,
+    "evidence": 0,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 2
+    }
+  },
+  {
+    "name": "legal_queued_pickup_manager",
+    "state": 1,
+    "event": 0,
+    "evidence": 0,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 2
+    }
+  },
+  {
+    "name": "legal_triage_manager_handoff",
+    "state": 2,
+    "event": 1,
+    "evidence": 1,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 3
+    }
+  },
+  {
+    "name": "legal_ready_pickup_collaborator",
+    "state": 3,
+    "event": 2,
+    "evidence": 0,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 4
+    }
+  },
+  {
+    "name": "legal_in-progress_collaborator_handoff",
+    "state": 4,
+    "event": 3,
+    "evidence": 18,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 5
+    }
+  },
+  {
+    "name": "legal_testing_admin_handoff",
+    "state": 5,
+    "event": 4,
+    "evidence": 356,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 6
+    }
+  },
+  {
+    "name": "legal_testing_merge",
+    "state": 5,
+    "event": 6,
+    "evidence": 356,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 5
+    }
+  },
+  {
+    "name": "legal_review_consultant_closeout",
+    "state": 6,
+    "event": 5,
+    "evidence": 136,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 7
+    }
+  },
+  {
+    "name": "legal_testing_baton_back",
+    "state": 5,
+    "event": 8,
+    "evidence": 1024,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 4
+    }
+  },
+  {
+    "name": "legal_backlog_cancel",
+    "state": 0,
+    "event": 7,
+    "evidence": 512,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "legal_queued_cancel",
+    "state": 1,
+    "event": 7,
+    "evidence": 512,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "legal_triage_cancel",
+    "state": 2,
+    "event": 7,
+    "evidence": 512,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "legal_ready_cancel",
+    "state": 3,
+    "event": 7,
+    "evidence": 512,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "legal_in-progress_cancel",
+    "state": 4,
+    "event": 7,
+    "evidence": 512,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "legal_testing_cancel",
+    "state": 5,
+    "event": 7,
+    "evidence": 512,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "legal_review_cancel",
+    "state": 6,
+    "event": 7,
+    "evidence": 512,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "legal_dormant_cancel",
+    "state": 9,
+    "event": 7,
+    "evidence": 512,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "legal_deferred_cancel",
+    "state": 10,
+    "event": 7,
+    "evidence": 512,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 8
+    }
+  },
+  {
+    "name": "legal_in-progress_epic_pause",
+    "state": 4,
+    "event": 9,
+    "evidence": 0,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 9
+    }
+  },
+  {
+    "name": "legal_in-progress_epic_defer",
+    "state": 4,
+    "event": 10,
+    "evidence": 0,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 10
+    }
+  },
+  {
+    "name": "legal_dormant_resume",
+    "state": 9,
+    "event": 11,
+    "evidence": 0,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 2
+    }
+  },
+  {
+    "name": "legal_deferred_resume",
+    "state": 10,
+    "event": 11,
+    "evidence": 0,
+    "expected": {
+      "decision": 1,
+      "reason": "none",
+      "required_next": 4
+    }
+  }
+]


### PR DESCRIPTION
## Summary

W1b of Epic #3284. Adds the baton-fsm conformance corpus (W-method full coverage + adversarial fixtures, generated from the canonical TRANSITIONS table), a JS/WASM byte-identical conformance runner, a deployed-WASM-vs-source integrity diff, an agent x runtime matrix (JS/WASM executed byte-identical; Py/Go/Rust recorded pending-toolchain, never silently skipped), and an advisory baton-fsm-conformance CI gate (promotes to blocking at replay-eval precision 0.85+).

10 tests, 163 corpus cases, 0 mismatches. Cross-family (free-cloud): Groq llama-3.3-70b ACCEPT 98.

Refs #3288
merge-evidence-deferred-final: #3288

## Baton artifacts (full text on issue #3288)
MANAGER_HANDOFF / EDD / COLLABORATOR_HANDOFF / ADMIN_HANDOFF / CONSULTANT_CLOSEOUT posted on #3288.
