### PR TITLE
fix(governance): baton builder worktree fields (#3331)

### DIFF
--- a/.changes/unreleased/3331.md
+++ b/.changes/unreleased/3331.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- baton-comment-build: the canonical baton-artifact builder now emits the
+  worktree/verification fields its own validators require — `worktree_branch`
+  (MANAGER/COLLABORATOR), `worktree_behind_main` + the `Pre-handoff verification`
+  self-check block (COLLABORATOR), and `worktree_residual_risk` (CONSULTANT) are
+  allowed (optional) fields in `baton-artifact-schema.js`, so a builder-produced
+  artifact passes its megalint validators with no manual field additions (#3331).

--- a/scripts/global/baton-artifact-schema.js
+++ b/scripts/global/baton-artifact-schema.js
@@ -23,6 +23,11 @@ const MANAGER = [
   f('gates', { req: true }),
   f('related_tickets', { req: true }),
   f('overlap_decision', { req: true }),
+  // #3331: worktree-lifecycle-gate.checkManager requires worktree_branch on
+  // lane:code-change. OPTIONAL here (the gate skips other lanes; the historical
+  // replay corpus predates it), but ALLOWED so the builder can emit a CI-valid
+  // artifact unaided instead of throwing on the unknown key.
+  f('worktree_branch'),
   f('anneal_tier'),
   f('phase_gate_satisfied'),
   f('phase_0_sources'),
@@ -44,6 +49,14 @@ const COLLABORATOR = [
   // lives in collaborator-handoff.checkCrossFamily, which hard-requires it on live PRs.
   f('cross_family_receipt', {}),
   f('reviewer_family', {}),
+  // #3331: worktree-lifecycle-gate.checkCollaborator + collaborator-self-check
+  // require these on lane:code-change. OPTIONAL (lane-gated + corpus back-compat),
+  // but ALLOWED so a builder-produced handoff passes the validators unaided. The
+  // verification key is the literal phrase the self-check scans for, so the block
+  // is detected structurally regardless of the pasted formatChecks() value.
+  f('worktree_branch'),
+  f('worktree_behind_main'),
+  f('Pre-handoff verification', { block: true }),
 ];
 
 // ADMIN_HANDOFF — branch/commit + signer-independence + deploy-sync impact.
@@ -62,6 +75,10 @@ const CONSULTANT = [
   f('rubric_rating', { req: true }),
   f('anneal_tickets_filed', { req: true }),
   f('mid_flight_flaws', { req: true, block: true }),
+  // #3331: worktree-lifecycle-gate.checkConsultant requires worktree_residual_risk
+  // (none | <details>) on non-lightweight lanes. OPTIONAL for back-compat; ALLOWED
+  // so the builder can emit it unaided.
+  f('worktree_residual_risk'),
 ];
 
 // EPIC_RESCOPE — single narrative synthesis slot (irreducible per #2038).

--- a/tests/baton-artifact-worktree-fields-3331.spec.js
+++ b/tests/baton-artifact-worktree-fields-3331.spec.js
@@ -1,0 +1,75 @@
+// #3331 regression: the canonical baton-artifact builder must be ABLE to emit the
+// worktree/verification fields its own megalint validators require, so a
+// builder-produced artifact passes those validators with NO manual field
+// additions. Before this fix, baton-artifact-schema.js omitted the fields and the
+// builder's assertValid() threw `unknown field` on any attempt to supply them.
+// This spec asserts builder output models the validator (AC2) for MANAGER /
+// COLLABORATOR / CONSULTANT on lane:code-change.
+const { test, expect } = require('@playwright/test');
+const { buildArtifact } = require('../scripts/global/baton-artifact-builder');
+const wtGate = require('../scripts/global/worktree-lifecycle-gate');
+const { checkHandoffHasVerification } = require('../scripts/global/collaborator-self-check');
+const managerMega = require('../scripts/global/megalint/manager-handoff');
+
+const TM = 'claude-code:opus@local';
+const BRANCH = 'fix/3331-baton-builder-worktree-fields';
+const CLEAN_SUMMARY = { counts: { 'stale-safe': 0, 'stale-risky': 0, 'detached-temp': 0, 'rescue-needed': 0 }, total: 0 };
+
+test('builder MANAGER_HANDOFF carries worktree_branch and clears wtGate.checkManager', () => {
+  const out = buildArtifact({
+    artifact: 'MANAGER_HANDOFF', role: 'manager', teamModel: TM, ticket: '3331',
+    fields: {
+      scope: 'add worktree fields', lane: 'lane:code-change', test_strategy: 'tdd-pyramid',
+      acceptance: '- AC1', gates: 'lint, test', related_tickets: '#3328', overlap_decision: 'no-overlap',
+      worktree_branch: BRANCH,
+    },
+  });
+  expect(out).toContain(`worktree_branch: ${BRANCH}`);
+  expect(wtGate.checkManager(out, { lane: 'lane:code-change', branch: BRANCH, ticketRef: 3331 })).toEqual([]);
+  // Full megalint manager validator (clean of doc-coverage deps) is also satisfied.
+  const r = managerMega.validate({ comments: [{ body: out }], lane: 'lane:code-change', branch: BRANCH, ticketRef: 3331, issueNumber: 3331 });
+  expect(r.ok).toBe(true);
+});
+
+test('builder COLLABORATOR_HANDOFF carries worktree fields + self-check block and clears both gates', () => {
+  const out = buildArtifact({
+    artifact: 'COLLABORATOR_HANDOFF', role: 'collaborator', teamModel: TM, ticket: '3331',
+    fields: {
+      scope: 'impl', test_strategy: 'tdd-pyramid', per_ac_verification: '- AC1 PASS',
+      cross_family_rating: '9/10', cross_family_reviewer: 'qwen2.5-coder:32b@fleet', cross_family_findings: 'none',
+      worktree_branch: BRANCH, worktree_behind_main: '0',
+      'Pre-handoff verification': '(PASS)\n- [x] `branch-name-prefix` — pass',
+    },
+  });
+  expect(out).toContain(`worktree_branch: ${BRANCH}`);
+  expect(out).toContain('worktree_behind_main: 0');
+  expect(out).toContain('Pre-handoff verification');
+  expect(wtGate.checkCollaborator(out, { lane: 'lane:code-change', branch: BRANCH })).toEqual([]);
+  expect(checkHandoffHasVerification(out).ok).toBe(true);
+});
+
+test('builder CONSULTANT_CLOSEOUT carries worktree_residual_risk and clears wtGate.checkConsultant', () => {
+  const out = buildArtifact({
+    artifact: 'CONSULTANT_CLOSEOUT', role: 'consultant', teamModel: TM, ticket: '3331',
+    fields: {
+      status: 'review', verdict: 'approve_for_merge', 'verification-timestamp': '2026-06-29T00:00:00Z',
+      rubric_rating: '9/10', anneal_tickets_filed: 'none', mid_flight_flaws: 'none',
+      worktree_residual_risk: 'none',
+    },
+  });
+  expect(out).toContain('worktree_residual_risk: none');
+  expect(wtGate.checkConsultant(out, { lane: 'lane:code-change', worktreeSummary: CLEAN_SUMMARY })).toEqual([]);
+});
+
+test('worktree fields are accepted by the builder (no unknown-field throw) yet remain optional', () => {
+  // Optional: an artifact omitting them still builds (back-compat / non-code-change lanes).
+  expect(() => buildArtifact({
+    artifact: 'MANAGER_HANDOFF', role: 'manager', teamModel: TM,
+    fields: { scope: 's', lane: 'lane:config-only', test_strategy: 'manual-verify', acceptance: '-', gates: 'g', related_tickets: '#1', overlap_decision: 'no-overlap' },
+  })).not.toThrow();
+  // Present: supplying the field no longer throws unknown-field.
+  expect(() => buildArtifact({
+    artifact: 'CONSULTANT_CLOSEOUT', role: 'consultant', teamModel: TM,
+    fields: { status: 'review', verdict: 'approve_for_merge', 'verification-timestamp': 't', rubric_rating: '9/10', anneal_tickets_filed: 'none', mid_flight_flaws: 'none', worktree_residual_risk: 'none' },
+  })).not.toThrow();
+});


### PR DESCRIPTION
Refs #3331

merge-evidence-deferred-final: #3331

## Summary
The canonical baton-artifact builder omitted the worktree/verification fields its own megalint validators require, so `baton-artifact-builder.assertValid()` threw `unknown field` on any attempt to emit them — forcing manual hand-addition every baton cycle (same local/builder-vs-CI-validator parity class as #3315/#3328).

This adds them as OPTIONAL fields to `scripts/global/baton-artifact-schema.js`:
- MANAGER / COLLABORATOR: `worktree_branch`
- COLLABORATOR: `worktree_behind_main` + the `Pre-handoff verification` self-check block
- CONSULTANT: `worktree_residual_risk`

Optional (req:false) preserves back-compat with non-code-change lanes and the historical replay corpus (mirrors the #3016 `cross_family_receipt` precedent). `buildArtifact()` stays pure — no git/Date/random added — so the cross-runtime byte-identical invariant holds.

## Tests
`tests/baton-artifact-worktree-fields-3331.spec.js` asserts builder output models worktree-lifecycle-gate.checkManager/checkCollaborator/checkConsultant and collaborator-self-check.checkHandoffHasVerification (AC2). All baton-artifact specs green (35/35); lint clean.

## Baton trail (on issue #3331)
- MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT posted as comments on #3331.
- Cross-family review: ACCEPT 95/100 — llama-3.3-70b-versatile@groq (non-Anthropic; zero-cost free-cloud failover, fleet host unreachable).
- Follow-on Tier-2 anneal: #3333 (preflight bounded free-cloud failover).
