### PR TITLE
feat(governance): post-merge consultant audit CI

### DIFF
--- a/.changes/unreleased/3293.md
+++ b/.changes/unreleased/3293.md
@@ -1,0 +1,8 @@
+### post-merge Consultant cross-model audit (Baton Authority Plane W5) — #3293
+
+Add `scripts/global/baton-postmerge-audit/` plus a `post-merge-consultant-audit` workflow that runs the
+Consultant as a post-merge advisory cross-model auditor for all teams. It is plane-separated from the
+deterministic FSM gate: it NEVER blocks merge. An audit failure opens a Tier-3 escalation ticket to the
+Manager instead of blocking. The cross-family invariant (the reviewer model family must differ from the
+author family) is enforced by a family registry. Absorbs #3235/#3236. The CI dispatch is wired but inert
+behind a passing-verdict placeholder until the HAMR/fleet dispatch adapter ships (documented follow-on).

--- a/.github/workflows/post-merge-consultant-audit.yml
+++ b/.github/workflows/post-merge-consultant-audit.yml
@@ -1,0 +1,79 @@
+# Post-merge consultant audit (ADVISORY — never gates merge)
+# Refs #3293, Epic #3284 W5. Plane separation: the deterministic FSM
+# (W1a/W2) is the sole blocking gate; this is post-merge inference/advice.
+name: post-merge-consultant-audit
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+  issues: write
+jobs:
+  audit:
+    name: post-merge-consultant-audit
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 2
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            // Post-merge advisory audit — NEVER blocks merge
+            const { runPostMergeAudit } = require(
+              './scripts/global/baton-postmerge-audit/post-merge-auditor'
+            );
+            const sha = context.sha;
+            const { data: prs } = await github.rest.repos
+              .listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+              });
+            const mergedPr = prs.find(pr => pr.merged_at) || prs[0];
+            if (!mergedPr) {
+              console.log('No merged PR for this push; skipping.');
+              return;
+            }
+            const ghClient = {
+              createIssue: async ({ title, body, labels }) => {
+                const { data } = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title, body, labels,
+                });
+                return { number: data.number, url: data.html_url };
+              },
+            };
+            // Dispatch placeholder — routes through HAMR/fleet in production.
+            // Returns a passing verdict so the workflow is wired but inert
+            // until the dispatch adapter ships.
+            const dispatch = async () => ({
+              verdict: 'ACCEPT', score: 8,
+              reviewer_model_family: 'qwen', findings: [],
+            });
+            const authorTeamModel = 'claude-code:opus@claude-code-cli';
+            try {
+              const result = await runPostMergeAudit(
+                {
+                  number: mergedPr.number, title: mergedPr.title,
+                  diff: '(workflow-level diff not yet wired)',
+                  url: mergedPr.html_url,
+                },
+                { dispatch, ghClient, authorTeamModel }
+              );
+              console.log('Audit result:', JSON.stringify(result, null, 2));
+              await core.summary.addRaw([
+                '### Post-merge consultant audit (advisory)',
+                '',
+                `Verdict: ${result.audit.verdict}`,
+                `Score: ${result.audit.score}`,
+                `Reviewer family: ${result.audit.reviewer_model_family}`,
+                `Merge-blocking: ${result.mergeBlocking}`,
+                `Escalated: ${result.escalation ? result.escalation.escalated : false}`,
+              ].join('\n')).write();
+            } catch (err) {
+              // Advisory — log and continue, never fail the workflow
+              console.log('Post-merge audit error (advisory):', err.message);
+            }

