### PR TITLE
test(governance): synthetic e2e cross-team consult protocol verifier (#1591)

### DIFF
--- a/.changes/unreleased/1591.md
+++ b/.changes/unreleased/1591.md
@@ -1,0 +1,3 @@
+- test(governance): synthetic end-to-end cross-team consult protocol verifier (#1591 AC4)
+
+Refs #1334 #1305

--- a/scripts/global/cross-team-consult-e2e.js
+++ b/scripts/global/cross-team-consult-e2e.js
@@ -1,0 +1,92 @@
+'use strict';
+// cross-team-consult-e2e — #1591 (AC4 of #1334). Synthetic state-machine chaining
+// AC1–AC3 pure helpers; no live GitHub. Caller supplies registry + timestamps.
+
+const Auto = require('./cross-team-auto-apply.js');
+const Reaper = require('./cross-team-claim-reaper.js');
+const Sub = require('./cross-team-signer-substrate.js');
+
+const EPIC_LABELS = ['type:epic', 'priority:P2', 'area:governance'];
+const DEFAULT_REAPER_NOW_MS = Date.UTC(2026, 4, 17, 0, 0, 0);
+const MANAGER_COMMENT = [
+  '## MANAGER_HANDOFF', '', 'CONSULTANT_EPIC_CLOSEOUT-pending: evidence anchor.',
+  'cross-team Consultant required for SOX baseline.',
+  'Signed-by: Orla Mason', 'Team&Model: claude-code:opus-4-7@anthropic', 'Role: manager',
+].join('\n');
+
+function initialState() { return { labels: [...EPIC_LABELS], comments: [] }; }
+function asComments(state) { return (state.comments || []).map(c => ({ body: c.body || c })); }
+
+function applyManagerRequest(state) {
+  const decision = Auto.decideApply({ commentBody: MANAGER_COMMENT, labels: state.labels });
+  if (!decision.apply) return { ok: false, reason: decision.reason, state };
+  const labels = state.labels.filter(l => !Auto.SUPPRESS_LABELS.includes(l));
+  labels.push(decision.label);
+  return { ok: true, step: 'manager-auto-apply', label: decision.label,
+    state: { labels, comments: [...state.comments, { body: MANAGER_COMMENT }] } };
+}
+
+function applyClaim(state, { substrate, alias, expires }) {
+  if (!state.labels.includes('consultant:cross-team-needed')) {
+    return { ok: false, step: 'claim', reason: 'no-needed-label', state };
+  }
+  const body = `CROSS_TEAM_CLAIM: substrate=${substrate}, alias=${alias}, expires=${expires}`;
+  const labels = state.labels.filter(l => l !== 'consultant:cross-team-needed');
+  labels.push('consultant:cross-team-in-progress');
+  return { ok: true, step: 'claim', state: { labels, comments: [...state.comments, { body }] } };
+}
+
+function applyReaper(state, registry, nowMs) {
+  const expired = Reaper.findExpiredClaims([{ issueNumber: 1, comments: asComments(state) }], registry, nowMs);
+  if (!expired.length) return { ok: false, step: 'reaper', reason: 'no-expired-claims', state };
+  const body = Reaper.buildExpiredComment(expired[0].claim, new Date(nowMs).toISOString());
+  const labels = state.labels.filter(l => l !== 'consultant:cross-team-in-progress');
+  if (!labels.includes('consultant:cross-team-needed')) labels.push('consultant:cross-team-needed');
+  return { ok: true, step: 'reaper-expire', state: { labels, comments: [...state.comments, { body }] } };
+}
+
+function canReclaim(state, registry) {
+  return state.labels.includes('consultant:cross-team-needed')
+    && !Sub.activeClaim(asComments(state), registry || {});
+}
+
+function verifyCloseout(state, closeoutBody, registry) {
+  const comments = asComments(state);
+  comments.push({ body: closeoutBody });
+  return Sub.enforceSubstrateMatch({
+    closeoutTeam: Sub.extractCloseoutTeam(closeoutBody),
+    activeClaim: Sub.activeClaim(comments, registry), labels: state.labels,
+  });
+}
+
+function runSyntheticFlow(registry, opts = {}) {
+  const substrate = opts.substrate || 'codex-cli';
+  const alias = opts.alias || 'Quill Vale';
+  const claimExpires = opts.claimExpires || '2026-05-16T00:00:00Z';
+  const reaperNowMs = opts.reaperNowMs || DEFAULT_REAPER_NOW_MS;
+  const trace = [];
+  let state = initialState();
+  for (const step of [
+    () => applyManagerRequest(state),
+    () => applyClaim(state, { substrate, alias, expires: claimExpires }),
+    () => applyReaper(state, registry, reaperNowMs),
+  ]) {
+    const result = step();
+    trace.push(result);
+    if (!result.ok) return { ok: false, trace };
+    state = result.state;
+  }
+  if (!canReclaim(state, registry)) return { ok: false, trace, reason: 'reclaim-unavailable' };
+  const reclaim = applyClaim(state, { substrate, alias, expires: opts.reclaimExpires || '2026-05-20T00:00:00Z' });
+  trace.push(reclaim);
+  if (!reclaim.ok) return { ok: false, trace };
+  state = reclaim.state;
+  const match = verifyCloseout(state, 'CONSULTANT_EPIC_CLOSEOUT\nTeam&Model: codex:gpt-5@codex-cli\nRole: consultant', registry);
+  const mismatch = verifyCloseout(state, 'CONSULTANT_EPIC_CLOSEOUT\nTeam&Model: claude-code:opus@anthropic\nRole: consultant', registry);
+  return { ok: match.ok && !mismatch.ok, trace, state, signerGate: { match, mismatch }, reclaimAvailable: true };
+}
+
+module.exports = {
+  EPIC_LABELS, MANAGER_COMMENT, initialState, applyManagerRequest, applyClaim,
+  applyReaper, canReclaim, verifyCloseout, runSyntheticFlow,
+};

--- a/tests/cross-team-consult-e2e.spec.js
+++ b/tests/cross-team-consult-e2e.spec.js
@@ -1,0 +1,57 @@
+// Synthetic end-to-end verification for cross-team consult protocol (#1591 AC4 of #1334).
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const E2E = require(path.resolve(__dirname, '..', 'scripts', 'global', 'cross-team-consult-e2e.js'));
+
+const REGISTRY = {
+  substrateTeamMap: { 'github-copilot': 'copilot', 'codex-cli': 'codex', 'claude-code-cli': 'claude-code' },
+};
+const CLAIM = { substrate: 'codex-cli', alias: 'Quill Vale', expires: '2026-05-16T00:00:00Z' };
+const REAPER_NOW = Date.UTC(2026, 4, 17, 0, 0, 0);
+
+test('step: Manager request auto-applies consultant:cross-team-needed', () => {
+  const result = E2E.applyManagerRequest(E2E.initialState());
+  expect(result.ok).toBe(true);
+  expect(result.state.labels).toContain('consultant:cross-team-needed');
+});
+
+test('step: claim swaps label to :in-progress and posts CROSS_TEAM_CLAIM', () => {
+  const state = E2E.applyManagerRequest(E2E.initialState()).state;
+  const result = E2E.applyClaim(state, CLAIM);
+  expect(result.ok).toBe(true);
+  expect(result.state.labels).toContain('consultant:cross-team-in-progress');
+  expect(result.state.labels).not.toContain('consultant:cross-team-needed');
+});
+
+test('step: reaper expires stale claim and reverts label to :needed', () => {
+  let state = E2E.applyManagerRequest(E2E.initialState()).state;
+  state = E2E.applyClaim(state, CLAIM).state;
+  const result = E2E.applyReaper(state, REGISTRY, REAPER_NOW);
+  expect(result.ok).toBe(true);
+  expect(result.state.labels).toContain('consultant:cross-team-needed');
+  expect(result.state.comments.at(-1).body).toContain('CROSS_TEAM_CLAIM_EXPIRED');
+});
+
+test('canReclaim: true after EXPIRED marker clears active claim', () => {
+  let state = E2E.applyManagerRequest(E2E.initialState()).state;
+  state = E2E.applyClaim(state, CLAIM).state;
+  state = E2E.applyReaper(state, REGISTRY, REAPER_NOW).state;
+  expect(E2E.canReclaim(state, REGISTRY)).toBe(true);
+});
+
+test('signer gate: matching team passes, mismatched team fails', () => {
+  let state = E2E.applyManagerRequest(E2E.initialState()).state;
+  state = E2E.applyClaim(state, { ...CLAIM, expires: '2026-05-20T00:00:00Z' }).state;
+  const match = E2E.verifyCloseout(state, 'CONSULTANT_EPIC_CLOSEOUT\nTeam&Model: codex:gpt-5@codex-cli\nRole: consultant', REGISTRY);
+  const mismatch = E2E.verifyCloseout(state, 'CONSULTANT_EPIC_CLOSEOUT\nTeam&Model: claude-code:opus@anthropic\nRole: consultant', REGISTRY);
+  expect(match.ok).toBe(true);
+  expect(mismatch.ok).toBe(false);
+});
+
+test('AC4 full synthetic flow: manager → claim → expire → reclaim → signer gate', () => {
+  const flow = E2E.runSyntheticFlow(REGISTRY, { claimExpires: CLAIM.expires, reaperNowMs: REAPER_NOW });
+  expect(flow.ok).toBe(true);
+  expect(flow.signerGate.match.ok).toBe(true);
+  expect(flow.signerGate.mismatch.ok).toBe(false);
+  expect(flow.trace.map(t => t.step)).toEqual(['manager-auto-apply', 'claim', 'reaper-expire', 'claim']);
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/global/cross-team-consult-e2e.js` — pure synthetic state-machine chaining AC1–AC3 helpers (auto-apply, claim, reaper, signer-substrate) to exercise the full cross-team consult protocol without live GitHub API calls.
- Adds `tests/cross-team-consult-e2e.spec.js` with 6 deterministic integration tests covering all AC4 steps from #1334.

Closes #1591
Refs #1334 #1305 #1589 #1590

## Drift remediation (Manager pickup)

Oldest independent backlog ticket (2026-05-15). Re-scoped from placeholder body; AC1–AC3 already shipped; AC5 remains in #1592 (complementary, not redundant).

## Test plan

- [x] `npx playwright test tests/cross-team-consult-e2e.spec.js` → 6/6 pass
- [x] `npm run lint` → 100-line cap clean
- [x] `npm run lint:readability:diff` → no net-new warnings
- [x] `node scripts/global/closeout-preflight.js 1591` → PASS


Made with [Cursor](https://cursor.com)