### PR TITLE
feat(hooks): memory-write poka-yoke guard for friction notes

### DIFF
--- a/.changes/unreleased/3383.md
+++ b/.changes/unreleased/3383.md
@@ -1,0 +1,3 @@
+### memory-write poka-yoke guard — deterministic-friction notes need a disposition (#3383)
+
+Phase-1 of Epic #3380. New `hooks/scripts/memory_write_guard.py` (advisory) intercepts memory-dir writes: a guardrail-candidate (deterministic-friction) note without a `disposition:` line emits an advisory to file a guardrail instead. Judgment/preference notes write frictionlessly; fail-open; `MEMORY_GUARD_BYPASS=1` escape hatch. Wired into `pretool_guard.py`.

--- a/hooks/scripts/memory_write_guard.py
+++ b/hooks/scripts/memory_write_guard.py
@@ -1,0 +1,79 @@
+"""memory_write_guard (Epic #3380 / #3383): PreToolUse poka-yoke. A deterministic-friction
+(guardrail-candidate) memory note may not be written WITHOUT a disposition line, while genuine
+judgment/preference notes write frictionlessly. Ships ADVISORY (warns, allows); promotion to
+blocking is replay-eval-gated per Phase-0 #3381 Q6. Fail-open: any error -> allow.
+
+Runtime-agnostic shim: reads the SAME shared lexicon as scripts/global/friction-classifier.js
+(config/friction-lexicon.json), so all four teams route identically (G5)."""
+import json
+import os
+import re
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_LEXICON_PATH = os.path.join(_REPO_ROOT, "config", "friction-lexicon.json")
+_DEFECT_MARKERS = ("false-block", "false block", "misfire", "collision", "blocks",
+                   "rejects", "trips", "denies", "regresses", "wrong", "stale")
+_DISPOSITION_RE = re.compile(r"^\s*disposition:\s*(guardrail\s*#\d+|defer\b)", re.I | re.M)
+_MEMORY_DIR_RE = re.compile(r"/memory/|MEMORY\.md$|/\.claude/.*memory")
+
+
+def load_lexicon(path=None):
+    try:
+        with open(path or _LEXICON_PATH, encoding="utf-8") as handle:
+            return json.load(handle)
+    except Exception:
+        return {"mechanical": [], "judgment": []}
+
+
+def _hits(text, terms):
+    lower = text.lower()
+    return [w for w in (terms or []) if w in lower]
+
+
+# classify_note(body, lexicon?) -> destination in {guardrail-candidate, semantic-memory, skill, forget}
+def classify_note(body, lexicon=None):
+    try:
+        lex = lexicon if lexicon is not None else load_lexicon()
+        text = (body or "").strip()
+        if not text:
+            return "semantic-memory"
+        judg = _hits(text, lex.get("judgment", []))
+        if judg:  # judgment/preference WINS on collision (anti-over-route)
+            return "semantic-memory"
+        mech = _hits(text, lex.get("mechanical", []))
+        looks_defect = any(m in text.lower() for m in _DEFECT_MARKERS)
+        if mech and looks_defect:
+            return "guardrail-candidate"
+        return "semantic-memory"
+    except Exception:
+        return "semantic-memory"  # fail-open
+
+
+def is_memory_path(path):
+    return bool(path) and bool(_MEMORY_DIR_RE.search(path))
+
+
+# check_memory_write(path, body, env?) -> (decision, reason). decision in {allow, advise}.
+# ADVISORY contract: guardrail-candidate without a disposition -> advise (still allowed).
+def check_memory_write(path, body, env=None):
+    try:
+        env = env if env is not None else os.environ
+        if str(env.get("MEMORY_GUARD_BYPASS", "")) == "1":
+            return ("allow", "[memory-guard bypass] MEMORY_GUARD_BYPASS=1 — audit warning, allowed")
+        if not is_memory_path(path):
+            return ("allow", "not a memory-dir write")
+        if classify_note(body) != "guardrail-candidate":
+            return ("allow", "judgment/skill/forget note — frictionless")
+        if _DISPOSITION_RE.search(body or ""):
+            return ("allow", "guardrail-candidate carries a disposition line")
+        return ("advise", "deterministic-friction note: file a guardrail ticket "
+                "(add 'disposition: guardrail #<N>') or 'disposition: defer <reason>'")
+    except Exception as exc:  # fail-open: never block legitimate work
+        return ("allow", "memory-guard fail-open: " + str(exc)[:80])
+
+
+if __name__ == "__main__":
+    import sys
+    p = sys.argv[1] if len(sys.argv) > 1 else ""
+    b = sys.argv[2] if len(sys.argv) > 2 else sys.stdin.read()
+    print(json.dumps(dict(zip(("decision", "reason"), check_memory_write(p, b)))))

--- a/hooks/scripts/memory_write_guard.py
+++ b/hooks/scripts/memory_write_guard.py
@@ -4,7 +4,8 @@ judgment/preference notes write frictionlessly. Ships ADVISORY (warns, allows); 
 blocking is replay-eval-gated per Phase-0 #3381 Q6. Fail-open: any error -> allow.
 
 Runtime-agnostic shim: reads the SAME shared lexicon as scripts/global/friction-classifier.js