--- a/scripts/global/baton-postmerge-audit/family-registry.js
+++ b/scripts/global/baton-postmerge-audit/family-registry.js
@@ -1,0 +1,65 @@
+'use strict';
+// family-registry.js — team-to-model-family mapping and cross-family assertion
+// for the post-merge consultant audit (W5, Epic #3284, Refs #3293).
+// The cross-family invariant: the reviewer model family MUST differ from the
+// authoring team's primary family. This is enforced for ALL teams.
+
+// Each team maps to a PRIMARY model family. Teams that use multiple families
+// (copilot routes to claude/gpt/qwen/gemini; cursor routes to claude/gpt)
+// map to their dominant family for authorship attribution. The reviewer must
+// belong to a DIFFERENT family than the author's primary.
+const TEAM_FAMILY_MAP = {
+  'claude-code': 'anthropic',
+  'copilot': 'openai',
+  'codex': 'openai',
+  'antigravity': 'google',
+  'openclaw': 'local',
+  'cursor': 'openai',
+};
+
+// Recognized model families for reviewer classification.
+const KNOWN_FAMILIES = [
+  'anthropic', 'openai', 'google', 'meta', 'mistral',
+  'qwen', 'local', 'cohere', 'deepseek',
+];
+
+/**
+ * Resolve the primary model family for a given team name.
+ * Returns the family string or null if the team is unknown.
+ */
+function teamToFamily(team) {
+  if (!team || typeof team !== 'string') return null;
+  const normalized = team.toLowerCase().trim();
+  return TEAM_FAMILY_MAP[normalized] || null;
+}
+
+/**
+ * Assert that the reviewer's model family differs from the author team's
+ * primary family (the cross-family invariant).
+ * Returns true when cross-family holds (different families).
+ * Returns false when the invariant is violated (same family).
+ * Throws on missing/invalid inputs so callers cannot silently skip the check.
+ */
+function assertCrossFamily(authorTeam, reviewerFamily) {
+  if (!authorTeam || typeof authorTeam !== 'string') {
+    throw new Error('assertCrossFamily: authorTeam is required');
+  }
+  if (!reviewerFamily || typeof reviewerFamily !== 'string') {
+    throw new Error('assertCrossFamily: reviewerFamily is required');
+  }
+  const authorFamily = teamToFamily(authorTeam);
+  if (!authorFamily) {
+    throw new Error(
+      `assertCrossFamily: unknown team "${authorTeam}"`
+    );
+  }
+  const normalizedReviewer = reviewerFamily.toLowerCase().trim();
+  return authorFamily !== normalizedReviewer;
+}
+
+module.exports = {
+  TEAM_FAMILY_MAP,
+  KNOWN_FAMILIES,
+  teamToFamily,
+  assertCrossFamily,
+};

--- a/scripts/global/baton-postmerge-audit/post-merge-auditor.js
+++ b/scripts/global/baton-postmerge-audit/post-merge-auditor.js
@@ -1,0 +1,87 @@
+'use strict';
+// post-merge-auditor.js — cross-model audit of a merged change (ADVISORY,
+// NEVER blocks merge). Refs #3293, Epic #3284. Plane separation: the
+// deterministic FSM (W1a/W2) is the sole blocking authority; this LLM
+// Consultant is post-merge inference/advice.
+
+const { assertCrossFamily, teamToFamily } = require('./family-registry');
+const { escalateOnAuditFailure, shouldEscalate } = require('./tier3-escalation');
+
+/** Extract team name from "team:model@substrate" -> "team". */
+function parseAuthorTeam(authorTeamModel) {
+  if (!authorTeamModel || typeof authorTeamModel !== 'string') return null;
+  const colonIdx = authorTeamModel.indexOf(':');
+  if (colonIdx === -1) return authorTeamModel.trim();
+  return authorTeamModel.slice(0, colonIdx).trim();
+}
+
+/** Build the prompt for the cross-model audit dispatch. */
+function buildAuditPrompt(mergedPr) {
+  const title = mergedPr.title || 'untitled';
+  const prNum = mergedPr.number || 'unknown';
+  const diff = mergedPr.diff || '(no diff available)';
+  return [
+    `Review this merged PR #${prNum}: "${title}".`,
+    'Evaluate for correctness, security, and governance.',
+    'Return a structured verdict (ACCEPT or REJECT),',
+    'a numeric score (1-10), and specific findings.',
+    '', 'Diff:', diff,
+  ].join('\n');
+}
+
+/** Check cross-family invariant; return violation result or null. */
+function checkFamilyViolation(authorTeam, reviewerFamily) {
+  if (!authorTeam || !reviewerFamily) return null;
+  if (assertCrossFamily(authorTeam, reviewerFamily)) return null;
+  const ownFamily = teamToFamily(authorTeam);
+  return {
+    verdict: 'FAMILY_VIOLATION', score: null,
+    reviewer_model_family: reviewerFamily,
+    findings: [
+      'Cross-family invariant violated: reviewer family'
+      + ` "${reviewerFamily}" matches author team`
+      + ` "${authorTeam}" (family: ${ownFamily})`,
+    ],
+    familyViolation: true,
+  };
+}
+
+/** Build a normalized audit envelope from dispatch output. */
+function buildAuditEnvelope(auditResult) {
+  return {
+    verdict: auditResult.verdict || 'UNKNOWN',
+    score: auditResult.score != null ? auditResult.score : null,
+    reviewer_model_family: auditResult.reviewer_model_family || 'unknown',
+    findings: auditResult.findings || [],
+    familyViolation: false,
+  };
+}
+
+/**
+ * Run the post-merge consultant audit.
+ * mergeBlocking is ALWAYS false — this is advisory only.
+ */
+async function runPostMergeAudit(mergedPr, opts = {}) {
+  const { dispatch, ghClient, authorTeamModel } = opts;
+  if (!dispatch) throw new Error('runPostMergeAudit: dispatch is required');
+  if (!mergedPr) throw new Error('runPostMergeAudit: mergedPr is required');
+  const authorTeam = parseAuthorTeam(authorTeamModel);
+  const prompt = buildAuditPrompt(mergedPr);
+  const raw = await dispatch(prompt, { taskClass: 'post-merge-audit', authorTeam });
+  const violation = checkFamilyViolation(authorTeam, raw.reviewer_model_family);
+  if (violation) return { audit: violation, escalation: null, mergeBlocking: false };
+  const audit = buildAuditEnvelope(raw);
+  let escalation = null;
+  if (ghClient && shouldEscalate(audit)) {
+    escalation = await escalateOnAuditFailure(audit, mergedPr, ghClient);
+  }
+  return { audit, escalation, mergeBlocking: false };
+}
+
+module.exports = {
+  runPostMergeAudit,
+  parseAuthorTeam,
+  buildAuditPrompt,
+  checkFamilyViolation,
+  buildAuditEnvelope,
+};

