### PR TITLE
fix(hooks): raise blast-radius and anomaly caps

### DIFF
--- a/.changes/unreleased/3316.md
+++ b/.changes/unreleased/3316.md
@@ -1,0 +1,8 @@
+Raised the per-session blast-radius and behavioral-anomaly thresholds to the
+"Generous" tier so a large multi-child Epic in a single session is no longer
+falsely halted: anomaly thresholds `writes_in_session` 50→250, `sensitive_path_reads`
+10→15, `pushes_in_session` 5→25; blast-radius caps `max_files_per_session` 200→1000,
+`max_pushes_per_session` 20→50, `max_cost_usd_per_session` $5→$20. Added a
+`MEGINGJORD_SESSION_ANOMALY_DISABLED=1` bypass for the anomaly halt (parity with
+`MEGINGJORD_BLAST_RADIUS_DISABLED`); the breach is still recorded to `incidents.jsonl`
+with `override:true` (audited, never silent). Refs #2913, #2917.

--- a/config/governance-rules.yaml
+++ b/config/governance-rules.yaml
@@ -24,13 +24,13 @@ version: 1
 generated_by: seed-rules-v1
 # #2913: session behavioral anomaly detection thresholds (Gap G-15 / ASI05 / EU-AI-Act-Art14)
 session_anomaly_thresholds:
-  writes_in_session: 50
-  sensitive_path_reads: 10
-  pushes_in_session: 5
+  writes_in_session: 250
+  sensitive_path_reads: 15
+  pushes_in_session: 25
 blast_radius_caps:
-  max_files_per_session: 200
-  max_pushes_per_session: 20
-  max_cost_usd_per_session: 5.00
+  max_files_per_session: 1000
+  max_pushes_per_session: 50
+  max_cost_usd_per_session: 20.00
 rules:
 
   - rule_id: refs-not-closes-in-pr

