### PR TITLE
fix(governance): local preflight doc-coverage parity

### DIFF
--- a/.changes/unreleased/3328.md
+++ b/.changes/unreleased/3328.md
@@ -1,0 +1,7 @@
+fix(governance): local closeout-preflight enforces doc-coverage format like CI (#3328)
+
+The pre-push `closeout-preflight` now runs the `doc-coverage` validator with the
+same strictness as CI's `collaborator-gate` whenever a COLLABORATOR_HANDOFF is
+posted — catching a heading-form `### doc-coverage:` block and a non-enum N/A
+reason locally instead of only in CI. `doc-coverage` is registered as a
+first-class megalint validator. Closes the #3315 format-parity recurrence.

--- a/scripts/global/closeout-preflight.js
+++ b/scripts/global/closeout-preflight.js
@@ -67,8 +67,23 @@ function hasCloseoutComment(comments) {
   return (comments || []).some((c) => CLOSEOUT_ARTIFACT_RE.test(c.body || ''));
 }
 
-function selectPreflightValidators(prExists, closeoutAlreadyPosted) {
+// #3328: a posted COLLABORATOR_HANDOFF *artifact* (header on its own line), not a
+// prose mention inside another artifact. Anchored like CLOSEOUT_ARTIFACT_RE so a
+// MANAGER_HANDOFF that names "COLLABORATOR_HANDOFF" in its scope text never trips it.
+const COLLAB_HANDOFF_ARTIFACT_RE = /(?:^|\n)\s*(?:\*\*|##\s*)?COLLABORATOR_HANDOFF\b/i;
+function hasCollaboratorHandoff(comments) {
+  return (comments || []).some((c) => COLLAB_HANDOFF_ARTIFACT_RE.test(c.body || ''));
+}
+
+// #3328: the local pre-push preflight now runs `doc-coverage` with the SAME strictness
+// as CI's collaborator-gate — but ONLY once a COLLABORATOR_HANDOFF is actually posted.
+// The doc-coverage validator falls back to the issue body when no handoff is present,
+// which would false-fail every legitimate pre-handoff push ("missing doc-coverage
+// block"). Gating on handoff presence keeps ordering relaxed while closing the
+// format-parity gap (#3315 recurrence) the moment the artifact exists.
+function selectPreflightValidators(prExists, closeoutAlreadyPosted, collaboratorHandoffPosted) {
   const validators = ['manager-handoff'];
+  if (collaboratorHandoffPosted) validators.push('doc-coverage');
   const enforceCloseoutNow = prExists || closeoutAlreadyPosted;
   if (enforceCloseoutNow) validators.push('consultant-closeout');
   if (prExists) validators.push('merge-evidence-pr-gate');
@@ -97,7 +112,8 @@ async function run(opts = {}) {
   const prBody = await fetchPrBody(branch, opts);
   if (prBody !== null) input.prBody = prBody;
   const { validators, closeoutDeferred } = selectPreflightValidators(
-    prBody !== null, hasCloseoutComment(input.comments));
+    prBody !== null, hasCloseoutComment(input.comments),
+    hasCollaboratorHandoff(input.comments));
   if (closeoutDeferred) {
     console.log(`closeout-preflight: consultant-closeout deferred to PR-open (deferred-final flow; no PR yet) #${issueNum}`);
   }
@@ -116,4 +132,4 @@ async function run(opts = {}) {
 if (require.main === module) run().then((code) => process.exit(code));
 
 module.exports = { extractIssueFromBranch, readIssue, fetchPrBody, toValidatorInput, run,
-  hasCloseoutComment, selectPreflightValidators, batonBackGateBlocks };
+  hasCloseoutComment, hasCollaboratorHandoff, selectPreflightValidators, batonBackGateBlocks };

--- a/scripts/global/megalint/index.js
+++ b/scripts/global/megalint/index.js
@@ -5,6 +5,10 @@
 
 const manager = require('./manager-handoff.js');
 const collaborator = require('./collaborator-handoff.js');
+// #3328: doc-coverage exposed as a first-class validator so the local pre-push
+// closeout-preflight can enforce the COLLABORATOR_HANDOFF doc-coverage block
+// (N/A enum reason + bare `doc-coverage:` header) with the SAME strictness as CI.
+const docCoverage = require('./doc-coverage.js');
 const admin = require('./admin-handoff.js');
 const consultant = require('./consultant-closeout.js');
 const signer = require('./signer-fidelity.js');
@@ -45,6 +49,7 @@ const parityValidatorAdapter = {
 const VALIDATORS = {
   'manager-handoff': manager,
   'collaborator-handoff': collaborator,
+  'doc-coverage': docCoverage,
   'admin-handoff': admin,
   'consultant-closeout': consultant,
   'signer-fidelity': signer,

--- a/tests/closeout-preflight-doc-coverage.spec.js
+++ b/tests/closeout-preflight-doc-coverage.spec.js
@@ -1,0 +1,144 @@
+'use strict';
+// #3328 — parity regression: the LOCAL pre-push closeout-preflight must reject the
+// same baton-artifact FORMAT defects CI's collaborator-gate rejects (the #3315
+// recurrence): a heading-form `### doc-coverage:` block, a non-enum N/A reason, and
+// a labelled/missing MANAGER_HANDOFF `acceptance:` field. A correctly-formatted pair
+// passes local and CI identically.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const SCRIPT = path.join(ROOT, 'scripts', 'global', 'closeout-preflight.js');
+const preflight = require('../scripts/global/closeout-preflight.js');
+const megalint = require('../scripts/global/megalint');
+const collaboratorHandoff = require('../scripts/global/megalint/collaborator-handoff.js');
+
+const BRANCH = 'fix/3328-local-preflight-doc-coverage';
+const LABELS = ['lane:code-change', 'area:scripts'];
+
+// A schema-valid MANAGER_HANDOFF with `acceptance:` content on its own (block) line —
+// the canonical baton-builder form, which extractField parses correctly.
+const MANAGER_HANDOFF_OK =
+  '## MANAGER_HANDOFF\nscope: wire doc-coverage into preflight\nlane: lane:code-change\n'
+  + 'test_strategy: tdd-pyramid\nacceptance:\nAC1 local==CI\ngates: CI\n'
+  + 'related_tickets: #3315\noverlap_decision: none\n'
+  + `worktree_branch: ${'fix/3328-local-preflight-doc-coverage'}\n`
+  + 'Signed-by: Orla Mason\nTeam&Model: claude-code:claude-opus-4-8@local\nRole: manager';
+
+// The defect form CI rejects: a labelled `acceptance (checklist):` header parses as
+// missing-acceptance (the colon is not adjacent to the field name).
+const MANAGER_HANDOFF_BAD_ACCEPTANCE =
+  '## MANAGER_HANDOFF\nscope: wire doc-coverage into preflight\nlane: lane:code-change\n'
+  + 'test_strategy: tdd-pyramid\nacceptance (checklist):\n- AC1\ngates: CI\n'
+  + 'related_tickets: #3315\noverlap_decision: none\n'
+  + `worktree_branch: ${'fix/3328-local-preflight-doc-coverage'}\n`
+  + 'Signed-by: Orla Mason\nTeam&Model: claude-code:claude-opus-4-8@local\nRole: manager';
+
+const DOC_BLOCK_OK =
+  'doc-coverage:\n'
+  + '  .changes/unreleased/: UPDATED: .changes/unreleased/3328.md\n'
+  + '  README.md: N/A: no-user-visible-change — internal validator wiring\n'
+  + '  docs/howto/: N/A: out-of-scope — no operator-runbook change';
+
+// #2 the heading form `### doc-coverage:` is NOT recognized as a block header.
+const DOC_BLOCK_HEADING =
+  '### doc-coverage:\n'
+  + '  .changes/unreleased/: UPDATED: .changes/unreleased/3328.md\n'
+  + '  README.md: N/A: no-user-visible-change — internal validator wiring\n'
+  + '  docs/howto/: N/A: out-of-scope — no operator-runbook change';
+
+// #3 a non-enum N/A reason (the repeated surface path instead of an enum reason).
+const DOC_BLOCK_BAD_NA =
+  'doc-coverage:\n'
+  + '  .changes/unreleased/: UPDATED: .changes/unreleased/3328.md\n'
+  + '  README.md: N/A: README.md — repeated path not an enum reason\n'
+  + '  docs/howto/: N/A: out-of-scope — no operator-runbook change';
+
+const collabHandoff = (docBlock) =>
+  `## COLLABORATOR_HANDOFF\nticket: #3328\n${docBlock}\n`
+  + 'Signed-by: Orla Harper\nTeam&Model: claude-code:claude-opus-4-8@local\nRole: collaborator';
+
+function runPreflight(managerBody, docBlock) {
+  const issue = {
+    title: 'Local closeout-preflight doc-coverage parity',
+    body: 'Wire doc-coverage into the pre-push preflight',
+    comments: [{ body: managerBody }, { body: collabHandoff(docBlock) }],
+    labels: LABELS, state: 'open',
+  };
+  return spawnSync(process.execPath, [SCRIPT], {
+    env: {
+      ...process.env,
+      CLOSEOUT_PREFLIGHT_BRANCH: BRANCH,
+      CLOSEOUT_PREFLIGHT_ISSUE_JSON: JSON.stringify(issue),
+    },
+    encoding: 'utf8',
+  });
+}
+
+// ---- AC2: correctly-formatted pair passes local pre-push ----
+test('AC2: a well-formed MANAGER_HANDOFF + doc-coverage block passes local pre-push', () => {
+  const r = runPreflight(MANAGER_HANDOFF_OK, DOC_BLOCK_OK);
+  assert.equal(r.status, 0, r.stdout + r.stderr);
+  assert.match(r.stdout, /PASS #3328/);
+});
+
+// ---- AC1: each FORMAT defect now fails LOCALLY (matching CI) ----
+test('AC1: a heading-form `### doc-coverage:` block fails local pre-push', () => {
+  const r = runPreflight(MANAGER_HANDOFF_OK, DOC_BLOCK_HEADING);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /FAIL \[doc-coverage\]/);
+  assert.match(r.stderr, /doc-coverage-missing/);
+});
+
+test('AC1: a non-enum N/A reason fails local pre-push', () => {
+  const r = runPreflight(MANAGER_HANDOFF_OK, DOC_BLOCK_BAD_NA);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /FAIL \[doc-coverage\]/);
+  assert.match(r.stderr, /doc-coverage-invalid-na/);
+});
+
+test('AC1: a labelled `acceptance (...)` MANAGER_HANDOFF fails local pre-push', () => {
+  const r = runPreflight(MANAGER_HANDOFF_BAD_ACCEPTANCE, DOC_BLOCK_OK);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /FAIL \[manager-handoff\]/);
+  assert.match(r.stderr, /missing-acceptance/);
+});
+
+// ---- Parity: the local `doc-coverage` validator and CI's collaborator-gate agree ----
+test('parity: local doc-coverage verdict matches CI collaborator-gate doc-coverage path', () => {
+  for (const [docBlock, expectOk] of [
+    [DOC_BLOCK_OK, true], [DOC_BLOCK_HEADING, false], [DOC_BLOCK_BAD_NA, false],
+  ]) {
+    const comments = [{ body: collabHandoff(docBlock) }];
+    // Local path: the megalint-registered doc-coverage validator (used by closeout-preflight).
+    const local = megalint.run('doc-coverage', { comments, labels: LABELS, lane: 'lane:code-change' });
+    // CI path: collaborator-handoff.validate runs the same doc-coverage checkBlock internally.
+    const ci = collaboratorHandoff.validate({ comments, labels: LABELS });
+    const ciDocBlocking = (ci.violations || [])
+      .filter((v) => v.rule.startsWith('doc-coverage') && v.severity !== 'advisory');
+    assert.equal(local.ok, expectOk, `local doc-coverage verdict mismatch for ${expectOk}`);
+    assert.equal(ciDocBlocking.length === 0, expectOk, 'CI doc-coverage verdict diverged from local');
+  }
+});
+
+// ---- Unit: validator selection + handoff detection ----
+test('selectPreflightValidators adds doc-coverage only when a COLLABORATOR_HANDOFF is posted', () => {
+  const without = preflight.selectPreflightValidators(false, false, false);
+  assert.deepEqual(without.validators, ['manager-handoff']);
+  const withHandoff = preflight.selectPreflightValidators(false, false, true);
+  assert.ok(withHandoff.validators.includes('doc-coverage'));
+  assert.ok(withHandoff.validators.includes('manager-handoff'));
+});
+
+test('hasCollaboratorHandoff matches the artifact header, not a prose mention', () => {
+  assert.equal(preflight.hasCollaboratorHandoff([{ body: '## COLLABORATOR_HANDOFF\nx' }]), true);
+  assert.equal(preflight.hasCollaboratorHandoff([{ body: 'COLLABORATOR_HANDOFF\nx' }]), true);
+  // A MANAGER_HANDOFF that names the artifact in prose must NOT count.
+  assert.equal(preflight.hasCollaboratorHandoff([
+    { body: 'MANAGER_HANDOFF\nscope: post the COLLABORATOR_HANDOFF after impl' },
+  ]), false);
+  assert.equal(preflight.hasCollaboratorHandoff([]), false);
+});

--- a/tests/closeout-preflight.spec.js
+++ b/tests/closeout-preflight.spec.js
@@ -22,6 +22,9 @@ function runWith(issueJson, branch, prBody) {
 const MANAGER_HANDOFF_FIXTURE =
   'MANAGER_HANDOFF\nscope: fix pre-push\nlane: lane:code-change\ntest_strategy: tdd-pyramid\n'
   + 'acceptance: pass/fail\ngates: CI\nrelated_tickets: #3008\noverlap_decision: none\n'
+  // #3328: worktree_branch is required by manager-handoff (wtGate.checkManager) for
+  // lane:code-change; the fixture predates that requirement and was failing on main.
+  + 'worktree_branch: fix/1566-closeout-preflight\n'
   + 'Signed-by: Orla Mason\nTeam&Model: claude-code:opus@anthropic\nRole: manager';
 
 const CONSULTANT_CLOSEOUT_FIXTURE =
@@ -29,6 +32,9 @@ const CONSULTANT_CLOSEOUT_FIXTURE =
   + 'verification-timestamp: 2026-06-21T00:00:00Z\n'
   + 'rubric_rating: G1:9 G2:9 G3:9 G4:9 G5:9 G6:9 G7:9 G8:9 G9:9 -> min(G1..G9)=9, rubric 9/10\n'
   + 'anneal_tickets_filed: none\nmid_flight_flaws: none\n'
+  // #3328: worktree_residual_risk is required by consultant-closeout; the fixture
+  // predates that requirement and was failing on main.
+  + 'worktree_residual_risk: none\n'
   + 'Signed-by: Orla Vale\nTeam&Model: claude-code:opus@anthropic\nRole: consultant';
 
 test('closeout-preflight passes when linked issue has a valid consultant closeout', () => {


### PR DESCRIPTION
Refs #3328

merge-evidence-deferred-final: #3328

## Summary
The pre-push `closeout-preflight` now runs the `doc-coverage` validator with the
SAME strictness as CI's `collaborator-gate` whenever a COLLABORATOR_HANDOFF is
posted — closing the #3315 format-parity recurrence where a `### doc-coverage:`
heading and a non-enum `N/A` reason passed locally but were rejected by CI.

- Register `doc-coverage` as a first-class megalint validator (`megalint/index.js`).
- Wire it into `closeout-preflight`, gated on COLLABORATOR_HANDOFF presence so
  legitimate pre-handoff pushes are not false-failed.
- `manager-handoff` (acceptance same-line format) was already enforced locally.
- Parity regression spec + repair of two stale fixtures (`worktree_branch`,
  `worktree_residual_risk`) that predate current validator requirements.

## Test evidence (tdd-pyramid)
- `tests/closeout-preflight-doc-coverage.spec.js` — 7/7 pass (AC1 heading + N/A +
  acceptance failures; AC2 well-formed pass; local↔CI parity assertion).
- doc-coverage / megalint specs 49/49 pass; lint green.
- Local pre-push `closeout-preflight` PASSED on the real #3328 artifacts.

## Baton trail (artifacts on #3328)
- MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF posted on the issue.
- CONSULTANT_CLOSEOUT deferred to PR-open (deferred-final flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