--- a/scripts/global/baton-postmerge-audit/tier3-escalation.js
+++ b/scripts/global/baton-postmerge-audit/tier3-escalation.js
@@ -1,0 +1,85 @@
+'use strict';
+// tier3-escalation.js — opens a Tier-3 escalation ticket to the Manager
+// when a post-merge consultant audit fails. NEVER blocks merge (merge
+// already happened). Refs #3293, Epic #3284.
+
+const AUDIT_FAIL_THRESHOLD = 5;
+
+const TIER3_LABELS = [
+  'type:bug', 'priority:P2', 'area:governance',
+  'lane:code-change', 'anneal:tier-3',
+];
+
+/** Format the PR reference string. */
+function formatPrRef(mergedPr) {
+  return mergedPr.number ? `#${mergedPr.number}` : (mergedPr.url || 'unknown');
+}
+
+/** Format the findings list as indented lines. */
+function formatFindings(findings) {
+  if (!Array.isArray(findings) || findings.length === 0) {
+    return '  (no structured findings)';
+  }
+  return findings.map(
+    (finding, idx) => `  ${idx + 1}. ${finding}`
+  ).join('\n');
+}
+
+/** Build the body for a Tier-3 escalation ticket. */
+function buildEscalationBody(auditResult, mergedPr) {
+  const prRef = formatPrRef(mergedPr);
+  const score = auditResult.score != null ? String(auditResult.score) : 'N/A';
+  const reviewerFamily = auditResult.reviewer_model_family || 'unknown';
+  return [
+    '## Tier-3 anneal: post-merge consultant audit failure',
+    '',
+    `Merged PR: ${prRef}`,
+    `Audit verdict: ${auditResult.verdict}`,
+    `Audit score: ${score}`,
+    `Reviewer model family: ${reviewerFamily}`,
+    '', 'Findings:', formatFindings(auditResult.findings),
+    '',
+    'Per Epic #3284 plane separation: the deterministic FSM is the',
+    'only blocking authority. This is post-merge advisory. The Manager',
+    'must triage whether the findings warrant a follow-up fix.',
+    '', 'Refs #3293',
+  ].join('\n');
+}
+
+/** Determine whether the audit result warrants escalation. */
+function shouldEscalate(auditResult) {
+  if (!auditResult) return false;
+  const verdict = String(auditResult.verdict || '').toUpperCase();
+  if (verdict === 'REJECT') return true;
+  if (auditResult.score != null
+    && auditResult.score < AUDIT_FAIL_THRESHOLD) return true;
+  return false;
+}
+
+/**
+ * Open a Tier-3 escalation ticket when the audit fails.
+ * ghClient: { createIssue({ title, body, labels }) }
+ * A passing audit is a no-op.
+ */
+async function escalateOnAuditFailure(auditResult, mergedPr, ghClient) {
+  if (!shouldEscalate(auditResult)) {
+    return { escalated: false, reason: 'audit-passed' };
+  }
+  const prRef = formatPrRef(mergedPr);
+  const title = `Tier-3 anneal: post-merge audit failure on ${prRef} (verdict=${auditResult.verdict})`;
+  const body = buildEscalationBody(auditResult, mergedPr);
+  const issue = await ghClient.createIssue({
+    title, body, labels: TIER3_LABELS,
+  });
+  return { escalated: true, issue };
+}
+
+module.exports = {
+  escalateOnAuditFailure,
+  shouldEscalate,
+  buildEscalationBody,
+  formatPrRef,
+  formatFindings,
+  TIER3_LABELS,
+  AUDIT_FAIL_THRESHOLD,
+};