-(config/friction-lexicon.json), so all four teams route identically (G5)."""
+(config/friction-lexicon.json), so all four teams route identically (G5).
+"""
 import json
 import os
 import re

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -479,6 +479,19 @@ def main() -> int:
                 return emit("deny",
                     "Write to /memories/ blocked: use the memory tool for memory operations. "
                     "Raw file writes to /memories/ are a governance injection vector (G-07, #2903).")
+        # #3383 Epic #3380: guardrail-first memory-write poka-yoke (ADVISORY; never denies).
+        # A deterministic-friction note SHOULD become a guardrail, not a context-growing memory
+        # note. Warns (does not block); promotion to blocking is replay-eval-gated. Fail-open.
+        try:
+            from memory_write_guard import check_memory_write
+            _note_body = "\n".join(values)
+            for _mpath in iter_paths(payload.get("tool_input", {})):
+                _decision, _why = check_memory_write(str(_mpath), _note_body)
+                if _decision == "advise":
+                    sys.stderr.write("[memory-guard advisory #3383] " + _why + "\n")
+                    break
+        except Exception:
+            pass
         if active_ticket_is_no_code_lane(state, cwd):
             return emit("deny", "File edit blocked: lane:no-code-remediation is issue-only. Re-route ticket to lane:code-change.")
         # Canonical-main write guard: block writes whether cwd is main checkout

--- a/tests/test_memory_write_guard.py
+++ b/tests/test_memory_write_guard.py
@@ -1,0 +1,70 @@
+"""Tests for memory_write_guard (Epic #3380 / #3383). Run: pytest tests/test_memory_write_guard.py"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "hooks", "scripts"))
+import memory_write_guard as g  # noqa: E402
+
+MEM = "/home/u/.claude/projects/x/memory/feedback_foo.md"
+
+
+def test_guardrail_candidate_without_disposition_advises():
+    body = "The merge-gate false-blocks via gh json; enforcer rejects the redirect."
+    decision, _ = g.check_memory_write(MEM, body)
+    assert decision == "advise"
+
+
+def test_guardrail_candidate_with_disposition_allowed():
+    body = "merge-gate false-block via gh json.\ndisposition: guardrail #4321"
+    decision, _ = g.check_memory_write(MEM, body)
+    assert decision == "allow"
+
+
+def test_defer_disposition_allowed():
+    body = "validator misfire collision in regex.\ndisposition: defer needs design"
+    assert g.check_memory_write(MEM, body)[0] == "allow"
+
+
+def test_judgment_note_frictionless():
+    body = "Client prefers cost over speed; never drop to a paid model. Patience over speed."
+    assert g.check_memory_write(MEM, body)[0] == "allow"
+
+
+def test_judgment_wins_on_collision():
+    # names a mechanical surface AND a preference -> judgment wins -> allow (no guardrail push)
+    body = "Client prefers the merge-gate stay strict even when it false-blocks."
+    assert g.check_memory_write(MEM, body)[0] == "allow"
+
+
+def test_non_memory_path_allowed():
+    assert g.check_memory_write("/repo/src/foo.js", "merge-gate false-block")[0] == "allow"
+
+
+def test_empty_and_none_fail_open():
+    assert g.check_memory_write(MEM, "")[0] == "allow"
+    assert g.check_memory_write(MEM, None)[0] == "allow"
+
+
+def test_bypass_env_allows_with_audit():
+    body = "merge-gate false-block misfire"
+    decision, reason = g.check_memory_write(MEM, body, env={"MEMORY_GUARD_BYPASS": "1"})
+    assert decision == "allow" and "bypass" in reason.lower()
+
+
+def test_chaos_never_raises_and_only_allow_or_advise():
+    rnd = 12345
+    noise = ["merge-gate false-block", "client prefers x", "", "\x00�",
+             "a" * 9000, "disposition: guardrail #1", "step 1 step 2 step 3", "<<>>|&"]
+    for i in range(5000):
+        rnd = (rnd * 1103515245 + 12345) & 0x7FFFFFFF
+        body = noise[rnd % len(noise)]
+        path = MEM if (rnd >> 3) % 2 else "/x/src/a.js"
+        decision, _ = g.check_memory_write(path, body)
+        assert decision in ("allow", "advise")
+
+
+def test_classify_note_fail_open_on_bad_lexicon(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    assert g.classify_note("merge-gate false-block", lexicon=g.load_lexicon(str(bad))) in (
+        "semantic-memory", "guardrail-candidate")


### PR DESCRIPTION
## Memory-write poka-yoke guard — Phase-1 of Epic #3380

Refs #3383
Refs #3381
merge-evidence-deferred-final: #3383

Advisory `PreToolUse` guard (`hooks/scripts/memory_write_guard.py`, wired into `pretool_guard.py`):
a **guardrail-candidate** (deterministic-friction) memory note written *without* a `disposition:` line
emits an advisory to file a guardrail instead of growing always-resident memory. Genuine
judgment/preference notes write frictionlessly (judgment wins on collision). Fail-open (any error →
allow; never blocks legitimate work); `MEMORY_GUARD_BYPASS=1` audited escape hatch.

Runtime-agnostic: reads the same shared `config/friction-lexicon.json` as the JS classifier (G5).

### Evidence
- 10/10 logic checks incl. 5000-record chaos no-raise; ruff (lint-py) clean; pytest suite added.
- Cross-family review (free $0 panel): groq 98 / gpt-oss 95 / mistral 95 — median 95, unanimous ACCEPT.

Baton artifacts (COLLABORATOR_HANDOFF, EDD, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT) posted on #3383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