--- a/docs/howto/pre-push-gates.md
+++ b/docs/howto/pre-push-gates.md
@@ -175,8 +175,15 @@ Until those teams sign off, the gate enforces on the Claude-Code surface only.
 ## Session push counter — genuine-ship accounting (#3265)
 
 A session-level guard (the G-15 blast-radius counter, Refs #2913) halts the session
-when the number of pushes in one session exceeds `pushes_in_session` (default 5). It
-exists for human-oversight (ASI05 / EU-AI-Act Art.14) against a runaway agent.
+when the number of pushes in one session exceeds `pushes_in_session` (default 25,
+raised from 5 in #3316 so a large multi-child Epic in a single session is not falsely
+halted). It exists for human-oversight (ASI05 / EU-AI-Act Art.14) against a runaway
+agent. The companion anomaly thresholds (`writes_in_session` 250, `sensitive_path_reads`
+15) and the blast-radius caps (`max_files_per_session` 1000, `max_pushes_per_session`
+50, `max_cost_usd_per_session` 20.00) live in `config/governance-rules.yaml`. Set
+`MEGINGJORD_SESSION_ANOMALY_DISABLED=1` to bypass the anomaly halt for a known-large
+session — the breach is still recorded to `incidents.jsonl` (audited, not silent),
+parity with `MEGINGJORD_BLAST_RADIUS_DISABLED=1` for the blast-radius caps.
 
 Only a **genuine, successful, code-shipping push** counts toward that limit. The
 counter (`hooks/scripts/tool_activity.py` via `admin_patterns.is_countable_push`,

--- a/hooks/scripts/blast_radius_cap.py
+++ b/hooks/scripts/blast_radius_cap.py
@@ -10,9 +10,9 @@ from typing import Any
 ENV_BYPASS = "MEGINGJORD_BLAST_RADIUS_DISABLED"
 COST_PER_CALL_USD = 0.05
 DEFAULT_CAPS = {
-    "max_files_per_session": 200,
-    "max_pushes_per_session": 20,
-    "max_cost_usd_per_session": 5.00,
+    "max_files_per_session": 1000,
+    "max_pushes_per_session": 50,
+    "max_cost_usd_per_session": 20.00,
 }
 
 

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -10,7 +10,9 @@ from admin_patterns import (  # noqa: E501
     RE_RELEASE_INTEGRITY, RE_VSCE_PUBLISH, SECRET_FILE_RE, iter_paths, iter_strings)
 from canonical_main_enforcer import is_main_checkout, evaluate_path, main_checkout_root
 from blast_radius_cap import ENV_BYPASS, check_caps, emit_cap_incident, load_caps
-from session_anomaly import check_anomaly, emit_anomaly_incident
+from session_anomaly import (
+    ENV_ANOMALY_BYPASS, check_anomaly, emit_anomaly_incident,
+)
 from governance_state import ensure_state, save_state
 from baton_handoff_checks import linked_issue_has_authoritative_manager_handoff
 from one_ticket_per_worktree import check_one_ticket_per_worktree
@@ -186,11 +188,17 @@ def enforce_blast_radius(tool: str, state: dict, cwd: str) -> int | None:
     return emit("deny", f"Session blast-radius cap exceeded: {reason}")
 
 def enforce_session_anomaly(state: dict, cwd: str) -> int | None:
-    """#2913: deny when session aggregate counters exceed anomaly thresholds (G-15)."""
+    """#2913: deny when session aggregate counters exceed anomaly thresholds (G-15).
+    #3316: MEGINGJORD_SESSION_ANOMALY_DISABLED=1 bypasses (audited incident still
+    emitted) for parity with the blast-radius cap override.
+    """
     reason = check_anomaly(state, cwd)
     if not reason:
         return None
-    emit_anomaly_incident(reason, cwd)
+    override = os.environ.get(ENV_ANOMALY_BYPASS, "0") == "1"
+    emit_anomaly_incident(reason, cwd, override=override)
+    if override:
+        return None
     return emit("deny",
         f"Session anomaly detected — human review required: {reason}. "
         "Refs #2913 (G-15 / ASI05 / EU-AI-Act-Art14).")

--- a/hooks/scripts/session_anomaly.py
+++ b/hooks/scripts/session_anomaly.py
@@ -13,10 +13,11 @@ from pathlib import Path
 from typing import Any
 
 INCIDENTS_PATH = Path.home() / ".megingjord" / "incidents.jsonl"
+ENV_ANOMALY_BYPASS = "MEGINGJORD_SESSION_ANOMALY_DISABLED"
 DEFAULT_THRESHOLDS: dict[str, int] = {
-    "writes_in_session": 50,
-    "sensitive_path_reads": 10,
-    "pushes_in_session": 5,
+    "writes_in_session": 250,
+    "sensitive_path_reads": 15,
+    "pushes_in_session": 25,
 }
 _SENSITIVE_RE = re.compile(
     r"(?i)(\.env|secrets?[\\/]|credentials?[\\/]|private_key|"
@@ -85,8 +86,12 @@ def check_anomaly(state: dict[str, Any], cwd: str) -> str | None:
     return None
 
 
-def emit_anomaly_incident(reason: str, cwd: str) -> None:
-    """Append ANOMALY_DETECTED v3 event to incidents.jsonl. Never raises."""
+def emit_anomaly_incident(reason: str, cwd: str, override: bool = False) -> None:
+    """Append ANOMALY_DETECTED v3 event to incidents.jsonl. Never raises.
+
+    #3316: when override is True the breach is still recorded (audited, not
+    silent) with the bypass env named, for parity with blast-radius caps.
+    """
     try:
         INCIDENTS_PATH.parent.mkdir(parents=True, exist_ok=True)
         event = {
@@ -100,6 +105,8 @@ def emit_anomaly_incident(reason: str, cwd: str) -> None:
             "reason": reason,
             "gap": "G-15",
             "refs": ["ASI05", "EU-AI-Act-Art14"],
+            "override": bool(override),
+            "override_env": ENV_ANOMALY_BYPASS if override else None,
         }
         with INCIDENTS_PATH.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(event) + "\n")

--- a/tests/hooks/test_blast_radius_cap.py
+++ b/tests/hooks/test_blast_radius_cap.py
@@ -18,16 +18,16 @@ import pretool_guard  # noqa: E402
 
 class BlastRadiusCapTests(unittest.TestCase):
     def test_check_caps_detects_file_breach(self):
-        reason = br.check_caps({"files_edited_count": 201}, br.DEFAULT_CAPS)
-        self.assertIn("files_edited_count=201", reason)
+        reason = br.check_caps({"files_edited_count": 1001}, br.DEFAULT_CAPS)
+        self.assertIn("files_edited_count=1001", reason)
 
     def test_check_caps_detects_push_breach(self):
-        reason = br.check_caps({"push_count": 21}, br.DEFAULT_CAPS)
-        self.assertIn("push_count=21", reason)
+        reason = br.check_caps({"push_count": 51}, br.DEFAULT_CAPS)
+        self.assertIn("push_count=51", reason)
 
     def test_check_caps_detects_cost_breach(self):
-        reason = br.check_caps({"provider_call_count": 101}, br.DEFAULT_CAPS)
-        self.assertIn("estimated_cost_usd=5.05", reason)
+        reason = br.check_caps({"provider_call_count": 401}, br.DEFAULT_CAPS)
+        self.assertIn("estimated_cost_usd=20.05", reason)
 
     def test_load_caps_reads_yaml_block(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -56,7 +56,7 @@ class BlastRadiusCapTests(unittest.TestCase):
 class PretoolGuardIntegrationTests(unittest.TestCase):
     def test_pretool_guard_denies_when_cap_exceeded(self):
         payload = {"tool_name": "run_in_terminal", "tool_input": {"command": "echo hi"}, "cwd": str(REPO_ROOT)}
-        state = {"flags": {}, "admin_ops": {}, "blast_radius": {"files_edited_count": 999}, "active_ticket": 2917}
+        state = {"flags": {}, "admin_ops": {}, "blast_radius": {"files_edited_count": 1001}, "active_ticket": 2917}
         captured = {}
 
         def fake_emit(decision, reason, extra=None):
@@ -73,7 +73,7 @@ class PretoolGuardIntegrationTests(unittest.TestCase):
 
     def test_pretool_guard_allows_with_override_env(self):
         payload = {"tool_name": "run_in_terminal", "tool_input": {"command": "echo hi"}, "cwd": str(REPO_ROOT)}
-        state = {"flags": {}, "admin_ops": {}, "blast_radius": {"files_edited_count": 999}, "active_ticket": 2917}
+        state = {"flags": {}, "admin_ops": {}, "blast_radius": {"files_edited_count": 1001}, "active_ticket": 2917}
         with patch("pretool_guard.ensure_state", return_value=state), \
              patch("state_store.reset_on_branch_change", return_value=state), \
              patch.dict(os.environ, {br.ENV_BYPASS: "1"}, clear=False), \

--- a/tests/hooks/test_session_anomaly_detection.py
+++ b/tests/hooks/test_session_anomaly_detection.py
@@ -1,6 +1,7 @@
 """Tests for #2913 session behavioral anomaly detection (Gap G-15)."""
 import io
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -101,6 +102,17 @@ class EmitAnomalyIncidentTests(unittest.TestCase):
         self.assertEqual(payload["gap"], "G-15")
         self.assertIn("total_writes", payload["reason"])
 
+    def test_writes_override_fields_when_bypassed(self):
+        with tempfile.TemporaryDirectory() as home:
+            with patch("pathlib.Path.home", return_value=Path(home)):
+                sa.INCIDENTS_PATH = Path(home) / ".megingjord" / "incidents.jsonl"
+                sa.emit_anomaly_incident("total_writes=999", "/tmp/r", override=True)
+            log = Path(home) / ".megingjord" / "incidents.jsonl"
+            payload = json.loads(log.read_text(encoding="utf-8").strip())
+        self.assertTrue(payload["override"])
+        self.assertEqual(payload["override_env"], sa.ENV_ANOMALY_BYPASS)
+
+
 
 class PretoolGuardAnomalyIntegrationTests(unittest.TestCase):
     def _make_payload(self, tool="run_in_terminal"):
@@ -110,7 +122,7 @@ class PretoolGuardAnomalyIntegrationTests(unittest.TestCase):
         payload = self._make_payload()
         state = {
             "flags": {}, "admin_ops": {}, "blast_radius": {"push_count": 0},
-            "session": {"total_writes": 99, "total_reads_sensitive_paths": 0, "total_pushes": 0},
+            "session": {"total_writes": 999, "total_reads_sensitive_paths": 0, "total_pushes": 0},
             "active_ticket": 2913,
         }
         captured = {}
@@ -127,6 +139,21 @@ class PretoolGuardAnomalyIntegrationTests(unittest.TestCase):
             pretool_guard.main()
         self.assertEqual(captured.get("decision"), "deny")
         self.assertIn("anomaly detected", captured.get("reason", "").lower())
+
+    def test_allows_with_anomaly_override_env(self):
+        payload = self._make_payload()
+        state = {
+            "flags": {}, "admin_ops": {}, "blast_radius": {"push_count": 0},
+            "session": {"total_writes": 9999, "total_reads_sensitive_paths": 0, "total_pushes": 0},
+            "active_ticket": 3316,
+        }
+        with patch("pretool_guard.ensure_state", return_value=state), \
+             patch("state_store.reset_on_branch_change", return_value=state), \
+             patch.dict(os.environ, {sa.ENV_ANOMALY_BYPASS: "1"}, clear=False), \
+             patch("session_anomaly.emit_anomaly_incident"), \
+             patch("sys.stdin", io.StringIO(json.dumps(payload))):
+            code = pretool_guard.main()
+        self.assertEqual(code, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #3316
merge-evidence-deferred-final: #3316

## Summary

Raise the per-session blast-radius caps and behavioral-anomaly thresholds to the
"Generous" tier so a large multi-child Epic in a single session is no longer falsely
halted, and add a `MEGINGJORD_SESSION_ANOMALY_DISABLED=1` override (parity with
`MEGINGJORD_BLAST_RADIUS_DISABLED`) — the breach is still recorded to `incidents.jsonl`
with `override:true` (audited, never silent).

| Threshold | Old | New |
|---|---|---|
| anomaly writes_in_session | 50 | 250 |
| anomaly sensitive_path_reads | 10 | 15 |
| anomaly pushes_in_session | 5 | 25 |
| blast max_files_per_session | 200 | 1000 |
| blast max_pushes_per_session | 20 | 50 |
| blast max_cost_usd_per_session | $5 | $20 |

Code defaults (`DEFAULT_THRESHOLDS` / `DEFAULT_CAPS`) kept in sync with the YAML.

## Baton artifacts (full text on issue #3316)

- MANAGER_HANDOFF — scope/AC/gates; lane:code-change; test_strategy tdd-pyramid.
- COLLABORATOR_HANDOFF — per-AC PASS; cross_family_reviewer free-cloud:groq (Llama), 70/100; doc-coverage.
- ADMIN_HANDOFF — branch fix/3316-blast-radius-thresholds; commit e8162bf; signer-independence PASS (Harper≠Reyes).
- CONSULTANT_CLOSEOUT — deferred to post-merge (deferred-final flow).

## Test evidence

20/20 python unittest + 2/2 Playwright spec wrappers green; ruff + 100-line lint clean.