--- a/tests/baton-audit-cross-family.spec.js
+++ b/tests/baton-audit-cross-family.spec.js
@@ -1,0 +1,160 @@
+// Refs #3293, Epic #3284 W5 — cross-family invariant tests (AC3)
+// Validates that the audit enforces the cross-family non-Anthropic-reviewer
+// invariant for ALL teams in the family registry.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  assertCrossFamily, teamToFamily, TEAM_FAMILY_MAP, KNOWN_FAMILIES,
+} = require(
+  '../scripts/global/baton-postmerge-audit/family-registry'
+);
+const { runPostMergeAudit } = require(
+  '../scripts/global/baton-postmerge-audit/post-merge-auditor'
+);
+
+// -- assertCrossFamily unit tests --
+
+test('AC3: claude-code author + non-Anthropic reviewer is cross-family', () => {
+  assert.equal(assertCrossFamily('claude-code', 'qwen'), true);
+  assert.equal(assertCrossFamily('claude-code', 'openai'), true);
+  assert.equal(assertCrossFamily('claude-code', 'google'), true);
+  assert.equal(assertCrossFamily('claude-code', 'meta'), true);
+  assert.equal(assertCrossFamily('claude-code', 'mistral'), true);
+});
+
+test('AC3: claude-code author + anthropic reviewer is family violation', () => {
+  assert.equal(assertCrossFamily('claude-code', 'anthropic'), false);
+  assert.equal(assertCrossFamily('claude-code', 'Anthropic'), false);
+});
+
+test('AC3: copilot author + openai reviewer is family violation', () => {
+  assert.equal(assertCrossFamily('copilot', 'openai'), false);
+  assert.equal(assertCrossFamily('copilot', 'OpenAI'), false);
+});
+
+test('AC3: copilot author + non-openai reviewer is cross-family', () => {
+  assert.equal(assertCrossFamily('copilot', 'anthropic'), true);
+  assert.equal(assertCrossFamily('copilot', 'google'), true);
+  assert.equal(assertCrossFamily('copilot', 'qwen'), true);
+});
+
+test('AC3: codex author + openai reviewer is family violation', () => {
+  assert.equal(assertCrossFamily('codex', 'openai'), false);
+});
+
+test('AC3: codex author + non-openai reviewer is cross-family', () => {
+  assert.equal(assertCrossFamily('codex', 'anthropic'), true);
+  assert.equal(assertCrossFamily('codex', 'qwen'), true);
+});
+
+test('AC3: antigravity author + google reviewer is family violation', () => {
+  assert.equal(assertCrossFamily('antigravity', 'google'), false);
+});
+
+test('AC3: antigravity author + non-google reviewer is cross-family', () => {
+  assert.equal(assertCrossFamily('antigravity', 'anthropic'), true);
+  assert.equal(assertCrossFamily('antigravity', 'openai'), true);
+  assert.equal(assertCrossFamily('antigravity', 'qwen'), true);
+});
+
+test('AC3: cursor author + openai reviewer is family violation', () => {
+  assert.equal(assertCrossFamily('cursor', 'openai'), false);
+});
+
+test('AC3: cursor author + non-openai reviewer is cross-family', () => {
+  assert.equal(assertCrossFamily('cursor', 'anthropic'), true);
+});
+
+test('AC3: openclaw author + local reviewer is family violation', () => {
+  assert.equal(assertCrossFamily('openclaw', 'local'), false);
+});
+
+test('AC3: openclaw author + non-local reviewer is cross-family', () => {
+  assert.equal(assertCrossFamily('openclaw', 'anthropic'), true);
+  assert.equal(assertCrossFamily('openclaw', 'openai'), true);
+});
+
+// -- teamToFamily unit tests --
+
+test('teamToFamily maps all known teams', () => {
+  for (const [team, family] of Object.entries(TEAM_FAMILY_MAP)) {
+    assert.equal(teamToFamily(team), family,
+      `teamToFamily("${team}") should return "${family}"`);
+  }
+});
+
+test('teamToFamily returns null for unknown team', () => {
+  assert.equal(teamToFamily('nonexistent'), null);
+  assert.equal(teamToFamily(''), null);
+  assert.equal(teamToFamily(null), null);
+});
+
+// -- assertCrossFamily error handling --
+
+test('assertCrossFamily throws on missing authorTeam', () => {
+  assert.throws(() => assertCrossFamily(null, 'qwen'),
+    { message: /authorTeam is required/ });
+  assert.throws(() => assertCrossFamily('', 'qwen'),
+    { message: /authorTeam is required/ });
+});
+
+test('assertCrossFamily throws on missing reviewerFamily', () => {
+  assert.throws(() => assertCrossFamily('claude-code', null),
+    { message: /reviewerFamily is required/ });
+  assert.throws(() => assertCrossFamily('claude-code', ''),
+    { message: /reviewerFamily is required/ });
+});
+
+test('assertCrossFamily throws on unknown team', () => {
+  assert.throws(() => assertCrossFamily('unknown-team', 'qwen'),
+    { message: /unknown team/ });
+});
+
+// -- Integration: auditor rejects same-family reviewer --
+
+test('AC3 integration: auditor returns FAMILY_VIOLATION for same-family', async () => {
+  const dispatch = async () => ({
+    verdict: 'ACCEPT', score: 10,
+    reviewer_model_family: 'anthropic', findings: [],
+  });
+  const result = await runPostMergeAudit(
+    { number: 50, title: 'test', diff: 'diff' },
+    { dispatch, authorTeamModel: 'claude-code:opus@claude-code-cli' }
+  );
+  assert.equal(result.audit.verdict, 'FAMILY_VIOLATION');
+  assert.equal(result.audit.familyViolation, true);
+  assert.equal(result.mergeBlocking, false,
+    'even family violations must not block merge');
+});
+
+test('AC3 integration: auditor accepts cross-family reviewer', async () => {
+  const dispatch = async () => ({
+    verdict: 'ACCEPT', score: 8,
+    reviewer_model_family: 'qwen', findings: [],
+  });
+  const result = await runPostMergeAudit(
+    { number: 51, title: 'test', diff: 'diff' },
+    { dispatch, authorTeamModel: 'claude-code:sonnet@claude-code-cli' }
+  );
+  assert.equal(result.audit.verdict, 'ACCEPT');
+  assert.equal(result.audit.familyViolation, false);
+});
+
+// -- All teams x all families matrix --
+
+test('AC3 exhaustive: every team rejects own-family reviewer', () => {
+  for (const [team, family] of Object.entries(TEAM_FAMILY_MAP)) {
+    assert.equal(assertCrossFamily(team, family), false,
+      `${team} author + ${family} reviewer should be a violation`);
+  }
+});
+
+test('AC3 exhaustive: every team accepts other-family reviewers', () => {
+  for (const [team, ownFamily] of Object.entries(TEAM_FAMILY_MAP)) {
+    for (const otherFamily of KNOWN_FAMILIES) {
+      if (otherFamily === ownFamily) continue;
+      assert.equal(assertCrossFamily(team, otherFamily), true,
+        `${team} author + ${otherFamily} reviewer should be cross-family`);
+    }
+  }
+});

--- a/tests/baton-postmerge-audit.spec.js
+++ b/tests/baton-postmerge-audit.spec.js
@@ -1,0 +1,202 @@
+// Refs #3293, Epic #3284 W5 — post-merge consultant audit tests
+// Validates: AC1 (post-merge, no merge-blocking), AC2 (Tier-3 escalation
+// on failing audit), and the eval-harness fixtures.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { runPostMergeAudit } = require(
+  '../scripts/global/baton-postmerge-audit/post-merge-auditor'
+);
+const { escalateOnAuditFailure, shouldEscalate, AUDIT_FAIL_THRESHOLD } = require(
+  '../scripts/global/baton-postmerge-audit/tier3-escalation'
+);
+
+// Load eval fixtures
+const fixtures = require(
+  './eval/baton-postmerge-audit/fixtures.json'
+).fixtures;
+
+// -- Helpers --
+
+function fakeDispatch(result) {
+  return async () => result;
+}
+
+function fakeGhClient() {
+  const created = [];
+  return {
+    createIssue: async (params) => {
+      const issue = { number: 9000 + created.length, url: 'https://fake' };
+      created.push({ ...params, ...issue });
+      return issue;
+    },
+    created,
+  };
+}
+
+// -- AC1: Post-merge advisory, NEVER merge-blocking --
+
+test('AC1: passing audit returns mergeBlocking=false', async () => {
+  const dispatch = fakeDispatch({
+    verdict: 'ACCEPT', score: 8,
+    reviewer_model_family: 'qwen', findings: [],
+  });
+  const result = await runPostMergeAudit(
+    { number: 1, title: 'test', diff: 'x' },
+    { dispatch, authorTeamModel: 'claude-code:opus@claude-code-cli' }
+  );
+  assert.equal(result.mergeBlocking, false);
+  assert.equal(result.audit.verdict, 'ACCEPT');
+});
+
+test('AC1: failing audit still returns mergeBlocking=false', async () => {
+  const dispatch = fakeDispatch({
+    verdict: 'REJECT', score: 2,
+    reviewer_model_family: 'qwen', findings: ['flaw found'],
+  });
+  const ghClient = fakeGhClient();
+  const result = await runPostMergeAudit(
+    { number: 2, title: 'bad', diff: 'y' },
+    { dispatch, ghClient, authorTeamModel: 'claude-code:sonnet@claude-code-cli' }
+  );
+  assert.equal(result.mergeBlocking, false,
+    'post-merge audit must NEVER return mergeBlocking=true');
+});
+
+test('AC1: family violation still returns mergeBlocking=false', async () => {
+  const dispatch = fakeDispatch({
+    verdict: 'ACCEPT', score: 9,
+    reviewer_model_family: 'anthropic', findings: [],
+  });
+  const result = await runPostMergeAudit(
+    { number: 3, title: 'same-family', diff: 'z' },
+    { dispatch, authorTeamModel: 'claude-code:opus@claude-code-cli' }
+  );
+  assert.equal(result.mergeBlocking, false);
+  assert.equal(result.audit.familyViolation, true);
+});
+
+// -- AC2: Failing audit opens Tier-3 ticket --
+
+test('AC2: REJECT verdict triggers escalation via ghClient', async () => {
+  const dispatch = fakeDispatch({
+    verdict: 'REJECT', score: 3,
+    reviewer_model_family: 'google', findings: ['auth bypass'],
+  });
+  const ghClient = fakeGhClient();
+  const result = await runPostMergeAudit(
+    { number: 10, title: 'auth fix', diff: 'diff' },
+    { dispatch, ghClient, authorTeamModel: 'claude-code:opus@claude-code-cli' }
+  );
+  assert.equal(result.escalation.escalated, true);
+  assert.equal(ghClient.created.length, 1);
+  const ticket = ghClient.created[0];
+  assert.ok(ticket.title.includes('Tier-3'));
+  assert.ok(ticket.title.includes('#10'));
+  assert.ok(ticket.body.includes('auth bypass'));
+  assert.deepEqual(ticket.labels, [
+    'type:bug', 'priority:P2', 'area:governance',
+    'lane:code-change', 'anneal:tier-3',
+  ]);
+});
+
+test('AC2: low score (below threshold) triggers escalation', async () => {
+  const dispatch = fakeDispatch({
+    verdict: 'PARTIAL', score: 2,
+    reviewer_model_family: 'qwen', findings: ['incomplete tests'],
+  });
+  const ghClient = fakeGhClient();
+  const result = await runPostMergeAudit(
+    { number: 11, title: 'tests', diff: 'diff' },
+    { dispatch, ghClient, authorTeamModel: 'codex:gpt-5@codex-cli' }
+  );
+  assert.equal(result.escalation.escalated, true);
+  assert.equal(ghClient.created.length, 1);
+});
+
+test('AC2: passing audit does NOT escalate', async () => {
+  const dispatch = fakeDispatch({
+    verdict: 'ACCEPT', score: 9,
+    reviewer_model_family: 'qwen', findings: [],
+  });
+  const ghClient = fakeGhClient();
+  const result = await runPostMergeAudit(
+    { number: 12, title: 'good', diff: 'diff' },
+    { dispatch, ghClient, authorTeamModel: 'claude-code:opus@claude-code-cli' }
+  );
+  assert.equal(result.escalation, null);
+  assert.equal(ghClient.created.length, 0);
+});
+
+// -- shouldEscalate unit tests --
+
+test('shouldEscalate: REJECT verdict returns true', () => {
+  assert.equal(shouldEscalate({ verdict: 'REJECT', score: 7 }), true);
+});
+
+test('shouldEscalate: low score returns true', () => {
+  assert.equal(shouldEscalate({ verdict: 'PARTIAL', score: 2 }), true);
+});
+
+test('shouldEscalate: passing audit returns false', () => {
+  assert.equal(shouldEscalate({ verdict: 'ACCEPT', score: 8 }), false);
+});
+
+test('shouldEscalate: null input returns false', () => {
+  assert.equal(shouldEscalate(null), false);
+});
+
+test('shouldEscalate: score exactly at threshold returns false', () => {
+  assert.equal(
+    shouldEscalate({ verdict: 'ACCEPT', score: AUDIT_FAIL_THRESHOLD }),
+    false
+  );
+});
+
+// -- Eval fixture-driven tests --
+
+test('eval fixtures: all produce expected verdicts and mergeBlocking=false', async () => {
+  for (const fixture of fixtures) {
+    const ghClient = fakeGhClient();
+    const dispatch = fakeDispatch(fixture.input.dispatchResult);
+    const result = await runPostMergeAudit(
+      fixture.input.mergedPr,
+      {
+        dispatch,
+        ghClient,
+        authorTeamModel: fixture.input.authorTeamModel,
+      }
+    );
+    assert.equal(result.mergeBlocking, false,
+      `fixture ${fixture.id}: mergeBlocking must be false`);
+    assert.equal(result.audit.verdict, fixture.expected.verdict,
+      `fixture ${fixture.id}: verdict mismatch`);
+    if (fixture.expected.escalated != null) {
+      const didEscalate = result.escalation
+        ? result.escalation.escalated : false;
+      assert.equal(didEscalate, fixture.expected.escalated,
+        `fixture ${fixture.id}: escalation mismatch`);
+    }
+    if (fixture.expected.familyViolation != null) {
+      assert.equal(result.audit.familyViolation,
+        fixture.expected.familyViolation,
+        `fixture ${fixture.id}: familyViolation mismatch`);
+    }
+  }
+});
+
+// -- Error handling --
+
+test('runPostMergeAudit throws on missing dispatch', async () => {
+  await assert.rejects(
+    () => runPostMergeAudit({ number: 1 }, {}),
+    { message: /dispatch is required/ }
+  );
+});
+
+test('runPostMergeAudit throws on missing mergedPr', async () => {
+  await assert.rejects(
+    () => runPostMergeAudit(null, { dispatch: async () => ({}) }),
+    { message: /mergedPr is required/ }
+  );
+});

--- a/tests/eval/baton-postmerge-audit/fixtures.json
+++ b/tests/eval/baton-postmerge-audit/fixtures.json
@@ -1,0 +1,95 @@
+{
+  "description": "Eval fixtures for post-merge consultant audit (Refs #3293, Epic #3284)",
+  "fixtures": [
+    {
+      "id": "passing-audit",
+      "input": {
+        "mergedPr": { "number": 100, "title": "feat: add widget", "diff": "diff --git a/widget.js" },
+        "authorTeamModel": "claude-code:opus@claude-code-cli",
+        "dispatchResult": {
+          "verdict": "ACCEPT",
+          "score": 8,
+          "reviewer_model_family": "qwen",
+          "findings": []
+        }
+      },
+      "expected": {
+        "verdict": "ACCEPT",
+        "mergeBlocking": false,
+        "escalated": false
+      }
+    },
+    {
+      "id": "failing-audit-reject",
+      "input": {
+        "mergedPr": { "number": 101, "title": "fix: patch auth", "diff": "diff --git a/auth.js" },
+        "authorTeamModel": "claude-code:sonnet@claude-code-cli",
+        "dispatchResult": {
+          "verdict": "REJECT",
+          "score": 3,
+          "reviewer_model_family": "google",
+          "findings": ["Missing input validation on auth token"]
+        }
+      },
+      "expected": {
+        "verdict": "REJECT",
+        "mergeBlocking": false,
+        "escalated": true
+      }
+    },
+    {
+      "id": "low-score-audit",
+      "input": {
+        "mergedPr": { "number": 102, "title": "chore: update config", "diff": "diff --git a/config.json" },
+        "authorTeamModel": "copilot:gpt-5@github-copilot",
+        "dispatchResult": {
+          "verdict": "PARTIAL",
+          "score": 3,
+          "reviewer_model_family": "anthropic",
+          "findings": ["Config format not validated"]
+        }
+      },
+      "expected": {
+        "verdict": "PARTIAL",
+        "mergeBlocking": false,
+        "escalated": true
+      }
+    },
+    {
+      "id": "cross-family-violation",
+      "input": {
+        "mergedPr": { "number": 103, "title": "feat: add logging", "diff": "diff --git a/log.js" },
+        "authorTeamModel": "claude-code:opus@claude-code-cli",
+        "dispatchResult": {
+          "verdict": "ACCEPT",
+          "score": 9,
+          "reviewer_model_family": "anthropic",
+          "findings": []
+        }
+      },
+      "expected": {
+        "verdict": "FAMILY_VIOLATION",
+        "mergeBlocking": false,
+        "familyViolation": true
+      }
+    },
+    {
+      "id": "antigravity-author-openai-reviewer",
+      "input": {
+        "mergedPr": { "number": 104, "title": "feat: add panel", "diff": "diff --git a/panel.js" },
+        "authorTeamModel": "antigravity:gemini@google",
+        "dispatchResult": {
+          "verdict": "ACCEPT",
+          "score": 7,
+          "reviewer_model_family": "openai",
+          "findings": []
+        }
+      },
+      "expected": {
+        "verdict": "ACCEPT",
+        "mergeBlocking": false,
+        "escalated": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Refs #3293
merge-evidence-deferred-final: #3293

Baton Authority Plane W5 (Epic #3284). Runs the Consultant as a post-merge advisory cross-model auditor wired into CI for all teams.

- Audit triggers post-merge (push to main, continue-on-error) and NEVER gates merge — plane-separated from the deterministic FSM blocking gate (W1a/W2).
- An audit failure opens a Tier-3 escalation ticket to the Manager instead of blocking.
- Cross-family invariant (reviewer model family differs from author family) enforced by a family registry.
- CI dispatch is wired but inert behind a passing-verdict placeholder until the HAMR/fleet dispatch adapter ships (documented follow-on). Absorbs #3235/#3236.

Baton artifacts posted on #3293: MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT.

test_strategy: eval-harness — 35 tests across 2 spec files + eval fixtures, lint + readability clean.
Cross-family: mistral:mistral-large-latest (Mistral) ACCEPT 100/100, receipt e10033bc5968fde4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
